### PR TITLE
Release v0.1.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.86] - 2026-04-26
+
+### Fixed
+- 未知の拡張子のテキストファイルが File Viewer で開けず base64 化されていた問題を修正
+  - NUL バイト / 制御文字のヒューリスティックで判定し、テキストっぽければ UTF-8 で返す
+  - バイナリファイルは引き続き base64 で返却
+
 ## [0.1.85] - 2026-04-26
 
 ### Fixed

--- a/backend/src/services/file-service.ts
+++ b/backend/src/services/file-service.ts
@@ -206,7 +206,7 @@ export class FileService {
 
     const ext = extname(validPath).toLowerCase();
     const mimeType = MIME_TYPES[ext] || 'application/octet-stream';
-    const isText = TEXT_EXTENSIONS.has(ext) || this.isTextMime(mimeType);
+    const knownText = TEXT_EXTENSIONS.has(ext) || this.isTextMime(mimeType);
     const isImage = IMAGE_EXTENSIONS.has(ext);
 
     // Images and media are served via the streaming /files/raw endpoint.
@@ -228,6 +228,9 @@ export class FileService {
     // Read file
     const buffer = await readFile(validPath);
     const contentBuffer = truncated ? buffer.subarray(0, readSize) : buffer;
+
+    // Unknown extensions: try to decode as text if buffer looks textual
+    const isText = knownText || this.looksLikeText(contentBuffer);
 
     let content: string;
     let encoding: 'utf-8' | 'base64';
@@ -268,6 +271,26 @@ export class FileService {
    */
   private isTextMime(mime: string): boolean {
     return mime.startsWith('text/') || mime === 'application/json';
+  }
+
+  /**
+   * Heuristic: treat buffer as text if it contains no NUL bytes and
+   * the proportion of non-printable control bytes is low.
+   * Used to render unknown-extension files as text when possible.
+   */
+  private looksLikeText(buf: Buffer, maxCheck = 8192): boolean {
+    const len = Math.min(buf.length, maxCheck);
+    if (len === 0) return true;
+    let nonText = 0;
+    for (let i = 0; i < len; i++) {
+      const b = buf[i];
+      if (b === 0) return false;
+      // Allow tab(9), LF(10), CR(13), ESC(27); flag other C0 controls
+      if (b < 32 && b !== 9 && b !== 10 && b !== 13 && b !== 27) {
+        nonText++;
+      }
+    }
+    return nonText / len < 0.3;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- File Viewer で未知の拡張子のテキストファイルを開けるように修正

## Changes

### Fixed
- 未知の拡張子のテキストファイルが File Viewer で開けず base64 化されていた問題を修正
  - NUL バイト / 制御文字のヒューリスティックで判定し、テキストっぽければ UTF-8 で返す
  - バイナリファイルは引き続き base64 で返却

## Test plan
- [x] `bun run test` — backend 129 / frontend 36 全 pass
- [x] `bun run lint` — 関連の新規エラーなし
- [x] curl で動作確認 (.xyz ファイル → utf-8 / バイナリ → base64)
- [x] dev サーバ + ブラウザで `.xyz` を開いて CodeViewer 表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)