### PR TITLE
fix(metrics): use Keychain credentials for /v1/models so context max is correct

### DIFF
--- a/backend/src/services/anthropic-models.ts
+++ b/backend/src/services/anthropic-models.ts
@@ -1,6 +1,5 @@
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { VERSION } from '../cli';
+import { getClaudeAccessToken } from '../utils/claude-credentials';
 
 interface ModelInfo {
   id: string;
@@ -11,25 +10,14 @@ interface ModelsListResponse {
   data: ModelInfo[];
 }
 
-const CLAUDE_DIR = join(homedir(), '.claude');
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 const FALLBACK_MAX_TOKENS = 200_000;
 
 let cache: { timestamp: number; map: Map<string, number> } | null = null;
 let inflight: Promise<Map<string, number>> | null = null;
 
-async function getAccessToken(): Promise<string | null> {
-  try {
-    const content = await readFile(join(CLAUDE_DIR, '.credentials.json'), 'utf-8');
-    const data = JSON.parse(content);
-    return data?.claudeAiOauth?.accessToken ?? null;
-  } catch {
-    return null;
-  }
-}
-
 async function fetchModels(): Promise<Map<string, number>> {
-  const token = await getAccessToken();
+  const token = await getClaudeAccessToken();
   if (!token) return new Map();
   try {
     const response = await fetch('https://api.anthropic.com/v1/models?limit=100', {
@@ -37,7 +25,7 @@ async function fetchModels(): Promise<Map<string, number>> {
         Authorization: `Bearer ${token}`,
         'anthropic-version': '2023-06-01',
         'anthropic-beta': 'oauth-2025-04-20',
-        'User-Agent': 'claude-code/2.0.32',
+        'User-Agent': `cchub/${VERSION}`,
       },
     });
     if (!response.ok) return new Map();

--- a/backend/src/services/anthropic-usage.ts
+++ b/backend/src/services/anthropic-usage.ts
@@ -1,8 +1,6 @@
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { t } from '../i18n';
 import { VERSION } from '../cli';
+import { getClaudeAccessToken } from '../utils/claude-credentials';
 import type { UsageLimitsErrorReason, UsageLimitsStatus } from '../../../shared/types';
 
 function parseRetryAfter(header: string | null): number | null {
@@ -45,7 +43,6 @@ export interface UsageLimits {
 }
 
 export class AnthropicUsageService {
-  private claudeDir: string;
   private lastSuccessfulResult: UsageLimits | null = null;
   private lastFetchAt = 0;
   private inflight: Promise<UsageLimits | null> | null = null;
@@ -55,36 +52,8 @@ export class AnthropicUsageService {
   private rateLimitedUntil = 0;
   private lastErrorReason: UsageLimitsErrorReason | undefined;
 
-  constructor() {
-    this.claudeDir = join(homedir(), '.claude');
-  }
-
   private async getAccessToken(): Promise<string | null> {
-    // 1. Try the file-based credential store first.
-    try {
-      const content = await readFile(join(this.claudeDir, '.credentials.json'), 'utf-8');
-      const data = JSON.parse(content);
-      const token = data?.claudeAiOauth?.accessToken;
-      if (token) return token;
-    } catch {
-      // fall through to keychain on macOS
-    }
-
-    // 2. macOS Keychain fallback (newer Claude Code stores creds here).
-    if (process.platform === 'darwin') {
-      try {
-        const result = Bun.spawnSync(['security', 'find-generic-password', '-s', 'Claude Code-credentials', '-w']);
-        if (result.exitCode === 0) {
-          const out = result.stdout.toString().trim();
-          const data = JSON.parse(out);
-          return data?.claudeAiOauth?.accessToken || null;
-        }
-      } catch {
-        // ignore
-      }
-    }
-
-    return null;
+    return getClaudeAccessToken();
   }
 
   getStatus(): UsageLimitsStatus {

--- a/backend/src/utils/claude-credentials.ts
+++ b/backend/src/utils/claude-credentials.ts
@@ -1,0 +1,48 @@
+// Read the Claude Code OAuth access token from disk, with macOS Keychain
+// fallback for newer Claude Code installations that no longer write
+// ~/.claude/.credentials.json.
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+interface ClaudeCredentials {
+  claudeAiOauth?: {
+    accessToken?: string;
+  };
+}
+
+/**
+ * Returns the OAuth access token, or null if not available.
+ *
+ * Lookup order:
+ *   1. ~/.claude/.credentials.json  (older installs)
+ *   2. macOS Keychain item "Claude Code-credentials"  (newer installs on darwin)
+ */
+export async function getClaudeAccessToken(): Promise<string | null> {
+  // 1. File-based credential store
+  try {
+    const content = await readFile(join(homedir(), '.claude', '.credentials.json'), 'utf-8');
+    const data = JSON.parse(content) as ClaudeCredentials;
+    const token = data?.claudeAiOauth?.accessToken;
+    if (token) return token;
+  } catch {
+    // fall through
+  }
+
+  // 2. macOS Keychain
+  if (process.platform === 'darwin') {
+    try {
+      const result = Bun.spawnSync(['security', 'find-generic-password', '-s', 'Claude Code-credentials', '-w']);
+      if (result.exitCode === 0) {
+        const out = result.stdout.toString().trim();
+        const data = JSON.parse(out) as ClaudeCredentials;
+        return data?.claudeAiOauth?.accessToken ?? null;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Symptom

The `ctx` indicator on the session list was stuck at 100% (red) on macOS for any session whose context exceeded 200K tokens. The actual context value (~310K) was correct but the maximum was wrong.

```
session=cc-hub
  contextTokens=310302       ← correct
  contextMaxTokens=200000    ← wrong, should be 1,000,000 for opus-4-7
  contextPercent=100         ← clamped from 155%
```

## Root cause

`anthropic-models.ts:getAccessToken()` only read the OAuth token from `~/.claude/.credentials.json`. Newer Claude Code on macOS stores credentials in the Keychain instead. With no token, the `/v1/models` fetch returned `{}`, the model→max map was empty, and `getMaxInputTokens()` returned the 200K fallback.

We had already added Keychain support for `/api/oauth/usage` in `anthropic-usage.ts` (v0.1.93) but didn't extend the same fix to `/v1/models`. This PR consolidates both.

## Fix

- Extract the file → Keychain credential lookup into a single utility `backend/src/utils/claude-credentials.ts`
- Use it from both `anthropic-models.ts` and `anthropic-usage.ts`
- Update `anthropic-models.ts` User-Agent from `claude-code/2.0.32` to `cchub/<version>` (matching the v0.1.93 change to `anthropic-usage.ts`)

## Validation

```
# Before
contextMaxTokens=200000  contextPercent=100

# After (same session, same context size)
contextMaxTokens=1000000 contextPercent=32.2
```

`/v1/models` correctly reports `claude-opus-4-7 → 1000000` when the Keychain token is used.

## Linux impact

`getClaudeAccessToken` reads `~/.claude/.credentials.json` first regardless of platform — the Keychain branch is gated on `process.platform === 'darwin'`. Linux behavior is identical to before.

## Test plan

- [x] `bun run --filter backend lint` passes
- [x] Local `/api/sessions` returns correct `contextMaxTokens` (1M for opus-4-7)
- [ ] Manual: confirm `ctx` bar shows green (low) instead of stuck red after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)