### PR TITLE
feat(session-list): use amber-200 for recap text

### DIFF
--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -29,6 +29,7 @@ const ACCENT_HEX: Record<SessionTheme, string> = {
   teal: '#14b8a6', blue: '#3b82f6', indigo: '#6366f1', purple: '#a855f7', pink: '#ec4899',
 };
 
+
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
@@ -773,10 +774,10 @@ function SessionItem({
 
         {/* Auto recap (away_summary) — timestamp shown inline at the tail */}
         {extSession.ccRecap && (
-          <p className="mt-1 text-[12px] text-zinc-400 leading-relaxed line-clamp-3">
+          <p className="mt-1 text-[12px] text-amber-200 leading-relaxed line-clamp-3">
             {extSession.ccRecap}
             {extSession.ccRecapAt && (
-              <span className="ml-2 text-[10px] text-zinc-600">
+              <span className="ml-2 text-[10px] text-zinc-500">
                 {formatRelativeTime(extSession.ccRecapAt, t, i18n.language)}
               </span>
             )}


### PR DESCRIPTION
## Summary
- セッションカードの recap テキスト色を `text-zinc-400` → `text-amber-200` に変更
- タイムスタンプも `text-zinc-600` → `text-zinc-500` で微調整
- 暗い背景でも読みやすく、寂しさが解消される

## Test plan
- [x] dev 環境 (mobile viewport) で SessionList の recap が amber トーンで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)