### PR TITLE
Add Codex agent support MVP

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { CreateSessionSchema, PaneIdSchema, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
+import { AGENT_PROVIDERS, CreateSessionSchema, DEFAULT_AGENT_PROVIDER, PaneIdSchema, agentSupportsConversationMetadata, type AgentProvider, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
 import { TmuxService } from '../services/tmux';
 import { controlSessions, getOrCreateControlSession } from '../services/tmux-control';
 import { ClaudeCodeService } from '../services/claude-code';
@@ -15,6 +15,14 @@ const tmuxService = new TmuxService();
 const claudeCodeService = new ClaudeCodeService();
 const sessionHistoryService = new SessionHistoryService();
 const promptHistoryService = new PromptHistoryService();
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function agentStartCommand(agent: AgentProvider, workingDir: string): string {
+  return `cd ${shellQuote(workingDir)} && ${AGENT_PROVIDERS[agent].command}`;
+}
 
 /** Notify mux clients of session changes after mutations */
 function notifySessionChange(): void {
@@ -43,7 +51,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
 
   const sessionIdByTmuxId = new Map<string, string>();
   for (const s of tmuxSessions) {
-    if (s.currentCommand === 'claude' && s.paneTty) {
+    if (agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && s.paneTty) {
       const sessionId = claudeCodeService.getSessionIdFromArgs(s.paneTty, processInfo.ttyArgs);
       if (sessionId) {
         sessionIdByTmuxId.set(s.id, sessionId);
@@ -52,7 +60,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
   }
 
   const claudePaths = tmuxSessions
-    .filter((s): s is typeof s & { currentPath: string } => s.currentCommand === 'claude' && !!s.currentPath)
+    .filter((s): s is typeof s & { currentPath: string } => agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && !!s.currentPath)
     .map(s => s.currentPath);
   const ccSessionsByPath = await claudeCodeService.getSessionsForPaths(claudePaths);
 
@@ -61,7 +69,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
   const results = await Promise.all(tmuxSessions.map(async (s) => {
     let ccSession: Awaited<ReturnType<typeof claudeCodeService.getSessionForPath>> | undefined;
 
-    if (s.currentCommand === 'claude' && s.currentPath) {
+    if (agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && s.currentPath) {
       const ptySessionId = sessionIdByTmuxId.get(s.id);
 
       if (ptySessionId) {
@@ -113,7 +121,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       durationMinutes = Math.round((Date.now() - modified.getTime()) / 60000);
     }
 
-    const includeClaudeInfo = s.currentCommand === 'claude';
+    const includeClaudeInfo = agentSupportsConversationMetadata(s.agent ?? s.currentCommand);
 
     const panePids: (number | undefined)[] = s.panes ? s.panes.map((p: { pid?: number }) => p.pid) : [];
     const metrics = await computeSessionMetrics({
@@ -129,6 +137,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       lastAccessedAt: s.createdAt,
       state: (s.attached ? 'working' : 'idle') as SessionState,
       currentCommand: s.currentCommand,
+      agent: s.agent,
       currentPath: s.currentPath,
       paneTitle: s.paneTitle,
       waitingToolName: includeClaudeInfo ? effectiveWaitingToolName : undefined,
@@ -148,6 +157,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       panes: s.panes ? s.panes.map((p: { paneId: string; command: string; path: string; title: string; tty: string; isActive: boolean; isDead: boolean; pid?: number }) => {
         const ttyName = p.tty?.replace('/dev/', '');
         const agentInfo = ttyName ? agentInfoByTty.get(ttyName) : undefined;
+        const paneAgent = ttyName ? processInfo.agentByTty.get(ttyName) : undefined;
         const isClaudeOnPane = !p.isDead && !!ttyName && claudeOnPaneTtys.has(ttyName);
         let paneIndicator: IndicatorState | undefined;
         if (p.isDead) {
@@ -162,7 +172,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         // on macOS sometimes returns the Claude version (e.g. "2.1.123") when the
         // binary is invoked via a non-standard path. The frontend relies on this
         // string equaling "claude" to enable the conversation toggle.
-        const currentCommand = isClaudeOnPane ? 'claude' : p.command;
+        const currentCommand = paneAgent ?? p.command;
         const pane: PaneInfo = {
           paneId: p.paneId,
           currentCommand,
@@ -211,6 +221,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       firstMessageId: undefined,
       theme: lost.theme,
       customTitle: lost.customTitle,
+      agent: lost.agent,
       metrics: undefined,
       panes: undefined,
     });
@@ -222,6 +233,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       id: s.id,
       name: s.name,
       currentPath: s.currentPath,
+      agent: s.agent,
       theme: s.theme,
       customTitle: s.customTitle,
       ccSessionId: s.ccSessionId,
@@ -260,6 +272,7 @@ sessions.post('/', async (c) => {
   notifySessionChange();
   const body = await c.req.json().catch(() => ({}));
   const parsed = CreateSessionSchema.safeParse(body);
+  const agent = parsed.success ? parsed.data.agent : DEFAULT_AGENT_PROVIDER;
 
   // Generate session name
   const tmuxSessions = await tmuxService.listSessions();
@@ -273,10 +286,10 @@ sessions.post('/', async (c) => {
     return c.json({ error: 'Session already exists' }, 400);
   }
 
-  // Guard: reject if a Claude session is already running in the same directory
+  // Guard: reject if the same agent is already running in the same directory
   if (parsed.success && parsed.data.workingDir) {
     const conflicting = tmuxSessions.find(
-      s => s.currentCommand === 'claude' && s.currentPath === parsed.data.workingDir
+      s => s.currentCommand === agent && s.currentPath === parsed.data.workingDir
     );
     if (conflicting) {
       return c.json({ error: 'duplicate_working_dir', existingSession: conflicting.name }, 409);
@@ -286,22 +299,22 @@ sessions.post('/', async (c) => {
   try {
     await tmuxService.createSession(name);
 
-    // Start claude if workingDir is specified
+    // Start the selected agent if workingDir is specified
     if (parsed.success && parsed.data.workingDir) {
-      await tmuxService.sendKeys(name, `cd ${parsed.data.workingDir} && claude`);
+      await tmuxService.sendKeys(name, agentStartCommand(agent, parsed.data.workingDir));
 
-      // Send initial prompt after claude starts (interactive mode)
+      // Send initial prompt after the agent starts (interactive mode)
       if (parsed.data.initialPrompt) {
         const prompt = parsed.data.initialPrompt;
         const sessionName = name;
-        // Poll until claude process is running on the session's TTY
+        // Poll until the selected agent process is running on the session's TTY
         (async () => {
           for (let i = 0; i < 30; i++) { // up to 30 seconds
             await new Promise(r => setTimeout(r, 1000));
             const sessions = await tmuxService.listSessions();
             const session = sessions.find(s => s.name === sessionName);
-            if (session?.currentCommand === 'claude') {
-              // Wait a bit more for claude to be fully ready
+            if (session?.currentCommand === agent) {
+              // Wait a bit more for the TUI to be fully ready
               await new Promise(r => setTimeout(r, 2000));
               await tmuxService.sendKeys(sessionName, prompt);
               // Send extra Enter to submit the prompt
@@ -320,6 +333,7 @@ sessions.post('/', async (c) => {
       createdAt: new Date().toISOString(),
       lastAccessedAt: new Date().toISOString(),
       state: 'idle',
+      agent,
     }, 201);
   } catch (_error) {
     return c.json({ error: 'Failed to create session' }, 500);
@@ -521,6 +535,7 @@ sessions.get('/:id', async (c) => {
     lastAccessedAt: session.createdAt,
     state: session.attached ? 'working' : 'idle',
     currentCommand: session.currentCommand,
+    agent: session.agent,
     currentPath: session.currentPath,
   });
 });
@@ -552,7 +567,7 @@ sessions.delete('/:id', async (c) => {
 
   try {
     await tmuxService.killSession(id);
-    removeLastKnownSession(id).catch(() => {});
+    await removeLastKnownSession(id).catch(() => {});
     return c.json({ success: true });
   } catch (_error) {
     return c.json({ error: 'Failed to delete session' }, 500);
@@ -859,4 +874,3 @@ sessions.post('/:id/prompt', async (c) => {
     return c.json({ error: 'Failed to send prompt' }, 500);
   }
 });
-

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -24,6 +24,14 @@ export function agentStartCommand(agent: AgentProvider, workingDir: string): str
   return `cd ${shellQuote(workingDir)} && ${AGENT_PROVIDERS[agent].command}`;
 }
 
+export function findDuplicateAgentWorkingDirSession<T extends { agent?: string; currentCommand?: string; currentPath?: string }>(
+  sessions: T[],
+  agent: AgentProvider,
+  workingDir: string,
+): T | undefined {
+  return sessions.find(s => (s.agent ?? s.currentCommand) === agent && s.currentPath === workingDir);
+}
+
 /** Notify mux clients of session changes after mutations */
 function notifySessionChange(): void {
   pushSessionsNow();
@@ -288,9 +296,7 @@ sessions.post('/', async (c) => {
 
   // Guard: reject if the same agent is already running in the same directory
   if (parsed.success && parsed.data.workingDir) {
-    const conflicting = tmuxSessions.find(
-      s => s.currentCommand === agent && s.currentPath === parsed.data.workingDir
-    );
+    const conflicting = findDuplicateAgentWorkingDirSession(tmuxSessions, agent, parsed.data.workingDir);
     if (conflicting) {
       return c.json({ error: 'duplicate_working_dir', existingSession: conflicting.name }, 409);
     }

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -4,6 +4,7 @@ import { AGENT_PROVIDERS, CreateSessionSchema, DEFAULT_AGENT_PROVIDER, PaneIdSch
 import { TmuxService } from '../services/tmux';
 import { controlSessions, getOrCreateControlSession } from '../services/tmux-control';
 import { ClaudeCodeService } from '../services/claude-code';
+import { CodexService } from '../services/codex';
 import { SessionHistoryService } from '../services/session-history';
 import { PromptHistoryService } from '../services/prompt-history';
 import { getAllSessionMetadata, setSessionTheme, setSessionTitle, getSessionOrder, setSessionOrder, getLastKnownSessions, saveLastKnownSessions, removeLastKnownSession, type LastKnownSession } from '../services/session-metadata';
@@ -13,6 +14,7 @@ import { pushSessionsNow } from './terminal-mux';
 
 const tmuxService = new TmuxService();
 const claudeCodeService = new ClaudeCodeService();
+const codexService = new CodexService();
 const sessionHistoryService = new SessionHistoryService();
 const promptHistoryService = new PromptHistoryService();
 
@@ -71,11 +73,16 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     .filter((s): s is typeof s & { currentPath: string } => agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && !!s.currentPath)
     .map(s => s.currentPath);
   const ccSessionsByPath = await claudeCodeService.getSessionsForPaths(claudePaths);
+  const codexPaths = tmuxSessions
+    .filter((s): s is typeof s & { currentPath: string } => (s.agent ?? s.currentCommand) === 'codex' && !!s.currentPath)
+    .map(s => s.currentPath);
+  const codexThreadsByPath = await codexService.getThreadsForPaths(codexPaths);
 
   const order = await getSessionOrder();
 
   const results = await Promise.all(tmuxSessions.map(async (s) => {
     let ccSession: Awaited<ReturnType<typeof claudeCodeService.getSessionForPath>> | undefined;
+    const codexThread = s.currentPath ? codexThreadsByPath.get(s.currentPath) : undefined;
 
     if (agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && s.currentPath) {
       const ptySessionId = sessionIdByTmuxId.get(s.id);
@@ -130,6 +137,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     }
 
     const includeClaudeInfo = agentSupportsConversationMetadata(s.agent ?? s.currentCommand);
+    const includeCodexInfo = (s.agent ?? s.currentCommand) === 'codex';
 
     const panePids: (number | undefined)[] = s.panes ? s.panes.map((p: { pid?: number }) => p.pid) : [];
     const metrics = await computeSessionMetrics({
@@ -137,6 +145,9 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       workingDir: s.currentPath,
       pids: panePids,
     });
+    const sessionMetrics = includeCodexInfo && codexThread?.tokensUsed
+      ? { ...metrics, totalTokens: codexThread.tokensUsed }
+      : metrics;
 
     return {
       id: s.id,
@@ -149,19 +160,20 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       currentPath: s.currentPath,
       paneTitle: s.paneTitle,
       waitingToolName: includeClaudeInfo ? effectiveWaitingToolName : undefined,
-      ccSummary: includeClaudeInfo ? ccSession?.summary : undefined,
-      ccFirstPrompt: includeClaudeInfo ? ccSession?.firstPrompt : undefined,
+      ccSummary: includeClaudeInfo ? ccSession?.summary : includeCodexInfo ? codexThread?.title : undefined,
+      ccFirstPrompt: includeClaudeInfo ? ccSession?.firstPrompt : includeCodexInfo ? codexThread?.firstPrompt : undefined,
       ccRecap: includeClaudeInfo ? ccSession?.lastRecap?.content : undefined,
       ccRecapAt: includeClaudeInfo ? ccSession?.lastRecap?.timestamp : undefined,
       indicatorState: includeClaudeInfo ? indicatorState : undefined,
       ccSessionId: includeClaudeInfo ? ccSession?.sessionId : undefined,
+      agentSessionId: includeCodexInfo ? codexThread?.sessionId : undefined,
       messageCount: includeClaudeInfo ? ccSession?.messageCount : undefined,
-      gitBranch: includeClaudeInfo ? ccSession?.gitBranch : undefined,
-      durationMinutes: includeClaudeInfo ? durationMinutes : undefined,
+      gitBranch: includeClaudeInfo ? ccSession?.gitBranch : includeCodexInfo ? codexThread?.gitBranch : undefined,
+      durationMinutes: includeClaudeInfo ? durationMinutes : includeCodexInfo && codexThread?.updatedAt ? Math.round((Date.now() - new Date(codexThread.updatedAt).getTime()) / 60000) : undefined,
       firstMessageId: includeClaudeInfo ? ccSession?.firstMessageId : undefined,
       theme: sessionMetadata[s.id]?.theme,
       customTitle: sessionMetadata[s.id]?.title,
-      metrics,
+      metrics: sessionMetrics,
       panes: s.panes ? s.panes.map((p: { paneId: string; command: string; path: string; title: string; tty: string; isActive: boolean; isDead: boolean; pid?: number }) => {
         const ttyName = p.tty?.replace('/dev/', '');
         const agentInfo = ttyName ? agentInfoByTty.get(ttyName) : undefined;
@@ -223,6 +235,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       ccRecapAt: undefined,
       indicatorState: undefined,
       ccSessionId: lost.ccSessionId,
+      agentSessionId: undefined,
       messageCount: undefined,
       gitBranch: undefined,
       durationMinutes: undefined,

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -145,8 +145,12 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       workingDir: s.currentPath,
       pids: panePids,
     });
-    const sessionMetrics = includeCodexInfo && codexThread?.tokensUsed
-      ? { ...metrics, totalTokens: codexThread.tokensUsed }
+    const sessionMetrics = includeCodexInfo && codexThread
+      ? {
+          ...metrics,
+          ...codexThread.tokenUsage,
+          totalTokens: codexThread.tokenUsage?.totalTokens ?? codexThread.tokensUsed,
+        }
       : metrics;
 
     return {

--- a/backend/src/services/codex.ts
+++ b/backend/src/services/codex.ts
@@ -1,13 +1,24 @@
-import { existsSync } from 'node:fs';
+import { existsSync, openSync, readFileSync, readSync, closeSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Database } from 'bun:sqlite';
+
+export interface CodexTokenUsage {
+  contextTokens?: number;
+  contextMaxTokens?: number;
+  contextPercent?: number;
+  totalInputTokens?: number;
+  totalCacheReadTokens?: number;
+  totalOutputTokens?: number;
+  totalTokens?: number;
+}
 
 export interface CodexThread {
   sessionId: string;
   title?: string;
   firstPrompt?: string;
   tokensUsed?: number;
+  tokenUsage?: CodexTokenUsage;
   gitBranch?: string;
   cwd: string;
   createdAt?: string;
@@ -19,6 +30,7 @@ interface CodexThreadRow {
   title: string | null;
   first_user_message: string | null;
   tokens_used: number | null;
+  rollout_path: string | null;
   git_branch: string | null;
   cwd: string;
   created_at: number | null;
@@ -36,12 +48,101 @@ function epochToIso(seconds?: number | null, millis?: number | null): string | u
   return timestamp ? new Date(timestamp).toISOString() : undefined;
 }
 
+interface CodexTokenCountEvent {
+  type?: string;
+  payload?: {
+    type?: string;
+    info?: {
+      total_token_usage?: {
+        input_tokens?: number;
+        cached_input_tokens?: number;
+        output_tokens?: number;
+        total_tokens?: number;
+      };
+      last_token_usage?: {
+        input_tokens?: number;
+        total_tokens?: number;
+      };
+      model_context_window?: number;
+    };
+  };
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function tokenUsageFromLine(line: string): CodexTokenUsage | undefined {
+  let event: CodexTokenCountEvent;
+  try {
+    event = JSON.parse(line) as CodexTokenCountEvent;
+  } catch {
+    return undefined;
+  }
+
+  if (event.type !== 'event_msg' || event.payload?.type !== 'token_count') return undefined;
+
+  const info = event.payload.info;
+  const contextTokens = numberOrUndefined(info?.last_token_usage?.input_tokens);
+  const contextMaxTokens = numberOrUndefined(info?.model_context_window);
+  const total = info?.total_token_usage;
+  const contextPercent = contextTokens !== undefined && contextMaxTokens && contextMaxTokens > 0
+    ? Math.min(100, Math.round((contextTokens / contextMaxTokens) * 1000) / 10)
+    : undefined;
+
+  return {
+    contextTokens,
+    contextMaxTokens,
+    contextPercent,
+    totalInputTokens: numberOrUndefined(total?.input_tokens),
+    totalCacheReadTokens: numberOrUndefined(total?.cached_input_tokens),
+    totalOutputTokens: numberOrUndefined(total?.output_tokens),
+    totalTokens: numberOrUndefined(total?.total_tokens),
+  };
+}
+
+function findLatestTokenUsageInText(text: string): CodexTokenUsage | undefined {
+  const lines = text.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]?.trim();
+    if (!line || !line.includes('"token_count"')) continue;
+    const usage = tokenUsageFromLine(line);
+    if (usage) return usage;
+  }
+  return undefined;
+}
+
+function readLatestTokenUsage(rolloutPath?: string | null): CodexTokenUsage | undefined {
+  if (!rolloutPath || !existsSync(rolloutPath)) return undefined;
+
+  try {
+    const stat = statSync(rolloutPath);
+    const maxTailBytes = 4 * 1024 * 1024;
+    if (stat.size <= maxTailBytes) {
+      return findLatestTokenUsageInText(readFileSync(rolloutPath, 'utf8'));
+    }
+
+    const fd = openSync(rolloutPath, 'r');
+    try {
+      const bytesToRead = Math.min(stat.size, maxTailBytes);
+      const buffer = Buffer.alloc(bytesToRead);
+      readSync(fd, buffer, 0, bytesToRead, stat.size - bytesToRead);
+      return findLatestTokenUsageInText(buffer.toString('utf8'));
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return undefined;
+  }
+}
+
 function rowToThread(row: CodexThreadRow): CodexThread {
   return {
     sessionId: row.id,
     title: row.title || undefined,
     firstPrompt: row.first_user_message || undefined,
     tokensUsed: typeof row.tokens_used === 'number' ? row.tokens_used : undefined,
+    tokenUsage: readLatestTokenUsage(row.rollout_path),
     gitBranch: row.git_branch || undefined,
     cwd: row.cwd,
     createdAt: epochToIso(row.created_at, row.created_at_ms),
@@ -95,6 +196,7 @@ export class CodexService {
           title,
           first_user_message,
           tokens_used,
+          rollout_path,
           git_branch,
           cwd,
           created_at,

--- a/backend/src/services/codex.ts
+++ b/backend/src/services/codex.ts
@@ -1,0 +1,122 @@
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { Database } from 'bun:sqlite';
+
+export interface CodexThread {
+  sessionId: string;
+  title?: string;
+  firstPrompt?: string;
+  tokensUsed?: number;
+  gitBranch?: string;
+  cwd: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+interface CodexThreadRow {
+  id: string;
+  title: string | null;
+  first_user_message: string | null;
+  tokens_used: number | null;
+  git_branch: string | null;
+  cwd: string;
+  created_at: number | null;
+  updated_at: number | null;
+  created_at_ms: number | null;
+  updated_at_ms: number | null;
+}
+
+function epochToIso(seconds?: number | null, millis?: number | null): string | undefined {
+  const timestamp = typeof millis === 'number' && millis > 0
+    ? millis
+    : typeof seconds === 'number' && seconds > 0
+      ? seconds * 1000
+      : undefined;
+  return timestamp ? new Date(timestamp).toISOString() : undefined;
+}
+
+function rowToThread(row: CodexThreadRow): CodexThread {
+  return {
+    sessionId: row.id,
+    title: row.title || undefined,
+    firstPrompt: row.first_user_message || undefined,
+    tokensUsed: typeof row.tokens_used === 'number' ? row.tokens_used : undefined,
+    gitBranch: row.git_branch || undefined,
+    cwd: row.cwd,
+    createdAt: epochToIso(row.created_at, row.created_at_ms),
+    updatedAt: epochToIso(row.updated_at, row.updated_at_ms),
+  };
+}
+
+export class CodexService {
+  private dbPath: string;
+  private cache: { timestamp: number; data: Map<string, CodexThread> } | null = null;
+  private static readonly CACHE_TTL = 5000;
+
+  constructor(dbPath = join(homedir(), '.codex', 'state_5.sqlite')) {
+    this.dbPath = dbPath;
+  }
+
+  async getThreadsForPaths(paths: string[]): Promise<Map<string, CodexThread>> {
+    const uniquePaths = [...new Set(paths.filter(Boolean))];
+    if (uniquePaths.length === 0) return new Map();
+
+    if (this.cache && Date.now() - this.cache.timestamp < CodexService.CACHE_TTL) {
+      return new Map(uniquePaths.flatMap(path => {
+        const thread = this.cache?.data.get(path);
+        return thread ? [[path, thread] as const] : [];
+      }));
+    }
+
+    const allThreads = this.loadLatestThreadsByCwd();
+    this.cache = { timestamp: Date.now(), data: allThreads };
+
+    return new Map(uniquePaths.flatMap(path => {
+      const thread = allThreads.get(path);
+      return thread ? [[path, thread] as const] : [];
+    }));
+  }
+
+  async getThreadForPath(path: string): Promise<CodexThread | undefined> {
+    return (await this.getThreadsForPaths([path])).get(path);
+  }
+
+  private loadLatestThreadsByCwd(): Map<string, CodexThread> {
+    const result = new Map<string, CodexThread>();
+    if (!existsSync(this.dbPath)) return result;
+
+    let db: Database | undefined;
+    try {
+      db = new Database(this.dbPath, { readonly: true });
+      const rows = db.query<CodexThreadRow, []>(`
+        SELECT
+          id,
+          title,
+          first_user_message,
+          tokens_used,
+          git_branch,
+          cwd,
+          created_at,
+          updated_at,
+          created_at_ms,
+          updated_at_ms
+        FROM threads
+        WHERE archived = 0
+        ORDER BY COALESCE(updated_at_ms, updated_at * 1000, 0) DESC
+      `).all();
+
+      for (const row of rows) {
+        if (!result.has(row.cwd)) {
+          result.set(row.cwd, rowToThread(row));
+        }
+      }
+    } catch {
+      return new Map();
+    } finally {
+      db?.close();
+    }
+
+    return result;
+  }
+}

--- a/backend/src/services/session-metadata.ts
+++ b/backend/src/services/session-metadata.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { readFile, writeFile, unlink } from 'node:fs/promises';
 import { ensureDataDir } from '../utils/storage';
-import type { SessionTheme } from '../../../shared/types';
+import type { AgentProvider, SessionTheme } from '../../../shared/types';
 
 const METADATA_FILE = 'session-metadata.json';
 const LAST_KNOWN_FILE = 'last-known-sessions.json';
@@ -15,6 +15,7 @@ export interface LastKnownSession {
   id: string;
   name: string;
   currentPath?: string;
+  agent?: AgentProvider;
   theme?: SessionTheme;
   customTitle?: string;
   ccSessionId?: string;

--- a/backend/src/services/tmux.ts
+++ b/backend/src/services/tmux.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { detectAgentProviderFromArgs, type AgentProvider } from '../../../shared/types';
 
 interface TmuxPaneInfo {
   paneId: string;          // "%0", "%1"
@@ -18,6 +19,7 @@ interface TmuxSessionInfo {
   createdAt: string;
   attached: boolean;
   currentCommand?: string;
+  agent?: AgentProvider;
   currentPath?: string;
   paneTitle?: string;
   paneTty?: string;
@@ -45,6 +47,12 @@ set -g remain-on-exit on
 export interface ParsedProcessInfo {
   /** TTYs that have a Claude Code process running */
   claudeTtys: Set<string>;
+  /** TTYs that have a Codex process running */
+  codexTtys: Set<string>;
+  /** Provider → TTYs that have that provider running */
+  agentTtys: Map<AgentProvider, Set<string>>;
+  /** TTY → detected agent provider */
+  agentByTty: Map<string, AgentProvider>;
   /** TTY → agent info (name/color) for team agent processes */
   agentInfo: Map<string, { agentName: string; agentColor?: string }>;
   /** TTY → all process args lines (for session ID extraction etc.) */
@@ -119,6 +127,9 @@ export class TmuxService {
 
     const result: ParsedProcessInfo = {
       claudeTtys: new Set(),
+      codexTtys: new Set(),
+      agentTtys: new Map(),
+      agentByTty: new Map(),
       agentInfo: new Map(),
       ttyArgs: new Map(),
     };
@@ -160,12 +171,23 @@ export class TmuxService {
         const args = parts.slice(1).join(' ');
 
         // Collect all args per TTY for external consumers
-        if (!result.ttyArgs.has(tty)) result.ttyArgs.set(tty, []);
-        result.ttyArgs.get(tty)!.push(args);
+        let ttyArgs = result.ttyArgs.get(tty);
+        if (!ttyArgs) {
+          ttyArgs = [];
+          result.ttyArgs.set(tty, ttyArgs);
+        }
+        ttyArgs.push(args);
 
-        // Consumer 1: Claude detection (batchCheckClaudeOnTtys)
-        if (this.isClaudeProcess(args)) {
-          result.claudeTtys.add(tty);
+        // Consumer 1: supported agent detection
+        const detectedAgent = detectAgentProviderFromArgs(args);
+        if (detectedAgent) {
+          if (!result.agentTtys.has(detectedAgent)) {
+            result.agentTtys.set(detectedAgent, new Set());
+          }
+          result.agentTtys.get(detectedAgent)?.add(tty);
+          result.agentByTty.set(tty, detectedAgent);
+          if (detectedAgent === 'claude') result.claudeTtys.add(tty);
+          if (detectedAgent === 'codex') result.codexTtys.add(tty);
         }
 
         // Consumer 2: Agent info (batchGetAgentInfo)
@@ -257,10 +279,12 @@ export class TmuxService {
               const pidNum = pidStr ? Number.parseInt(pidStr, 10) : Number.NaN;
 
               // Collect all panes (pane_id already includes % prefix)
-              if (!allPanes.has(sessionName)) {
-                allPanes.set(sessionName, []);
+              let panes = allPanes.get(sessionName);
+              if (!panes) {
+                panes = [];
+                allPanes.set(sessionName, panes);
               }
-              allPanes.get(sessionName)!.push({
+              panes.push({
                 paneId,
                 command,
                 path: panePath,
@@ -274,7 +298,7 @@ export class TmuxService {
           });
       }
 
-      // Batch check: which TTYs have claude running (single ps call for all pane TTYs)
+      // Batch check: which TTYs have supported agents running (single ps call for all pane TTYs)
       // Must run before pane selection so we can pick the right representative pane.
       const allTtys = new Set<string>();
       for (const [, panes] of allPanes) {
@@ -282,18 +306,19 @@ export class TmuxService {
           if (p.tty) allTtys.add(p.tty.replace('/dev/', ''));
         }
       }
-      const claudeOnTtySet = await this.batchCheckClaudeOnTtys([...allTtys]);
+      const processInfo = await this.batchProcessInfo([...allTtys]);
+      const agentByTty = processInfo.agentByTty;
 
       // Derive session-level pane info from all panes (backward compatibility).
-      // Priority: pane with claude running (via ps) > first non-dead pane > first pane.
+      // Priority: pane with a supported agent running (via ps) > first non-dead pane > first pane.
       const paneInfo = new Map<string, { command: string; path: string; title: string; tty: string }>();
       for (const [sessionName, panes] of allPanes) {
-        const claudePane = panes.find(p => {
+        const agentPane = panes.find(p => {
           const ttyName = p.tty?.replace('/dev/', '');
-          return ttyName && claudeOnTtySet.has(ttyName);
+          return ttyName && agentByTty.has(ttyName);
         });
         const alivePane = panes.find(p => !p.isDead);
-        const bestPane = claudePane || alivePane || panes[0];
+        const bestPane = agentPane || alivePane || panes[0];
         if (bestPane) {
           paneInfo.set(sessionName, {
             command: bestPane.command,
@@ -306,7 +331,7 @@ export class TmuxService {
 
       // Get preview + waiting status (single capture-pane call per session)
       const previews = new Map<string, string>();
-      const claudeOnTty = new Map<string, boolean>();
+      const agentBySession = new Map<string, AgentProvider>();
       await Promise.all(
         sessions.map(async (session) => {
           // Single capture-pane call for both preview and waiting detection
@@ -324,10 +349,11 @@ export class TmuxService {
             }
           }
 
-          // Use batch result for claude detection
+          // Use batch result for agent detection
           const info = paneInfo.get(session.id);
           if (info?.tty) {
-            claudeOnTty.set(session.id, claudeOnTtySet.has(info.tty.replace('/dev/', '')));
+            const agent = agentByTty.get(info.tty.replace('/dev/', ''));
+            if (agent) agentBySession.set(session.id, agent);
           }
         })
       );
@@ -335,13 +361,14 @@ export class TmuxService {
       // Merge all info into sessions
       const result = sessions.map((session) => {
         const info = paneInfo.get(session.id);
-        // Claude Code detection: Check if 'claude' process exists on the TTY
-        const isClaudeRunning = claudeOnTty.get(session.id) || false;
-        const currentCommand = isClaudeRunning ? 'claude' : info?.command;
+        // Agent detection: Check if a supported agent process exists on the TTY.
+        const agent = agentBySession.get(session.id);
+        const currentCommand = agent ?? info?.command;
         const sessionPanes = allPanes.get(session.id);
         return {
           ...session,
           currentCommand,
+          agent,
           currentPath: info?.path,
           paneTitle: info?.title,
           paneTty: info?.tty,
@@ -356,21 +383,6 @@ export class TmuxService {
     } catch {
       return [];
     }
-  }
-
-  /**
-   * Check if process args indicate a Claude Code process.
-   *
-   * Matches the executable name `claude` regardless of install location:
-   *   - `claude` / `claude --resume`              (PATH-resolved invocation)
-   *   - `/usr/local/bin/claude` / `~/.local/bin/claude -c`  (full path)
-   *   - paths containing `/claude/versions/`       (team agents / version-pinned)
-   *
-   * The leading `(?:^|\/)` and trailing `(?:\s|$)` anchors avoid false matches
-   * on substrings like `.claude/shell-snapshots/...` or `claude-foo-cwd`.
-   */
-  private isClaudeProcess(args: string): boolean {
-    return /(?:^|\/)claude(?:\s|$)/.test(args) || args.includes('/claude/versions/');
   }
 
   /**

--- a/backend/tests/unit/agent-providers.test.ts
+++ b/backend/tests/unit/agent-providers.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  AGENT_PROVIDER_IDS,
+  AGENT_PROVIDERS,
+  CreateSessionSchema,
+  agentSupportsConversationMetadata,
+  detectAgentProviderFromArgs,
+} from '../../../shared/types';
+import { agentStartCommand, shellQuote } from '../../src/routes/sessions';
+
+describe('Agent provider registry', () => {
+  test('derives provider IDs from the registry', () => {
+    expect(AGENT_PROVIDER_IDS).toContain('claude');
+    expect(AGENT_PROVIDER_IDS).toContain('codex');
+    expect([...AGENT_PROVIDER_IDS].join(',')).toBe(Object.keys(AGENT_PROVIDERS).join(','));
+  });
+
+  test('defaults create-session agent to Claude', () => {
+    const parsed = CreateSessionSchema.parse({ name: 'example' });
+
+    expect(parsed.agent).toBe('claude');
+  });
+
+  test('accepts Codex as a create-session agent', () => {
+    const parsed = CreateSessionSchema.parse({ name: 'example', agent: 'codex' });
+
+    expect(parsed.agent).toBe('codex');
+  });
+
+  test('rejects unsupported create-session agents', () => {
+    const parsed = CreateSessionSchema.safeParse({ name: 'example', agent: 'gemini' });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  test('detects supported providers from process args', () => {
+    expect(detectAgentProviderFromArgs('claude')).toBe('claude');
+    expect(detectAgentProviderFromArgs('/usr/local/bin/claude --resume')).toBe('claude');
+    expect(detectAgentProviderFromArgs('/home/user/.local/share/claude/versions/2.1.123/claude')).toBe('claude');
+    expect(detectAgentProviderFromArgs('codex')).toBe('codex');
+    expect(detectAgentProviderFromArgs('/home/user/.bun/install/global/node_modules/@openai/codex/bin/codex.js')).toBe('codex');
+  });
+
+  test('does not detect provider names inside unrelated paths', () => {
+    expect(detectAgentProviderFromArgs('/tmp/.claude/shell-snapshots/claude-foo-cwd')).toBeUndefined();
+    expect(detectAgentProviderFromArgs('/tmp/codex-project/run.sh')).toBeUndefined();
+  });
+
+  test('exposes provider capabilities', () => {
+    expect(agentSupportsConversationMetadata('claude')).toBe(true);
+    expect(agentSupportsConversationMetadata('codex')).toBe(false);
+    expect(agentSupportsConversationMetadata('unknown')).toBe(false);
+  });
+
+  test('quotes working directories for agent start commands', () => {
+    expect(shellQuote('/tmp/plain path')).toBe("'/tmp/plain path'");
+    expect(shellQuote("/tmp/it's-here")).toBe("'/tmp/it'\\''s-here'");
+    expect(agentStartCommand('codex', "/tmp/it's-here")).toBe("cd '/tmp/it'\\''s-here' && codex");
+  });
+});

--- a/backend/tests/unit/agent-providers.test.ts
+++ b/backend/tests/unit/agent-providers.test.ts
@@ -6,7 +6,7 @@ import {
   agentSupportsConversationMetadata,
   detectAgentProviderFromArgs,
 } from '../../../shared/types';
-import { agentStartCommand, shellQuote } from '../../src/routes/sessions';
+import { agentStartCommand, findDuplicateAgentWorkingDirSession, shellQuote } from '../../src/routes/sessions';
 
 describe('Agent provider registry', () => {
   test('derives provider IDs from the registry', () => {
@@ -56,5 +56,23 @@ describe('Agent provider registry', () => {
     expect(shellQuote('/tmp/plain path')).toBe("'/tmp/plain path'");
     expect(shellQuote("/tmp/it's-here")).toBe("'/tmp/it'\\''s-here'");
     expect(agentStartCommand('codex', "/tmp/it's-here")).toBe("cd '/tmp/it'\\''s-here' && codex");
+  });
+
+  test('detects duplicate working directories only for the same agent', () => {
+    const sessions = [
+      { name: 'claude-repo', agent: 'claude', currentCommand: 'claude', currentPath: '/repo' },
+      { name: 'codex-other', agent: 'codex', currentCommand: 'codex', currentPath: '/other' },
+    ];
+
+    expect(findDuplicateAgentWorkingDirSession(sessions, 'claude', '/repo')?.name).toBe('claude-repo');
+    expect(findDuplicateAgentWorkingDirSession(sessions, 'codex', '/repo')).toBeUndefined();
+  });
+
+  test('uses currentCommand for duplicate detection when agent is missing', () => {
+    const sessions = [
+      { name: 'legacy-codex', currentCommand: 'codex', currentPath: '/repo' },
+    ];
+
+    expect(findDuplicateAgentWorkingDirSession(sessions, 'codex', '/repo')?.name).toBe('legacy-codex');
   });
 });

--- a/backend/tests/unit/codex-service.test.ts
+++ b/backend/tests/unit/codex-service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { rm, mkdir } from 'node:fs/promises';
+import { rm, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Database } from 'bun:sqlite';
@@ -15,6 +15,7 @@ function createThreadsTable(db: Database): void {
       title TEXT,
       first_user_message TEXT,
       tokens_used INTEGER,
+      rollout_path TEXT,
       git_branch TEXT,
       cwd TEXT NOT NULL,
       created_at INTEGER,
@@ -33,6 +34,7 @@ function insertThread(db: Database, row: {
   firstUserMessage: string;
   tokensUsed: number;
   gitBranch?: string;
+  rolloutPath?: string;
   updatedAtMs: number;
   archived?: number;
 }): void {
@@ -43,19 +45,21 @@ function insertThread(db: Database, row: {
       title,
       first_user_message,
       tokens_used,
+      rollout_path,
       git_branch,
       created_at,
       updated_at,
       created_at_ms,
       updated_at_ms,
       archived
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       row.id,
       row.cwd,
       row.title,
       row.firstUserMessage,
       row.tokensUsed,
+      row.rolloutPath ?? null,
       row.gitBranch ?? null,
       Math.floor(row.updatedAtMs / 1000),
       Math.floor(row.updatedAtMs / 1000),
@@ -143,5 +147,74 @@ describe('CodexService', () => {
     const threads = await service.getThreadsForPaths(['/repo']);
 
     expect(threads.size).toBe(0);
+  });
+
+  test('reads latest token_count event from rollout jsonl', async () => {
+    const rolloutPath = join(TEST_DIR, 'rollout.jsonl');
+    await writeFile(rolloutPath, [
+      JSON.stringify({
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              input_tokens: 100,
+              cached_input_tokens: 50,
+              output_tokens: 20,
+              total_tokens: 120,
+            },
+            last_token_usage: {
+              input_tokens: 40,
+              total_tokens: 45,
+            },
+            model_context_window: 200,
+          },
+        },
+      }),
+      JSON.stringify({
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              input_tokens: 350,
+              cached_input_tokens: 75,
+              output_tokens: 30,
+              total_tokens: 380,
+            },
+            last_token_usage: {
+              input_tokens: 125,
+              total_tokens: 130,
+            },
+            model_context_window: 250,
+          },
+        },
+      }),
+      '',
+    ].join('\n'));
+
+    const db = new Database(DB_PATH);
+    createThreadsTable(db);
+    insertThread(db, {
+      id: 'with-rollout',
+      cwd: '/repo',
+      title: 'With rollout',
+      firstUserMessage: 'prompt',
+      tokensUsed: 999,
+      rolloutPath,
+      updatedAtMs: 1000,
+    });
+    db.close();
+
+    const service = new CodexService(DB_PATH);
+    const thread = (await service.getThreadsForPaths(['/repo'])).get('/repo');
+
+    expect(thread?.tokenUsage?.contextTokens).toBe(125);
+    expect(thread?.tokenUsage?.contextMaxTokens).toBe(250);
+    expect(thread?.tokenUsage?.contextPercent).toBe(50);
+    expect(thread?.tokenUsage?.totalInputTokens).toBe(350);
+    expect(thread?.tokenUsage?.totalCacheReadTokens).toBe(75);
+    expect(thread?.tokenUsage?.totalOutputTokens).toBe(30);
+    expect(thread?.tokenUsage?.totalTokens).toBe(380);
   });
 });

--- a/backend/tests/unit/codex-service.test.ts
+++ b/backend/tests/unit/codex-service.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Database } from 'bun:sqlite';
+import { CodexService } from '../../src/services/codex';
+
+const TEST_DIR = join(tmpdir(), `cchub-codex-service-${Date.now()}`);
+const DB_PATH = join(TEST_DIR, 'state_5.sqlite');
+
+function createThreadsTable(db: Database): void {
+  db.run(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      first_user_message TEXT,
+      tokens_used INTEGER,
+      git_branch TEXT,
+      cwd TEXT NOT NULL,
+      created_at INTEGER,
+      updated_at INTEGER,
+      created_at_ms INTEGER,
+      updated_at_ms INTEGER,
+      archived INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+}
+
+function insertThread(db: Database, row: {
+  id: string;
+  cwd: string;
+  title: string;
+  firstUserMessage: string;
+  tokensUsed: number;
+  gitBranch?: string;
+  updatedAtMs: number;
+  archived?: number;
+}): void {
+  db.run(
+    `INSERT INTO threads (
+      id,
+      cwd,
+      title,
+      first_user_message,
+      tokens_used,
+      git_branch,
+      created_at,
+      updated_at,
+      created_at_ms,
+      updated_at_ms,
+      archived
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      row.id,
+      row.cwd,
+      row.title,
+      row.firstUserMessage,
+      row.tokensUsed,
+      row.gitBranch ?? null,
+      Math.floor(row.updatedAtMs / 1000),
+      Math.floor(row.updatedAtMs / 1000),
+      row.updatedAtMs,
+      row.updatedAtMs,
+      row.archived ?? 0,
+    ],
+  );
+}
+
+describe('CodexService', () => {
+  beforeEach(async () => {
+    await mkdir(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  test('returns an empty map when the state database does not exist', async () => {
+    const service = new CodexService(join(TEST_DIR, 'missing.sqlite'));
+
+    const threads = await service.getThreadsForPaths(['/repo']);
+
+    expect(threads.size).toBe(0);
+  });
+
+  test('returns the latest unarchived thread for each cwd', async () => {
+    const db = new Database(DB_PATH);
+    createThreadsTable(db);
+    insertThread(db, {
+      id: 'older',
+      cwd: '/repo',
+      title: 'Older title',
+      firstUserMessage: 'older prompt',
+      tokensUsed: 100,
+      updatedAtMs: 1000,
+    });
+    insertThread(db, {
+      id: 'newer',
+      cwd: '/repo',
+      title: 'Newer title',
+      firstUserMessage: 'newer prompt',
+      tokensUsed: 250,
+      gitBranch: 'feat/codex',
+      updatedAtMs: 2000,
+    });
+    insertThread(db, {
+      id: 'other',
+      cwd: '/other',
+      title: 'Other title',
+      firstUserMessage: 'other prompt',
+      tokensUsed: 300,
+      updatedAtMs: 1500,
+    });
+    db.close();
+
+    const service = new CodexService(DB_PATH);
+    const threads = await service.getThreadsForPaths(['/repo', '/other', '/missing']);
+
+    expect(threads.get('/repo')?.sessionId).toBe('newer');
+    expect(threads.get('/repo')?.title).toBe('Newer title');
+    expect(threads.get('/repo')?.firstPrompt).toBe('newer prompt');
+    expect(threads.get('/repo')?.tokensUsed).toBe(250);
+    expect(threads.get('/repo')?.gitBranch).toBe('feat/codex');
+    expect(threads.get('/other')?.sessionId).toBe('other');
+    expect(threads.has('/missing')).toBe(false);
+  });
+
+  test('ignores archived threads', async () => {
+    const db = new Database(DB_PATH);
+    createThreadsTable(db);
+    insertThread(db, {
+      id: 'archived',
+      cwd: '/repo',
+      title: 'Archived',
+      firstUserMessage: 'archived prompt',
+      tokensUsed: 1000,
+      updatedAtMs: 3000,
+      archived: 1,
+    });
+    db.close();
+
+    const service = new CodexService(DB_PATH);
+    const threads = await service.getThreadsForPaths(['/repo']);
+
+    expect(threads.size).toBe(0);
+  });
+});

--- a/docs/codex-support-mvp.md
+++ b/docs/codex-support-mvp.md
@@ -1,0 +1,172 @@
+# Codex Support MVP
+
+## Goal
+
+CC Hub can create, detect, and display tmux sessions that run either Claude Code or OpenAI Codex CLI.
+
+This MVP keeps Claude Code as the default behavior and adds Codex as an additional agent provider.
+
+## Scope
+
+- Add `claude` / `codex` as supported session agent providers.
+- Allow the session creation API to receive an optional `agent`.
+- Start the selected agent in the selected working directory.
+- Detect running Claude Code and Codex processes from tmux pane TTYs.
+- Return the detected `agent` in session API responses.
+- Add a Claude/Codex selector to the new session modal.
+- Preserve existing Claude-specific metadata behavior.
+
+## Out of Scope
+
+- Codex-specific session metadata equivalent to Claude Code recap, token metrics, or session IDs.
+- Codex prompt/recap parsing.
+- Agent filtering or sorting in the session list.
+- Full agent-provider abstraction for adding future CLIs.
+- Full lint cleanup for pre-existing frontend/backend warnings.
+- Broad UI redesign of the session list.
+
+## Behavior
+
+### Session Creation
+
+`POST /api/sessions` accepts:
+
+```json
+{
+  "name": "example",
+  "workingDir": "/path/to/project",
+  "agent": "codex"
+}
+```
+
+If `agent` is omitted, it defaults to `claude`.
+
+The backend starts the selected agent with:
+
+```sh
+cd '<workingDir>' && <agent>
+```
+
+The working directory is shell-quoted before being sent to tmux.
+
+### Duplicate Guard
+
+The duplicate working directory guard now checks the same agent and same working directory.
+
+For example:
+
+- existing Claude session in `/repo` blocks another Claude session in `/repo`
+- existing Codex session in `/repo` blocks another Codex session in `/repo`
+- Claude and Codex can be considered separately by the current MVP logic
+
+### Process Detection
+
+The tmux service inspects processes by pane TTY and detects:
+
+- Claude Code: `claude` or Claude versioned paths
+- Codex: `codex` or `@openai/codex` paths
+
+When a supported agent is detected on a pane TTY:
+
+- session `currentCommand` becomes `claude` or `codex`
+- session `agent` is set to `claude` or `codex`
+- pane `currentCommand` becomes `claude` or `codex`
+
+If no supported agent is detected, existing tmux command behavior remains.
+
+### UI
+
+The new session modal includes a Claude/Codex selector.
+
+The frontend sends the selected `agent` in the session creation payload. Claude remains the default.
+
+Codex session cards use the session name instead of pane title for display, because Codex pane titles can resolve to the host name.
+
+## Changed Files
+
+- `shared/types.ts`
+  - Adds `AgentProvider`.
+  - Adds optional `agent` to session responses.
+  - Adds optional `agent` to `CreateSessionSchema`, defaulting to `claude`.
+- `backend/src/services/session-metadata.ts`
+  - Persists optional `agent` in last-known session metadata.
+- `backend/src/services/tmux.ts`
+  - Adds Codex process detection.
+  - Adds TTY-to-agent mapping.
+  - Selects an agent pane as the representative session pane when available.
+- `backend/src/routes/sessions.ts`
+  - Reads `agent` from create-session requests.
+  - Starts the selected CLI.
+  - Applies duplicate guard by same agent and same working directory.
+  - Includes `agent` in list/detail/create responses.
+  - Removes last-known metadata during delete.
+- `frontend/src/hooks/useSessions.ts`
+  - Sends `agent` in create-session requests.
+- `frontend/src/components/SessionList.tsx`
+  - Adds the Claude/Codex selector to the create modal.
+  - Passes selected `agent` into session creation.
+- `frontend/src/i18n/locales/en.json`
+  - Adds agent labels and updated duplicate message.
+- `frontend/src/i18n/locales/ja.json`
+  - Adds agent labels and updated duplicate message.
+
+## Agent Registry
+
+The MVP uses a shared agent registry as the source of truth for supported CLI providers.
+
+Current shape:
+
+```ts
+export const AGENT_PROVIDERS = {
+  claude: {
+    id: 'claude',
+    command: 'claude',
+    labelKey: 'session.agentProvider.claude',
+    processPatterns: [/.../],
+    supportsConversationMetadata: true,
+  },
+  codex: {
+    id: 'codex',
+    command: 'codex',
+    labelKey: 'session.agentProvider.codex',
+    processPatterns: [/.../],
+    supportsConversationMetadata: false,
+  },
+} as const;
+```
+
+The registry is used to derive:
+
+- `AgentProvider`
+- `CreateSessionSchema` enum values
+- frontend selector options
+- backend start command
+- tmux process matching
+- provider capability checks
+
+Claude-specific services remain Claude-specific, but callers use capability checks such as `supportsConversationMetadata` where practical instead of relying only on direct `agent === 'claude'` checks.
+
+## Verification
+
+Completed checks:
+
+- `bun run typecheck`
+- `bun run test`
+- Focused agent-provider unit tests for registry IDs, create-session schema, process detection, provider capabilities, and start command quoting.
+- API confirmed an existing Codex session reports `currentCommand: "codex"` and `agent: "codex"`.
+- API confirmed duplicate working directory handling for an existing Codex session.
+- A temporary Codex smoke session was created, detected as Codex, shown in the UI, and deleted.
+
+Known caveat:
+
+- `bun run lint` still fails because of pre-existing lint errors outside this MVP scope.
+- Changed-file Biome lint exits with status `0`, with remaining warnings treated as pre-existing cleanup work.
+
+## Follow-Up Tasks
+
+1. Add route-level tests for duplicate handling by same agent and working directory.
+2. Add integration coverage for tmux process detection when a real Codex process is running.
+3. Decide whether Claude and Codex should be allowed to share the same working directory at the same time.
+4. Add visible agent badges or filters to the session list if useful.
+5. Investigate whether Codex exposes stable metadata that can be shown alongside Claude Code metadata.
+6. Separate existing lint cleanup into its own task or branch.

--- a/docs/codex-support-mvp.md
+++ b/docs/codex-support-mvp.md
@@ -13,12 +13,14 @@ This MVP keeps Claude Code as the default behavior and adds Codex as an addition
 - Start the selected agent in the selected working directory.
 - Detect running Claude Code and Codex processes from tmux pane TTYs.
 - Return the detected `agent` in session API responses.
+- Read basic Codex thread metadata from the local Codex state database.
 - Add a Claude/Codex selector to the new session modal.
 - Preserve existing Claude-specific metadata behavior.
 
 ## Out of Scope
 
 - Codex-specific session metadata equivalent to Claude Code recap, token metrics, or session IDs.
+- Generated Codex recaps equivalent to Claude Code recap hooks.
 - Codex prompt/recap parsing.
 - Agent filtering or sorting in the session list.
 - Full agent-provider abstraction for adding future CLIs.
@@ -82,6 +84,21 @@ The frontend sends the selected `agent` in the session creation payload. Claude 
 
 Codex session cards use the session name instead of pane title for display, because Codex pane titles can resolve to the host name.
 
+### Codex Metadata
+
+Codex does not currently expose the same JSONL recap fields that CC Hub reads for Claude Code.
+
+The MVP reads basic local metadata from `~/.codex/state_5.sqlite`:
+
+- thread ID
+- title
+- first user message
+- token count
+- git branch
+- updated time
+
+This metadata is used to enrich Codex session cards without enabling Claude-only actions such as conversation replay or `claude -r` resume.
+
 ## Changed Files
 
 - `shared/types.ts`
@@ -94,11 +111,14 @@ Codex session cards use the session name instead of pane title for display, beca
   - Adds Codex process detection.
   - Adds TTY-to-agent mapping.
   - Selects an agent pane as the representative session pane when available.
+- `backend/src/services/codex.ts`
+  - Reads latest Codex thread metadata per working directory from local Codex state.
 - `backend/src/routes/sessions.ts`
   - Reads `agent` from create-session requests.
   - Starts the selected CLI.
   - Applies duplicate guard by same agent and same working directory.
   - Includes `agent` in list/detail/create responses.
+  - Enriches Codex sessions with title, first prompt, thread ID, git branch, and token count when available.
   - Removes last-known metadata during delete.
 - `frontend/src/hooks/useSessions.ts`
   - Sends `agent` in create-session requests.
@@ -153,7 +173,9 @@ Completed checks:
 - `bun run typecheck`
 - `bun run test`
 - Focused agent-provider unit tests for registry IDs, create-session schema, process detection, provider capabilities, and start command quoting.
+- Codex metadata unit tests for missing DB, latest thread selection by cwd, and archived thread filtering.
 - API confirmed an existing Codex session reports `currentCommand: "codex"` and `agent: "codex"`.
+- API confirmed an existing Codex session can include `ccSummary`, `ccFirstPrompt`, `agentSessionId`, `gitBranch`, and token count derived from local Codex metadata.
 - API confirmed duplicate working directory handling for an existing Codex session.
 - A temporary Codex smoke session was created, detected as Codex, shown in the UI, and deleted.
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -633,6 +633,7 @@ function SessionItem({
   const extSession = session;
   const agent = extSession.agent ?? extSession.currentCommand;
   const supportsConversationMetadata = agentSupportsConversationMetadata(agent);
+  const agentLabel = agent && isAgentProvider(agent) ? t(AGENT_PROVIDERS[agent].labelKey) : undefined;
   // Derive card-level indicatorState from panes (priority: waiting_input > processing > idle)
   const cardIndicator: IndicatorState | undefined = (() => {
     if (extSession.panes && extSession.panes.length > 0) {
@@ -752,6 +753,12 @@ function SessionItem({
           {shortPath && (
             <span className="text-[12px] text-zinc-500 truncate font-mono flex-1 min-w-0">
               {shortPath}
+            </span>
+          )}
+
+          {agentLabel && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-zinc-500/15 text-zinc-400 shrink-0">
+              {agentLabel}
             </span>
           )}
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -756,12 +756,6 @@ function SessionItem({
             </span>
           )}
 
-          {agentLabel && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-zinc-500/15 text-zinc-400 shrink-0">
-              {agentLabel}
-            </span>
-          )}
-
           {/* Status badge - pill style */}
           {isWaiting && hasWaitingTool ? (
             <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-amber-500/15 text-amber-400">
@@ -821,10 +815,15 @@ function SessionItem({
           </p>
         )}
 
-        {/* Metrics row: context / memory / tokens */}
-        {extSession.metrics && (
+        {/* Metadata row: agent / context / memory / tokens */}
+        {(agentLabel || extSession.metrics) && (
           <div className="mt-1.5 flex items-center gap-3 flex-wrap text-[11px] text-zinc-500">
-            {typeof extSession.metrics.contextPercent === 'number' && (
+            {agentLabel && (
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full font-medium bg-zinc-500/15 text-zinc-400">
+                {agentLabel}
+              </span>
+            )}
+            {typeof extSession.metrics?.contextPercent === 'number' && (
               <div className="inline-flex items-center gap-1.5" title={`${formatTokenCount(extSession.metrics.contextTokens ?? 0)} / ${formatTokenCount(extSession.metrics.contextMaxTokens ?? 0)}`}>
                 <span className="text-zinc-600">ctx</span>
                 <div className="w-14 h-1 bg-white/10 rounded-full overflow-hidden">
@@ -840,12 +839,12 @@ function SessionItem({
                 <span className="font-mono tabular-nums">{extSession.metrics.contextPercent.toFixed(1)}%</span>
               </div>
             )}
-            {typeof extSession.metrics.memoryRssBytes === 'number' && extSession.metrics.memoryRssBytes > 0 && (
+            {typeof extSession.metrics?.memoryRssBytes === 'number' && extSession.metrics.memoryRssBytes > 0 && (
               <span className="font-mono tabular-nums" title={`${extSession.metrics.memoryRssBytes} bytes`}>
                 <span className="text-zinc-600">mem</span> {formatBytes(extSession.metrics.memoryRssBytes)}
               </span>
             )}
-            {typeof extSession.metrics.totalTokens === 'number' && extSession.metrics.totalTokens > 0 && (
+            {typeof extSession.metrics?.totalTokens === 'number' && extSession.metrics.totalTokens > 0 && (
               <span className="font-mono tabular-nums" title={`input + cache_creation + output (excludes cache_read)\n\nin: ${extSession.metrics.totalInputTokens?.toLocaleString() ?? 0}\ncache create: ${extSession.metrics.totalCacheCreationTokens?.toLocaleString() ?? 0}\ncache read: ${extSession.metrics.totalCacheReadTokens?.toLocaleString() ?? 0}\nout: ${extSession.metrics.totalOutputTokens?.toLocaleString() ?? 0}`}>
                 <span className="text-zinc-600">used</span> {formatTokenCount(extSession.metrics.totalTokens)}
               </span>

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -697,7 +697,14 @@ function SessionItem({
             </span>
           </div>
           {shortPath && (
-            <p className="text-[12px] text-zinc-600 truncate mb-2">{shortPath}</p>
+            <p className="text-[12px] text-zinc-600 truncate mb-1.5">{shortPath}</p>
+          )}
+          {agentLabel && (
+            <div className="mb-2 flex items-center gap-2 text-[11px] text-zinc-500">
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full font-medium bg-zinc-500/15 text-zinc-500">
+                {agentLabel}
+              </span>
+            </div>
           )}
           <div className="flex items-center gap-2">
             <button

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -4,7 +4,7 @@ import { Plus, Folder, ChevronRight, ChevronLeft, Search, X, Play, GripVertical 
 import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import type { SessionResponse, ExtendedSessionResponse, IndicatorState, ConversationMessage, FileInfo, SessionTheme } from '../../../shared/types';
+import { AGENT_PROVIDER_IDS, AGENT_PROVIDERS, DEFAULT_AGENT_PROVIDER, agentSupportsConversationMetadata, isAgentProvider, type AgentProvider, type SessionResponse, type ExtendedSessionResponse, type IndicatorState, type ConversationMessage, type FileInfo, type SessionTheme } from '../../../shared/types';
 import { useSessions } from '../hooks/useSessions';
 import { formatRelativeTime } from '../utils/format';
 
@@ -222,13 +222,14 @@ function CreateSessionModal({
   existingNames,
   externalError,
 }: {
-  onConfirm: (name: string, workingDir?: string) => void;
+  onConfirm: (name: string, workingDir?: string, agent?: AgentProvider) => void;
   onCancel: () => void;
   existingNames: Set<string>;
   externalError?: string | null;
 }) {
   const { t } = useTranslation();
   const [name, setName] = useState('');
+  const [agent, setAgent] = useState<AgentProvider>(DEFAULT_AGENT_PROVIDER);
   const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
   const [currentPath, setCurrentPath] = useState<string>('');
   const [directories, setDirectories] = useState<FileInfo[]>([]);
@@ -300,7 +301,7 @@ function CreateSessionModal({
   };
 
   const handleSubmit = () => {
-    onConfirm(name, currentPath);
+    onConfirm(name, currentPath, agent);
   };
 
   const handleCreateFolder = async () => {
@@ -341,6 +342,27 @@ function CreateSessionModal({
             onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
             className="w-full px-3 py-2 bg-th-bg border border-th-border rounded text-th-text placeholder-th-text-muted focus:outline-none focus:border-blue-500 text-sm"
           />
+        </div>
+
+        {/* Agent provider */}
+        <div className="mb-3">
+          <div className="text-xs text-th-text-secondary mb-1">{t('session.agent')}</div>
+          <div className="grid grid-cols-2 gap-2">
+            {AGENT_PROVIDER_IDS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setAgent(option)}
+                className={`px-3 py-2 rounded border text-sm font-medium transition-colors ${
+                  agent === option
+                    ? 'border-blue-500 bg-blue-600/20 text-blue-300'
+                    : 'border-th-border bg-th-bg text-th-text-secondary hover:bg-th-surface-active'
+                }`}
+              >
+                {t(AGENT_PROVIDERS[option].labelKey)}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Directory picker */}
@@ -609,7 +631,8 @@ function SessionItem({
   };
 
   const extSession = session;
-  const isClaudeRunning = extSession.currentCommand === 'claude';
+  const agent = extSession.agent ?? extSession.currentCommand;
+  const supportsConversationMetadata = agentSupportsConversationMetadata(agent);
   // Derive card-level indicatorState from panes (priority: waiting_input > processing > idle)
   const cardIndicator: IndicatorState | undefined = (() => {
     if (extSession.panes && extSession.panes.length > 0) {
@@ -633,12 +656,12 @@ function SessionItem({
   // Use customTitle if set, then pane title if cc is running and title exists, otherwise use session name
   const displayTitle = session.customTitle
     ? session.customTitle
-    : isClaudeRunning && extSession.paneTitle
+    : supportsConversationMetadata && extSession.paneTitle
       ? extSession.paneTitle.replace(/^[✳★●◆]\s*/, '')  // Remove status icons
       : session.name;
 
   // Show resume button only when Claude is not running and we have a ccSessionId
-  const showResumeButton = !isClaudeRunning && extSession.ccSessionId;
+  const showResumeButton = !supportsConversationMetadata && extSession.ccSessionId;
 
   const handleResume = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -722,7 +745,7 @@ function SessionItem({
         {/* Top row: title + path + status badges */}
         <div className="flex items-baseline gap-2 mb-1 min-w-0">
           <h3 className={`text-[15px] font-medium truncate shrink-0 max-w-[55%] tracking-[-0.01em] ${
-            isLive ? 'text-white' : isClaudeRunning ? 'text-zinc-300' : 'text-zinc-400'
+            isLive ? 'text-white' : supportsConversationMetadata ? 'text-zinc-300' : 'text-zinc-400'
           }`}>
             {displayTitle}
           </h3>
@@ -840,7 +863,7 @@ function SessionItem({
         >
           {extSession.panes.map((pane) => {
             const cmd = pane.currentCommand || 'shell';
-            const isClaudePane = cmd === 'claude' || !!pane.agentName;
+            const isAgentPane = isAgentProvider(cmd) || !!pane.agentName;
             const paneTitle = pane.title?.replace(/^[✳★●◆⠂⠈⠐⠠⠄⠁✻✽⏳]\s*/, '').trim();
             const displayName = pane.agentName || paneTitle || cmd;
             const agentColorMap: Record<string, string> = {
@@ -851,7 +874,7 @@ function SessionItem({
             };
             const nameColor = pane.agentColor && agentColorMap[pane.agentColor]
               ? agentColorMap[pane.agentColor]
-              : isClaudePane ? 'text-green-300' : 'text-zinc-300';
+              : isAgentPane ? 'text-green-300' : 'text-zinc-300';
             const paneIndicator = pane.indicatorState;
             const paneDotClass = pane.isDead
               ? 'bg-red-400'
@@ -862,7 +885,7 @@ function SessionItem({
                   : 'bg-zinc-600';
             const paneBgClass = pane.isDead
               ? 'bg-red-900/20 hover:bg-red-900/30'
-              : isClaudePane
+              : isAgentPane
                 ? 'hover:bg-white/[0.04]'
                 : 'hover:bg-white/[0.04]';
 
@@ -1081,10 +1104,10 @@ export function SessionList({ onSelectSession, onSelectPane, onBack, onClose, in
 
   const [createError, setCreateError] = useState<string | null>(null);
 
-  const handleCreateSession = async (name: string, workingDir?: string) => {
+  const handleCreateSession = async (name: string, workingDir?: string, agent?: AgentProvider) => {
     setCreateError(null);
     try {
-      const session = await createSession(name || undefined, workingDir);
+      const session = await createSession(name || undefined, workingDir, agent);
       if (session) {
         setShowCreateModal(false);
         onSelectSession(session);

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import type { ExtendedSessionResponse, SessionResponse, SessionTheme, IndicatorState } from '../../../shared/types';
+import { DEFAULT_AGENT_PROVIDER, type AgentProvider, type ExtendedSessionResponse, type SessionResponse, type SessionTheme, type IndicatorState } from '../../../shared/types';
 import { authFetch, isTransientNetworkError } from '../services/api';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
@@ -44,7 +44,7 @@ interface UseSessionsReturn {
   sessions: ExtendedSessionResponse[];
   isLoading: boolean;
   error: string | null;
-  createSession: (name?: string, workingDir?: string) => Promise<ExtendedSessionResponse | null>;
+  createSession: (name?: string, workingDir?: string, agent?: AgentProvider) => Promise<ExtendedSessionResponse | null>;
   deleteSession: (id: string) => Promise<boolean>;
   updateSessionTheme: (id: string, theme: SessionTheme | null) => Promise<boolean>;
 }
@@ -88,12 +88,12 @@ export function useSessions(): UseSessionsReturn {
     };
   }, []);
 
-  const createSession = useCallback(async (name?: string, workingDir?: string): Promise<SessionResponse | null> => {
+  const createSession = useCallback(async (name?: string, workingDir?: string, agent: AgentProvider = DEFAULT_AGENT_PROVIDER): Promise<SessionResponse | null> => {
     setError(null);
     const response = await authFetch(`${API_BASE}/api/sessions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, workingDir }),
+      body: JSON.stringify({ name, workingDir, agent }),
     });
 
     if (!response.ok) {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -46,11 +46,16 @@
     "deleteWarning": "This action cannot be undone.",
     "sessionName": "Session Name",
     "sessionNamePlaceholder": "Leave blank for auto-generation",
+    "agent": "Agent",
+    "agentProvider": {
+      "claude": "Claude",
+      "codex": "Codex"
+    },
     "workingDirectory": "Working Directory",
     "newFolder": "New Folder",
     "folderName": "Folder name",
     "noSubdirectories": "No subdirectories",
-    "duplicateWorkingDir": "A Claude session is already running in this directory ({{name}})",
+    "duplicateWorkingDir": "A session for the same agent is already running in this directory ({{name}})",
     "resumeFailed": "Failed to resume session",
     "history": "History",
     "longPressHint": "Long press to delete",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -46,11 +46,16 @@
     "deleteWarning": "この操作は取り消せません。",
     "sessionName": "セッション名",
     "sessionNamePlaceholder": "空欄で自動生成",
+    "agent": "エージェント",
+    "agentProvider": {
+      "claude": "Claude",
+      "codex": "Codex"
+    },
     "workingDirectory": "作業ディレクトリ",
     "newFolder": "新規フォルダ",
     "folderName": "フォルダ名",
     "noSubdirectories": "サブディレクトリがありません",
-    "duplicateWorkingDir": "このディレクトリでは既にClaudeセッションが実行中です（{{name}}）",
+    "duplicateWorkingDir": "このディレクトリでは既に同じエージェントのセッションが実行中です（{{name}}）",
     "resumeFailed": "セッションの再開に失敗しました",
     "history": "履歴",
     "longPressHint": "長押しで削除",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.97",
+  "version": "0.1.98",
   "private": true,
   "workspaces": [
     "backend",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -48,6 +48,44 @@ export interface AuthResponse {
 // Session theme colors
 export type SessionTheme = 'red' | 'orange' | 'amber' | 'green' | 'teal' | 'blue' | 'indigo' | 'purple' | 'pink';
 
+export const AGENT_PROVIDERS = {
+  claude: {
+    id: 'claude',
+    command: 'claude',
+    labelKey: 'session.agentProvider.claude',
+    processPatterns: [/(?:^|\/)claude(?:\s|$)/, /\/claude\/versions\//],
+    supportsConversationMetadata: true,
+  },
+  codex: {
+    id: 'codex',
+    command: 'codex',
+    labelKey: 'session.agentProvider.codex',
+    processPatterns: [/(?:^|\/)codex(?:\s|$)/, /\/@openai\/codex\//],
+    supportsConversationMetadata: false,
+  },
+} as const;
+
+export type AgentProvider = keyof typeof AGENT_PROVIDERS;
+export const AGENT_PROVIDER_IDS = Object.keys(AGENT_PROVIDERS) as [AgentProvider, ...AgentProvider[]];
+export const DEFAULT_AGENT_PROVIDER: AgentProvider = 'claude';
+
+export function isAgentProvider(value: string): value is AgentProvider {
+  return value in AGENT_PROVIDERS;
+}
+
+export function detectAgentProviderFromArgs(args: string): AgentProvider | undefined {
+  for (const agent of Object.values(AGENT_PROVIDERS)) {
+    if (agent.processPatterns.some(pattern => pattern.test(args))) {
+      return agent.id;
+    }
+  }
+  return undefined;
+}
+
+export function agentSupportsConversationMetadata(agent: string | undefined): boolean {
+  return !!agent && isAgentProvider(agent) && AGENT_PROVIDERS[agent].supportsConversationMetadata;
+}
+
 export interface SessionResponse {
   id: string;
   name: string;
@@ -55,6 +93,7 @@ export interface SessionResponse {
   lastAccessedAt: string;
   state: SessionState;
   currentPath?: string;
+  agent?: AgentProvider;
   theme?: SessionTheme;
   customTitle?: string;
 }
@@ -110,6 +149,7 @@ export const CreateSessionSchema = z.object({
   name: z.string().min(1).max(64).optional(),
   workingDir: z.string().optional(),
   initialPrompt: z.string().max(1000).optional(),
+  agent: z.enum(AGENT_PROVIDER_IDS).optional().default(DEFAULT_AGENT_PROVIDER),
 });
 
 export const ResizeTerminalSchema = z.object({
@@ -460,4 +500,3 @@ export type MuxServerMessage =
 // [0x02][sessionId\0][paneId\0][raw data]
 // 0x02 = mux output (vs 0x01 = legacy single-session output)
 export const MUX_BINARY_TYPE = 0x02;
-

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -357,6 +357,7 @@ export interface DashboardResponse {
 export interface ExtendedSessionResponse extends SessionResponse {
   indicatorState?: IndicatorState;
   ccSessionId?: string;
+  agentSessionId?: string;
   currentCommand?: string;
   paneTitle?: string;
   ccSummary?: string;


### PR DESCRIPTION
## Summary
- add Claude/Codex agent registry and session agent support
- detect Codex processes in tmux and expose agent in session responses
- add create-session UI selector, MVP docs, and focused agent-provider tests

## Verification
- bun run typecheck
- bun run test