### PR TITLE
Release v0.1.89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.89] - 2026-04-27
+
+### Changed
+- セッションカードの recap テキスト色を `text-zinc-400` (灰) → `text-amber-200` (薄い琥珀) に変更し、暗背景での視認性とカードの華やかさを改善
+- recap タイムスタンプを `text-zinc-600` → `text-zinc-500` に微調整
+
 ## [0.1.88] - 2026-04-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- セッションカードの recap テキストを amber トーンに変更してカードを華やかに (#112)

## Test plan
- [x] dev 環境で SessionList の recap が amber-200 で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)