### PR TITLE
fix(terminal): scrollback duplication on reconnect + CJK glyph overlap

### DIFF
--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -430,11 +430,14 @@ export function DesktopLayout({
       console.log(`[TP] initial-content for ${paneId}: ${data.length} bytes, expected=${wasExpected}`);
       expectingContentRef.current = false;
 
+      // Unexpected initial-content (e.g. WS reconnect): xterm.js still has the previous
+      // scrollback in its buffer. The fresh payload from the backend includes scrollback +
+      // visible, so writing it on top duplicates everything the user already sees.
+      // Skip the write and let the live %output stream pick up where it left off.
+      if (!wasExpected) return;
+
       // Expected (first connect, zoom, explicit request): full clear including scrollback
-      // Unexpected (reconnect): clear visible screen only, preserve scrollback & scroll position
-      const clearSeq = wasExpected
-        ? new Uint8Array([0x1b, 0x5b, 0x32, 0x4a, 0x1b, 0x5b, 0x33, 0x4a, 0x1b, 0x5b, 0x48]) // ESC[2J + ESC[3J + ESC[H
-        : new Uint8Array([0x1b, 0x5b, 0x32, 0x4a, 0x1b, 0x5b, 0x48]); // ESC[2J + ESC[H (no scrollback clear)
+      const clearSeq = new Uint8Array([0x1b, 0x5b, 0x32, 0x4a, 0x1b, 0x5b, 0x33, 0x4a, 0x1b, 0x5b, 0x48]); // ESC[2J + ESC[3J + ESC[H
 
       // Filter mouse tracking sequences from initial content to prevent
       // xterm.js from entering mouse mode (which blocks text selection)
@@ -451,13 +454,9 @@ export function DesktopLayout({
         for (const cb of callbacks) {
           cb(combined);
         }
-        // Only scroll to bottom on expected content (first connect, zoom)
-        // On reconnect, preserve user's scroll position
-        if (wasExpected) {
-          requestAnimationFrame(() => {
-            terminalRefs.current?.get(paneId)?.scrollToBottom();
-          });
-        }
+        requestAnimationFrame(() => {
+          terminalRefs.current?.get(paneId)?.scrollToBottom();
+        });
       } else {
         // Buffer for replay when Terminal component mounts and registers callback
         if (!initialContentBufferRef.current.has(paneId)) {

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -284,7 +284,7 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
       scrollSensitivity: 3,
       allowProposedApi: true,
       minimumContrastRatio: isLightMode() ? 4.5 : 1,
-      rescaleOverlappingGlyphs: false,
+      rescaleOverlappingGlyphs: true,
       drawBoldTextInBrightColors: false,
       convertEol: false,
       ignoreBracketedPasteMode: false,


### PR DESCRIPTION
## Summary
ターミナル表示の不安定さに直結していた 2 つのバグを修正:
1. **scrollback 二重化** (再接続時) — 同じ出力が上下に2回表示される
2. **CJK グリフの重なり** — 日本語+ASCII混在で文字が隣接セルにかぶる

## 問題1: scrollback 二重化

### 症状
WebSocket が再接続すると、ユーザーがスクロールアップした古い履歴が **2回繰り返し** 表示される。

### 原因
`DesktopLayout.tsx` の \`onInitialContent\` で:
- **expected** (初回接続/zoom): \`ESC[2J + ESC[3J + ESC[H\` で scrollback含め全消し → 新しい initial-content書き込み
- **unexpected** (再接続): \`ESC[2J + ESC[H\` で可視域のみクリア (scrollback 保持)

しかしバックエンドは再接続時にも \`capture-pane -S - -E -1\` で **scrollback全部 + visible** を送ってくるため、保持された旧 scrollback の上に **新 scrollback が重複して** 書かれる。

### 修正
unexpected パスでは initial-content 自体を破棄し、live \`%output\` ストリームに任せる。
xterm.js の既存バッファがそのまま使われるため二重化せず、ユーザーのスクロール位置も保持される。

## 問題2: CJK グリフの重なり

### 症状
日本語+ASCII 混在の出力で、文字が隣接セルにはみ出して重なる (例: \`Read\` → \`R ad\`)

### 原因
\`Terminal.tsx\` の \`rescaleOverlappingGlyphs: false\` により、全角グリフが2セル分を超えてもサイズ調整されず、隣接セルの文字と重なって描画されていた。

### 修正
\`rescaleOverlappingGlyphs: true\` に変更。Unicode11 addon と組み合わせて全角グリフが正しく縮小描画される。

## 検証
- [x] typecheck 全 workspace 通過
- [x] backend 134 tests 通過
- [x] agent-browser で 4 シナリオ確認:
  - 初回ロード (m0a セッション)
  - アクティブセッション (cchub-work-1, 大量の日本語+ASCII)
  - scrollback 表示 (スクロールアップ)
  - セッション切替→戻り
- [x] スクリーンショット比較で重複・重なり無しを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)