### PR TITLE
fix(macos): detect Claude Code at pane level for non-standard install paths

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -148,21 +148,24 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       panes: s.panes ? s.panes.map((p: { paneId: string; command: string; path: string; title: string; tty: string; isActive: boolean; isDead: boolean; pid?: number }) => {
         const ttyName = p.tty?.replace('/dev/', '');
         const agentInfo = ttyName ? agentInfoByTty.get(ttyName) : undefined;
+        const isClaudeOnPane = !p.isDead && !!ttyName && claudeOnPaneTtys.has(ttyName);
         let paneIndicator: IndicatorState | undefined;
         if (p.isDead) {
           paneIndicator = 'completed';
+        } else if (isClaudeOnPane) {
+          // Use session-level indicator for Claude panes (hook/jsonl based)
+          paneIndicator = indicatorState === 'completed' ? 'waiting_input' : indicatorState;
         } else {
-          const isClaudeOnPane = ttyName ? claudeOnPaneTtys.has(ttyName) : false;
-          if (isClaudeOnPane) {
-            // Use session-level indicator for Claude panes (hook/jsonl based)
-            paneIndicator = indicatorState === 'completed' ? 'waiting_input' : indicatorState;
-          } else {
-            paneIndicator = 'idle';
-          }
+          paneIndicator = 'idle';
         }
+        // Prefer the ps-based detection over tmux's pane_current_command, which
+        // on macOS sometimes returns the Claude version (e.g. "2.1.123") when the
+        // binary is invoked via a non-standard path. The frontend relies on this
+        // string equaling "claude" to enable the conversation toggle.
+        const currentCommand = isClaudeOnPane ? 'claude' : p.command;
         const pane: PaneInfo = {
           paneId: p.paneId,
-          currentCommand: p.command,
+          currentCommand,
           currentPath: p.path,
           title: p.title || undefined,
           agentName: agentInfo?.agentName,

--- a/backend/src/services/tmux.ts
+++ b/backend/src/services/tmux.ts
@@ -360,10 +360,17 @@ export class TmuxService {
 
   /**
    * Check if process args indicate a Claude Code process.
-   * Matches 'claude ...' (main binary) or paths containing '/claude/versions/' (team agents).
+   *
+   * Matches the executable name `claude` regardless of install location:
+   *   - `claude` / `claude --resume`              (PATH-resolved invocation)
+   *   - `/usr/local/bin/claude` / `~/.local/bin/claude -c`  (full path)
+   *   - paths containing `/claude/versions/`       (team agents / version-pinned)
+   *
+   * The leading `(?:^|\/)` and trailing `(?:\s|$)` anchors avoid false matches
+   * on substrings like `.claude/shell-snapshots/...` or `claude-foo-cwd`.
    */
   private isClaudeProcess(args: string): boolean {
-    return args.startsWith('claude ') || args === 'claude' || args.includes('/claude/versions/');
+    return /(?:^|\/)claude(?:\s|$)/.test(args) || args.includes('/claude/versions/');
   }
 
   /**


### PR DESCRIPTION
## Symptom

On macOS, the conversation toggle (💬) in each pane header was rendered disabled even while Claude Code was running. The button condition is `disabled = !showConversation && !claudeAvailable`, where `claudeAvailable = activeTmuxPane?.currentCommand === 'claude'`. The API was returning `currentCommand: '2.1.123'` (the Claude Code version string) instead of `'claude'`.

## Root cause

Two layered bugs:

1. **Regex too restrictive** — `isClaudeProcess` in `backend/src/services/tmux.ts` only accepted `'claude '` / `'claude'` / `'/claude/versions/'` substrings in `ps` args. The user installer at `~/.local/bin/claude` produces args like `/Users/foo/.local/bin/claude -c`, which matched none of these. Result: ps-based detection failed and the session was tagged as "not running Claude".
2. **Pane-level data not mirrored** — Even when session-level detection succeeded, `pane.currentCommand` in `buildSessionsList` was forwarded straight from `tmux`'s `pane_current_command`. On macOS this sometimes returns the version (`2.1.123`) instead of `claude`. The session-level override (`tmux.ts:339-340`) had been in place for a while but was never extended to panes.

## Fix

```ts
// backend/src/services/tmux.ts
private isClaudeProcess(args: string): boolean {
  return /(?:^|\/)claude(?:\s|$)/.test(args) || args.includes('/claude/versions/');
}
```

The new regex matches `claude` only when:
- preceded by start-of-string or `/` (so `myclaude` and `.claude/...` don't match)
- followed by whitespace or end-of-string (so `claude-foo` and `claudex` don't match)

```ts
// backend/src/routes/sessions.ts (per-pane mapping)
const isClaudeOnPane = !p.isDead && !!ttyName && claudeOnPaneTtys.has(ttyName);
const currentCommand = isClaudeOnPane ? 'claude' : p.command;
```

Mirrors the session-level override.

## Validation

### Regex test cases (17/17 passed)
| Input | Old | New | Expected |
|-------|:-:|:-:|:-:|
| `claude` | ✅ | ✅ | match |
| `claude --resume` | ✅ | ✅ | match |
| `/usr/local/bin/claude` | ❌ | ✅ | match |
| `/Users/foo/.local/bin/claude -c` | ❌ | ✅ | match |
| `/opt/homebrew/bin/claude --resume` | ❌ | ✅ | match |
| `/foo/claude/versions/1.0.0/cli` | ✅ | ✅ | match |
| `/Users/foo/.claude/shell-snapshots/x.sh` | ❌ | ❌ | no match |
| `/some/path/claude-output.py` | ❌ | ❌ | no match |
| `/some/path/myclaude` | ❌ | ❌ | no match |
| `python /tmp/claude-output.py` | ❌ | ❌ | no match |

### API verification
```
# Before
session=cc-hub currentCommand='2.1.123'
  pane=%3 currentCommand='2.1.123' ACTIVE

# After
session=cc-hub currentCommand='claude'
  pane=%3 currentCommand='claude' ACTIVE
```

## Linux impact

**No regressions.** Linux's `tmux pane_current_command` already reports `claude` correctly, so:
- `p.command === 'claude'` was already true
- new override evaluates to `isClaudeOnPane ? 'claude' : 'claude'` = `'claude'` — no-op

The regex change is strictly additive (matches more cases, none fewer). Linux users invoking via full path (`/usr/local/bin/claude`) gain detection that was previously missed there too.

### Other code paths reading `pane.currentCommand`
- `PaneContainer.tsx:250` — chat toggle disabled state ← intent of fix
- `SessionList.tsx:842` — pane label in expanded session list (will show `claude` instead of `2.1.123`)
- `App.tsx:1031` — pane tab label fallback (same improvement)

All session-level checks (`s.currentCommand === 'claude'` at sessions.ts:46/55/64/116/279/303/463) were unaffected because session-level was already overridden via `tmux.ts:339-340`.

## Test plan

- [x] Regex matches/non-matches verified against 17 cases
- [x] Local API now returns `pane.currentCommand: 'claude'` for active pane
- [x] `bun run --filter backend lint` passes
- [ ] Manual: confirm conversation toggle is enabled in browser after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)