### PR TITLE
fix(terminal): restore initial-content rendering on WS reconnect

### DIFF
--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -430,14 +430,17 @@ export function DesktopLayout({
       console.log(`[TP] initial-content for ${paneId}: ${data.length} bytes, expected=${wasExpected}`);
       expectingContentRef.current = false;
 
-      // Unexpected initial-content (e.g. WS reconnect): xterm.js still has the previous
-      // scrollback in its buffer. The fresh payload from the backend includes scrollback +
-      // visible, so writing it on top duplicates everything the user already sees.
-      // Skip the write and let the live %output stream pick up where it left off.
-      if (!wasExpected) return;
-
       // Expected (first connect, zoom, explicit request): full clear including scrollback
-      const clearSeq = new Uint8Array([0x1b, 0x5b, 0x32, 0x4a, 0x1b, 0x5b, 0x33, 0x4a, 0x1b, 0x5b, 0x48]); // ESC[2J + ESC[3J + ESC[H
+      // Unexpected (WS reconnect): clear visible only so user's scroll position is preserved.
+      // Note: the unexpected path can re-introduce scrollback duplicates because the fresh
+      // payload includes both scrollback and visible. The alternative (skip the write entirely)
+      // caused worse symptoms — CC's input prompts that arrived during disconnect were never
+      // rendered, so the user could miss permission/plan/AskUserQuestion prompts.
+      // The duplication is mostly an upstream Claude Code TUI redraw issue
+      // (anthropics/claude-code#49086), so we accept it here in exchange for reliable updates.
+      const clearSeq = wasExpected
+        ? new Uint8Array([0x1b, 0x5b, 0x32, 0x4a, 0x1b, 0x5b, 0x33, 0x4a, 0x1b, 0x5b, 0x48]) // ESC[2J + ESC[3J + ESC[H
+        : new Uint8Array([0x1b, 0x5b, 0x32, 0x4a, 0x1b, 0x5b, 0x48]); // ESC[2J + ESC[H (no scrollback clear)
 
       // Filter mouse tracking sequences from initial content to prevent
       // xterm.js from entering mouse mode (which blocks text selection)
@@ -454,9 +457,13 @@ export function DesktopLayout({
         for (const cb of callbacks) {
           cb(combined);
         }
-        requestAnimationFrame(() => {
-          terminalRefs.current?.get(paneId)?.scrollToBottom();
-        });
+        // Only scroll to bottom on expected content (first connect, zoom).
+        // On reconnect, preserve user's scroll position.
+        if (wasExpected) {
+          requestAnimationFrame(() => {
+            terminalRefs.current?.get(paneId)?.scrollToBottom();
+          });
+        }
       } else {
         // Buffer for replay when Terminal component mounts and registers callback
         if (!initialContentBufferRef.current.has(paneId)) {


### PR DESCRIPTION
## Summary
PR #104 (v0.1.78) の副作用で「**WS 再接続時に prompt が画面に出ない**」問題が起きていたので、当該箇所を v0.1.77 動作に revert。

## 症状
ユーザー報告: 「ターミナル操作中に CC から入力を求められるタイミングで止まっていて、リロードして気づくということを繰り返してます」

### 原因
PR #104 で追加した \`if (!wasExpected) return;\` により、WS 再接続時の \`initial-content\` が破棄される。CC が permission/plan/AskUserQuestion 等の prompt を出した瞬間に WS が切断・再接続すると:

1. CC が prompt UI を tmux に書き出す
2. WS が切断 → 復帰
3. backend が新しい visible を含む \`initial-content\` を送信
4. **frontend で破棄** ← ここが問題
5. xterm には古い表示が残ったまま、prompt が見えない
6. ユーザーがリロードして気づく

PR #104 の意図は scrollback 二重化解消だったが、これは上流 [Claude Code の TUI redraw バグ](https://github.com/anthropics/claude-code/issues/49086) (v2.1.116/2.1.118/2.1.119 でも未解決) が支配的なため、cchub 側で完全には直せない。

### 修正
\`onInitialContent\` を v0.1.77 動作に戻す:
- \`wasExpected=true\`: ESC[2J + ESC[3J + ESC[H + 書き込み (full clear、scroll to bottom)
- \`wasExpected=false\`: ESC[2J + ESC[H + 書き込み (visible only クリア、scroll 位置保持)

PR #104 の \`rescaleOverlappingGlyphs: true\` (CJK 重なり対策) は **維持**。良い部分だけ残す。

## トレードオフ
- ✅ WS 再接続後も prompt が確実に見える
- ✅ ユーザーのスクロール位置は保持される
- ⚠️ scrollback 二重化が再現する可能性 (上流バグ起因なので諦める)

## Test plan
- [x] typecheck 全 workspace 通過
- [x] backend 134 tests 通過
- [x] dev で表示が更新されること確認
- [ ] 実運用で WS 再接続後に prompt が表示されることを確認

## Future
真の解決には backend 側 raw byte ring buffer 実装が必要 ([別 issue 検討])。

🤖 Generated with [Claude Code](https://claude.com/claude-code)