### PR TITLE
fix: accurate context % (per-model max) + used tokens (cumulative)

### DIFF
--- a/backend/src/services/anthropic-models.ts
+++ b/backend/src/services/anthropic-models.ts
@@ -1,0 +1,79 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+interface ModelInfo {
+  id: string;
+  max_input_tokens: number;
+}
+
+interface ModelsListResponse {
+  data: ModelInfo[];
+}
+
+const CLAUDE_DIR = join(homedir(), '.claude');
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const FALLBACK_MAX_TOKENS = 200_000;
+
+let cache: { timestamp: number; map: Map<string, number> } | null = null;
+let inflight: Promise<Map<string, number>> | null = null;
+
+async function getAccessToken(): Promise<string | null> {
+  try {
+    const content = await readFile(join(CLAUDE_DIR, '.credentials.json'), 'utf-8');
+    const data = JSON.parse(content);
+    return data?.claudeAiOauth?.accessToken ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchModels(): Promise<Map<string, number>> {
+  const token = await getAccessToken();
+  if (!token) return new Map();
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/models?limit=100', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': 'oauth-2025-04-20',
+        'User-Agent': 'claude-code/2.0.32',
+      },
+    });
+    if (!response.ok) return new Map();
+    const data = (await response.json()) as ModelsListResponse;
+    const map = new Map<string, number>();
+    for (const m of data.data ?? []) {
+      if (m.id && typeof m.max_input_tokens === 'number') {
+        map.set(m.id, m.max_input_tokens);
+      }
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+async function getModelMap(): Promise<Map<string, number>> {
+  const now = Date.now();
+  if (cache && now - cache.timestamp < CACHE_TTL_MS && cache.map.size > 0) {
+    return cache.map;
+  }
+  if (inflight) return inflight;
+  inflight = fetchModels();
+  try {
+    const map = await inflight;
+    if (map.size > 0) {
+      cache = { timestamp: now, map };
+    }
+    return cache?.map ?? map;
+  } finally {
+    inflight = null;
+  }
+}
+
+export async function getMaxInputTokens(modelId: string | undefined): Promise<number> {
+  if (!modelId) return FALLBACK_MAX_TOKENS;
+  const map = await getModelMap();
+  return map.get(modelId) ?? FALLBACK_MAX_TOKENS;
+}

--- a/backend/src/services/session-metrics.ts
+++ b/backend/src/services/session-metrics.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { createInterface } from 'node:readline';
 import type { SessionMetrics } from '../../../shared/types';
+import { getMaxInputTokens } from './anthropic-models';
 
 const CONTEXT_MAX_DEFAULT = 200_000;
 
@@ -66,17 +67,23 @@ async function getProcessTreeRSS(pid: number): Promise<number> {
 interface JsonlCacheEntry {
   mtimeMs: number;
   size: number;
-  totalOutputTokens: number;
+  totalInputTokens: number;
+  totalCacheCreationTokens: number;
   totalCacheReadTokens: number;
+  totalOutputTokens: number;
   contextTokens: number;
+  latestModel?: string;
 }
 
 const jsonlCache = new Map<string, JsonlCacheEntry>();
 
 async function readJsonlUsage(filePath: string): Promise<{
-  totalOutputTokens: number;
+  totalInputTokens: number;
+  totalCacheCreationTokens: number;
   totalCacheReadTokens: number;
+  totalOutputTokens: number;
   contextTokens: number;
+  latestModel?: string;
 } | null> {
   try {
     const stat = await fs.promises.stat(filePath);
@@ -85,9 +92,12 @@ async function readJsonlUsage(filePath: string): Promise<{
       return cached;
     }
 
-    let totalOutputTokens = 0;
+    let totalInputTokens = 0;
+    let totalCacheCreationTokens = 0;
     let totalCacheReadTokens = 0;
+    let totalOutputTokens = 0;
     let contextTokens = 0;
+    let latestModel: string | undefined;
 
     const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
     const rl = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
@@ -101,10 +111,16 @@ async function readJsonlUsage(filePath: string): Promise<{
           const createTok = Number(usage.cache_creation_input_tokens) || 0;
           const readTok = Number(usage.cache_read_input_tokens) || 0;
           const outTok = Number(usage.output_tokens) || 0;
-          totalOutputTokens += outTok;
+          totalInputTokens += inTok;
+          totalCacheCreationTokens += createTok;
           totalCacheReadTokens += readTok;
+          totalOutputTokens += outTok;
           // Last assistant message's effective context = in + cache_creation + cache_read
           contextTokens = inTok + createTok + readTok;
+          const model = obj?.message?.model;
+          if (typeof model === 'string' && model && model !== '<synthetic>') {
+            latestModel = model;
+          }
         }
       } catch {
         // Skip malformed lines
@@ -114,9 +130,12 @@ async function readJsonlUsage(filePath: string): Promise<{
     const entry: JsonlCacheEntry = {
       mtimeMs: stat.mtimeMs,
       size: stat.size,
-      totalOutputTokens,
+      totalInputTokens,
+      totalCacheCreationTokens,
       totalCacheReadTokens,
+      totalOutputTokens,
       contextTokens,
+      latestModel,
     };
     jsonlCache.set(filePath, entry);
     return entry;
@@ -129,11 +148,10 @@ export interface MetricsInput {
   ccSessionId?: string;
   workingDir?: string;
   pids?: (number | undefined)[];
-  contextMaxTokens?: number;
 }
 
 export async function computeSessionMetrics(input: MetricsInput): Promise<SessionMetrics | undefined> {
-  const { ccSessionId, workingDir, pids, contextMaxTokens = CONTEXT_MAX_DEFAULT } = input;
+  const { ccSessionId, workingDir, pids } = input;
   const metrics: SessionMetrics = {};
 
   if (ccSessionId && workingDir) {
@@ -141,13 +159,19 @@ export async function computeSessionMetrics(input: MetricsInput): Promise<Sessio
     const filePath = path.join(projectDir, `${ccSessionId}.jsonl`);
     const usage = await readJsonlUsage(filePath);
     if (usage) {
+      const max = await getMaxInputTokens(usage.latestModel ?? undefined);
+      const contextMaxTokens = max > 0 ? max : CONTEXT_MAX_DEFAULT;
       metrics.contextTokens = usage.contextTokens;
       metrics.contextMaxTokens = contextMaxTokens;
       metrics.contextPercent = contextMaxTokens > 0
         ? Math.min(100, Math.round((usage.contextTokens / contextMaxTokens) * 1000) / 10)
         : undefined;
-      metrics.totalOutputTokens = usage.totalOutputTokens;
+      metrics.totalInputTokens = usage.totalInputTokens;
+      metrics.totalCacheCreationTokens = usage.totalCacheCreationTokens;
       metrics.totalCacheReadTokens = usage.totalCacheReadTokens;
+      metrics.totalOutputTokens = usage.totalOutputTokens;
+      // Effective usage = input + cache_creation + output (cache_read is billed at 10%, treated as noise)
+      metrics.totalTokens = usage.totalInputTokens + usage.totalCacheCreationTokens + usage.totalOutputTokens;
     }
   }
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -804,9 +804,9 @@ function SessionItem({
                 <span className="text-zinc-600">mem</span> {formatBytes(extSession.metrics.memoryRssBytes)}
               </span>
             )}
-            {typeof extSession.metrics.totalOutputTokens === 'number' && extSession.metrics.totalOutputTokens > 0 && (
-              <span className="font-mono tabular-nums" title={`output: ${extSession.metrics.totalOutputTokens.toLocaleString()}`}>
-                <span className="text-zinc-600">out</span> {formatTokenCount(extSession.metrics.totalOutputTokens)}
+            {typeof extSession.metrics.totalTokens === 'number' && extSession.metrics.totalTokens > 0 && (
+              <span className="font-mono tabular-nums" title={`input + cache_creation + output (excludes cache_read)\n\nin: ${extSession.metrics.totalInputTokens?.toLocaleString() ?? 0}\ncache create: ${extSession.metrics.totalCacheCreationTokens?.toLocaleString() ?? 0}\ncache read: ${extSession.metrics.totalCacheReadTokens?.toLocaleString() ?? 0}\nout: ${extSession.metrics.totalOutputTokens?.toLocaleString() ?? 0}`}>
+                <span className="text-zinc-600">used</span> {formatTokenCount(extSession.metrics.totalTokens)}
               </span>
             )}
           </div>

--- a/frontend/src/components/SessionListMini.tsx
+++ b/frontend/src/components/SessionListMini.tsx
@@ -177,8 +177,8 @@ function SessionMiniItem({
           {typeof extSession.metrics.memoryRssBytes === 'number' && extSession.metrics.memoryRssBytes > 0 && (
             <span>{formatBytesMini(extSession.metrics.memoryRssBytes)}</span>
           )}
-          {typeof extSession.metrics.totalOutputTokens === 'number' && extSession.metrics.totalOutputTokens > 0 && (
-            <span>{formatTokensMini(extSession.metrics.totalOutputTokens)}</span>
+          {typeof extSession.metrics.totalTokens === 'number' && extSession.metrics.totalTokens > 0 && (
+            <span>{formatTokensMini(extSession.metrics.totalTokens)}</span>
           )}
         </div>
       )}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -95,12 +95,15 @@ export interface PaneInfo {
 }
 
 export interface SessionMetrics {
-  contextTokens?: number;         // current context window size (last assistant message sum)
-  contextMaxTokens?: number;      // model-specific max (default 200000)
-  contextPercent?: number;        // 0-100
-  totalOutputTokens?: number;     // cumulative output tokens
-  totalCacheReadTokens?: number;  // cumulative cache reads (rough total usage)
-  memoryRssBytes?: number;        // total RSS across session's panes
+  contextTokens?: number;              // current context window size (last assistant message sum)
+  contextMaxTokens?: number;           // model-specific max (from Anthropic /v1/models)
+  contextPercent?: number;             // 0-100
+  totalInputTokens?: number;           // cumulative uncached input tokens
+  totalCacheCreationTokens?: number;   // cumulative cache creation tokens
+  totalCacheReadTokens?: number;       // cumulative cache read tokens
+  totalOutputTokens?: number;          // cumulative output tokens
+  totalTokens?: number;                // effective usage: input + cache_creation + output (cache_read excluded)
+  memoryRssBytes?: number;             // total RSS across session's panes
 }
 
 export const CreateSessionSchema = z.object({


### PR DESCRIPTION
## Summary
- **ctx%** が実際と合わない問題を修正（Opus 4.7 は 1M context、200k hardcode を実測に）
- **利用トークン量** を output のみから **累計 used (input + cache_creation + output)** に変更

## 問題と解決

### ctx%
- **前**: hardcode `max = 200k` → Opus 4.7 で 100% cap (実際は 26%)
- **後**: Anthropic `/v1/models` API から `max_input_tokens` を取得
  - `backend/src/services/anthropic-models.ts` 新規
  - OAuth トークンで認証 (`~/.claude/.credentials.json` 流用)
  - 24h キャッシュ、inflight 重複排除
  - Claude Code の `/context` と ±1% で一致確認

### used トークン
- **前**: `out 228k` (output_tokens のみ) — "Claude の生成量" だけ
- **後**: `used 2.4M` (input + cache_creation + output) — レート制限寄与度に近い値
  - `cache_read` は billing 10% なので除外（含めると 79M に膨れて誤解の元）
  - tooltip に内訳表示

## 比較表 (cchub-work-1 の実測)

| | 前 | 後 |
|---|---|---|
| ctx% | 100% (cap) | **28.4%** |
| used | `out 228k` | `used 2.4M` |

## 変更内容
- `backend/src/services/anthropic-models.ts` 新規
- `backend/src/services/session-metrics.ts`
  - jsonl から `message.model` 取得
  - model → max の動的ルックアップ
  - totalInputTokens, totalCacheCreationTokens も累積
- `shared/types.ts`: `SessionMetrics` を拡張 (`totalInputTokens`, `totalCacheCreationTokens`, `totalTokens`)
- `frontend/src/components/SessionList.tsx`, `SessionListMini.tsx`: ラベル `out` → `used`、tooltip 内訳

## Test plan
- [x] typecheck 全 workspace 通過
- [x] backend 134 tests 通過
- [x] dev で 13 セッション全て正確な ctx% 表示
- [x] /context と ±1% で一致確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)