### PR TITLE
Release v0.1.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.88] - 2026-04-27
+
+### Fixed
+- macOS で `/api/sessions` のレスポンスから `currentPath` / `panes` / `ccSummary` 等が欠落していた問題を修正 (#110)
+  - `ps -eo tty,args --no-headers` (GNU 専用) を `ps -A -o tty,args` + ユーザー空間でのヘッダースキップに変更し、BSD ps と GNU ps の両方で動作するように
+  - `tmux list-panes` のフィールドセパレータを `\x1f` から ASCII の `||~~||` に変更（macOS + Bun.spawn で 0x1f が `_` に化ける問題を回避）
+
 ## [0.1.87] - 2026-04-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- macOS 互換性修正 (#110) を含むリリース
- `ps` コマンドを POSIX 準拠 (`-A -o tty,args`) に変更し BSD/GNU 両対応
- tmux list-panes セパレータを `\x1f` → `||~~||` に変更し macOS + Bun.spawn のバイト化け回避

## Test plan
- [x] Linux 上で `/api/sessions` レスポンスを baseline と PR 適用後で比較し、構造的フィールドが完全一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)