### PR TITLE
feat(macos): store cchub password in Keychain + help text fixes

### DIFF
--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -23,7 +23,7 @@ CC Hub v${VERSION} - Claude Code Session Manager
 
 ${t('cli.usage')}
   ${t('cli.serverStart')}
-  cchub setup [options]     systemd service setup
+  cchub setup [options]     Register service (systemd on Linux, launchd on macOS)
   cchub uninstall           Remove service registration
   cchub update [options]    Check and apply updates
   cchub status              Show service status
@@ -41,7 +41,7 @@ update options:
 ${t('cli.examples')}
   ${t('cli.exampleStart')}
   ${t('cli.exampleWithPort')}
-  cchub setup -P secret      Setup systemd service
+  cchub setup -P secret      Register service with password (stored in Keychain on macOS)
   cchub update               Update to latest
 `);
 }

--- a/backend/src/commands/setup.ts
+++ b/backend/src/commands/setup.ts
@@ -4,6 +4,17 @@ import { mkdir, writeFile, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { t } from '../i18n';
+import { storePassword as storePasswordInKeychain } from '../utils/keychain';
+
+/** Escape special characters for safe inclusion in XML/plist content. */
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
 
 // ─── Linux: systemd ───
 
@@ -45,9 +56,14 @@ WantedBy=timers.target
 
 // ─── macOS: launchd ───
 
-function buildLaunchdPlist(execPath: string, port: number, password?: string): string {
+/**
+ * Build the launchd plist for the cchub server.
+ * The password is NOT embedded here — it is read from the macOS Keychain at
+ * runtime by `cchub` itself, so the plist file stays free of secrets.
+ */
+function buildLaunchdPlist(execPath: string, port: number): string {
   const args = [execPath, '-p', String(port)];
-  if (password) args.push('-P', password);
+  const logPath = join(homedir(), '.cc-hub', 'cchub.log');
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -57,16 +73,16 @@ function buildLaunchdPlist(execPath: string, port: number, password?: string): s
   <string>com.cchub.server</string>
   <key>ProgramArguments</key>
   <array>
-${args.map(a => `    <string>${a}</string>`).join('\n')}
+${args.map(a => `    <string>${escapeXml(a)}</string>`).join('\n')}
   </array>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
   <true/>
   <key>StandardOutPath</key>
-  <string>${join(homedir(), '.cc-hub', 'cchub.log')}</string>
+  <string>${escapeXml(logPath)}</string>
   <key>StandardErrorPath</key>
-  <string>${join(homedir(), '.cc-hub', 'cchub.log')}</string>
+  <string>${escapeXml(logPath)}</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
@@ -78,6 +94,7 @@ ${args.map(a => `    <string>${a}</string>`).join('\n')}
 }
 
 function buildLaunchdUpdatePlist(execPath: string): string {
+  const logPath = join(homedir(), '.cc-hub', 'update.log');
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -86,7 +103,7 @@ function buildLaunchdUpdatePlist(execPath: string): string {
   <string>com.cchub.update</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${execPath}</string>
+    <string>${escapeXml(execPath)}</string>
     <string>update</string>
     <string>--auto</string>
   </array>
@@ -96,9 +113,9 @@ function buildLaunchdUpdatePlist(execPath: string): string {
     <integer>4</integer>
   </dict>
   <key>StandardOutPath</key>
-  <string>${join(homedir(), '.cc-hub', 'update.log')}</string>
+  <string>${escapeXml(logPath)}</string>
   <key>StandardErrorPath</key>
-  <string>${join(homedir(), '.cc-hub', 'update.log')}</string>
+  <string>${escapeXml(logPath)}</string>
 </dict>
 </plist>
 `;
@@ -126,9 +143,19 @@ async function setupLaunchd(port: number, password?: string): Promise<void> {
   await mkdir(launchAgentsDir, { recursive: true });
   await mkdir(logDir, { recursive: true });
 
-  // Main service plist
+  // Store password in macOS Keychain instead of embedding in plist (which is
+  // world-readable). cchub at runtime reads it back via `security`.
+  if (password) {
+    if (storePasswordInKeychain(password)) {
+      console.log('🔐 パスワードを Keychain に保存しました (service: cchub)');
+    } else {
+      console.log('⚠️  Keychain への保存に失敗しました');
+    }
+  }
+
+  // Main service plist (no password embedded — read from Keychain at runtime)
   const plistPath = join(launchAgentsDir, 'com.cchub.server.plist');
-  await writeFile(plistPath, buildLaunchdPlist(execPath, port, password));
+  await writeFile(plistPath, buildLaunchdPlist(execPath, port));
   console.log(`✅ サービスファイル: ${plistPath}`);
 
   // Update plist

--- a/backend/src/commands/uninstall.ts
+++ b/backend/src/commands/uninstall.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { t } from '../i18n';
+import { deletePassword as deletePasswordFromKeychain } from '../utils/keychain';
 
 export async function uninstallService(): Promise<void> {
   if (platform() === 'darwin') {
@@ -39,6 +40,11 @@ async function uninstallLaunchd(): Promise<void> {
     console.log(`✅ ${t('uninstall.removedUpdate')}: ${updatePlistPath}`);
   } else {
     console.log(`⏭️  ${t('uninstall.notFound')}: ${updatePlistPath}`);
+  }
+
+  // Remove password from Keychain (no-op if not stored)
+  if (deletePasswordFromKeychain()) {
+    console.log('🔐 Keychain からパスワードを削除しました');
   }
 
   console.log('');

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -275,10 +275,29 @@ if (needsCert) {
   console.log(`📜 Certificate generated: ${certDir}`);
 }
 
-// Store password in environment for auth middleware
-if (args.password) {
-  process.env.CCHUB_PASSWORD = args.password;
-  console.log(`🔒 ${t('server.passwordEnabled')}`);
+// Store password in environment for auth middleware. Priority:
+//   1. -P CLI arg
+//   2. CCHUB_PASSWORD env var (set by systemd EnvironmentFile etc.)
+//   3. macOS Keychain (service: cchub) — populated by `cchub setup`
+let resolvedPassword: string | undefined = args.password;
+let passwordSource: 'cli' | 'env' | 'keychain' | 'none' = args.password ? 'cli' : 'none';
+if (!resolvedPassword && process.env.CCHUB_PASSWORD) {
+  resolvedPassword = process.env.CCHUB_PASSWORD;
+  passwordSource = 'env';
+}
+if (!resolvedPassword && process.platform === 'darwin') {
+  const { readPassword } = await import('./utils/keychain');
+  const fromKeychain = readPassword();
+  if (fromKeychain) {
+    resolvedPassword = fromKeychain;
+    passwordSource = 'keychain';
+  }
+}
+if (resolvedPassword) {
+  process.env.CCHUB_PASSWORD = resolvedPassword;
+  const sourceLabel = passwordSource === 'keychain' ? ' (Keychain)' :
+    passwordSource === 'env' ? ' (env)' : '';
+  console.log(`🔒 ${t('server.passwordEnabled')}${sourceLabel}`);
 } else {
   console.log(`⚠️  ${t('server.passwordNotSet')}`);
 }

--- a/backend/src/utils/keychain.ts
+++ b/backend/src/utils/keychain.ts
@@ -1,0 +1,52 @@
+// macOS Keychain helpers for storing the cchub server password.
+//
+// Linux has no equivalent reliable headless secret store, so these helpers are
+// no-ops on non-darwin platforms.
+
+const SERVICE = 'cchub';
+
+function getAccount(): string {
+  return process.env.USER || 'cchub';
+}
+
+/** Read the cchub password from the macOS Keychain. Returns undefined if not stored or not on darwin. */
+export function readPassword(): string | undefined {
+  if (process.platform !== 'darwin') return undefined;
+  try {
+    const result = Bun.spawnSync(['security', 'find-generic-password', '-s', SERVICE, '-w']);
+    if (result.exitCode !== 0) return undefined;
+    const out = result.stdout.toString().trim();
+    return out || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Store (or update) the cchub password in the macOS Keychain. Returns true on success. */
+export function storePassword(password: string): boolean {
+  if (process.platform !== 'darwin') return false;
+  try {
+    // -U updates the existing entry if present, otherwise adds a new one.
+    const result = Bun.spawnSync([
+      'security', 'add-generic-password',
+      '-s', SERVICE,
+      '-a', getAccount(),
+      '-w', password,
+      '-U',
+    ]);
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Delete the cchub password from the macOS Keychain. Returns true if deleted. */
+export function deletePassword(): boolean {
+  if (process.platform !== 'darwin') return false;
+  try {
+    const result = Bun.spawnSync(['security', 'delete-generic-password', '-s', SERVICE]);
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Improvements to `cchub setup` on macOS:

1. **Password is no longer stored in plain text in the launchd plist.** Previously `cchub setup -P pass` wrote the password into `~/Library/LaunchAgents/com.cchub.server.plist` as `<string>pass</string>`, which is readable by anyone with home directory access (and would corrupt the plist if the password contained `<`, `>`, `&`, `"`, or `'`). Now the password lives in the macOS Keychain (`security add-generic-password -s cchub`) and `cchub` retrieves it at startup.
2. **Help output no longer says "systemd" on macOS.** `cchub --help` previously described `setup` as "systemd service setup" regardless of platform.
3. **All user-supplied strings interpolated into plist files are now XML-escaped** (defensive — no observable impact on typical inputs).

## Behavior changes

### macOS, fresh setup
```sh
cchub setup -P mypass
# 🔐 パスワードを Keychain に保存しました (service: cchub)
# ✅ サービスファイル: ~/Library/LaunchAgents/com.cchub.server.plist  (no -P inside)
```

### macOS, existing setup (compatibility)
Existing installations keep working — their plist still has `-P pass` and that path through `args.password` is unchanged. To migrate, re-run `cchub setup -P pass`. The plist will be regenerated without the password and the password moves to Keychain.

### Server startup priority for password
1. `-P` CLI arg (highest)
2. `CCHUB_PASSWORD` env var (e.g. systemd `EnvironmentFile`)
3. macOS Keychain (`service: cchub`)
4. None — auth disabled

The source is logged on startup for transparency: `🔒 Authentication enabled (Keychain)`.

### `cchub uninstall` on macOS
Now also removes the Keychain entry (logged as `🔐 Keychain からパスワードを削除しました` if anything was stored).

### Linux
No change. There is no equivalent reliable headless secret store on Linux for unattended services, so the existing `EnvironmentFile=%h/.config/cchub/env` approach is kept.

## Test plan

- [x] `bun run --filter backend lint` passes
- [x] Round-trip test: `storePassword` → `readPassword` → `deletePassword` works correctly on macOS, including passwords containing `<`, `>`, `&`, `"`, `'`
- [x] `cchub --help` no longer claims "systemd" for setup
- [ ] Manual: `cchub setup -P testpw` on macOS writes plist without password and creates Keychain entry; subsequent `cchub` startup logs `(Keychain)` source
- [ ] Manual: `cchub uninstall` on macOS removes the Keychain entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)