### PR TITLE
feat: improve create session modal with directory picker

### DIFF
--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -8,7 +8,7 @@ interface UseSessionsReturn {
   isLoading: boolean;
   error: string | null;
   fetchSessions: () => Promise<void>;
-  createSession: (name?: string) => Promise<SessionResponse | null>;
+  createSession: (name?: string, workingDir?: string) => Promise<SessionResponse | null>;
   deleteSession: (id: string) => Promise<boolean>;
 }
 
@@ -35,14 +35,14 @@ export function useSessions(): UseSessionsReturn {
     }
   }, []);
 
-  const createSession = useCallback(async (name?: string): Promise<SessionResponse | null> => {
+  const createSession = useCallback(async (name?: string, workingDir?: string): Promise<SessionResponse | null> => {
     setError(null);
 
     try {
       const response = await fetch(`${API_BASE}/api/sessions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name, workingDir }),
       });
 
       if (!response.ok) {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -88,6 +88,7 @@ export const RegisterSchema = z.object({
 
 export const CreateSessionSchema = z.object({
   name: z.string().min(1).max(64).optional(),
+  workingDir: z.string().optional(),
 });
 
 export const ResizeTerminalSchema = z.object({


### PR DESCRIPTION
## Summary
- Add directory browser to session creation modal for selecting working directory
- Position modal above mobile keyboard (top-aligned) for better UX on tablets
- Auto-suggest session name from selected directory name
- Add new folder creation functionality within the directory picker
- Auto-start claude after navigating to selected directory
- Hide hidden directories (starting with `.`) in directory picker
- Fix session identification bug that showed unrelated session info for new directories

## Changes
- `backend/src/routes/files.ts`: Add `/api/files/browse` and `/api/files/mkdir` endpoints
- `backend/src/routes/sessions.ts`: Support `workingDir` parameter, auto-start claude
- `shared/types.ts`: Add `workingDir` to `CreateSessionSchema`
- `frontend/src/components/SessionList.tsx`: Complete modal redesign with directory picker
- `frontend/src/hooks/useSessions.ts`: Support `workingDir` in `createSession`

## Test plan
- [ ] Create new session with directory selection
- [ ] Verify session name is auto-suggested from directory name
- [ ] Create new folder and start session in it
- [ ] Verify claude starts automatically after session creation
- [ ] Verify hidden directories are not shown
- [ ] Verify no unrelated session info appears for new directories

🤖 Generated with [Claude Code](https://claude.ai/code)