### PR TITLE
feat: add type checking with TypeScript 7.0 beta (tsgo)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
         run: bun run lint
         continue-on-error: true
 
+      - name: Run typecheck
+        run: bun run typecheck
+
       - name: Run tests
         run: bun run test
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "build": "bun build src/index.ts --outdir dist --target bun",
     "start": "bun run dist/index.js",
     "test": "bun test",
-    "lint": "bunx @biomejs/biome lint src/"
+    "lint": "bunx @biomejs/biome lint src/",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@hono/zod-validator": "^0.7.6",

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { CreateSessionSchema, PaneIdSchema, type IndicatorState, type PaneInfo, type ExtendedSessionResponse } from '../../../shared/types';
+import { CreateSessionSchema, PaneIdSchema, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
 import { TmuxService } from '../services/tmux';
 import { controlSessions, getOrCreateControlSession } from '../services/tmux-control';
 import { ClaudeCodeService } from '../services/claude-code';
@@ -93,7 +93,6 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       }
     }
 
-    const isClaudeRunning = s.currentCommand === 'claude';
     // Indicator state: hook events are the source of truth
     // Default for running Claude = completed (idle/waiting for user input)
     const hookResult = ccSession?.sessionId ? getIndicatorOverride(ccSession.sessionId) : null;
@@ -120,7 +119,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       name: s.name,
       createdAt: s.createdAt,
       lastAccessedAt: s.createdAt,
-      state: s.attached ? 'working' as const : 'idle' as const,
+      state: (s.attached ? 'working' : 'idle') as SessionState,
       currentCommand: s.currentCommand,
       currentPath: s.currentPath,
       paneTitle: s.paneTitle,
@@ -180,11 +179,22 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       name: lost.name,
       createdAt: '',
       lastAccessedAt: '',
-      state: 'lost',
+      state: 'lost' as SessionState,
+      currentCommand: undefined,
       currentPath: lost.currentPath,
+      paneTitle: undefined,
+      waitingToolName: undefined,
+      ccSummary: undefined,
+      ccFirstPrompt: undefined,
+      indicatorState: undefined,
+      ccSessionId: lost.ccSessionId,
+      messageCount: undefined,
+      gitBranch: undefined,
+      durationMinutes: undefined,
+      firstMessageId: undefined,
       theme: lost.theme,
       customTitle: lost.customTitle,
-      ccSessionId: lost.ccSessionId,
+      panes: undefined,
     });
   }
 

--- a/backend/src/services/__tests__/tmux-layout-parser.test.ts
+++ b/backend/src/services/__tests__/tmux-layout-parser.test.ts
@@ -50,15 +50,15 @@ describe('parseTmuxLayout', () => {
 
     // Left child: vertical split
     const left = result.children?.[0];
-    expect(left.type).toBe('vertical');
-    expect(left.children).toHaveLength(2);
-    expect(left.children?.[0].paneId).toBe(0);
-    expect(left.children?.[1].paneId).toBe(2);
+    expect(left?.type).toBe('vertical');
+    expect(left?.children).toHaveLength(2);
+    expect(left?.children?.[0].paneId).toBe(0);
+    expect(left?.children?.[1].paneId).toBe(2);
 
     // Right child: leaf
     const right = result.children?.[1];
-    expect(right.type).toBe('leaf');
-    expect(right.paneId).toBe(1);
+    expect(right?.type).toBe('leaf');
+    expect(right?.paneId).toBe(1);
   });
 
   test('three-way horizontal split', () => {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
     "declaration": true,
     "outDir": "dist",
-    "types": ["bun-types"],
+    "types": ["bun"],
     "resolveJsonModule": true,
     "paths": {
       "shared": ["../shared/types.ts"]

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "cc-hub",
+      "devDependencies": {
+        "@typescript/native-preview": "^7.0.0-dev.20260421.2",
+      },
     },
     "backend": {
       "name": "backend",
@@ -605,6 +608,22 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260421.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2", "", { "os": "linux", "cpu": "arm" }, "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2", "", { "os": "linux", "cpu": "x64" }, "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2", "", { "os": "win32", "cpu": "x64" }, "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "bun test src/",
     "test:e2e": "playwright test",
-    "lint": "bunx @biomejs/biome lint src/"
+    "lint": "bunx @biomejs/biome lint src/",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/frontend/src/components/SessionTab.tsx
+++ b/frontend/src/components/SessionTab.tsx
@@ -18,6 +18,7 @@ const stateColors: Record<SessionState, string> = {
   waiting_input: 'bg-red-500',
   waiting_permission: 'bg-red-500',
   disconnected: 'bg-gray-500',
+  lost: 'bg-gray-400',
 };
 
 export function SessionTab({ id, name, state, isActive, onSelect, onClose, onDelete }: SessionTabProps) {

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import type { ExtendedSessionResponse, SessionTheme, IndicatorState } from '../../../shared/types';
+import type { ExtendedSessionResponse, SessionResponse, SessionTheme, IndicatorState } from '../../../shared/types';
 import { authFetch, isTransientNetworkError } from '../services/api';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare module '*.css';

--- a/glasses/package.json
+++ b/glasses/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "pack": "evenhub pack",
     "test": "echo 'no tests'",
-    "lint": "echo 'no lint'"
+    "lint": "echo 'no lint'",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@evenrealities/even_hub_sdk": "^0.0.9"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "test": "bun run --filter '*' test",
     "test:e2e": "bun run --filter frontend test:e2e",
     "lint": "bun run --filter '*' lint",
+    "typecheck": "bun run --filter '*' typecheck",
     "setup": "bun run scripts/setup.ts"
+  },
+  "devDependencies": {
+    "@typescript/native-preview": "^7.0.0-dev.20260421.2"
   }
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -7,6 +7,9 @@
   "exports": {
     ".": "./types.ts"
   },
+  "scripts": {
+    "typecheck": "tsgo --noEmit"
+  },
   "dependencies": {
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary
- **型チェック基盤を新規整備**。これまで backend/frontend/shared では `tsc` が走っておらず、型健全性が実質未検証だった
- **TypeScript 7.0 beta (tsgo)** を採用し、tsc 5.9.3 比で **約 6.8× 高速化** を実測 (合計 9.27s → 1.37s)
- 既存の型エラー 13 件を修正
- CI の test.yml に `typecheck` ステップを追加

## 計測結果 (`tsc --noEmit` vs `tsgo --noEmit` 各3回平均)

| Workspace | tsc 5.9.3 | tsgo 7.0.0-dev | 高速化倍率 |
|-----------|-----------|----------------|-----------|
| backend | 2.59s | 0.38s | 約 6.8× |
| frontend | 6.05s | 0.87s | 約 6.9× |
| shared | 0.63s | 0.12s | 約 5.2× |
| **合計** | **9.27s** | **1.37s** | **約 6.8×** |

## 変更内容

### 型エラー修正
- `backend/src/routes/sessions.ts` — `state` の型絞り込み解除、lost session の必須プロパティ補完、未使用変数削除
- `backend/src/services/__tests__/tmux-layout-parser.test.ts` — optional chaining に変更
- `frontend/src/components/SessionTab.tsx` — `Record<SessionState, string>` に `lost` キー追加
- `frontend/src/hooks/useSessions.ts` — `SessionResponse` 型を import

### 設定・型宣言
- `backend/tsconfig.json` — `bun-types` → `bun` (`@types/bun` に整合)
- `frontend/src/vite-env.d.ts` — 新規、CSS side-effect import の module 宣言 (tsgo 固有の TS2882 対応)

### スクリプト / CI
- 各 workspace `package.json`: `"typecheck": "tsgo --noEmit"` 追加
- root `package.json`: `"typecheck": "bun run --filter '*' typecheck"` 追加
- `.github/workflows/test.yml`: typecheck ステップ追加
- `@typescript/native-preview@beta` を devDependency に追加

## Test plan
- [x] `bun run typecheck` で全 workspace exit 0
- [x] `bun test` で backend 134 tests 全通過
- [x] dev 環境起動し `/api/sessions` `/api/dashboard` `/api/notify` WebSocket `/ws/mux` 正常応答確認
- [x] ログに error/warn なし
- [ ] CI green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)