### PR TITLE
Release v0.1.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.92] - 2026-04-29
+
+### Changed
+- 会話履歴ビューの背景色をセッションテーマカラーに同期
+  - ターミナル背景と一致した色（pink / indigo / teal 等）でチャットビュー全体（コンテナ・エコー行・ローディング表示）を着色
+  - 視覚的な一体感を向上、セッション切替時のテーマも追従
+
 ## [0.1.91] - 2026-04-29
 
 ### Added

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { SessionList } from './components/SessionList';
 import { DesktopLayout } from './components/DesktopLayout';
 import { FileViewer } from './components/files/FileViewer';
 import { ChatView } from './components/chat/ChatView';
+import { getTerminalThemes } from './components/terminal-themes';
 import { LoginForm } from './components/LoginForm';
 import { Onboarding, useOnboarding } from './components/Onboarding';
 import { useAuth } from './hooks/useAuth';
@@ -929,8 +930,9 @@ export function App() {
             // Keeping ChatView mounted preserves the conversation subscription so
             // messages are pre-loaded by the time the user toggles to chat mode —
             // avoiding the black/loading flash on every open.
+            const themeBg = getTerminalThemes()[activeSession.theme || 'default'].background;
             const chatOverlay = activeSession.ccSessionId ? (
-              <div className="h-full flex flex-col bg-[#0a0a0a]">
+              <div className="h-full flex flex-col" style={{ backgroundColor: themeBg }}>
                 <div
                   className="flex items-center gap-2 px-3 py-2 border-b border-white/[0.06] shrink-0"
                   style={{ paddingTop: 'max(env(safe-area-inset-top, 0px), 8px)' }}
@@ -973,6 +975,7 @@ export function App() {
                     subtitle={activeSession.currentPath?.replace(/^\/home\/[^/]+\//, '~/')}
                     inline
                     enabled
+                    theme={activeSession.theme}
                     onScrollGesture={() => mobileTerminalRef.current?.hideKeyboard()}
                     onAtBottomChange={(atBottom) => {
                       if (atBottom) mobileTerminalRef.current?.showKeyboard();

--- a/frontend/src/components/ConversationViewer.tsx
+++ b/frontend/src/components/ConversationViewer.tsx
@@ -4,7 +4,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import type { ConversationMessage, ToolUseInfo, ToolResultInfo } from '../../../shared/types';
+import type { ConversationMessage, ToolUseInfo, ToolResultInfo, SessionTheme } from '../../../shared/types';
+import { getTerminalThemes } from './terminal-themes';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
@@ -269,6 +270,8 @@ interface ConversationViewerProps {
    *  parent uses this to hide the keyboard while the user is reading
    *  history and re-show it when they return to the latest message. */
   onAtBottomChange?: (atBottom: boolean) => void;
+  /** Session theme — used to color the background to match the Terminal. */
+  theme?: SessionTheme;
 }
 
 // Markdown components configuration
@@ -414,6 +417,7 @@ export function ConversationViewer({
   inline = false,
   onScrollGesture,
   onAtBottomChange,
+  theme,
 }: ConversationViewerProps) {
   const { t } = useTranslation();
   const parentRef = useRef<HTMLDivElement>(null);
@@ -648,11 +652,12 @@ export function ConversationViewer({
 
   // Container class based on inline mode
   const containerClass = inline
-    ? 'h-full flex flex-col bg-[#0a0a0a] relative'
-    : 'fixed inset-0 z-50 flex flex-col bg-[#0a0a0a]';
+    ? 'h-full flex flex-col relative'
+    : 'fixed inset-0 z-50 flex flex-col';
+  const themeBg = getTerminalThemes()[theme || 'default'].background;
 
   return (
-    <div className={containerClass}>
+    <div className={containerClass} style={{ backgroundColor: themeBg }}>
       {/* Floating font-size controls (bottom-left) — only visible when the
           user is actively changing the size (via pinch / button) or hovering
           the bottom-left hot-zone on desktop. Tap the small "Aa" badge on
@@ -769,7 +774,7 @@ export function ConversationViewer({
 
       {/* Footer - only show in modal mode */}
       {!inline && (
-        <div className="flex items-center px-3 py-2 border-t border-white/[0.06] bg-[#0a0a0a] shrink-0">
+        <div className="flex items-center px-3 py-2 border-t border-white/[0.06] shrink-0" style={{ backgroundColor: themeBg }}>
           <button
             onClick={onClose}
             className="p-1.5 text-zinc-500 hover:text-zinc-300 transition-colors"

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -492,6 +492,7 @@ function TerminalPane({
             // the active pane (same as Terminal mode) — no in-view composer.
             showComposer={!isTablet}
             paneId={controlModeContext.getControlConfig(paneId)?.paneId}
+            theme={session?.theme}
           />
         )}
         {sessionId ? (

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -3,6 +3,8 @@ import { ConversationViewer } from '../ConversationViewer';
 import { useConversationStream } from '../../hooks/useConversationStream';
 import { useInputEcho } from '../../hooks/useInputEcho';
 import { ChatComposer } from './ChatComposer';
+import { getTerminalThemes } from '../terminal-themes';
+import type { SessionTheme } from '../../../../shared/types';
 
 interface ChatViewProps {
   sessionId: string;
@@ -21,6 +23,8 @@ interface ChatViewProps {
   onScrollGesture?: () => void;
   /** Notified when the conversation transitions to/from the bottom. */
   onAtBottomChange?: (atBottom: boolean) => void;
+  /** Session theme — propagated to ConversationViewer for matching bg color. */
+  theme?: SessionTheme;
 }
 
 export function ChatView({
@@ -34,6 +38,7 @@ export function ChatView({
   paneId,
   onScrollGesture,
   onAtBottomChange,
+  theme,
 }: ChatViewProps) {
   const { t } = useTranslation();
   const { messages, isReady, ccSessionId } = useConversationStream({
@@ -45,11 +50,13 @@ export function ChatView({
   const resolvedTitle = title ?? t('conversation.claude');
   const resolvedSubtitle = subtitle ?? (ccSessionId ? `cc:${ccSessionId.slice(0, 8)}` : undefined);
 
+  const themeBg = getTerminalThemes()[theme || 'default'].background;
+
   // Avoid showing a "Loading..." flash every time the view opens. Until the
   // initial conversation arrives, render an empty container.
   if (!isReady && messages.length === 0) {
-    const emptyClass = inline ? 'h-full bg-[#0a0a0a]' : 'fixed inset-0 z-50 bg-[#0a0a0a]';
-    return <div className={emptyClass} />;
+    const emptyClass = inline ? 'h-full' : 'fixed inset-0 z-50';
+    return <div className={emptyClass} style={{ backgroundColor: themeBg }} />;
   }
 
   const composer = showComposer ? (
@@ -60,7 +67,10 @@ export function ChatView({
   // is currently typing via FloatingKeyboard / InputBar (terminal echo
   // surrogate). Only relevant when the in-view composer is not present.
   const echoLine = !composer ? (
-    <div className="shrink-0 px-3 py-1.5 border-t border-white/[0.06] bg-[#0a0a0a] font-mono text-[13px] text-zinc-300 whitespace-pre overflow-x-auto min-h-[32px] flex items-center">
+    <div
+      className="shrink-0 px-3 py-1.5 border-t border-white/[0.06] font-mono text-[13px] text-zinc-300 whitespace-pre overflow-x-auto min-h-[32px] flex items-center"
+      style={{ backgroundColor: themeBg }}
+    >
       <span className="text-blue-400/70 mr-2 select-none">{'>'}</span>
       {echo ? <span>{echo}<span className="inline-block w-[8px] h-[14px] bg-zinc-300 ml-[1px] align-middle animate-pulse" /></span> : <span className="text-zinc-700">入力待ち…</span>}
     </div>
@@ -77,6 +87,7 @@ export function ChatView({
       inline={inline}
       onScrollGesture={onScrollGesture}
       onAtBottomChange={onAtBottomChange}
+      theme={theme}
     />
   );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- **feat(chat)**: 会話履歴ビューの背景色をセッションテーマカラー（pink / indigo / teal 等）に同期。ターミナル背景と一致し視覚的な一体感を向上
- コンテナ・フッター・ローディング状態・エコー行・モバイルチャットオーバーレイすべてがテーマカラーで統一

## Notes
詳細は CHANGELOG.md 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)