### PR TITLE
feat: per-session metrics (context, memory, tokens)

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -7,6 +7,7 @@ import { ClaudeCodeService } from '../services/claude-code';
 import { SessionHistoryService } from '../services/session-history';
 import { PromptHistoryService } from '../services/prompt-history';
 import { getAllSessionMetadata, setSessionTheme, setSessionTitle, getSessionOrder, setSessionOrder, getLastKnownSessions, saveLastKnownSessions, removeLastKnownSession, type LastKnownSession } from '../services/session-metadata';
+import { computeSessionMetrics } from '../services/session-metrics';
 import { getIndicatorOverride } from './notify';
 import { pushSessionsNow } from './terminal-mux';
 
@@ -114,6 +115,13 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
 
     const includeClaudeInfo = s.currentCommand === 'claude';
 
+    const panePids: (number | undefined)[] = s.panes ? s.panes.map((p: { pid?: number }) => p.pid) : [];
+    const metrics = await computeSessionMetrics({
+      ccSessionId: includeClaudeInfo ? ccSession?.sessionId : undefined,
+      workingDir: s.currentPath,
+      pids: panePids,
+    });
+
     return {
       id: s.id,
       name: s.name,
@@ -134,7 +142,8 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       firstMessageId: includeClaudeInfo ? ccSession?.firstMessageId : undefined,
       theme: sessionMetadata[s.id]?.theme,
       customTitle: sessionMetadata[s.id]?.title,
-      panes: s.panes ? s.panes.map((p: { paneId: string; command: string; path: string; title: string; tty: string; isActive: boolean; isDead: boolean }) => {
+      metrics,
+      panes: s.panes ? s.panes.map((p: { paneId: string; command: string; path: string; title: string; tty: string; isActive: boolean; isDead: boolean; pid?: number }) => {
         const ttyName = p.tty?.replace('/dev/', '');
         const agentInfo = ttyName ? agentInfoByTty.get(ttyName) : undefined;
         let paneIndicator: IndicatorState | undefined;
@@ -159,6 +168,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
           isActive: p.isActive,
           isDead: p.isDead || undefined,
           indicatorState: (hookState === 'processing' && p.title?.startsWith('✳')) ? paneIndicator : (hookState ?? paneIndicator),
+          pid: p.pid,
         };
         return pane;
       }) : undefined,
@@ -194,6 +204,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       firstMessageId: undefined,
       theme: lost.theme,
       customTitle: lost.customTitle,
+      metrics: undefined,
       panes: undefined,
     });
   }

--- a/backend/src/services/session-metrics.ts
+++ b/backend/src/services/session-metrics.ts
@@ -1,0 +1,137 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { createInterface } from 'node:readline';
+import type { SessionMetrics } from '../../../shared/types';
+
+const CONTEXT_MAX_DEFAULT = 200_000;
+
+function pathToProjectDir(workingDir: string): string {
+  const dirName = workingDir.replace(/\//g, '-');
+  return path.join(os.homedir(), '.claude', 'projects', dirName);
+}
+
+async function getProcessTreeRSS(pid: number): Promise<number> {
+  const queue: number[] = [pid];
+  const visited = new Set<number>();
+  let totalBytes = 0;
+  while (queue.length > 0) {
+    const p = queue.shift();
+    if (p === undefined || visited.has(p)) continue;
+    visited.add(p);
+    try {
+      const status = await Bun.file(`/proc/${p}/status`).text();
+      const m = status.match(/VmRSS:\s+(\d+)\s+kB/);
+      if (m?.[1]) totalBytes += Number.parseInt(m[1], 10) * 1024;
+      const childrenText = await Bun.file(`/proc/${p}/task/${p}/children`).text();
+      const childPids = childrenText.trim().split(/\s+/).filter(Boolean).map(Number);
+      for (const c of childPids) if (!visited.has(c)) queue.push(c);
+    } catch {
+      // Process may have exited
+    }
+  }
+  return totalBytes;
+}
+
+interface JsonlCacheEntry {
+  mtimeMs: number;
+  size: number;
+  totalOutputTokens: number;
+  totalCacheReadTokens: number;
+  contextTokens: number;
+}
+
+const jsonlCache = new Map<string, JsonlCacheEntry>();
+
+async function readJsonlUsage(filePath: string): Promise<{
+  totalOutputTokens: number;
+  totalCacheReadTokens: number;
+  contextTokens: number;
+} | null> {
+  try {
+    const stat = await fs.promises.stat(filePath);
+    const cached = jsonlCache.get(filePath);
+    if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+      return cached;
+    }
+
+    let totalOutputTokens = 0;
+    let totalCacheReadTokens = 0;
+    let contextTokens = 0;
+
+    const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
+    const rl = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+    for await (const line of rl) {
+      if (!line) continue;
+      try {
+        const obj = JSON.parse(line);
+        const usage = obj?.message?.usage;
+        if (usage && typeof usage === 'object') {
+          const inTok = Number(usage.input_tokens) || 0;
+          const createTok = Number(usage.cache_creation_input_tokens) || 0;
+          const readTok = Number(usage.cache_read_input_tokens) || 0;
+          const outTok = Number(usage.output_tokens) || 0;
+          totalOutputTokens += outTok;
+          totalCacheReadTokens += readTok;
+          // Last assistant message's effective context = in + cache_creation + cache_read
+          contextTokens = inTok + createTok + readTok;
+        }
+      } catch {
+        // Skip malformed lines
+      }
+    }
+
+    const entry: JsonlCacheEntry = {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      totalOutputTokens,
+      totalCacheReadTokens,
+      contextTokens,
+    };
+    jsonlCache.set(filePath, entry);
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+export interface MetricsInput {
+  ccSessionId?: string;
+  workingDir?: string;
+  pids?: (number | undefined)[];
+  contextMaxTokens?: number;
+}
+
+export async function computeSessionMetrics(input: MetricsInput): Promise<SessionMetrics | undefined> {
+  const { ccSessionId, workingDir, pids, contextMaxTokens = CONTEXT_MAX_DEFAULT } = input;
+  const metrics: SessionMetrics = {};
+
+  if (ccSessionId && workingDir) {
+    const projectDir = pathToProjectDir(workingDir);
+    const filePath = path.join(projectDir, `${ccSessionId}.jsonl`);
+    const usage = await readJsonlUsage(filePath);
+    if (usage) {
+      metrics.contextTokens = usage.contextTokens;
+      metrics.contextMaxTokens = contextMaxTokens;
+      metrics.contextPercent = contextMaxTokens > 0
+        ? Math.min(100, Math.round((usage.contextTokens / contextMaxTokens) * 1000) / 10)
+        : undefined;
+      metrics.totalOutputTokens = usage.totalOutputTokens;
+      metrics.totalCacheReadTokens = usage.totalCacheReadTokens;
+    }
+  }
+
+  if (pids && pids.length > 0) {
+    const validPids = pids.filter((p): p is number => typeof p === 'number' && Number.isFinite(p));
+    if (validPids.length > 0) {
+      let total = 0;
+      for (const pid of validPids) {
+        total += await getProcessTreeRSS(pid);
+      }
+      metrics.memoryRssBytes = total;
+    }
+  }
+
+  if (Object.keys(metrics).length === 0) return undefined;
+  return metrics;
+}

--- a/backend/src/services/tmux.ts
+++ b/backend/src/services/tmux.ts
@@ -9,6 +9,7 @@ interface TmuxPaneInfo {
   tty: string;
   isActive: boolean;
   isDead: boolean;
+  pid?: number;            // pane_pid (shell PID)
 }
 
 interface TmuxSessionInfo {
@@ -220,7 +221,7 @@ export class TmuxService {
 
       // Get pane info for each session (command, path, title, tty, pane_id, active)
       // Use | as separator since path can contain :
-      const panesProc = Bun.spawn(['tmux', 'list-panes', '-a', '-F', '#{session_name}\x1f#{pane_id}\x1f#{pane_current_command}\x1f#{pane_title}\x1f#{pane_tty}\x1f#{pane_active}\x1f#{pane_dead}\x1f#{pane_current_path}'], {
+      const panesProc = Bun.spawn(['tmux', 'list-panes', '-a', '-F', '#{session_name}\x1f#{pane_id}\x1f#{pane_current_command}\x1f#{pane_title}\x1f#{pane_tty}\x1f#{pane_active}\x1f#{pane_dead}\x1f#{pane_pid}\x1f#{pane_current_path}'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -237,12 +238,13 @@ export class TmuxService {
           .filter((line) => line.length > 0)
           .forEach((line) => {
             const parts = line.split('\x1f');
-            if (parts.length >= 8) {
-              const [sessionName, paneId, command, title, tty, active, dead, ...pathParts] = parts;
+            if (parts.length >= 9) {
+              const [sessionName, paneId, command, title, tty, active, dead, pidStr, ...pathParts] = parts;
               // Path might contain \x1f (unlikely), so join the rest
               const panePath = pathParts.join('\x1f');
               const isActive = active === '1';
               const isDead = dead === '1';
+              const pidNum = pidStr ? Number.parseInt(pidStr, 10) : Number.NaN;
 
               // Collect all panes (pane_id already includes % prefix)
               if (!allPanes.has(sessionName)) {
@@ -256,6 +258,7 @@ export class TmuxService {
                 tty,
                 isActive,
                 isDead,
+                pid: Number.isFinite(pidNum) ? pidNum : undefined,
               });
             }
           });

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -28,6 +28,19 @@ const ACCENT_HEX: Record<SessionTheme, string> = {
   teal: '#14b8a6', blue: '#3b82f6', indigo: '#6366f1', purple: '#a855f7', pink: '#ec4899',
 };
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+function formatTokenCount(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
 import { useSessionHistory } from '../hooks/useSessionHistory';
 import { authFetch } from '../services/api';
 import { SessionHistory } from './SessionHistory';
@@ -765,6 +778,38 @@ function SessionItem({
           <p className="mt-1.5 text-[12px] text-zinc-600 truncate leading-relaxed">
             {extSession.ccSummary || extSession.ccFirstPrompt}
           </p>
+        )}
+
+        {/* Metrics row: context / memory / tokens */}
+        {extSession.metrics && (
+          <div className="mt-1.5 flex items-center gap-3 flex-wrap text-[11px] text-zinc-500">
+            {typeof extSession.metrics.contextPercent === 'number' && (
+              <div className="inline-flex items-center gap-1.5" title={`${formatTokenCount(extSession.metrics.contextTokens ?? 0)} / ${formatTokenCount(extSession.metrics.contextMaxTokens ?? 0)}`}>
+                <span className="text-zinc-600">ctx</span>
+                <div className="w-14 h-1 bg-white/10 rounded-full overflow-hidden">
+                  <div
+                    className={`h-full transition-all ${
+                      extSession.metrics.contextPercent >= 80 ? 'bg-red-500' :
+                      extSession.metrics.contextPercent >= 60 ? 'bg-amber-500' :
+                      'bg-emerald-500'
+                    }`}
+                    style={{ width: `${Math.max(2, extSession.metrics.contextPercent)}%` }}
+                  />
+                </div>
+                <span className="font-mono tabular-nums">{extSession.metrics.contextPercent.toFixed(1)}%</span>
+              </div>
+            )}
+            {typeof extSession.metrics.memoryRssBytes === 'number' && extSession.metrics.memoryRssBytes > 0 && (
+              <span className="font-mono tabular-nums" title={`${extSession.metrics.memoryRssBytes} bytes`}>
+                <span className="text-zinc-600">mem</span> {formatBytes(extSession.metrics.memoryRssBytes)}
+              </span>
+            )}
+            {typeof extSession.metrics.totalOutputTokens === 'number' && extSession.metrics.totalOutputTokens > 0 && (
+              <span className="font-mono tabular-nums" title={`output: ${extSession.metrics.totalOutputTokens.toLocaleString()}`}>
+                <span className="text-zinc-600">out</span> {formatTokenCount(extSession.metrics.totalOutputTokens)}
+              </span>
+            )}
+          </div>
         )}
 
         {!hintSeen && (

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -775,7 +775,7 @@ function SessionItem({
 
         {/* Last prompt / summary */}
         {(extSession.ccSummary || extSession.ccFirstPrompt) && (
-          <p className="mt-1.5 text-[12px] text-zinc-600 truncate leading-relaxed">
+          <p className="mt-1.5 text-[12px] text-zinc-600 leading-relaxed line-clamp-2">
             {extSession.ccSummary || extSession.ccFirstPrompt}
           </p>
         )}

--- a/frontend/src/components/SessionListMini.tsx
+++ b/frontend/src/components/SessionListMini.tsx
@@ -142,7 +142,7 @@ function SessionMiniItem({
         )}
       </div>
       {(extSession.ccSummary || extSession.ccFirstPrompt) && (
-        <div className="text-[10px] text-blue-400 mt-0.5 truncate pl-3.5">
+        <div className="text-[10px] text-blue-400 mt-0.5 line-clamp-2 pl-3.5">
           {extSession.ccSummary || extSession.ccFirstPrompt}
         </div>
       )}

--- a/frontend/src/components/SessionListMini.tsx
+++ b/frontend/src/components/SessionListMini.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { SessionResponse, SessionTheme, IndicatorState, ConversationMessage } from '../../../shared/types';
+import type { SessionResponse, SessionTheme, IndicatorState, ConversationMessage, SessionMetrics } from '../../../shared/types';
 import { useSessions } from '../hooks/useSessions';
 import { useSessionHistory } from '../hooks/useSessionHistory';
 import { authFetch } from '../services/api';
@@ -50,6 +50,7 @@ function SessionMiniItem({
     messageCount?: number;
     gitBranch?: string;
     durationMinutes?: number;
+    metrics?: SessionMetrics;
   };
 
   const isClaudeRunning = extSession.currentCommand === 'claude';
@@ -156,8 +157,45 @@ function SessionMiniItem({
           )}
         </div>
       )}
+      {extSession.metrics && (
+        <div className="flex items-center gap-2 mt-0.5 text-[10px] pl-3.5 font-mono tabular-nums text-th-text-muted">
+          {typeof extSession.metrics.contextPercent === 'number' && (
+            <div className="inline-flex items-center gap-1">
+              <div className="w-8 h-0.5 bg-white/10 rounded-full overflow-hidden">
+                <div
+                  className={`h-full ${
+                    extSession.metrics.contextPercent >= 80 ? 'bg-red-500' :
+                    extSession.metrics.contextPercent >= 60 ? 'bg-amber-500' :
+                    'bg-emerald-500'
+                  }`}
+                  style={{ width: `${Math.max(2, extSession.metrics.contextPercent)}%` }}
+                />
+              </div>
+              <span>{extSession.metrics.contextPercent.toFixed(0)}%</span>
+            </div>
+          )}
+          {typeof extSession.metrics.memoryRssBytes === 'number' && extSession.metrics.memoryRssBytes > 0 && (
+            <span>{formatBytesMini(extSession.metrics.memoryRssBytes)}</span>
+          )}
+          {typeof extSession.metrics.totalOutputTokens === 'number' && extSession.metrics.totalOutputTokens > 0 && (
+            <span>{formatTokensMini(extSession.metrics.totalOutputTokens)}</span>
+          )}
+        </div>
+      )}
     </div>
   );
+}
+
+function formatBytesMini(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}K`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)}M`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}G`;
+}
+
+function formatTokensMini(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
 }
 
 type TabType = 'sessions' | 'history' | 'search';

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -91,6 +91,16 @@ export interface PaneInfo {
   isActive: boolean;
   isDead?: boolean;
   indicatorState?: IndicatorState;
+  pid?: number;            // tmux pane_pid (shell/subprocess PID)
+}
+
+export interface SessionMetrics {
+  contextTokens?: number;         // current context window size (last assistant message sum)
+  contextMaxTokens?: number;      // model-specific max (default 200000)
+  contextPercent?: number;        // 0-100
+  totalOutputTokens?: number;     // cumulative output tokens
+  totalCacheReadTokens?: number;  // cumulative cache reads (rough total usage)
+  memoryRssBytes?: number;        // total RSS across session's panes
 }
 
 export const CreateSessionSchema = z.object({
@@ -299,6 +309,7 @@ export interface ExtendedSessionResponse extends SessionResponse {
   gitBranch?: string;
   durationMinutes?: number;
   firstMessageId?: string;
+  metrics?: SessionMetrics;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- セッション一覧の各カードに **コンテキスト使用率・メモリ使用率・トークン使用量** を表示
- バックエンドで .jsonl 解析と /proc ツリー走査を実装、mtime キャッシュで性能担保
- デスクトップ (SessionList) とモバイル/タブレット (SessionListMini) 両方に反映

## 実装内容

### 型定義
- `SessionMetrics` 新規 (`contextTokens`, `contextMaxTokens`, `contextPercent`, `totalOutputTokens`, `totalCacheReadTokens`, `memoryRssBytes`)
- `ExtendedSessionResponse` / `PaneInfo` を拡張

### バックエンド
- `backend/src/services/session-metrics.ts` — 新規
  - .jsonl 全走査で累計 output/cache トークン集計、最新 assistant メッセージから context 推定
  - mtime + size でキャッシュ（同一ファイルの再解析を回避）
  - `/proc/<pid>/task/<pid>/children` を再帰探索して RSS 合計
- `backend/src/services/tmux.ts` — `list-panes` フォーマットに `#{pane_pid}` 追加
- `backend/src/routes/sessions.ts` — `GET /api/sessions` 応答に `metrics` を含める

### フロントエンド
- `SessionList.tsx` — カード下部にメトリクス行追加。context % は色分け (緑/アンバー/赤) プログレスバー
- `SessionListMini.tsx` — 縮小版を同じデザインで追加

## パフォーマンス
| 状態 | レスポンス |
|-----|-----------|
| 初回 (13セッション、キャッシュなし) | ~180ms |
| 2回目以降 (キャッシュヒット) | 56-83ms |

## Test plan
- [x] `bun run typecheck` 全 workspace 通過
- [x] `bun test` backend 134 tests 通過
- [x] dev 環境で実機確認、13 セッション全てでメトリクス表示
- [x] 色分け動作確認 (20% 緑 / 65% アンバー / 87%・100% 赤)

## Screenshot
カード表示例（デスクトップ）:
- `ctx ▮▮▮▮▯▯▯ 87.7%` `mem 2.0 GB` `out 127k`
- `ctx ▮▮▯▯▯▯▯ 24.3%` `mem 780 MB` `out 15k`

🤖 Generated with [Claude Code](https://claude.com/claude-code)