### PR TITLE
feat: improve file viewer UX for mobile

### DIFF
--- a/frontend/src/components/TabletLayout.tsx
+++ b/frontend/src/components/TabletLayout.tsx
@@ -205,13 +205,18 @@ export function TabletLayout({
     }
   }, []);
 
-  // URL extract from terminal buffer
+  // URL extract from terminal buffer (toggle menu)
   const handleUrlExtract = useCallback(() => {
+    // If menu is already open, close it
+    if (showUrlMenu) {
+      setShowUrlMenu(false);
+      return;
+    }
     const urls = terminalRef.current?.extractUrls() || [];
     setDetectedUrls(urls);
     setUrlPage(0);
     setShowUrlMenu(true);
-  }, []);
+  }, [showUrlMenu]);
 
   // Copy URL to clipboard
   const handleCopyUrl = useCallback((url: string) => {

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -586,8 +586,14 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
     fileInputRef.current?.click();
   };
 
-  // Extract URLs from terminal buffer
+  // Extract URLs from terminal buffer (toggle menu)
   const handleExtractUrls = () => {
+    // If menu is already open, close it
+    if (showUrlMenu) {
+      setShowUrlMenu(false);
+      return;
+    }
+
     const term = terminalRef.current;
     if (!term) return;
 
@@ -843,13 +849,13 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
           {/* Custom overlay content (from parent) - only show when overlay is visible */}
           {showOverlay && overlayContent}
 
-          {/* Minimal tap area to show overlay when hidden (keyboard visible state) */}
+          {/* Tap area to show overlay when hidden (keyboard visible state) */}
           {!showOverlay && overlayContent && onOverlayTap && (
             <div
-              className="h-2 flex items-center justify-center"
+              className="h-4 flex items-center justify-center"
               onClick={onOverlayTap}
             >
-              <div className="w-8 h-0.5 bg-gray-600 rounded-full" />
+              <div className="w-10 h-1 bg-gray-600 rounded-full" />
             </div>
           )}
 

--- a/frontend/src/components/files/CodeViewer.tsx
+++ b/frontend/src/components/files/CodeViewer.tsx
@@ -3,6 +3,10 @@ import hljs from 'highlight.js'; // 全言語サポート
 import 'highlight.js/styles/github-dark.css';
 
 const WORDWRAP_STORAGE_KEY = 'cchub-wordwrap';
+const FONTSIZE_STORAGE_KEY = 'cchub-fontsize';
+const DEFAULT_FONTSIZE = 14;
+const MIN_FONTSIZE = 8;
+const MAX_FONTSIZE = 32;
 
 function getWordWrapSetting(fileName: string): boolean {
   try {
@@ -28,6 +32,37 @@ function setWordWrapSetting(fileName: string, value: boolean) {
   }
 }
 
+function getFontSizeSetting(): number {
+  try {
+    const stored = localStorage.getItem(FONTSIZE_STORAGE_KEY);
+    if (stored) {
+      const size = parseInt(stored, 10);
+      if (!isNaN(size) && size >= MIN_FONTSIZE && size <= MAX_FONTSIZE) {
+        return size;
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_FONTSIZE;
+}
+
+function setFontSizeSetting(size: number) {
+  try {
+    localStorage.setItem(FONTSIZE_STORAGE_KEY, String(size));
+  } catch {
+    // ignore
+  }
+}
+
+// Calculate distance between two touch points
+function getTouchDistance(touches: TouchList): number {
+  if (touches.length < 2) return 0;
+  const dx = touches[0].clientX - touches[1].clientX;
+  const dy = touches[0].clientY - touches[1].clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
 interface CodeViewerProps {
   content: string;
   language?: string;
@@ -44,7 +79,15 @@ export function CodeViewer({
   truncated = false,
 }: CodeViewerProps) {
   const codeRef = useRef<HTMLElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [wordWrap, setWordWrap] = useState(() => getWordWrapSetting(fileName || ''));
+  const [fontSize, setFontSize] = useState(() => getFontSizeSetting());
+
+  // Pinch zoom state
+  const pinchStateRef = useRef<{
+    initialDistance: number;
+    initialFontSize: number;
+  } | null>(null);
 
   const toggleWordWrap = useCallback(() => {
     const newValue = !wordWrap;
@@ -53,6 +96,58 @@ export function CodeViewer({
       setWordWrapSetting(fileName, newValue);
     }
   }, [wordWrap, fileName]);
+
+  // Reset font size to default
+  const resetFontSize = useCallback(() => {
+    setFontSize(DEFAULT_FONTSIZE);
+    setFontSizeSetting(DEFAULT_FONTSIZE);
+  }, []);
+
+  // Pinch zoom handlers
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 2) {
+        // Prevent default zoom behavior
+        e.preventDefault();
+        pinchStateRef.current = {
+          initialDistance: getTouchDistance(e.touches),
+          initialFontSize: fontSize,
+        };
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (e.touches.length === 2 && pinchStateRef.current) {
+        e.preventDefault();
+        const currentDistance = getTouchDistance(e.touches);
+        const scale = currentDistance / pinchStateRef.current.initialDistance;
+        const newSize = Math.round(pinchStateRef.current.initialFontSize * scale);
+        const clampedSize = Math.max(MIN_FONTSIZE, Math.min(MAX_FONTSIZE, newSize));
+        setFontSize(clampedSize);
+      }
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (pinchStateRef.current && e.touches.length < 2) {
+        // Save the final font size
+        setFontSizeSetting(fontSize);
+        pinchStateRef.current = null;
+      }
+    };
+
+    container.addEventListener('touchstart', handleTouchStart, { passive: false });
+    container.addEventListener('touchmove', handleTouchMove, { passive: false });
+    container.addEventListener('touchend', handleTouchEnd);
+
+    return () => {
+      container.removeEventListener('touchstart', handleTouchStart);
+      container.removeEventListener('touchmove', handleTouchMove);
+      container.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [fontSize]);
 
   useEffect(() => {
     if (codeRef.current) {
@@ -74,27 +169,7 @@ export function CodeViewer({
   const lines = content.split('\n');
 
   return (
-    <div className="flex flex-col h-full bg-gray-900 text-white font-mono text-sm">
-      {/* File name header */}
-      {fileName && (
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-700 bg-gray-800">
-          <svg className="w-4 h-4 text-gray-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
-          </svg>
-          <span className="text-sm text-gray-300 truncate flex-1">{fileName}</span>
-          <span className="text-xs text-gray-500">{language}</span>
-          <button
-            onClick={toggleWordWrap}
-            className={`p-1 rounded transition-colors ${wordWrap ? 'bg-blue-600 text-white' : 'text-gray-400 hover:text-white hover:bg-gray-700'}`}
-            title={wordWrap ? '折り返しOFF' : '折り返しON'}
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h10m-10 6h16M17 9l3 3-3 3" />
-            </svg>
-          </button>
-        </div>
-      )}
-
+    <div className="relative flex flex-col h-full bg-gray-900 text-white font-mono text-sm">
       {/* Truncation warning */}
       {truncated && (
         <div className="px-3 py-1.5 bg-yellow-900/50 text-yellow-300 text-xs border-b border-yellow-800">
@@ -103,13 +178,16 @@ export function CodeViewer({
       )}
 
       {/* Code content */}
-      <div className="flex-1 overflow-auto">
+      <div ref={containerRef} className="flex-1 overflow-auto touch-pan-y">
         <div className="flex min-h-full">
           {/* Line numbers - hidden when word wrap is enabled */}
           {showLineNumbers && !wordWrap && (
-            <div className="flex-shrink-0 select-none text-right py-3 bg-gray-800/50 border-r border-gray-700 text-gray-500 sticky left-0">
+            <div
+              className="flex-shrink-0 select-none text-right bg-gray-800/50 border-r border-gray-700 text-gray-500 sticky left-0"
+              style={{ fontSize: `${Math.max(10, fontSize - 2)}px`, lineHeight: `${fontSize * 1.5}px` }}
+            >
               {lines.map((_, i) => (
-                <div key={i} className="px-1.5 leading-6 text-xs">
+                <div key={i} className="px-1.5">
                   {i + 1}
                 </div>
               ))}
@@ -117,12 +195,35 @@ export function CodeViewer({
           )}
 
           {/* Code */}
-          <pre className={`flex-1 p-3 m-0 ${wordWrap ? 'whitespace-pre-wrap break-all' : 'overflow-x-auto'}`}>
-            <code ref={codeRef} className={`language-${language}`} style={{ lineHeight: '1.5rem' }}>
+          <pre
+            className={`flex-1 m-0 ${wordWrap ? 'whitespace-pre-wrap break-all' : 'overflow-x-auto'}`}
+            style={{ fontSize: `${fontSize}px`, lineHeight: `${fontSize * 1.5}px` }}
+          >
+            <code ref={codeRef} className={`language-${language}`}>
               {content}
             </code>
           </pre>
         </div>
+      </div>
+
+      {/* Floating controls - top right */}
+      <div className="absolute top-2 right-2 flex items-center gap-1 bg-gray-800/90 rounded-lg p-1 backdrop-blur-sm">
+        <button
+          onClick={resetFontSize}
+          className="px-1.5 py-0.5 text-xs text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
+          title="フォントサイズをリセット (ピンチでズーム)"
+        >
+          {fontSize}px
+        </button>
+        <button
+          onClick={toggleWordWrap}
+          className={`p-1 rounded transition-colors ${wordWrap ? 'bg-blue-600 text-white' : 'text-gray-400 hover:text-white hover:bg-gray-700'}`}
+          title={wordWrap ? '折り返しOFF' : '折り返しON'}
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h10m-10 6h16M17 9l3 3-3 3" />
+          </svg>
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/files/DiffViewer.tsx
+++ b/frontend/src/components/files/DiffViewer.tsx
@@ -263,11 +263,11 @@ export function DiffViewer({
 
       {/* Diff content */}
       <div ref={scrollContainerRef} className="flex-1 overflow-auto">
-        <div className="min-h-full">
+        <div className={`min-h-full ${wordWrap ? '' : 'min-w-fit'}`}>
           {diffLines.map((line, i) => (
             <div
               key={i}
-              className={`flex ${
+              className={`flex min-w-full ${
                 line.type === 'add' ? 'bg-green-900/30' :
                 line.type === 'remove' ? 'bg-red-900/30' :
                 ''

--- a/frontend/src/components/files/FileBrowser.tsx
+++ b/frontend/src/components/files/FileBrowser.tsx
@@ -109,24 +109,6 @@ export function FileBrowser({
 
   return (
     <div className="flex flex-col h-full bg-gray-900 text-white">
-      {/* Path bar */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-700 bg-gray-800">
-        {parentPath && (
-          <button
-            onClick={onNavigateUp}
-            className="p-1.5 hover:bg-gray-700 rounded transition-colors shrink-0"
-            title="上のフォルダへ"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-            </svg>
-          </button>
-        )}
-        <div className="flex-1 text-sm text-gray-300 truncate font-mono" title={currentPath}>
-          {shortPath}
-        </div>
-      </div>
-
       {/* File list */}
       <div className="flex-1 overflow-y-auto">
         {isLoading ? (
@@ -163,6 +145,24 @@ export function FileBrowser({
             ))}
           </div>
         )}
+      </div>
+
+      {/* Path bar - at bottom */}
+      <div className="flex items-center gap-2 px-3 py-2 border-t border-gray-700 bg-gray-800">
+        {parentPath && (
+          <button
+            onClick={onNavigateUp}
+            className="p-1.5 hover:bg-gray-700 rounded transition-colors shrink-0"
+            title="上のフォルダへ"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+        )}
+        <div className="flex-1 text-sm text-gray-300 truncate font-mono" title={currentPath}>
+          {shortPath}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/files/FileViewer.tsx
+++ b/frontend/src/components/files/FileViewer.tsx
@@ -420,8 +420,66 @@ export function FileViewer({ sessionWorkingDir, onClose, initialPath }: FileView
   return (
     <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center">
       <div className="bg-gray-900 w-full h-full lg:w-[90%] lg:h-[90%] lg:max-w-5xl lg:rounded-lg lg:shadow-2xl overflow-hidden flex flex-col">
-        {/* Header */}
-        <div className="flex items-center justify-between px-3 py-2 border-b border-gray-700 bg-gray-800">
+        {/* Error */}
+        {error && (
+          <div className="px-3 py-2 bg-red-900/50 text-red-300 text-sm border-b border-red-800">
+            {error}
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="flex-1 overflow-hidden">
+          {viewMode === 'browser' && (
+            <FileBrowser
+              files={files}
+              currentPath={currentPath}
+              parentPath={parentPath}
+              isLoading={isLoading}
+              onNavigate={navigateTo}
+              onNavigateUp={navigateUp}
+              onSelectFile={handleSelectFile}
+              showHidden={showHidden}
+            />
+          )}
+
+          {viewMode === 'file' && selectedFile && (
+            isImageFile(selectedFile.path) ? (
+              <ImageViewer
+                content={selectedFile.content}
+                mimeType={selectedFile.mimeType}
+                fileName={getFileName(selectedFile.path)}
+                size={selectedFile.size}
+              />
+            ) : (
+              <CodeViewer
+                content={selectedFile.content}
+                language={getLanguageFromPath(selectedFile.path)}
+                fileName={getFileName(selectedFile.path)}
+                truncated={selectedFile.truncated}
+              />
+            )
+          )}
+
+          {viewMode === 'changes' && (
+            <ChangesView
+              changes={changes}
+              isLoading={isLoading}
+              onSelectChange={handleChangeFileClick}
+            />
+          )}
+
+          {viewMode === 'diff' && selectedChange && (
+            <DiffViewer
+              oldContent={selectedChange.oldContent}
+              newContent={selectedChange.newContent}
+              fileName={getFileName(selectedChange.path)}
+              toolName={selectedChange.toolName}
+            />
+          )}
+        </div>
+
+        {/* Footer controls - at bottom for easier touch access */}
+        <div className="flex items-center justify-between px-3 py-2 border-t border-gray-700 bg-gray-800">
           <div className="flex items-center gap-2">
             {(viewMode === 'file' || viewMode === 'diff') && (
               <button
@@ -487,64 +545,6 @@ export function FileViewer({ sessionWorkingDir, onClose, initialPath }: FileView
               </svg>
             </button>
           </div>
-        </div>
-
-        {/* Error */}
-        {error && (
-          <div className="px-3 py-2 bg-red-900/50 text-red-300 text-sm border-b border-red-800">
-            {error}
-          </div>
-        )}
-
-        {/* Content */}
-        <div className="flex-1 overflow-hidden">
-          {viewMode === 'browser' && (
-            <FileBrowser
-              files={files}
-              currentPath={currentPath}
-              parentPath={parentPath}
-              isLoading={isLoading}
-              onNavigate={navigateTo}
-              onNavigateUp={navigateUp}
-              onSelectFile={handleSelectFile}
-              showHidden={showHidden}
-            />
-          )}
-
-          {viewMode === 'file' && selectedFile && (
-            isImageFile(selectedFile.path) ? (
-              <ImageViewer
-                content={selectedFile.content}
-                mimeType={selectedFile.mimeType}
-                fileName={getFileName(selectedFile.path)}
-                size={selectedFile.size}
-              />
-            ) : (
-              <CodeViewer
-                content={selectedFile.content}
-                language={getLanguageFromPath(selectedFile.path)}
-                fileName={getFileName(selectedFile.path)}
-                truncated={selectedFile.truncated}
-              />
-            )
-          )}
-
-          {viewMode === 'changes' && (
-            <ChangesView
-              changes={changes}
-              isLoading={isLoading}
-              onSelectChange={handleChangeFileClick}
-            />
-          )}
-
-          {viewMode === 'diff' && selectedChange && (
-            <DiffViewer
-              oldContent={selectedChange.oldContent}
-              newContent={selectedChange.newContent}
-              fileName={getFileName(selectedChange.path)}
-              toolName={selectedChange.toolName}
-            />
-          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Move file browser menu and path bar to bottom for easier touch access
- Move FileViewer footer controls to bottom on mobile
- Add pinch-to-zoom font size control in CodeViewer (8-32px range)
- Remove CodeViewer header, use floating controls instead
- Remove padding to maximize code display area
- Fix DiffViewer background color extending to line edges
- Add URL menu toggle behavior
- Increase overlay tap area size

## Test plan

- [ ] Open file viewer on mobile
- [ ] Verify controls are at bottom for easy thumb access
- [ ] Test pinch-to-zoom in code viewer
- [ ] Verify diff viewer background colors extend to edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)