### PR TITLE
feat: add session list sidebar toggle to terminal pane

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { TerminalPage } from './pages/TerminalPage';
 import { SessionList } from './components/SessionList';
-import { TabletLayout } from './components/TabletLayout';
+// TabletLayout is deprecated - now using DesktopLayout with isTablet prop
+// import { TabletLayout } from './components/TabletLayout';
 import { DesktopLayout } from './components/DesktopLayout';
 import { FileViewer } from './components/files/FileViewer';
 import { ConversationViewer } from './components/ConversationViewer';
@@ -452,16 +453,17 @@ export function App() {
     );
   }
 
-  // Tablet layout: split view with terminal, session list, and keyboard
+  // Tablet layout: use DesktopLayout with floating keyboard
   if (deviceType === 'tablet') {
     return (
-      <TabletLayout
+      <DesktopLayout
         sessions={openSessions}
         activeSessionId={activeSessionId}
         onSelectSession={handleSelectSession}
         onSessionStateChange={updateSessionState}
         onShowSessionList={handleShowSessionList}
         onReload={handleReload}
+        isTablet={true}
       />
     );
   }

--- a/frontend/src/components/FloatingKeyboard.tsx
+++ b/frontend/src/components/FloatingKeyboard.tsx
@@ -1,0 +1,287 @@
+import { useRef, useCallback, useState, useEffect } from 'react';
+import { Keyboard } from './Keyboard';
+
+const POSITION_KEY = 'cchub-floating-keyboard-position';
+const MINIMIZED_KEY = 'cchub-floating-keyboard-minimized';
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+interface FloatingKeyboardProps {
+  visible: boolean;
+  onClose: () => void;
+  onSend: (char: string) => void;
+  onFilePicker?: () => void;
+  onUrlExtract?: () => void;
+  isUploading?: boolean;
+}
+
+export function FloatingKeyboard({
+  visible,
+  onClose,
+  onSend,
+  onFilePicker,
+  onUrlExtract,
+  isUploading = false,
+}: FloatingKeyboardProps) {
+  const [inputMode, setInputMode] = useState<'keyboard' | 'input'>('keyboard');
+  const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Position state
+  const [position, setPosition] = useState<Position>(() => {
+    try {
+      const saved = localStorage.getItem(POSITION_KEY);
+      if (saved) return JSON.parse(saved);
+    } catch {}
+    // Default: bottom center
+    return { x: window.innerWidth / 2 - 200, y: window.innerHeight - 300 };
+  });
+
+  // Minimized state
+  const [minimized, setMinimized] = useState(() => {
+    try {
+      return localStorage.getItem(MINIMIZED_KEY) === 'true';
+    } catch {}
+    return false;
+  });
+
+  // Dragging state
+  const [isDragging, setIsDragging] = useState(false);
+  const dragOffset = useRef<Position>({ x: 0, y: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Save position to localStorage
+  useEffect(() => {
+    localStorage.setItem(POSITION_KEY, JSON.stringify(position));
+  }, [position]);
+
+  // Save minimized state to localStorage
+  useEffect(() => {
+    localStorage.setItem(MINIMIZED_KEY, String(minimized));
+  }, [minimized]);
+
+  // Drag start handler
+  const handleDragStart = useCallback((e: React.MouseEvent | React.TouchEvent) => {
+    e.preventDefault();
+    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+    const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+
+    dragOffset.current = {
+      x: clientX - position.x,
+      y: clientY - position.y,
+    };
+    setIsDragging(true);
+  }, [position]);
+
+  // Drag move/end handlers
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMove = (e: MouseEvent | TouchEvent) => {
+      const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+      const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+
+      const newX = clientX - dragOffset.current.x;
+      const newY = clientY - dragOffset.current.y;
+
+      // Clamp to viewport
+      const maxX = window.innerWidth - (containerRef.current?.offsetWidth || 400);
+      const maxY = window.innerHeight - (containerRef.current?.offsetHeight || 200);
+
+      setPosition({
+        x: Math.max(0, Math.min(maxX, newX)),
+        y: Math.max(0, Math.min(maxY, newY)),
+      });
+    };
+
+    const handleEnd = () => {
+      setIsDragging(false);
+    };
+
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleEnd);
+    document.addEventListener('touchmove', handleMove);
+    document.addEventListener('touchend', handleEnd);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleEnd);
+      document.removeEventListener('touchmove', handleMove);
+      document.removeEventListener('touchend', handleEnd);
+    };
+  }, [isDragging]);
+
+  // Mode switch handler
+  const handleModeSwitch = useCallback(() => {
+    setInputMode('input');
+    setTimeout(() => inputRef.current?.focus(), 50);
+  }, []);
+
+  const handleSwitchToKeyboard = useCallback(() => {
+    setInputMode('keyboard');
+    setInputValue('');
+  }, []);
+
+  // Input key handler
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      if (inputValue) {
+        onSend(inputValue);
+        setInputValue('');
+      }
+      onSend('\r');
+    } else if (e.key === 'Backspace' && !inputValue && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      onSend('\x7f');
+    } else if (!inputValue && !e.nativeEvent.isComposing) {
+      const arrowKeys: Record<string, string> = {
+        'ArrowUp': '\x1b[A',
+        'ArrowDown': '\x1b[B',
+        'ArrowLeft': '\x1b[D',
+        'ArrowRight': '\x1b[C',
+      };
+      if (arrowKeys[e.key]) {
+        e.preventDefault();
+        onSend(arrowKeys[e.key]);
+      }
+    }
+  };
+
+  // Toggle minimized
+  const toggleMinimize = useCallback(() => {
+    setMinimized(prev => !prev);
+  }, []);
+
+  if (!visible) return null;
+
+  // Minimized FAB button
+  if (minimized) {
+    return (
+      <div
+        ref={containerRef}
+        className="fixed z-50"
+        style={{ left: position.x, top: position.y }}
+      >
+        <div
+          className="flex items-center gap-1 bg-gray-800 border border-gray-600 rounded-lg shadow-lg cursor-move"
+          onMouseDown={handleDragStart}
+          onTouchStart={handleDragStart}
+        >
+          <button
+            onClick={toggleMinimize}
+            className="p-3 text-white hover:bg-gray-700 rounded-l-lg transition-colors"
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
+            </svg>
+          </button>
+          <button
+            onClick={onClose}
+            className="p-3 text-gray-400 hover:text-white hover:bg-gray-700 rounded-r-lg transition-colors"
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Expanded keyboard
+  return (
+    <div
+      ref={containerRef}
+      className="fixed z-50 bg-gray-900 border border-gray-700 rounded-lg shadow-2xl overflow-hidden"
+      style={{ left: position.x, top: position.y, width: 420 }}
+    >
+      {/* Header - drag handle */}
+      <div
+        className={`flex items-center justify-between px-2 py-1.5 bg-gray-800 border-b border-gray-700 cursor-move select-none ${isDragging ? 'bg-gray-700' : ''}`}
+        onMouseDown={handleDragStart}
+        onTouchStart={handleDragStart}
+      >
+        <div className="flex items-center gap-2">
+          <div className="flex gap-0.5">
+            <div className="w-1 h-4 bg-gray-600 rounded-full" />
+            <div className="w-1 h-4 bg-gray-600 rounded-full" />
+          </div>
+          <span className="text-xs text-gray-400">Keyboard</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={toggleMinimize}
+            className="p-1 text-gray-400 hover:text-white hover:bg-gray-600 rounded transition-colors"
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
+            </svg>
+          </button>
+          <button
+            onClick={onClose}
+            className="p-1 text-gray-400 hover:text-white hover:bg-gray-600 rounded transition-colors"
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="bg-black">
+        {inputMode === 'keyboard' ? (
+          <Keyboard
+            onSend={onSend}
+            onModeSwitch={handleModeSwitch}
+            onFilePicker={onFilePicker}
+            onUrlExtract={onUrlExtract}
+            isUploading={isUploading}
+            compact={true}
+          />
+        ) : (
+          <div className="p-2">
+            <div className="flex gap-2">
+              <input
+                ref={inputRef}
+                type="text"
+                inputMode="text"
+                lang="ja"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleInputKeyDown}
+                autoCapitalize="off"
+                autoCorrect="off"
+                autoComplete="off"
+                spellCheck={false}
+                enterKeyHint="send"
+                autoFocus
+                placeholder="日本語入力 - Enterで送信"
+                className="flex-1 px-3 py-2 bg-gray-900 border border-gray-700 rounded text-white placeholder-gray-500 focus:outline-none focus:border-green-500"
+                style={{ fontSize: '16px' }}
+              />
+              <button
+                onClick={handleSwitchToKeyboard}
+                className="px-3 py-2 bg-gray-700 hover:bg-gray-600 active:bg-gray-500 rounded text-white font-medium"
+              >
+                ABC
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -351,16 +351,34 @@ function SessionItem({
   const longPressTimerRef = useRef<number | null>(null);
   const longPressFiredRef = useRef(false);
 
-  const handleTouchStart = () => {
+  const handleTouchStart = (e: React.TouchEvent) => {
+    console.log('[SessionItem] Touch start:', session.name);
     longPressFiredRef.current = false;
     longPressTimerRef.current = window.setTimeout(() => {
+      console.log('[SessionItem] Long press fired:', session.name);
       longPressFiredRef.current = true;
+      // Prevent browser context menu by stopping event propagation
+      e.preventDefault();
       onDelete(session);
     }, 600);
   };
 
+  const handleContextMenu = (e: React.MouseEvent) => {
+    // Prevent browser context menu on long press
+    e.preventDefault();
+  };
+
   const handleTouchEnd = () => {
     if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const handleTouchMove = () => {
+    // Cancel long press when touch moves (scrolling)
+    if (longPressTimerRef.current) {
+      console.log('[SessionItem] Touch move - canceling long press');
       clearTimeout(longPressTimerRef.current);
       longPressTimerRef.current = null;
     }
@@ -432,9 +450,12 @@ function SessionItem({
     <div
       onClick={handleClick}
       onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchCancel}
-      className={`p-3 rounded cursor-pointer transition-colors ${
+      onContextMenu={handleContextMenu}
+      style={{ touchAction: 'pan-y', WebkitTouchCallout: 'none', WebkitUserSelect: 'none' }}
+      className={`p-3 rounded cursor-pointer transition-colors select-none ${
         isClaudeRunning
           ? 'bg-gray-800 hover:bg-gray-700 active:bg-gray-600 border-l-2 border-green-500'
           : 'bg-gray-800/60 hover:bg-gray-700/70 active:bg-gray-600/70'


### PR DESCRIPTION
## Summary
- TerminalPane内にセッション一覧サイドバートグル追加
- ドラッグでサイドバー幅調整（150px〜500px）
- ピンチズームでコンテンツ拡大縮小（50%〜200%）
- セッション選択時もサイドバーを維持
- レガシーペインタイプのマイグレーション対応
- 全ペインタイプにクローズボタン追加
- SessionListのロングプレスコンテキストメニュー修正

## Test plan
- [ ] ターミナルペインでセッション一覧トグルボタンが動作する
- [ ] サイドバー幅をドラッグで調整できる
- [ ] ピンチズームでセッション一覧を拡大縮小できる
- [ ] セッション選択後もサイドバーが開いたまま
- [ ] ペインのクローズボタンが動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)