### PR TITLE
feat(chat): conversation-mode view with live updates and per-pane toggle

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -324,6 +324,7 @@ export default {
           mux: true,
           visitorId: crypto.randomUUID(),
           subscriptions: new Map(),
+          conversationWatchers: new Map(),
           lastPingAt: Date.now(),
         },
       });

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -1,7 +1,8 @@
 import type { ServerWebSocket } from 'bun';
 import { TmuxService } from '../services/tmux';
 import { getOrCreateControlSession, type TmuxControlSession } from '../services/tmux-control';
-import type { ControlClientMessage, MuxClientMessage } from '../../../shared/types';
+import { ConversationWatcher } from '../services/conversation-watcher';
+import type { ControlClientMessage, MuxClientMessage, ConversationMessage } from '../../../shared/types';
 import { MUX_BINARY_TYPE } from '../../../shared/types';
 import { buildSessionsList } from './sessions';
 
@@ -19,6 +20,7 @@ export interface MuxData {
   mux: true;
   visitorId: string;
   subscriptions: Map<string, MuxSubscription>;
+  conversationWatchers: Map<string, ConversationWatcher>;
   lastPingAt: number;
 }
 
@@ -149,6 +151,16 @@ export async function muxMessage(ws: ServerWebSocket<MuxData>, message: string |
     return;
   }
 
+  if (msg.type === 'subscribe-conversation') {
+    await handleSubscribeConversation(ws, msg.sessionId);
+    return;
+  }
+
+  if (msg.type === 'unsubscribe-conversation') {
+    handleUnsubscribeConversation(ws, msg.sessionId);
+    return;
+  }
+
   // All other messages need sessionId
   const sessionId = (msg as { sessionId?: string }).sessionId;
   if (!sessionId) return;
@@ -174,6 +186,12 @@ export function muxClose(ws: ServerWebSocket<MuxData>, code: number, reason: str
     cleanupSubscription(ws, sessionId, sub);
   }
   ws.data.subscriptions.clear();
+
+  // Clean up conversation watchers
+  for (const watcher of ws.data.conversationWatchers.values()) {
+    try { watcher.stop(); } catch { /* ignore */ }
+  }
+  ws.data.conversationWatchers.clear();
 }
 
 async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) {
@@ -312,6 +330,75 @@ function cleanupSubscription(ws: ServerWebSocket<MuxData>, _sessionId: string, s
   }
   sub.controlSession.removeClientDeviceType(ws.data.visitorId);
   sub.controlSession.removeClient();
+}
+
+async function handleSubscribeConversation(ws: ServerWebSocket<MuxData>, sessionId: string) {
+  console.log(`[mux] subscribe-conversation: ${sessionId}`);
+
+  // Stop existing watcher for this session, if any
+  const existing = ws.data.conversationWatchers.get(sessionId);
+  if (existing) {
+    try { existing.stop(); } catch { /* ignore */ }
+    ws.data.conversationWatchers.delete(sessionId);
+  }
+
+  let workingDir: string | undefined;
+  try {
+    const sessions = await tmuxService.listSessions();
+    const session = sessions.find(s => s.id === sessionId);
+    workingDir = session?.currentPath;
+  } catch (err) {
+    console.warn(`[mux] subscribe-conversation: failed to list sessions: ${err}`);
+  }
+
+  if (!workingDir) {
+    try {
+      ws.send(JSON.stringify({ type: 'conversation-subscribed', sessionId, ccSessionId: null }));
+      ws.send(JSON.stringify({ type: 'initial-conversation', sessionId, messages: [] }));
+    } catch { /* disconnected */ }
+    return;
+  }
+
+  const watcher = new ConversationWatcher();
+  let initialMessages: ConversationMessage[] = [];
+  try {
+    initialMessages = await watcher.start(workingDir);
+  } catch (err) {
+    console.warn(`[mux] subscribe-conversation start failed for ${sessionId}:`, err);
+  }
+
+  watcher.onUpdate((newMessages) => {
+    try {
+      ws.send(JSON.stringify({ type: 'conversation-update', sessionId, messages: newMessages }));
+    } catch { /* disconnected */ }
+  });
+
+  ws.data.conversationWatchers.set(sessionId, watcher);
+
+  try {
+    ws.send(JSON.stringify({
+      type: 'conversation-subscribed',
+      sessionId,
+      ccSessionId: watcher.getCcSessionId(),
+    }));
+    ws.send(JSON.stringify({
+      type: 'initial-conversation',
+      sessionId,
+      messages: initialMessages,
+    }));
+  } catch { /* disconnected */ }
+}
+
+function handleUnsubscribeConversation(ws: ServerWebSocket<MuxData>, sessionId: string) {
+  console.log(`[mux] unsubscribe-conversation: ${sessionId}`);
+  const watcher = ws.data.conversationWatchers.get(sessionId);
+  if (watcher) {
+    try { watcher.stop(); } catch { /* ignore */ }
+    ws.data.conversationWatchers.delete(sessionId);
+  }
+  try {
+    ws.send(JSON.stringify({ type: 'conversation-unsubscribed', sessionId }));
+  } catch { /* disconnected */ }
 }
 
 async function handleControlMessage(

--- a/backend/src/services/conversation-watcher.ts
+++ b/backend/src/services/conversation-watcher.ts
@@ -1,0 +1,156 @@
+import { watch, type FSWatcher } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { SessionHistoryService } from './session-history';
+import { ClaudeCodeService } from './claude-code';
+import type { ConversationMessage } from '../../../shared/types';
+
+type ConversationListener = (newMessages: ConversationMessage[]) => void;
+
+const sessionHistoryService = new SessionHistoryService();
+const claudeCodeService = new ClaudeCodeService();
+const claudeProjectsDir = join(homedir(), '.claude', 'projects');
+
+function pathToProjectName(path: string): string {
+  return path.replace(/\//g, '-');
+}
+
+export class ConversationWatcher {
+  private watcher: FSWatcher | null = null;
+  private filePath: string | null = null;
+  private projectDirName: string | null = null;
+  private ccSessionId: string | null = null;
+  private parsedCount = 0;
+  private listeners = new Set<ConversationListener>();
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private reparsing = false;
+  private pendingReparse = false;
+  private lastMtimeMs = 0;
+
+  /**
+   * Start watching the conversation jsonl associated with the given working directory.
+   * Returns the initial set of conversation messages (may be empty if no session exists yet).
+   */
+  async start(workingDir: string): Promise<ConversationMessage[]> {
+    const session = await claudeCodeService.getSessionForPath(workingDir);
+    if (!session?.sessionId) {
+      return [];
+    }
+
+    const projectDirName = pathToProjectName(session.projectPath || workingDir);
+    const filePath = join(claudeProjectsDir, projectDirName, `${session.sessionId}.jsonl`);
+
+    this.filePath = filePath;
+    this.projectDirName = projectDirName;
+    this.ccSessionId = session.sessionId;
+
+    const messages = await sessionHistoryService.getConversation(session.sessionId, projectDirName);
+    this.parsedCount = messages.length;
+
+    try {
+      const fileStat = await stat(filePath);
+      this.lastMtimeMs = fileStat.mtimeMs;
+    } catch {
+      this.lastMtimeMs = 0;
+    }
+
+    try {
+      this.watcher = watch(filePath, { persistent: false }, () => this.onChange());
+    } catch (err) {
+      console.warn(`[conversation-watcher] failed to watch ${filePath}:`, err);
+    }
+
+    return messages;
+  }
+
+  onUpdate(listener: ConversationListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private onChange() {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      void this.reparseAndNotify();
+    }, 150);
+  }
+
+  private async reparseAndNotify(): Promise<void> {
+    if (!this.filePath || !this.ccSessionId || !this.projectDirName) return;
+    if (this.reparsing) {
+      this.pendingReparse = true;
+      return;
+    }
+    this.reparsing = true;
+    try {
+      let mtimeMs = 0;
+      try {
+        const fileStat = await stat(this.filePath);
+        mtimeMs = fileStat.mtimeMs;
+      } catch {
+        return;
+      }
+      if (mtimeMs === this.lastMtimeMs) {
+        return;
+      }
+      this.lastMtimeMs = mtimeMs;
+
+      const messages = await sessionHistoryService.getConversation(
+        this.ccSessionId,
+        this.projectDirName,
+      );
+
+      if (messages.length <= this.parsedCount) {
+        if (messages.length < this.parsedCount) {
+          this.parsedCount = messages.length;
+        }
+        return;
+      }
+
+      const newMessages = messages.slice(this.parsedCount);
+      this.parsedCount = messages.length;
+      for (const listener of this.listeners) {
+        try {
+          listener(newMessages);
+        } catch (err) {
+          console.warn('[conversation-watcher] listener error:', err);
+        }
+      }
+    } finally {
+      this.reparsing = false;
+      if (this.pendingReparse) {
+        this.pendingReparse = false;
+        void this.reparseAndNotify();
+      }
+    }
+  }
+
+  stop(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.watcher) {
+      try {
+        this.watcher.close();
+      } catch {
+        /* ignore */
+      }
+      this.watcher = null;
+    }
+    this.listeners.clear();
+    this.filePath = null;
+    this.projectDirName = null;
+    this.ccSessionId = null;
+    this.parsedCount = 0;
+    this.lastMtimeMs = 0;
+  }
+
+  getCcSessionId(): string | null {
+    return this.ccSessionId;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -973,6 +973,11 @@ export function App() {
                     subtitle={activeSession.currentPath?.replace(/^\/home\/[^/]+\//, '~/')}
                     inline
                     enabled
+                    onScrollGesture={() => mobileTerminalRef.current?.hideKeyboard()}
+                    onAtBottomChange={(atBottom) => {
+                      if (atBottom) mobileTerminalRef.current?.showKeyboard();
+                      else mobileTerminalRef.current?.hideKeyboard();
+                    }}
                   />
                 </div>
               </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,19 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { RotateCw, MessageSquare, FileText, BarChart3, ChevronDown, X as XIcon } from 'lucide-react';
+import { RotateCw, MessageSquare, FileText, BarChart3, ChevronDown, X as XIcon, Terminal as TerminalIcon } from 'lucide-react';
 import { Dashboard } from './components/dashboard/Dashboard';
 import { TerminalPage } from './pages/TerminalPage';
 import type { TerminalRef } from './components/Terminal';
 import { SessionList } from './components/SessionList';
 import { DesktopLayout } from './components/DesktopLayout';
 import { FileViewer } from './components/files/FileViewer';
-import { ConversationViewer } from './components/ConversationViewer';
+import { ChatView } from './components/chat/ChatView';
 import { LoginForm } from './components/LoginForm';
 import { Onboarding, useOnboarding } from './components/Onboarding';
-import { useSessionHistory } from './hooks/useSessionHistory';
 import { useAuth } from './hooks/useAuth';
 import { useSessions } from './hooks/useSessions';
 import { authFetch, isTransientNetworkError } from './services/api';
-import type { SessionResponse, ExtendedSessionResponse, SessionState, ConversationMessage, SessionTheme } from '../../shared/types';
+import type { SessionResponse, ExtendedSessionResponse, SessionState, SessionTheme, PaneInfo, IndicatorState } from '../../shared/types';
 
 // Loading screen with phase display and timeout detection
 function LoadingScreen({
@@ -80,6 +79,8 @@ interface OpenSession {
   ccSessionId?: string;
   currentCommand?: string;
   theme?: SessionTheme;
+  panes?: PaneInfo[];
+  indicatorState?: IndicatorState;
 }
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
@@ -229,11 +230,48 @@ export function App() {
   const fileViewerVisible = activeFileViewerDir ? fileViewerOpenDirs.has(activeFileViewerDir) : false;
   const overlayTimeoutRef = useRef<number | null>(null);
 
-  // Conversation viewer state
-  const { fetchConversation } = useSessionHistory();
-  const [showConversation, setShowConversation] = useState(false);
-  const [conversation, setConversation] = useState<ConversationMessage[]>([]);
-  const [loadingConversation, setLoadingConversation] = useState(false);
+  // Conversation viewer state — per-session (each session remembers whether
+  // it was last shown in chat mode or terminal mode). Persisted to localStorage.
+  const [conversationModeSessions, setConversationModeSessions] = useState<Set<string>>(() => {
+    try {
+      const saved = localStorage.getItem('cchub-conversation-mode-sessions');
+      return saved ? new Set(JSON.parse(saved)) : new Set();
+    } catch {
+      return new Set();
+    }
+  });
+  const showConversation = activeSessionId ? conversationModeSessions.has(activeSessionId) : false;
+  const setShowConversation = useCallback((show: boolean) => {
+    if (!activeSessionId) return;
+    setConversationModeSessions(prev => {
+      const has = prev.has(activeSessionId);
+      if (show === has) return prev;
+      const next = new Set(prev);
+      if (show) next.add(activeSessionId);
+      else next.delete(activeSessionId);
+      return next;
+    });
+  }, [activeSessionId]);
+
+  // Persist per-session conversation mode to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem('cchub-conversation-mode-sessions', JSON.stringify([...conversationModeSessions]));
+    } catch {
+      // ignore quota errors
+    }
+  }, [conversationModeSessions]);
+
+  // Mobile: open the soft keyboard automatically when entering ChatView,
+  // since the xterm area (which normally surfaces the keyboard on focus) is hidden.
+  // Also re-fire on session switch — when toggling between two chat-mode sessions,
+  // `showConversation` stays true but the Terminal is remounted (key=activeSessionId),
+  // so the previous showKeyboard() targeted a stale instance.
+  useEffect(() => {
+    if (!showConversation) return;
+    const id = setTimeout(() => mobileTerminalRef.current?.showKeyboard(), 150);
+    return () => clearTimeout(id);
+  }, [showConversation, activeSessionId]);
 
   // Mobile pane tabs state
   const [mobilePanes, setMobilePanes] = useState<{ paneId: string; width: number; height: number }[]>([]);
@@ -249,22 +287,24 @@ export function App() {
   type DeviceType = 'mobile' | 'tablet' | 'desktop';
 
   const checkIsTouchDevice = (): boolean => {
-    // タッチデバイス判定: タッチイベント対応 かつ 粗いポインター（指）
     const hasTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     const hasCoarsePointer = window.matchMedia('(pointer: coarse)').matches;
     return hasTouch && hasCoarsePointer;
   };
 
   const checkDeviceType = (): DeviceType => {
-    // PCの場合は常にdesktop（ソフトキーボード不要）
-    if (!checkIsTouchDevice()) return 'desktop';
-
-    // タッチデバイスの場合は短辺で判定（向きに依存しない）
-    // screen.width/height は物理解像度ベースで向きに左右されにくい
-    const shortSide = Math.min(screen.width, screen.height);
-    const longSide = Math.max(screen.width, screen.height);
-    if (shortSide >= 500 && longSide >= 640) return 'tablet';
-    return 'mobile';
+    // 実タッチデバイス: 物理解像度の短辺で判定（向きに依存しない）
+    if (checkIsTouchDevice()) {
+      const shortSide = Math.min(screen.width, screen.height);
+      const longSide = Math.max(screen.width, screen.height);
+      if (shortSide >= 500 && longSide >= 640) return 'tablet';
+      return 'mobile';
+    }
+    // 非タッチデバイス（PC + DevToolsエミュレーション含む）: ビューポート幅で判定
+    const w = window.innerWidth;
+    if (w < 640) return 'mobile';
+    if (w < 1024) return 'tablet';
+    return 'desktop';
   };
 
   const [deviceType, setDeviceType] = useState<DeviceType>(checkDeviceType);
@@ -283,15 +323,31 @@ export function App() {
 
   // Sessions are now delivered via WS push (no HTTP polling needed)
 
-  // Update openSessions theme from API (for mobile view)
+  // Update openSessions live fields from API (for mobile view)
   useEffect(() => {
     if (deviceType !== 'mobile' || apiSessions.length === 0) return;
     setOpenSessions(prev => prev.map(session => {
       const apiSession = apiSessions.find(s => s.id === session.id);
-      if (apiSession && apiSession.theme !== session.theme) {
-        return { ...session, theme: apiSession.theme };
+      if (!apiSession) return session;
+      const next = {
+        ...session,
+        theme: apiSession.theme,
+        currentCommand: apiSession.currentCommand,
+        ccSessionId: apiSession.ccSessionId,
+        panes: apiSession.panes,
+        indicatorState: apiSession.indicatorState,
+      };
+      // Skip update if nothing actually changed (avoid extra renders)
+      if (
+        next.theme === session.theme &&
+        next.currentCommand === session.currentCommand &&
+        next.ccSessionId === session.ccSessionId &&
+        next.panes === session.panes &&
+        next.indicatorState === session.indicatorState
+      ) {
+        return session;
       }
-      return session;
+      return next;
     }));
   }, [deviceType, apiSessions]);
 
@@ -586,6 +642,13 @@ export function App() {
 
       return filtered;
     });
+    // Clean up per-session conversation mode entry
+    setConversationModeSessions(prev => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
   }, [activeSessionId]);
 
   // Actually delete the session
@@ -637,36 +700,11 @@ export function App() {
   }, []);
 
   // Show conversation history for current session
-  const handleShowConversation = useCallback(async () => {
+  const handleShowConversation = useCallback(() => {
     const activeSession = openSessions.find(s => s.id === activeSessionId);
-    const ccSessionId = activeSession?.ccSessionId;
-    if (!ccSessionId) return;
-
+    if (!activeSession?.ccSessionId) return;
     setShowConversation(true);
-    setLoadingConversation(true);
-    setConversation([]);
-
-    try {
-      const messages = await fetchConversation(ccSessionId);
-      setConversation(messages);
-    } finally {
-      setLoadingConversation(false);
-    }
-  }, [openSessions, activeSessionId, fetchConversation]);
-
-  // Refresh conversation (for auto-refresh)
-  const handleRefreshConversation = useCallback(async () => {
-    const activeSession = openSessions.find(s => s.id === activeSessionId);
-    const ccSessionId = activeSession?.ccSessionId;
-    if (!ccSessionId) return;
-
-    try {
-      const messages = await fetchConversation(ccSessionId);
-      setConversation(messages);
-    } catch (err) {
-      console.error('Failed to refresh conversation:', err);
-    }
-  }, [openSessions, activeSessionId, fetchConversation]);
+  }, [openSessions, activeSessionId]);
 
   // Keep overlay visible (no auto-hide)
   const startOverlayTimer = useCallback(() => {
@@ -826,16 +864,27 @@ export function App() {
 
       {/* Right: Core actions */}
       <div className="flex items-center gap-1">
-        {activeSession?.ccSessionId && (
+        {activeSession?.ccSessionId && (showConversation ? (
+          <button
+            onClick={() => setShowConversation(false)}
+            className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
+            title="ターミナルに切替"
+            aria-label="Switch to Terminal"
+            data-onboarding="conversation"
+          >
+            <TerminalIcon className="w-5 h-5" />
+          </button>
+        ) : (
           <button
             onClick={handleShowConversation}
             className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
-            title="会話履歴"
+            title="会話履歴に切替"
+            aria-label="Switch to Chat"
             data-onboarding="conversation"
           >
             <MessageSquare className="w-5 h-5" />
           </button>
-        )}
+        ))}
         <button
           onClick={() => openFileViewer(activeSession?.currentPath || '/')}
           className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
@@ -869,24 +918,87 @@ export function App() {
       {/* Terminal - full screen */}
       {activeSession ? (
         <div className="flex-1 flex flex-col min-h-0" data-onboarding="terminal">
-          <TerminalPage
-            ref={mobileTerminalRef}
-            key={activeSessionId}
-            sessionId={activeSession.id}
-            onStateChange={(state) => updateSessionState(activeSession.id, state)}
-            overlayContent={overlayBar}
-            onOverlayTap={handleShowOverlay}
-            showOverlay={showOverlay}
-            theme={activeSession.theme}
-            onPanesChange={(panes) => {
-              setMobilePanes(panes);
-              // If active pane was removed, clear it so TerminalPage picks the first
-              if (mobileActivePaneId && !panes.some(p => p.paneId === mobileActivePaneId)) {
-                setMobileActivePaneId(null);
-              }
-            }}
-            externalActivePaneId={mobileActivePaneId}
-          />
+          {(() => {
+            // Use the session-level Claude indicator (set by hook events / jsonl).
+            // `state === 'working'` is unreliable here — it just means the tmux
+            // session is attached, so it would always be true once connected.
+            const indicator = activeSession.indicatorState;
+            const isProcessing = indicator === 'processing';
+            const isWaitingInput = indicator === 'waiting_input';
+            // Always-mounted chat overlay (visibility controlled via mainOverlayVisible).
+            // Keeping ChatView mounted preserves the conversation subscription so
+            // messages are pre-loaded by the time the user toggles to chat mode —
+            // avoiding the black/loading flash on every open.
+            const chatOverlay = activeSession.ccSessionId ? (
+              <div className="h-full flex flex-col bg-[#0a0a0a]">
+                <div
+                  className="flex items-center gap-2 px-3 py-2 border-b border-white/[0.06] shrink-0"
+                  style={{ paddingTop: 'max(env(safe-area-inset-top, 0px), 8px)' }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setShowConversation(false)}
+                    className="p-1.5 text-zinc-500 hover:text-zinc-300 shrink-0"
+                    title="ターミナルに切替"
+                    aria-label="Switch to Terminal"
+                  >
+                    <TerminalIcon className="w-5 h-5" />
+                  </button>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <h2 className="text-[13px] font-medium text-white truncate">
+                        {activeSession.name || 'Conversation'}
+                      </h2>
+                      {isProcessing && (
+                        <span className="inline-flex items-center gap-1 text-[10px] text-blue-300 bg-blue-500/15 px-1.5 py-0.5 rounded shrink-0">
+                          <span className="inline-block w-2 h-2 border border-blue-300 border-t-transparent rounded-full animate-spin" />
+                          処理中
+                        </span>
+                      )}
+                      {!isProcessing && isWaitingInput && (
+                        <span className="inline-flex items-center gap-1 text-[10px] text-amber-300 bg-amber-500/15 px-1.5 py-0.5 rounded shrink-0">
+                          入力待ち
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-[11px] text-zinc-500 truncate">
+                      {activeSession.currentPath?.replace(/^\/home\/[^/]+\//, '~/') || ''}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex-1 min-h-0">
+                  <ChatView
+                    sessionId={activeSession.id}
+                    title={activeSession.name}
+                    subtitle={activeSession.currentPath?.replace(/^\/home\/[^/]+\//, '~/')}
+                    inline
+                    enabled
+                  />
+                </div>
+              </div>
+            ) : null;
+            return (
+              <TerminalPage
+                ref={mobileTerminalRef}
+                key={activeSessionId}
+                sessionId={activeSession.id}
+                onStateChange={(state) => updateSessionState(activeSession.id, state)}
+                overlayContent={overlayBar}
+                onOverlayTap={handleShowOverlay}
+                showOverlay={showOverlay}
+                theme={activeSession.theme}
+                onPanesChange={(panes) => {
+                  setMobilePanes(panes);
+                  if (mobileActivePaneId && !panes.some(p => p.paneId === mobileActivePaneId)) {
+                    setMobileActivePaneId(null);
+                  }
+                }}
+                externalActivePaneId={mobileActivePaneId}
+                mainOverlay={chatOverlay}
+                mainOverlayVisible={showConversation}
+              />
+            );
+          })()}
           {/* Pane tab bar - only shown when multiple panes exist */}
           {mobilePanes.length > 1 && (() => {
             // Get pane command info from API sessions data
@@ -996,19 +1108,8 @@ export function App() {
       {/* Session List Overlay */}
       {sessionListOverlay}
 
-      {/* Conversation Viewer Modal */}
-      {showConversation && (
-        <ConversationViewer
-          title={activeSession?.name || 'Conversation'}
-          subtitle={activeSession?.currentPath?.replace(/^\/home\/[^/]+\//, '~/') || ''}
-          messages={conversation}
-          isLoading={loadingConversation}
-          onClose={() => setShowConversation(false)}
-          scrollToBottom={true}
-          isActive={activeSession?.currentCommand === 'claude'}
-          onRefresh={handleRefreshConversation}
-        />
-      )}
+      {/* (Conversation overlay is rendered inside TerminalPage as mainOverlay
+          so it replaces the xterm area while keeping the InputBar visible.) */}
 
       {/* Onboarding overlay */}
       {showOnboarding && <Onboarding onComplete={completeOnboarding} onStepAction={onboardingStepAction} />}

--- a/frontend/src/components/ConversationViewer.tsx
+++ b/frontend/src/components/ConversationViewer.tsx
@@ -8,6 +8,39 @@ import type { ConversationMessage, ToolUseInfo, ToolResultInfo } from '../../../
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
+// Conversation font size (shared across all sessions)
+const CV_FONT_SIZE_KEY = 'cchub-conversation-font-size';
+const CV_DEFAULT_FONT_SIZE = 13;
+const CV_MIN_FONT_SIZE = 9;
+const CV_MAX_FONT_SIZE = 24;
+
+function loadCvFontSize(): number {
+  try {
+    const saved = localStorage.getItem(CV_FONT_SIZE_KEY);
+    if (saved) {
+      const n = parseInt(saved, 10);
+      if (!Number.isNaN(n) && n >= CV_MIN_FONT_SIZE && n <= CV_MAX_FONT_SIZE) return n;
+    }
+  } catch {
+    // ignore
+  }
+  return CV_DEFAULT_FONT_SIZE;
+}
+
+function saveCvFontSize(n: number) {
+  try {
+    localStorage.setItem(CV_FONT_SIZE_KEY, String(n));
+  } catch {
+    // ignore
+  }
+}
+
+function getPinchDistance(touches: TouchList): number {
+  const dx = touches[0].clientX - touches[1].clientX;
+  const dy = touches[0].clientY - touches[1].clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
 // Convert [Image: source: /tmp/cchub-images/xxx.png] to actual image
 function processImageReferences(content: string): string {
   return content.replace(
@@ -37,17 +70,17 @@ function CollapsibleSection({
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   return (
-    <div className="my-1">
+    <div className="my-0.5">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 py-1 text-[11px] text-zinc-600 hover:text-zinc-400"
+        className="flex items-center gap-1.5 py-0.5 text-[length:var(--cv-fs-meta,11px)] text-zinc-600 hover:text-zinc-400"
       >
         <ChevronRight className={`w-3 h-3 shrink-0 transition-transform ${isOpen ? 'rotate-90' : ''}`} />
         <span>{icon}</span>
         <span className="truncate">{title}</span>
       </button>
       {isOpen && (
-        <div className="ml-4 pl-2 border-l border-white/[0.06] text-[11px] text-zinc-500 overflow-x-auto">
+        <div className="ml-4 pl-2 border-l border-white/[0.06] text-[length:var(--cv-fs-meta,11px)] text-zinc-500 overflow-x-auto">
           {children}
         </div>
       )}
@@ -144,15 +177,29 @@ function ToolResultDisplay({ results }: { results: ToolResultInfo[] }) {
             )}
             {hasImages && (
               <div className="flex flex-wrap gap-2 mt-1">
-                {result.images?.map((img, i) => (
-                  <img
-                    key={i}
-                    src={`data:${img.mediaType};base64,${img.data}`}
-                    alt="Tool result"
-                    className="max-w-[280px] h-auto rounded border border-white/[0.06]"
-                    loading="lazy"
-                  />
-                ))}
+                {result.images?.map((img, i) => {
+                  const src = `data:${img.mediaType};base64,${img.data}`;
+                  return (
+                    <img
+                      key={i}
+                      src={src}
+                      alt="Tool result"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        window.dispatchEvent(new CustomEvent('cchub-image-zoom', { detail: { src } }));
+                      }}
+                      onTouchEnd={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        window.dispatchEvent(new CustomEvent('cchub-image-zoom', { detail: { src } }));
+                      }}
+                      className="max-w-[280px] h-auto rounded border border-white/[0.06] cursor-zoom-in"
+                      loading="lazy"
+                      draggable={false}
+                    />
+                  );
+                })}
               </div>
             )}
             {!hasOutput && !hasImages && (
@@ -219,7 +266,7 @@ interface ConversationViewerProps {
 // Markdown components configuration
 const markdownComponents = {
   pre: ({ children }: { children?: React.ReactNode }) => (
-    <pre className="bg-white/[0.03] p-2 rounded overflow-x-auto my-1.5 text-[11px]">
+    <pre className="bg-white/[0.03] px-2 py-1 rounded overflow-x-auto my-1 text-[length:var(--cv-fs-meta,11px)]">
       {children}
     </pre>
   ),
@@ -231,13 +278,13 @@ const markdownComponents = {
       <code className="bg-white/[0.06] px-1 rounded text-zinc-300">{children}</code>
     );
   },
-  p: ({ children }: { children?: React.ReactNode }) => <p className="my-1">{children}</p>,
-  ul: ({ children }: { children?: React.ReactNode }) => <ul className="list-disc ml-4 my-1">{children}</ul>,
-  ol: ({ children }: { children?: React.ReactNode }) => <ol className="list-decimal ml-4 my-1">{children}</ol>,
-  li: ({ children }: { children?: React.ReactNode }) => <li className="my-0.5">{children}</li>,
-  h1: ({ children }: { children?: React.ReactNode }) => <h1 className="text-lg font-bold my-2">{children}</h1>,
-  h2: ({ children }: { children?: React.ReactNode }) => <h2 className="text-base font-bold my-2">{children}</h2>,
-  h3: ({ children }: { children?: React.ReactNode }) => <h3 className="text-sm font-bold my-1">{children}</h3>,
+  p: ({ children }: { children?: React.ReactNode }) => <p className="my-0.5">{children}</p>,
+  ul: ({ children }: { children?: React.ReactNode }) => <ul className="list-disc ml-4 my-0.5">{children}</ul>,
+  ol: ({ children }: { children?: React.ReactNode }) => <ol className="list-decimal ml-4 my-0.5">{children}</ol>,
+  li: ({ children }: { children?: React.ReactNode }) => <li className="my-0">{children}</li>,
+  h1: ({ children }: { children?: React.ReactNode }) => <h1 className="text-lg font-bold my-1">{children}</h1>,
+  h2: ({ children }: { children?: React.ReactNode }) => <h2 className="text-base font-bold my-1">{children}</h2>,
+  h3: ({ children }: { children?: React.ReactNode }) => <h3 className="text-sm font-bold my-0.5">{children}</h3>,
   strong: ({ children }: { children?: React.ReactNode }) => <strong className="font-bold text-th-text">{children}</strong>,
   a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
     <a href={href} className="text-blue-400 underline" target="_blank" rel="noopener noreferrer">
@@ -245,12 +292,12 @@ const markdownComponents = {
     </a>
   ),
   blockquote: ({ children }: { children?: React.ReactNode }) => (
-    <blockquote className="border-l-2 border-gray-500 pl-2 my-2 text-th-text-secondary">
+    <blockquote className="border-l-2 border-gray-500 pl-2 my-1 text-th-text-secondary">
       {children}
     </blockquote>
   ),
   table: ({ children }: { children?: React.ReactNode }) => (
-    <div className="overflow-x-auto my-2">
+    <div className="overflow-x-auto my-1">
       <table className="min-w-full text-xs border border-th-border">{children}</table>
     </div>
   ),
@@ -264,8 +311,21 @@ const markdownComponents = {
     <img
       src={src}
       alt={alt || 'Screenshot'}
-      className="max-w-[280px] h-auto rounded my-2 border border-white/[0.06]"
+      onClick={(e) => {
+        if (!src) return;
+        e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new CustomEvent('cchub-image-zoom', { detail: { src } }));
+      }}
+      onTouchEnd={(e) => {
+        if (!src) return;
+        e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new CustomEvent('cchub-image-zoom', { detail: { src } }));
+      }}
+      className="max-w-[280px] h-auto rounded my-2 border border-white/[0.06] cursor-zoom-in"
       loading="lazy"
+      draggable={false}
     />
   ),
 };
@@ -299,8 +359,8 @@ const MessageItem = memo(function MessageItem({ msg }: { msg: ConversationMessag
   const roleColor = msg.role === 'user' ? 'text-blue-400' : isSummaryMessage ? 'text-amber-400' : 'text-zinc-500';
 
   return (
-    <div className="py-2">
-      <div className={`text-[11px] font-medium ${roleColor} mb-1`}>
+    <div className="py-1">
+      <div className={`text-[length:var(--cv-fs-meta,11px)] font-medium ${roleColor} mb-0.5`}>
         {displayRole}
       </div>
 
@@ -309,7 +369,7 @@ const MessageItem = memo(function MessageItem({ msg }: { msg: ConversationMessag
 
       {/* Main text content */}
       {msg.content && (
-        <div className="text-[13px] text-zinc-300 markdown-content leading-relaxed">
+        <div className="text-zinc-300 markdown-content leading-snug">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={markdownComponents}
@@ -348,6 +408,94 @@ export function ConversationViewer({
   const { t } = useTranslation();
   const parentRef = useRef<HTMLDivElement>(null);
   const [prevMessageCount, setPrevMessageCount] = useState(0);
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+
+  // Inline images (rendered by markdownComponents) dispatch this event when
+  // tapped. Listening at the component level (rather than event delegation
+  // on the scroll container) sidesteps cases where parent handlers swallow
+  // the click on touch devices.
+  useEffect(() => {
+    const onZoom = (e: Event) => {
+      const detail = (e as CustomEvent<{ src: string }>).detail;
+      if (detail?.src) setLightboxSrc(detail.src);
+    };
+    window.addEventListener('cchub-image-zoom', onZoom);
+    return () => window.removeEventListener('cchub-image-zoom', onZoom);
+  }, []);
+
+  // Esc to close lightbox
+  useEffect(() => {
+    if (!lightboxSrc) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setLightboxSrc(null);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [lightboxSrc]);
+  const [fontSize, setFontSize] = useState<number>(loadCvFontSize);
+  const [showFontSizeIndicator, setShowFontSizeIndicator] = useState(false);
+  const fontSizeIndicatorTimerRef = useRef<number | null>(null);
+
+  const changeFontSize = useCallback((delta: number) => {
+    setFontSize(prev => {
+      const next = Math.max(CV_MIN_FONT_SIZE, Math.min(CV_MAX_FONT_SIZE, prev + delta));
+      if (next !== prev) saveCvFontSize(next);
+      return next;
+    });
+  }, []);
+  const resetFontSize = useCallback(() => {
+    setFontSize(CV_DEFAULT_FONT_SIZE);
+    saveCvFontSize(CV_DEFAULT_FONT_SIZE);
+  }, []);
+
+  // Briefly show the size indicator after any change
+  useEffect(() => {
+    setShowFontSizeIndicator(true);
+    if (fontSizeIndicatorTimerRef.current) clearTimeout(fontSizeIndicatorTimerRef.current);
+    fontSizeIndicatorTimerRef.current = window.setTimeout(() => setShowFontSizeIndicator(false), 1200);
+    return () => {
+      if (fontSizeIndicatorTimerRef.current) clearTimeout(fontSizeIndicatorTimerRef.current);
+    };
+  }, [fontSize]);
+
+  // Pinch-zoom on the message scroll container to change font size
+  useEffect(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    let pinch: { d: number; size: number } | null = null;
+    const onStart = (e: TouchEvent) => {
+      if (e.touches.length === 2) {
+        e.preventDefault();
+        pinch = { d: getPinchDistance(e.touches), size: fontSize };
+      }
+    };
+    const onMove = (e: TouchEvent) => {
+      if (e.touches.length === 2 && pinch) {
+        e.preventDefault();
+        const scale = getPinchDistance(e.touches) / pinch.d;
+        const next = Math.round(pinch.size * scale);
+        const clamped = Math.max(CV_MIN_FONT_SIZE, Math.min(CV_MAX_FONT_SIZE, next));
+        setFontSize(prev => (prev === clamped ? prev : clamped));
+      }
+    };
+    const onEnd = (e: TouchEvent) => {
+      if (e.touches.length < 2 && pinch) {
+        pinch = null;
+        // Persist the final size after pinch ends
+        setFontSize(prev => { saveCvFontSize(prev); return prev; });
+      }
+    };
+    el.addEventListener('touchstart', onStart, { passive: false });
+    el.addEventListener('touchmove', onMove, { passive: false });
+    el.addEventListener('touchend', onEnd);
+    el.addEventListener('touchcancel', onEnd);
+    return () => {
+      el.removeEventListener('touchstart', onStart);
+      el.removeEventListener('touchmove', onMove);
+      el.removeEventListener('touchend', onEnd);
+      el.removeEventListener('touchcancel', onEnd);
+    };
+  }, [fontSize]);
 
   const virtualizer = useVirtualizer({
     count: messages.length,
@@ -382,6 +530,29 @@ export function ConversationViewer({
     }
   }, [messages.length, isLoading, scrollToBottom, prevMessageCount, scrollToEnd]);
 
+  // Snap to bottom when the container becomes visible (e.g. unhidden after
+  // mounting under display:none). Without this, scrollToEnd above runs while
+  // the parent has 0 height and silently no-ops.
+  const messagesLenRef = useRef(messages.length);
+  messagesLenRef.current = messages.length;
+  useEffect(() => {
+    if (!scrollToBottom) return;
+    const el = parentRef.current;
+    if (!el) return;
+    let prevHeight = el.clientHeight;
+    const ro = new ResizeObserver(() => {
+      const h = el.clientHeight;
+      if (h > 0 && prevHeight === 0 && messagesLenRef.current > 0) {
+        requestAnimationFrame(() => {
+          virtualizer.scrollToIndex(messagesLenRef.current - 1, { align: 'end' });
+        });
+      }
+      prevHeight = h;
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [scrollToBottom, virtualizer]);
+
   // Auto-refresh when session is active (silently in background)
   useEffect(() => {
     if (!isActive || !onRefresh) return;
@@ -397,16 +568,62 @@ export function ConversationViewer({
 
   // Container class based on inline mode
   const containerClass = inline
-    ? 'h-full flex flex-col bg-[#0a0a0a]'
+    ? 'h-full flex flex-col bg-[#0a0a0a] relative'
     : 'fixed inset-0 z-50 flex flex-col bg-[#0a0a0a]';
 
   return (
     <div className={containerClass}>
+      {/* Floating font-size controls (bottom-left) — kept away from the
+          pane header's right-side icons. Hidden in modal mode. */}
+      {inline && (
+        <div className="absolute bottom-2 left-2 z-30 flex items-center gap-1 pointer-events-none">
+          {showFontSizeIndicator && (
+            <div className="bg-black/70 text-white text-[11px] font-medium px-2 py-1 rounded shadow pointer-events-none">
+              {fontSize}px
+            </div>
+          )}
+          <div className="flex items-center bg-black/60 backdrop-blur-sm rounded-md border border-white/[0.08] pointer-events-auto">
+            <button
+              type="button"
+              onClick={() => changeFontSize(-1)}
+              className="w-7 h-7 text-zinc-300 hover:text-white hover:bg-white/[0.08] flex items-center justify-center transition-colors text-sm"
+              aria-label="Decrease font size"
+              title="Decrease font size"
+            >
+              −
+            </button>
+            <button
+              type="button"
+              onClick={resetFontSize}
+              className="px-1.5 h-7 text-[10px] text-zinc-400 hover:text-white hover:bg-white/[0.08] border-x border-white/[0.06] transition-colors"
+              aria-label="Reset font size"
+              title="Reset font size"
+            >
+              A
+            </button>
+            <button
+              type="button"
+              onClick={() => changeFontSize(1)}
+              className="w-7 h-7 text-zinc-300 hover:text-white hover:bg-white/[0.08] flex items-center justify-center transition-colors text-sm"
+              aria-label="Increase font size"
+              title="Increase font size"
+            >
+              ＋
+            </button>
+          </div>
+        </div>
+      )}
       {/* Messages */}
       <div
         ref={parentRef}
-        className="flex-1 overflow-y-auto p-3 select-text overscroll-contain"
-        style={{ WebkitUserSelect: 'text', userSelect: 'text', WebkitTouchCallout: 'default' }}
+        className="flex-1 overflow-y-auto px-3 py-1 select-text overscroll-contain relative"
+        style={{
+          WebkitUserSelect: 'text',
+          userSelect: 'text',
+          WebkitTouchCallout: 'default',
+          fontSize: `${fontSize}px`,
+          ['--cv-fs-meta' as never]: `${Math.max(8, fontSize - 2)}px`,
+        }}
       >
         {isLoading ? (
           <div className="text-center text-th-text-muted py-8">
@@ -439,7 +656,7 @@ export function ConversationViewer({
                   data-index={virtualRow.index}
                   ref={virtualizer.measureElement}
                 >
-                  <div className="pb-3">
+                  <div className="pb-1">
                     <MessageItem msg={messages[virtualRow.index]} />
                   </div>
                 </div>
@@ -473,6 +690,33 @@ export function ConversationViewer({
               {isResuming ? t('session.resuming') : t('session.resume')}
             </button>
           )}
+        </div>
+      )}
+
+      {/* Image lightbox — tap an inline image to open at full size */}
+      {lightboxSrc && (
+        <div
+          className="fixed inset-0 z-[10000] bg-black/90 flex items-center justify-center p-4"
+          onClick={() => setLightboxSrc(null)}
+          onTouchEnd={() => setLightboxSrc(null)}
+        >
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setLightboxSrc(null); }}
+            className="absolute top-3 right-3 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <img
+            src={lightboxSrc}
+            alt="Expanded"
+            className="max-w-full max-h-full object-contain select-none"
+            onClick={(e) => e.stopPropagation()}
+            draggable={false}
+          />
         </div>
       )}
     </div>

--- a/frontend/src/components/ConversationViewer.tsx
+++ b/frontend/src/components/ConversationViewer.tsx
@@ -261,6 +261,14 @@ interface ConversationViewerProps {
   isActive?: boolean;  // Whether the session is actively running
   onRefresh?: () => void;  // Callback to refresh conversation
   inline?: boolean;  // If true, render inline instead of fullscreen modal
+  /** Fires once per touch gesture when the user starts scrolling. Used to
+   *  collapse the input bar / soft keyboard so more of the conversation is
+   *  visible (mirrors Terminal's behavior). */
+  onScrollGesture?: () => void;
+  /** Fires when the scroll position transitions to / from the bottom. The
+   *  parent uses this to hide the keyboard while the user is reading
+   *  history and re-show it when they return to the latest message. */
+  onAtBottomChange?: (atBottom: boolean) => void;
 }
 
 // Markdown components configuration
@@ -404,6 +412,8 @@ export function ConversationViewer({
   isActive = false,
   onRefresh,
   inline = false,
+  onScrollGesture,
+  onAtBottomChange,
 }: ConversationViewerProps) {
   const { t } = useTranslation();
   const parentRef = useRef<HTMLDivElement>(null);
@@ -497,6 +507,76 @@ export function ConversationViewer({
     };
   }, [fontSize]);
 
+  // Track scroll gestures and at-bottom state. The atBottom transition is
+  // only reported during/just-after a user touch — otherwise viewport
+  // changes from the keyboard showing/hiding would themselves toggle the
+  // state and cause the keyboard to oscillate.
+  const onScrollGestureRef = useRef(onScrollGesture);
+  onScrollGestureRef.current = onScrollGesture;
+  const onAtBottomChangeRef = useRef(onAtBottomChange);
+  onAtBottomChangeRef.current = onAtBottomChange;
+  const atBottomRef = useRef(true);
+  useEffect(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    const BOTTOM_THRESHOLD = 24;
+    const computeAtBottom = () => el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_THRESHOLD;
+
+    let userTouching = false;
+    let userTouchedUntil = 0; // timestamp; treat events within this window as user-driven
+    let startY: number | null = null;
+    let gestureFired = false;
+
+    let cooldownUntil = 0;
+    const reportIfChanged = () => {
+      if (Date.now() < cooldownUntil) return;
+      const atBottom = computeAtBottom();
+      if (atBottom === atBottomRef.current) return;
+      atBottomRef.current = atBottom;
+      cooldownUntil = Date.now() + 600; // ignore rapid layout-shift re-toggles
+      onAtBottomChangeRef.current?.(atBottom);
+    };
+
+    const onScroll = () => {
+      // Only react when the user is (or recently was) touching, to avoid
+      // feedback loops with keyboard show/hide layout shifts.
+      if (!userTouching && Date.now() > userTouchedUntil) return;
+      reportIfChanged();
+    };
+    const onStart = (e: TouchEvent) => {
+      userTouching = true;
+      if (e.touches.length !== 1) { startY = null; gestureFired = false; return; }
+      startY = e.touches[0].clientY;
+      gestureFired = false;
+    };
+    const onMove = (e: TouchEvent) => {
+      if (gestureFired || startY === null || e.touches.length !== 1) return;
+      const dy = Math.abs(e.touches[0].clientY - startY);
+      if (dy > 5) {
+        gestureFired = true;
+        onScrollGestureRef.current?.();
+      }
+    };
+    const onEnd = () => {
+      userTouching = false;
+      userTouchedUntil = Date.now() + 350; // momentum scroll window
+      startY = null;
+      gestureFired = false;
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    el.addEventListener('touchstart', onStart, { passive: true });
+    el.addEventListener('touchmove', onMove, { passive: true });
+    el.addEventListener('touchend', onEnd);
+    el.addEventListener('touchcancel', onEnd);
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      el.removeEventListener('touchstart', onStart);
+      el.removeEventListener('touchmove', onMove);
+      el.removeEventListener('touchend', onEnd);
+      el.removeEventListener('touchcancel', onEnd);
+    };
+  }, []);
+
   const virtualizer = useVirtualizer({
     count: messages.length,
     getScrollElement: () => parentRef.current,
@@ -573,43 +653,64 @@ export function ConversationViewer({
 
   return (
     <div className={containerClass}>
-      {/* Floating font-size controls (bottom-left) — kept away from the
-          pane header's right-side icons. Hidden in modal mode. */}
+      {/* Floating font-size controls (bottom-left) — only visible when the
+          user is actively changing the size (via pinch / button) or hovering
+          the bottom-left hot-zone on desktop. Tap the small "Aa" badge on
+          touch devices to reveal. */}
       {inline && (
-        <div className="absolute bottom-2 left-2 z-30 flex items-center gap-1 pointer-events-none">
-          {showFontSizeIndicator && (
-            <div className="bg-black/70 text-white text-[11px] font-medium px-2 py-1 rounded shadow pointer-events-none">
+        <div className="absolute bottom-2 left-2 z-30 group">
+          {/* Tiny always-visible trigger */}
+          <button
+            type="button"
+            onClick={() => {
+              setShowFontSizeIndicator(true);
+              if (fontSizeIndicatorTimerRef.current) clearTimeout(fontSizeIndicatorTimerRef.current);
+              fontSizeIndicatorTimerRef.current = window.setTimeout(() => setShowFontSizeIndicator(false), 4000);
+            }}
+            className={`w-6 h-6 rounded text-[10px] font-medium transition-opacity flex items-center justify-center bg-black/40 text-zinc-500 hover:text-zinc-300 ${
+              showFontSizeIndicator ? 'opacity-0' : 'opacity-60 hover:opacity-100'
+            }`}
+            aria-label="Show font size controls"
+            title="Font size"
+          >
+            Aa
+          </button>
+          {/* Full controls — shown on hover (desktop) or while indicator active */}
+          <div className={`absolute bottom-0 left-0 flex items-center gap-1 transition-opacity duration-150 ${
+            showFontSizeIndicator ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto'
+          }`}>
+            <div className="flex items-center bg-black/70 backdrop-blur-sm rounded-md border border-white/[0.08]">
+              <button
+                type="button"
+                onClick={() => changeFontSize(-1)}
+                className="w-7 h-7 text-zinc-300 hover:text-white hover:bg-white/[0.08] flex items-center justify-center transition-colors text-sm"
+                aria-label="Decrease font size"
+                title="Decrease font size"
+              >
+                −
+              </button>
+              <button
+                type="button"
+                onClick={resetFontSize}
+                className="px-1.5 h-7 text-[10px] text-zinc-400 hover:text-white hover:bg-white/[0.08] border-x border-white/[0.06] transition-colors"
+                aria-label="Reset font size"
+                title="Reset font size"
+              >
+                A
+              </button>
+              <button
+                type="button"
+                onClick={() => changeFontSize(1)}
+                className="w-7 h-7 text-zinc-300 hover:text-white hover:bg-white/[0.08] flex items-center justify-center transition-colors text-sm"
+                aria-label="Increase font size"
+                title="Increase font size"
+              >
+                ＋
+              </button>
+            </div>
+            <div className="bg-black/70 text-white text-[11px] font-medium px-2 py-1 rounded shadow">
               {fontSize}px
             </div>
-          )}
-          <div className="flex items-center bg-black/60 backdrop-blur-sm rounded-md border border-white/[0.08] pointer-events-auto">
-            <button
-              type="button"
-              onClick={() => changeFontSize(-1)}
-              className="w-7 h-7 text-zinc-300 hover:text-white hover:bg-white/[0.08] flex items-center justify-center transition-colors text-sm"
-              aria-label="Decrease font size"
-              title="Decrease font size"
-            >
-              −
-            </button>
-            <button
-              type="button"
-              onClick={resetFontSize}
-              className="px-1.5 h-7 text-[10px] text-zinc-400 hover:text-white hover:bg-white/[0.08] border-x border-white/[0.06] transition-colors"
-              aria-label="Reset font size"
-              title="Reset font size"
-            >
-              A
-            </button>
-            <button
-              type="button"
-              onClick={() => changeFontSize(1)}
-              className="w-7 h-7 text-zinc-300 hover:text-white hover:bg-white/[0.08] flex items-center justify-center transition-colors text-sm"
-              aria-label="Increase font size"
-              title="Increase font size"
-            >
-              ＋
-            </button>
           </div>
         </div>
       )}

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -217,7 +217,13 @@ export function DesktopLayout({
     ? apiSessions.map(apiSession => {
         const propSession = propSessions.find(p => p.id === apiSession.id);
         return propSession
-          ? { ...propSession, theme: apiSession.theme }
+          ? {
+              ...propSession,
+              theme: apiSession.theme,
+              currentCommand: apiSession.currentCommand,
+              ccSessionId: apiSession.ccSessionId,
+              panes: apiSession.panes,
+            }
           : {
               id: apiSession.id,
               name: apiSession.name,
@@ -226,6 +232,7 @@ export function DesktopLayout({
               ccSessionId: apiSession.ccSessionId,
               currentCommand: apiSession.currentCommand,
               theme: apiSession.theme,
+              panes: apiSession.panes,
             };
       })
     : propSessions;
@@ -908,6 +915,7 @@ export function DesktopLayout({
         setShowDashboard(prev => !prev);
         return;
       }
+
 
       // Ctrl/Cmd + Shift + Arrow: Resize active pane
       if (e.shiftKey && !e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight' || e.key === 'ArrowUp' || e.key === 'ArrowDown')) {

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -1,10 +1,11 @@
 import { useRef, useCallback, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Terminal as TerminalIcon, MessageSquare } from 'lucide-react';
 import { TerminalComponent, type TerminalRef } from './Terminal';
-import { ConversationViewer } from './ConversationViewer';
+import { ChatView } from './chat/ChatView';
 
 import { authFetch } from '../services/api';
-import type { SessionState, ConversationMessage, SessionTheme } from '../../../shared/types';
+import type { SessionState, SessionTheme, PaneInfo } from '../../../shared/types';
 import type { ControlModeConfig } from './Terminal';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
@@ -23,6 +24,7 @@ interface ExtendedSession {
   ccSessionId?: string;
   currentCommand?: string;
   theme?: SessionTheme;
+  panes?: PaneInfo[];
 }
 
 // Control mode context passed through the pane tree
@@ -150,11 +152,25 @@ function TerminalPane({
   const { t } = useTranslation();
   const terminalRef = useRef<TerminalRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [showConversation, setShowConversation] = useState(false);
-  const [messages, setMessages] = useState<ConversationMessage[]>([]);
-  const [isLoadingMessages, setIsLoadingMessages] = useState(false);
-  const [currentCcSessionId, setCurrentCcSessionId] = useState<string | null>(null);
-  const [isClaudeRunning, setIsClaudeRunning] = useState(false);
+  // Persist chat-mode state per pane so it survives remounts (e.g. after a
+  // split changes the React tree from <TerminalPane> to <SplitContainer>).
+  const conversationModeKey = sessionId ? `cchub-pane-conv-mode:${sessionId}:${paneId}` : null;
+  const [showConversation, setShowConversationState] = useState<boolean>(() => {
+    if (!conversationModeKey) return false;
+    try { return localStorage.getItem(conversationModeKey) === '1'; } catch { return false; }
+  });
+  const setShowConversation = useCallback<React.Dispatch<React.SetStateAction<boolean>>>((next) => {
+    setShowConversationState(prev => {
+      const value = typeof next === 'function' ? (next as (p: boolean) => boolean)(prev) : next;
+      if (conversationModeKey) {
+        try {
+          if (value) localStorage.setItem(conversationModeKey, '1');
+          else localStorage.removeItem(conversationModeKey);
+        } catch { /* ignore */ }
+      }
+      return value;
+    });
+  }, [conversationModeKey]);
   const [reloadKey, setReloadKey] = useState(0);
   const [confirmClose, setConfirmClose] = useState(false);
   const confirmCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -211,65 +227,38 @@ function TerminalPane({
 
   const session = sessionId ? sessions.find(s => s.id === sessionId) : null;
 
-  // Fetch fresh session info from API to get current ccSessionId
-  const fetchSessionInfo = useCallback(async () => {
-    if (!sessionId) return null;
-    try {
-      const response = await authFetch(`${API_BASE}/api/sessions`);
-      if (response.ok) {
-        const data = await response.json();
-        const freshSession = data.sessions.find((s: ExtendedSession) => s.id === sessionId);
-        if (freshSession) {
-          setCurrentCcSessionId(freshSession.ccSessionId || null);
-          setIsClaudeRunning(freshSession.currentCommand === 'claude');
-          return freshSession.ccSessionId || null;
-        }
-      }
-    } catch {
-      // Ignore errors
-    }
-    return null;
-  }, [sessionId]);
-
-  // Fetch conversation using fresh ccSessionId
-  const fetchConversation = useCallback(async (ccId?: string) => {
-    const targetCcSessionId = ccId || currentCcSessionId;
-    if (!targetCcSessionId) return;
-    try {
-      const response = await authFetch(`${API_BASE}/api/sessions/history/${targetCcSessionId}/conversation`);
-      if (response.ok) {
-        const data = await response.json();
-        setMessages(data.messages || []);
-      }
-    } catch {
-      // Ignore errors
-    }
-  }, [currentCcSessionId]);
-
-  // Reset conversation state when session changes
+  // Re-read persisted state when the (sessionId, paneId) pair changes — e.g.
+  // user picks a different session in this pane. Initial mount already
+  // hydrated from localStorage via useState, so this is a no-op then.
   useEffect(() => {
-    setShowConversation(false);
-    setMessages([]);
-    setCurrentCcSessionId(null);
-  }, [sessionId]);
-
-  // Handle toggle - fetch fresh session info first
-  const handleToggleConversation = useCallback(async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!showConversation) {
-      // Opening conversation - fetch fresh data
-      setIsLoadingMessages(true);
-      const freshCcSessionId = await fetchSessionInfo();
-      if (freshCcSessionId) {
-        await fetchConversation(freshCcSessionId);
-      }
-      setIsLoadingMessages(false);
+    if (!conversationModeKey) {
+      setShowConversationState(false);
+      return;
     }
-    setShowConversation(prev => !prev);
-  }, [showConversation, fetchSessionInfo, fetchConversation]);
+    try {
+      setShowConversationState(localStorage.getItem(conversationModeKey) === '1');
+    } catch {
+      setShowConversationState(false);
+    }
+  }, [conversationModeKey]);
 
-  // Check if we have a ccSessionId (from props or fresh fetch)
-  const hasCcSessionId = currentCcSessionId || session?.ccSessionId;
+  // Fall back to terminal view only if pane data has loaded AND Claude is
+  // not running on the active pane. Without the loaded check, the very first
+  // render after remount (e.g. after a split) sees panes=undefined and would
+  // wrongly clear chat mode.
+  const activeTmuxPane = session?.panes?.find(p => p.isActive);
+  const claudeRunning = activeTmuxPane?.currentCommand === 'claude';
+  const panesLoaded = !!session?.panes;
+  useEffect(() => {
+    if (!panesLoaded) return;
+    if (!claudeRunning && showConversation) {
+      setShowConversation(false);
+    }
+  }, [claudeRunning, showConversation, panesLoaded, setShowConversation]);
+
+  const handleToggleConversation = useCallback(() => {
+    setShowConversation(prev => !prev);
+  }, []);
 
   return (
     <div
@@ -289,22 +278,39 @@ function TerminalPane({
           </span>
         )}
         <div className={`flex items-center ${isTablet ? 'gap-0' : 'gap-1.5'}`}>
-          {/* Conversation toggle button - show for Claude sessions */}
-          {(hasCcSessionId || session?.currentCommand === 'claude') && (
-            <button
-              onClick={handleToggleConversation}
-              className={`${isTablet ? 'p-2.5' : 'p-1.5'} transition-colors ${
-                showConversation
-                  ? 'text-blue-400 hover:text-blue-300'
-                  : 'text-white/50 hover:text-th-text'
-              }`}
-              title={showConversation ? t('conversation.backToTerminal') : t('conversation.showHistory')}
-            >
-              <svg className={isTablet ? 'w-5 h-5' : 'w-[18px] h-[18px]'} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-              </svg>
-            </button>
-          )}
+          {/* Terminal / Chat single-icon toggle — shows the destination mode */}
+          {(() => {
+            const claudeAvailable = claudeRunning;
+            const disabled = !showConversation && !claudeAvailable;
+            return (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!disabled) handleToggleConversation();
+                }}
+                disabled={disabled}
+                className={`${isTablet ? 'p-2' : 'p-1'} rounded transition-colors ${
+                  disabled
+                    ? 'text-white/20 cursor-not-allowed'
+                    : 'text-white/60 hover:text-th-text hover:bg-white/[0.06]'
+                }`}
+                title={
+                  showConversation
+                    ? 'ターミナルに切替'
+                    : claudeAvailable
+                      ? '会話履歴に切替'
+                      : 'Claude Code が起動していません'
+                }
+                aria-label={showConversation ? 'Switch to Terminal' : 'Switch to Chat'}
+              >
+                {showConversation ? (
+                  <TerminalIcon className={isTablet ? 'w-4 h-4' : 'w-[14px] h-[14px]'} />
+                ) : (
+                  <MessageSquare className={isTablet ? 'w-4 h-4' : 'w-[14px] h-[14px]'} />
+                )}
+              </button>
+            );
+          })()}
           {/* File browser button (desktop only) */}
           {!isTablet && session?.currentPath && !showConversation && (
             <button
@@ -330,8 +336,8 @@ function TerminalPane({
               </svg>
             </button>
           )}
-          {/* Zoom button */}
-          {sessionId && !showConversation && controlModeContext.zoomPane && (
+          {/* Zoom button — only meaningful when there are multiple panes */}
+          {sessionId && !showConversation && controlModeContext.zoomPane && (session?.panes?.length ?? 0) > 1 && (
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -387,44 +393,45 @@ function TerminalPane({
               </button>
             </div>
           )}
-          {/* Close button with confirmation */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              if (confirmClose) {
-                // Second tap: actually close
-                if (confirmCloseTimerRef.current) {
-                  clearTimeout(confirmCloseTimerRef.current);
-                  confirmCloseTimerRef.current = null;
-                }
-                setConfirmClose(false);
-                onClose();
-              } else {
-                // First tap: show warning
-                setConfirmClose(true);
-                confirmCloseTimerRef.current = setTimeout(() => {
+          {/* Close button with confirmation — only shown when there are
+              multiple panes (the backend rejects closing the last pane). */}
+          {(session?.panes?.length ?? 0) > 1 && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                if (confirmClose) {
+                  if (confirmCloseTimerRef.current) {
+                    clearTimeout(confirmCloseTimerRef.current);
+                    confirmCloseTimerRef.current = null;
+                  }
                   setConfirmClose(false);
-                  confirmCloseTimerRef.current = null;
-                }, 3000);
-              }
-            }}
-            className={`${isTablet ? 'p-2.5' : 'p-1.5'} transition-colors ${
-              confirmClose
-                ? 'text-red-400 bg-red-900/50 rounded'
-                : 'text-white/50 hover:text-red-400'
-            }`}
-            title={confirmClose ? t('pane.confirmClose') : t('common.close')}
-          >
-            {confirmClose ? (
-              <span className={`${isTablet ? 'text-xs' : 'text-[10px]'} font-bold whitespace-nowrap`}>
-                {t('pane.confirmClose')}
-              </span>
-            ) : (
-              <svg className={isTablet ? 'w-5 h-5' : 'w-[18px] h-[18px]'} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            )}
-          </button>
+                  onClose();
+                } else {
+                  setConfirmClose(true);
+                  confirmCloseTimerRef.current = setTimeout(() => {
+                    setConfirmClose(false);
+                    confirmCloseTimerRef.current = null;
+                  }, 3000);
+                }
+              }}
+              className={`${isTablet ? 'p-2.5' : 'p-1.5'} transition-colors ${
+                confirmClose
+                  ? 'text-red-400 bg-red-900/50 rounded'
+                  : 'text-white/50 hover:text-red-400'
+              }`}
+              title={confirmClose ? t('pane.confirmClose') : t('common.close')}
+            >
+              {confirmClose ? (
+                <span className={`${isTablet ? 'text-xs' : 'text-[10px]'} font-bold whitespace-nowrap`}>
+                  {t('pane.confirmClose')}
+                </span>
+              ) : (
+                <svg className={isTablet ? 'w-5 h-5' : 'w-[18px] h-[18px]'} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              )}
+            </button>
+          )}
         </div>
       </div>
 
@@ -474,17 +481,17 @@ function TerminalPane({
 
       {/* Terminal, conversation, or session selector */}
       <div className="flex-1 min-h-0">
-        {showConversation && currentCcSessionId && (
-          <ConversationViewer
-            title="会話履歴"
+        {showConversation && sessionId && (
+          <ChatView
+            sessionId={sessionId}
+            title={t('conversation.history')}
             subtitle={session?.name}
-            messages={messages}
-            isLoading={isLoadingMessages}
-            onClose={() => setShowConversation(false)}
             inline={true}
-            scrollToBottom={true}
-            isActive={isClaudeRunning}
-            onRefresh={() => fetchConversation(currentCcSessionId || undefined)}
+            enabled={showConversation}
+            // Tablet has its own FloatingKeyboard that already routes input to
+            // the active pane (same as Terminal mode) — no in-view composer.
+            showComposer={!isTablet}
+            paneId={controlModeContext.getControlConfig(paneId)?.paneId}
           />
         )}
         {sessionId ? (

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -41,6 +41,10 @@ interface TerminalProps {
   showOverlay?: boolean;
   theme?: SessionTheme;
   controlMode?: ControlModeConfig;
+  /** When true, hides the xterm area but keeps the InputBar visible. */
+  hideTerminalArea?: boolean;
+  /** Replacement content shown in the xterm area when hideTerminalArea is true. */
+  terminalAreaOverlay?: React.ReactNode;
 }
 
 // Ref interface for external keyboard input
@@ -75,6 +79,8 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
   showOverlay = true,
   theme: sessionTheme,
   controlMode,
+  hideTerminalArea,
+  terminalAreaOverlay,
 }, ref) {
   const containerRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -1030,12 +1036,22 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
       >
         <div
           ref={containerRef}
-          className="absolute inset-0 p-1"
+          className={`absolute inset-0 p-1${hideTerminalArea ? ' invisible pointer-events-none' : ''}`}
           style={{
             ...(isTouchDevice ? { WebkitTouchCallout: 'none', WebkitUserSelect: 'none' } : {}),
             touchAction: 'none',
           }}
         />
+        {/* Always render the overlay container so ChatView keeps its state /
+            subscription mounted; toggle visibility via display style. */}
+        {terminalAreaOverlay && (
+          <div
+            className="absolute inset-0 z-20 bg-[#0a0a0a]"
+            style={{ display: hideTerminalArea ? 'block' : 'none' }}
+          >
+            {terminalAreaOverlay}
+          </div>
+        )}
         <div
           ref={overlayRef}
           className="absolute inset-0 z-10 pointer-events-none"

--- a/frontend/src/components/chat/ChatComposer.tsx
+++ b/frontend/src/components/chat/ChatComposer.tsx
@@ -1,0 +1,76 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { Send } from 'lucide-react';
+import { sendTerminalInput } from '../../hooks/useMultiplexedTerminal';
+
+interface ChatComposerProps {
+  sessionId: string;
+  paneId: string | undefined;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function ChatComposer({ sessionId, paneId, disabled, placeholder }: ChatComposerProps) {
+  const [value, setValue] = useState('');
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.style.height = 'auto';
+    ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+  }, [value]);
+
+  const send = useCallback(() => {
+    const text = value;
+    if (!text.trim() || !paneId) return;
+    if (text.includes('\n')) {
+      sendTerminalInput(sessionId, paneId, `\x1b[200~${text}\x1b[201~`);
+    } else {
+      sendTerminalInput(sessionId, paneId, text);
+    }
+    sendTerminalInput(sessionId, paneId, '\r');
+    setValue('');
+  }, [sessionId, paneId, value]);
+
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      send();
+    }
+  }, [send]);
+
+  const canSend = !disabled && !!paneId && value.trim().length > 0;
+
+  return (
+    <div
+      className="shrink-0 border-t border-white/[0.06] bg-[#0a0a0a] px-3 py-2"
+      style={{ paddingBottom: 'max(env(safe-area-inset-bottom, 0px), 8px)' }}
+    >
+      <div className="flex items-end gap-2">
+        <textarea
+          ref={taRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder ?? 'メッセージ...'}
+          disabled={disabled || !paneId}
+          rows={1}
+          className="flex-1 min-h-[40px] max-h-[200px] resize-none rounded-md bg-white/[0.04] border border-white/[0.06] px-3 py-2 text-[14px] text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-blue-500/40 disabled:opacity-50"
+        />
+        <button
+          type="button"
+          onClick={send}
+          disabled={!canSend}
+          aria-label="Send"
+          className={`shrink-0 h-10 px-3 rounded-md flex items-center justify-center transition-colors ${
+            canSend
+              ? 'bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white'
+              : 'bg-white/[0.04] text-zinc-600'
+          }`}
+        >
+          <Send className="w-5 h-5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -16,6 +16,11 @@ interface ChatViewProps {
    *  (used on desktop where there's no soft keyboard / Terminal InputBar). */
   showComposer?: boolean;
   paneId?: string;
+  /** Notified when the user starts a scroll gesture — parent can collapse
+   *  the keyboard / input bar to expand the visible area. */
+  onScrollGesture?: () => void;
+  /** Notified when the conversation transitions to/from the bottom. */
+  onAtBottomChange?: (atBottom: boolean) => void;
 }
 
 export function ChatView({
@@ -27,6 +32,8 @@ export function ChatView({
   bottomPadding,
   showComposer = false,
   paneId,
+  onScrollGesture,
+  onAtBottomChange,
 }: ChatViewProps) {
   const { t } = useTranslation();
   const { messages, isReady, ccSessionId } = useConversationStream({
@@ -68,6 +75,8 @@ export function ChatView({
       onClose={() => { /* close handled by parent */ }}
       scrollToBottom
       inline={inline}
+      onScrollGesture={onScrollGesture}
+      onAtBottomChange={onAtBottomChange}
     />
   );
 

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -1,0 +1,93 @@
+import { useTranslation } from 'react-i18next';
+import { ConversationViewer } from '../ConversationViewer';
+import { useConversationStream } from '../../hooks/useConversationStream';
+import { useInputEcho } from '../../hooks/useInputEcho';
+import { ChatComposer } from './ChatComposer';
+
+interface ChatViewProps {
+  sessionId: string;
+  title?: string;
+  subtitle?: string;
+  inline?: boolean;
+  enabled?: boolean;
+  /** Extra bottom padding (px) so trailing messages aren't covered by floating UI like a soft keyboard. */
+  bottomPadding?: number;
+  /** When set with a tmux paneId, render an input form below the conversation
+   *  (used on desktop where there's no soft keyboard / Terminal InputBar). */
+  showComposer?: boolean;
+  paneId?: string;
+}
+
+export function ChatView({
+  sessionId,
+  title,
+  subtitle,
+  inline = true,
+  enabled = true,
+  bottomPadding,
+  showComposer = false,
+  paneId,
+}: ChatViewProps) {
+  const { t } = useTranslation();
+  const { messages, isReady, ccSessionId } = useConversationStream({
+    sessionId,
+    enabled,
+  });
+  const echo = useInputEcho(sessionId);
+
+  const resolvedTitle = title ?? t('conversation.claude');
+  const resolvedSubtitle = subtitle ?? (ccSessionId ? `cc:${ccSessionId.slice(0, 8)}` : undefined);
+
+  // Avoid showing a "Loading..." flash every time the view opens. Until the
+  // initial conversation arrives, render an empty container.
+  if (!isReady && messages.length === 0) {
+    const emptyClass = inline ? 'h-full bg-[#0a0a0a]' : 'fixed inset-0 z-50 bg-[#0a0a0a]';
+    return <div className={emptyClass} />;
+  }
+
+  const composer = showComposer ? (
+    <ChatComposer sessionId={sessionId} paneId={paneId} />
+  ) : null;
+
+  // Prompt-style line at the bottom of the conversation showing what the user
+  // is currently typing via FloatingKeyboard / InputBar (terminal echo
+  // surrogate). Only relevant when the in-view composer is not present.
+  const echoLine = !composer ? (
+    <div className="shrink-0 px-3 py-1.5 border-t border-white/[0.06] bg-[#0a0a0a] font-mono text-[13px] text-zinc-300 whitespace-pre overflow-x-auto min-h-[32px] flex items-center">
+      <span className="text-blue-400/70 mr-2 select-none">{'>'}</span>
+      {echo ? <span>{echo}<span className="inline-block w-[8px] h-[14px] bg-zinc-300 ml-[1px] align-middle animate-pulse" /></span> : <span className="text-zinc-700">入力待ち…</span>}
+    </div>
+  ) : null;
+
+  const viewer = (
+    <ConversationViewer
+      title={resolvedTitle}
+      subtitle={resolvedSubtitle}
+      messages={messages}
+      isLoading={false}
+      onClose={() => { /* close handled by parent */ }}
+      scrollToBottom
+      inline={inline}
+    />
+  );
+
+  if (composer || echoLine) {
+    return (
+      <div className="h-full flex flex-col" style={bottomPadding ? { paddingBottom: bottomPadding } : undefined}>
+        <div className="flex-1 min-h-0">{viewer}</div>
+        {echoLine}
+        {composer}
+      </div>
+    );
+  }
+
+  if (bottomPadding && bottomPadding > 0) {
+    return (
+      <div className="h-full flex flex-col" style={{ paddingBottom: bottomPadding }}>
+        {viewer}
+      </div>
+    );
+  }
+
+  return viewer;
+}

--- a/frontend/src/hooks/useConversationStream.ts
+++ b/frontend/src/hooks/useConversationStream.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { subscribeConversation, unsubscribeConversation } from './useMultiplexedTerminal';
+import type { ConversationMessage } from '../../../shared/types';
+
+interface ConversationEventDetail {
+  type: 'conversation-subscribed' | 'conversation-unsubscribed' | 'initial-conversation' | 'conversation-update';
+  sessionId: string;
+  ccSessionId?: string | null;
+  messages?: ConversationMessage[];
+}
+
+interface UseConversationStreamOptions {
+  sessionId: string;
+  enabled?: boolean;
+  token?: string | null;
+}
+
+interface UseConversationStreamResult {
+  messages: ConversationMessage[];
+  isReady: boolean;
+  ccSessionId: string | null;
+}
+
+export function useConversationStream({
+  sessionId,
+  enabled = true,
+  token,
+}: UseConversationStreamOptions): UseConversationStreamResult {
+  const [messages, setMessages] = useState<ConversationMessage[]>([]);
+  const [isReady, setIsReady] = useState(false);
+  const [ccSessionId, setCcSessionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !sessionId) {
+      return;
+    }
+
+    setMessages([]);
+    setIsReady(false);
+    setCcSessionId(null);
+
+    const handler = (ev: Event) => {
+      const detail = (ev as CustomEvent<ConversationEventDetail>).detail;
+      if (!detail || detail.sessionId !== sessionId) return;
+
+      switch (detail.type) {
+        case 'conversation-subscribed':
+          setCcSessionId(detail.ccSessionId ?? null);
+          break;
+        case 'conversation-unsubscribed':
+          break;
+        case 'initial-conversation':
+          setMessages(detail.messages ?? []);
+          setIsReady(true);
+          break;
+        case 'conversation-update':
+          if (detail.messages && detail.messages.length > 0) {
+            setMessages(prev => [...prev, ...(detail.messages ?? [])]);
+          }
+          break;
+      }
+    };
+
+    window.addEventListener('cchub-conversation', handler);
+    subscribeConversation(sessionId, token);
+
+    return () => {
+      window.removeEventListener('cchub-conversation', handler);
+      unsubscribeConversation(sessionId);
+    };
+  }, [sessionId, enabled, token]);
+
+  return { messages, isReady, ccSessionId };
+}

--- a/frontend/src/hooks/useInputEcho.ts
+++ b/frontend/src/hooks/useInputEcho.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface InputEchoDetail {
+  sessionId: string;
+  paneId: string;
+  data: string;
+}
+
+const MAX_LEN = 80;
+const CLEAR_AFTER_MS = 4000;
+
+function appendChar(prev: string, char: string): string {
+  let next = prev;
+  if (char === '\x7f' || char === '\b') {
+    next = next.slice(0, -1);
+  } else if (char === '\r' || char === '\n') {
+    next = '';
+  } else if (char === '\x1b') {
+    next = `${next} ⎋ `;
+  } else if (char === '\x03') {
+    next = `${next} ^C `;
+  } else if (char === '\x04') {
+    next = `${next} ^D `;
+  } else if (char === '\x05') {
+    next = `${next} ^E `;
+  } else if (char === '\x0f') {
+    next = `${next} ^O `;
+  } else if (char === '\t') {
+    next = `${next} ⇥ `;
+  } else if (char === '\x1b[A') {
+    next = `${next}↑`;
+  } else if (char === '\x1b[B') {
+    next = `${next}↓`;
+  } else if (char === '\x1b[C') {
+    next = `${next}→`;
+  } else if (char === '\x1b[D') {
+    next = `${next}←`;
+  } else if (char.startsWith('\x1b[200~') && char.endsWith('\x1b[201~')) {
+    // bracketed paste: extract payload
+    next = `${next}${char.slice(6, -6)}`;
+  } else if (char.length === 1 && char.charCodeAt(0) >= 0x20) {
+    next = next + char;
+  } else if (char.length > 1) {
+    // multi-byte (CJK etc.) — strip control bytes if any
+    next = next + char.replace(/[\x00-\x1f\x7f]/g, '');
+  }
+  return next.slice(-MAX_LEN);
+}
+
+/**
+ * Subscribe to local input echoes for a given session. Returns the latest
+ * accumulated buffer of characters sent. Used by chat views to display the
+ * user's in-progress typing when the destination terminal is hidden.
+ */
+export function useInputEcho(sessionId: string | null | undefined): string {
+  const [buffer, setBuffer] = useState('');
+  const clearTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    setBuffer('');
+
+    const handler = (ev: Event) => {
+      const detail = (ev as CustomEvent<InputEchoDetail>).detail;
+      if (!detail || detail.sessionId !== sessionId) return;
+      setBuffer(prev => appendChar(prev, detail.data));
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+      clearTimerRef.current = window.setTimeout(() => setBuffer(''), CLEAR_AFTER_MS);
+    };
+
+    window.addEventListener('cchub-input-echo', handler);
+    return () => {
+      window.removeEventListener('cchub-input-echo', handler);
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    };
+  }, [sessionId]);
+
+  return buffer;
+}

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -56,6 +56,25 @@ let sharedReconnectTimeout: number | null = null;
 let subscribedSession: string | null = null;
 let wsReady = false; // true after server sends 'ready'
 
+// Conversation subscriptions (multiple sessions can be subscribed at once)
+const subscribedConversations = new Set<string>();
+const pendingConversationSubs = new Set<string>();
+const pendingConversationUnsubs = new Set<string>();
+
+function flushConversationPending() {
+  if (!sharedWs || sharedWs.readyState !== WebSocket.OPEN || !wsReady) return;
+  for (const sid of pendingConversationUnsubs) {
+    sharedWs.send(JSON.stringify({ type: 'unsubscribe-conversation', sessionId: sid }));
+    subscribedConversations.delete(sid);
+  }
+  pendingConversationUnsubs.clear();
+  for (const sid of pendingConversationSubs) {
+    sharedWs.send(JSON.stringify({ type: 'subscribe-conversation', sessionId: sid }));
+    subscribedConversations.add(sid);
+  }
+  pendingConversationSubs.clear();
+}
+
 // Current hook instance's callbacks (only one active at a time)
 type MuxCallbacks = {
   onPaneOutput?: (paneId: string, data: Uint8Array) => void;
@@ -198,6 +217,11 @@ function ensureConnection(token?: string | null) {
         if (currentSession) {
           subscribeToSession(currentSession, true);
         }
+        // Re-subscribe any conversation streams that were active before reconnect
+        for (const sid of subscribedConversations) {
+          pendingConversationSubs.add(sid);
+        }
+        flushConversationPending();
         break;
       }
       case 'subscribed': {
@@ -264,6 +288,13 @@ function ensureConnection(token?: string | null) {
         );
         break;
       }
+      case 'conversation-subscribed':
+      case 'conversation-unsubscribed':
+      case 'initial-conversation':
+      case 'conversation-update': {
+        window.dispatchEvent(new CustomEvent('cchub-conversation', { detail: msg }));
+        break;
+      }
     }
   };
 
@@ -310,6 +341,59 @@ function registerVisibilityListener() {
       ensureConnection();
     }
   });
+}
+
+// =============================================================================
+// Conversation stream API (shared singleton, multiple subscribers supported)
+// =============================================================================
+
+export function subscribeConversation(sessionId: string, token?: string | null) {
+  pendingConversationUnsubs.delete(sessionId);
+  if (sharedWs?.readyState === WebSocket.OPEN && wsReady) {
+    if (!subscribedConversations.has(sessionId)) {
+      sharedWs.send(JSON.stringify({ type: 'subscribe-conversation', sessionId }));
+      subscribedConversations.add(sessionId);
+    } else {
+      // Already subscribed — re-request initial messages
+      sharedWs.send(JSON.stringify({ type: 'subscribe-conversation', sessionId }));
+    }
+  } else {
+    pendingConversationSubs.add(sessionId);
+    ensureConnection(token);
+  }
+}
+
+export function unsubscribeConversation(sessionId: string) {
+  pendingConversationSubs.delete(sessionId);
+  subscribedConversations.delete(sessionId);
+  if (sharedWs?.readyState === WebSocket.OPEN && wsReady) {
+    sharedWs.send(JSON.stringify({ type: 'unsubscribe-conversation', sessionId }));
+  } else {
+    pendingConversationUnsubs.add(sessionId);
+  }
+}
+
+/**
+ * Send terminal input to a specific pane on a session, regardless of which session
+ * the active terminal hook is subscribed to. Used by ChatView's composer.
+ */
+export function sendTerminalInput(sessionId: string, paneId: string, data: string): boolean {
+  if (sharedWs?.readyState !== WebSocket.OPEN || !wsReady) return false;
+  const bytes = new TextEncoder().encode(data);
+  const base64 = uint8ArrayToBase64(bytes);
+  sharedWs.send(JSON.stringify({ type: 'input', sessionId, paneId, data: base64 }));
+  dispatchInputEcho(sessionId, paneId, data);
+  return true;
+}
+
+/**
+ * Notify listeners that input was sent to a pane. Used by chat views to show a
+ * local echo of in-progress typing when the destination terminal is hidden.
+ */
+export function dispatchInputEcho(sessionId: string, paneId: string, data: string) {
+  window.dispatchEvent(new CustomEvent('cchub-input-echo', {
+    detail: { sessionId, paneId, data },
+  }));
 }
 
 // =============================================================================
@@ -390,6 +474,7 @@ export function useMultiplexedTerminal(options: UseMultiplexedTerminalOptions): 
     const bytes = new TextEncoder().encode(data);
     const base64 = uint8ArrayToBase64(bytes);
     sendSessionMessage({ type: 'input', paneId, data: base64 });
+    if (subscribedSession) dispatchInputEcho(subscribedSession, paneId, data);
   }, []);
 
   const resize = useCallback((cols: number, rows: number) => {

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -22,6 +22,12 @@ interface TerminalPageProps {
   theme?: SessionTheme;
   onPanesChange?: (panes: PaneLeafInfo[]) => void;
   externalActivePaneId?: string | null;
+  /** When set, replaces the xterm area while keeping the InputBar visible below.
+   *  Always rendered (when truthy) so React state/subscriptions persist; visibility
+   *  is toggled via `mainOverlayVisible`. */
+  mainOverlay?: ReactNode;
+  /** Whether the mainOverlay is currently shown. Defaults to `!!mainOverlay`. */
+  mainOverlayVisible?: boolean;
 }
 
 export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(function TerminalPage({
@@ -35,6 +41,8 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(function 
   theme,
   onPanesChange,
   externalActivePaneId,
+  mainOverlay,
+  mainOverlayVisible,
 }, ref) {
   const [error, setError] = useState<string | null>(null);
   const [activePaneId, setActivePaneId] = useState<string | null>(null);
@@ -293,7 +301,8 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(function 
         </div>
       )}
 
-      {/* Terminal - full screen */}
+      {/* Terminal - full screen. mainOverlay (e.g. ChatView) replaces the
+          xterm area while the InputBar inside TerminalComponent remains visible. */}
       <main className="flex-1 relative overflow-hidden min-h-0 select-none">
         <TerminalComponent
           ref={ref}
@@ -304,6 +313,8 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(function 
           showOverlay={showOverlay}
           theme={theme}
           controlMode={controlMode}
+          hideTerminalArea={!!mainOverlay && (mainOverlayVisible ?? true)}
+          terminalAreaOverlay={mainOverlay}
         />
       </main>
     </div>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -426,6 +426,8 @@ export type ControlServerMessage =
 export type MuxClientMessage =
   | { type: 'subscribe'; sessionId: string }
   | { type: 'unsubscribe'; sessionId: string }
+  | { type: 'subscribe-conversation'; sessionId: string }
+  | { type: 'unsubscribe-conversation'; sessionId: string }
   | (ControlClientMessage & { sessionId: string });
 
 // Server → Client messages for /ws/mux
@@ -433,6 +435,10 @@ export type MuxServerMessage =
   | { type: 'subscribed'; sessionId: string }
   | { type: 'unsubscribed'; sessionId: string }
   | { type: 'sessions-updated'; sessions: SessionResponse[] }
+  | { type: 'conversation-subscribed'; sessionId: string; ccSessionId: string | null }
+  | { type: 'conversation-unsubscribed'; sessionId: string }
+  | { type: 'initial-conversation'; sessionId: string; messages: ConversationMessage[] }
+  | { type: 'conversation-update'; sessionId: string; messages: ConversationMessage[] }
   | (ControlServerMessage & { sessionId: string });
 
 // Binary frame format for mux output:


### PR DESCRIPTION
## Summary
- Adds an alternate view that replaces the xterm area with the live Claude conversation history while keeping existing input paths intact (Terminal InputBar / FloatingKeyboard / desktop ChatComposer).
- Backend: `ConversationWatcher` streams JSONL changes via `fs.watch` (150ms debounce). New WebSocket messages: `subscribe-conversation` / `initial-conversation` / `conversation-update` / `unsubscribe-conversation`.
- Frontend: `ChatView` renders `ConversationViewer` with the live message stream. Per-pane chat mode persisted to localStorage so split/remount keeps state. Per-session mode also persisted. Single-icon Terminal/Chat toggle. Close/zoom buttons hidden when only one pane exists.
- `ConversationViewer`: image lightbox (inline + tool-result), tighter density, persisted font size with pinch zoom and bottom-left controls, echo prompt line at the bottom mirroring keyboard sends.
- `ChatComposer`: textarea + send button on desktop. Tablet/mobile reuse the existing keyboards; sends dispatch echo events the chat view listens to.

## Test plan
- [ ] Mobile: open chat for a Claude session, type via Terminal InputBar, confirm message appears in conversation history; switch sessions and confirm per-session mode persists
- [ ] Tablet: open chat in a pane, type via FloatingKeyboard (keyboard / 入力 modes), confirm echo prompt at bottom of conversation reflects sent chars
- [ ] Desktop: open chat in a pane, type in ChatComposer textarea, confirm send goes to the right tmux pane
- [ ] Split a pane in chat mode → confirm chat view persists (does not revert to terminal)
- [ ] Tap an inline image in conversation → lightbox opens; tap background / × / Esc → closes
- [ ] Pinch / +/− buttons change conversation font size; size survives reload
- [ ] Processing / 入力待ち badges reflect the active Claude indicator (not just attached state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)