### PR TITLE
fix(backend/tmux): macOS compatibility for listSessions

### DIFF
--- a/backend/src/services/tmux.ts
+++ b/backend/src/services/tmux.ts
@@ -129,8 +129,10 @@ export class TmuxService {
     }
 
     try {
-      // Single ps call: TTY and args (stat/wchan no longer needed — indicator uses hook/jsonl)
-      const proc = Bun.spawn(['ps', '-eo', 'tty,args', '--no-headers'], {
+      // Single ps call: TTY and args (stat/wchan no longer needed — indicator uses hook/jsonl).
+      // `--no-headers` is GNU ps only; on macOS BSD ps it makes the command fail. Skip the
+      // header line in user-space instead so this works on both platforms.
+      const proc = Bun.spawn(['ps', '-A', '-o', 'tty,args'], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -144,7 +146,11 @@ export class TmuxService {
 
       const ttySet = new Set(ttyNames);
 
-      for (const line of output.split('\n')) {
+      const lines = output.split('\n');
+      // Drop the header line if present (e.g. "TT       COMMAND" / "TTY      ARGS").
+      const startIdx = lines[0]?.match(/^\s*(TTY|TT)\b/i) ? 1 : 0;
+      for (let i = startIdx; i < lines.length; i++) {
+        const line = lines[i];
         const parts = line.trim().split(/\s+/);
         if (parts.length < 2) continue;
 
@@ -219,9 +225,13 @@ export class TmuxService {
           };
         });
 
-      // Get pane info for each session (command, path, title, tty, pane_id, active)
-      // Use | as separator since path can contain :
-      const panesProc = Bun.spawn(['tmux', 'list-panes', '-a', '-F', '#{session_name}\x1f#{pane_id}\x1f#{pane_current_command}\x1f#{pane_title}\x1f#{pane_tty}\x1f#{pane_active}\x1f#{pane_dead}\x1f#{pane_pid}\x1f#{pane_current_path}'], {
+      // Get pane info for each session (command, path, title, tty, pane_id, active).
+      // Use a multi-char ASCII sentinel as separator. Originally `\x1f` (US control char) was used,
+      // but on macOS + Bun.spawn the 0x1f byte in argv gets corrupted to 0x5f ('_') by the time
+      // tmux's format parser sees it, so all panes failed to parse. ASCII-only sentinel avoids it.
+      const SEP = '||~~||';
+      const fmtString = `#{session_name}${SEP}#{pane_id}${SEP}#{pane_current_command}${SEP}#{pane_title}${SEP}#{pane_tty}${SEP}#{pane_active}${SEP}#{pane_dead}${SEP}#{pane_pid}${SEP}#{pane_current_path}`;
+      const panesProc = Bun.spawn(['tmux', 'list-panes', '-a', '-F', fmtString], {
         stdout: 'pipe',
         stderr: 'pipe',
       });
@@ -237,11 +247,11 @@ export class TmuxService {
           .split('\n')
           .filter((line) => line.length > 0)
           .forEach((line) => {
-            const parts = line.split('\x1f');
+            const parts = line.split(SEP);
             if (parts.length >= 9) {
               const [sessionName, paneId, command, title, tty, active, dead, pidStr, ...pathParts] = parts;
-              // Path might contain \x1f (unlikely), so join the rest
-              const panePath = pathParts.join('\x1f');
+              // Path might contain SEP (extremely unlikely), so join the rest
+              const panePath = pathParts.join(SEP);
               const isActive = active === '1';
               const isDead = dead === '1';
               const pidNum = pidStr ? Number.parseInt(pidStr, 10) : Number.NaN;


### PR DESCRIPTION
## 背景

macOS で実行すると、SessionList のカードがタイトルしか表示されず、`currentPath` / 対話サマリ / メトリクスなどが全て欠落していた。バックエンド `/api/sessions` を直接叩くと:

```json
{ "id": "Welcome", "name": "Welcome", "state": "working" }
```

としか返らず、`currentPath` `currentCommand` `paneTitle` `panes` `ccSummary` 等が undefined になっていた。

原因は backend/services/tmux.ts の **2 箇所が Linux 専用 API に依存していた** ため。Mac 専用分岐は入れず、両 OS 共通の API に揃える方針で修正した。

## 変更点

### 変更 1: `tmux list-panes` の format separator

`backend/src/services/tmux.ts` `listSessions()` (行 222 付近)

| | 旧 | 新 |
|---|---|---|
| separator | `\x1f` (US 制御文字, 1 byte) | `\|\|~~\|\|` (ASCII 6 文字) |
| 理由 | macOS + Bun.spawn だと argv に渡した 0x1f が実行時に 0x5f (`_`) に化け、フィールド分割が `parts.length === 1` になり全 pane が silently skip されていた | ASCII のみで Bun.spawn の文字化けを回避 |

実装上の対称性のため `pathParts.join(SEP)` の SEP も同じく更新。

### 変更 2: `ps` コマンドの呼び出し

`backend/src/services/tmux.ts` `batchProcessInfo()` (行 131 付近)

| | 旧 | 新 |
|---|---|---|
| コマンド | `ps -eo tty,args --no-headers` | `ps -A -o tty,args` + 先頭行のヘッダーをユーザー空間でスキップ |
| 理由 | `--no-headers` は GNU procps 専用。BSD ps (macOS) では `ps: illegal option -- -` で exit code != 0 → claudeTtys / agentInfo / ttyArgs が常に空 → isClaudeRunning が false のまま → ccSummary 等の Claude 情報全てが undefined | `-A` `-o tty,args` は POSIX 共通。ヘッダー行は `/^\s*(TTY\|TT)\b/i` で識別して 1 行スキップ |

## デグレチェックポイント

### Linux

- [ ] `bun run dev` 起動後、`/api/sessions` のレスポンスに以下が **以前と同様** に含まれること
  - `currentPath`, `currentCommand`, `paneTitle`, `paneTty`, `panes` (各 pane の `paneId` `currentPath` `currentCommand` `title` `pid` `isActive`)
  - Claude 起動セッションについて `ccSessionId`, `ccSummary` または `ccFirstPrompt`, `indicatorState`, `waitingToolName`, `messageCount`, `gitBranch`, `durationMinutes`
- [ ] SessionList UI でカードに作業ディレクトリ・対話サマリ・メトリクス (`ctx %`, `mem`, `used`) が表示されること
- [ ] team agent (`--agent-name` `--agent-color` 付き) のペインで、ペイン名・色がアバターに反映されること（`batchProcessInfo` の `agentInfo` 経路の確認）
- [ ] 複数ペインのセッションで、Claude が動いているペインが正しく代表ペインとして選ばれること（`paneInfo` 構築ロジックの確認）
- [ ] パスやタイトルに `||~~||` という文字列を含むケースが存在しないこと（実際上は無いはずだが、もし含まれても末尾フィールドは `pathParts.join(SEP)` で再結合する設計）

### macOS

- [ ] 上と同じ全項目が、本 PR 適用後に **動くようになっていること**
- [ ] `ps` のヘッダー行 (`TT       COMMAND`) が誤って tty として処理されないこと
- [ ] `tmux list-panes` のフィールドが全 9 個に分割されること（古い 8 フィールドフォーマットへの fallback ロジックは無いので、`parts.length >= 9` 判定が成立すること）

### 非対象（既知の残課題）

本 PR スコープ外。ヘッダー化けは Bun.spawn が argv に含まれる UTF-8 multi-byte を一部破壊する別の macOS 固有問題で、別途調査が必要:

- `pane_title` の先頭の `✳` (U+2733) や `⠂` (Braille) などが macOS 環境で `_` に置換されて返ってくる
- セッションリスト上は表示自体は出るが、icon prefix が `_ Claude Code` のように見える

## テスト

- macOS 14.7 (Apple Silicon) + tmux 3.6a + Bun 1.3.11 で `/api/sessions` のレスポンスに必要フィールドが揃うこと、SessionList UI に対話サマリ・メトリクスが表示されることを確認済み
- Linux での動作未検証 → 検証作業をお願いします

🤖 Generated with [Claude Code](https://claude.com/claude-code)