### PR TITLE
fix(mobile): restore Copy Prompt text injection into InputBar

### DIFF
--- a/frontend/src/components/InputBar.tsx
+++ b/frontend/src/components/InputBar.tsx
@@ -1,9 +1,13 @@
-import { useState, useRef, useCallback, memo } from 'react';
+import { useState, useRef, useCallback, memo, forwardRef, useImperativeHandle } from 'react';
 import { X, Clock, ChevronUp, ChevronDown, CornerDownLeft, FileText } from 'lucide-react';
 import { Keyboard } from './Keyboard';
 import { authFetch } from '../services/api';
 
 export type InputMode = 'hidden' | 'shortcuts' | 'input';
+
+export interface InputBarRef {
+  setText: (text: string) => void;
+}
 
 interface InputBarProps {
   inputMode: InputMode;
@@ -17,7 +21,7 @@ interface InputBarProps {
   hideKeyboard?: boolean;
 }
 
-export const InputBar = memo(function InputBar({
+export const InputBar = memo(forwardRef<InputBarRef, InputBarProps>(function InputBar({
   inputMode,
   setInputMode,
   sendRef,
@@ -27,11 +31,19 @@ export const InputBar = memo(function InputBar({
   onOverlayTap,
   showOverlay = true,
   hideKeyboard,
-}: InputBarProps) {
+}, ref) {
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState('');
   const [showInputHistory, setShowInputHistory] = useState(false);
+
+  useImperativeHandle(ref, () => ({
+    setText: (text: string) => {
+      setInputValue(text);
+      setInputMode('input');
+      setTimeout(() => inputRef.current?.focus(), 100);
+    },
+  }), [setInputMode]);
   const inputHistoryRef = useRef<string[]>(
     (() => { try { return JSON.parse(localStorage.getItem('cchub-input-history') || '[]'); } catch { return []; } })()
   );
@@ -445,4 +457,4 @@ export const InputBar = memo(function InputBar({
       )}
     </div>
   );
-});
+}));

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -14,7 +14,7 @@ import {
 } from './terminal-themes';
 import { useSelectionMode } from '../hooks/useSelectionMode';
 import { SelectionOverlay } from './SelectionOverlay';
-import { InputBar, type InputMode } from './InputBar';
+import { InputBar, type InputMode, type InputBarRef } from './InputBar';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
@@ -85,6 +85,7 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
   const refreshRef = useRef<() => void>(() => {});
   const closeInputBarRef = useRef<() => void>(() => {});
   const showKeyboardRef = useRef<() => void>(() => {});
+  const inputBarRef = useRef<InputBarRef>(null);
   const selectionRef = useRef<string>('');
   const [isInitialized, setIsInitialized] = useState(false);
   const [inputMode, setInputMode] = useState<InputMode>('hidden');
@@ -212,10 +213,8 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
       }
     },
     scrollToBottom: () => terminalRef.current?.scrollToBottom(),
-    setInputText: (_text: string) => {
-      // Mobile InputBar doesn't yet support pre-populating text;
-      // we just open the input mode so the user can paste manually.
-      setInputMode('input');
+    setInputText: (text: string) => {
+      inputBarRef.current?.setText(text);
     },
     changeFontSize: (delta: number) => {
       const term = terminalRef.current;
@@ -1077,6 +1076,7 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
 
       {/* Input bar (mobile/tablet keyboard) */}
       <InputBar
+        ref={inputBarRef}
         inputMode={inputMode}
         setInputMode={setInputMode}
         sendRef={sendRef}


### PR DESCRIPTION
## Summary
モバイル端末で FileViewer の Copy Prompt ボタンを押してもプロンプトが入力欄に挿入されない不具合を修正。

## Root Cause
6 週間前のリファクタ (commit \`ddbf5a1: refactor: split Terminal.tsx into focused modules\`) で \`inputValue\` state が \`InputBar\` に移動した際、Terminal の \`setInputText\` が引数を \`_text\` として破棄して \`setInputMode('input')\` だけ呼ぶ実装に退化していました。コメントには:
> Mobile InputBar doesn't yet support pre-populating text; we just open the input mode so the user can paste manually.
と書かれていましたが、結果として「入力モードに切り替わるだけで何も入らない」状態になっていました。

## Fix
- \`InputBar\` を \`forwardRef\` + \`useImperativeHandle\` 化し \`setText(text)\` を公開
- \`Terminal\` の \`setInputText\` から \`inputBarRef.current?.setText(text)\` を呼ぶ
- \`setText\` は \`setInputValue(text)\` + \`setInputMode('input')\` + \`focus\` を実行

App.tsx 側 (\`mobileTerminalRef.current?.setInputText(text)\`) と FileViewer/CodeViewer 側の経路は無変更です。

## Test plan
- [ ] 実機モバイルで CodeViewer 内のコード行をタップ → コメント追加 → Copy Prompt → 入力欄にプロンプトテキストが入っていることを確認
- [x] 型チェック (\`bunx tsc --noEmit\`) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)