### PR TITLE
Resume sessions using the agent's resume command

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { AGENT_PROVIDERS, CreateSessionSchema, DEFAULT_AGENT_PROVIDER, PaneIdSchema, agentSupportsConversationMetadata, type AgentProvider, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
+import { AGENT_PROVIDERS, AGENT_PROVIDER_IDS, CreateSessionSchema, DEFAULT_AGENT_PROVIDER, PaneIdSchema, agentResumeCommand, agentSupportsConversationMetadata, type AgentProvider, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
 import { TmuxService } from '../services/tmux';
 import { controlSessions, getOrCreateControlSession } from '../services/tmux-control';
 import { ClaudeCodeService } from '../services/claude-code';
@@ -284,6 +284,8 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
 
 const ResumeSessionSchema = z.object({
   ccSessionId: z.string().optional(),
+  sessionId: z.string().optional(),
+  agent: z.enum(AGENT_PROVIDER_IDS).optional(),
 });
 
 // GET /sessions - List all tmux sessions (debug/fallback only, frontend uses WS push)
@@ -478,6 +480,7 @@ sessions.get('/prompts/search', async (c) => {
 const ResumeHistorySchema = z.object({
   sessionId: z.string(),
   projectPath: z.string(),
+  agent: z.enum(AGENT_PROVIDER_IDS).optional(),
 });
 
 sessions.post('/history/resume', async (c) => {
@@ -489,16 +492,15 @@ sessions.post('/history/resume', async (c) => {
   }
 
   const { sessionId, projectPath } = parsed.data;
+  const agent: AgentProvider = parsed.data.agent ?? DEFAULT_AGENT_PROVIDER;
 
   try {
     // Generate a unique tmux session name based on project
     const projectName = projectPath.split('/').pop() || 'session';
     const tmuxSessions = await tmuxService.listSessions();
 
-    // Guard: reject if a Claude session is already running in the same directory
-    const conflicting = tmuxSessions.find(
-      s => s.currentCommand === 'claude' && s.currentPath === projectPath
-    );
+    // Guard: reject if the same agent is already running in the same directory
+    const conflicting = findDuplicateAgentWorkingDirSession(tmuxSessions, agent, projectPath);
     if (conflicting) {
       return c.json({ error: 'duplicate_working_dir', existingSession: conflicting.name }, 409);
     }
@@ -511,20 +513,21 @@ sessions.post('/history/resume', async (c) => {
     // Create new tmux session
     await tmuxService.createSession(tmuxSessionName);
 
-    // Change to project directory and run claude -r
-    const command = `cd ${projectPath} && claude -r ${sessionId}`;
+    // Change to project directory and run the agent's resume command
+    const command = `cd ${shellQuote(projectPath)} && ${agentResumeCommand(agent, sessionId)}`;
     const success = await tmuxService.sendKeys(tmuxSessionName, command);
 
     if (!success) {
       // Clean up the session if command failed
       await tmuxService.killSession(tmuxSessionName);
-      return c.json({ error: 'Failed to start Claude session' }, 500);
+      return c.json({ error: 'Failed to start agent session' }, 500);
     }
 
     return c.json({
       success: true,
       tmuxSessionId: tmuxSessionName,
       ccSessionId: sessionId,
+      agent,
     });
   } catch (_error) {
     return c.json({ error: 'Failed to resume session from history' }, 500);
@@ -597,23 +600,24 @@ sessions.delete('/:id', async (c) => {
   }
 });
 
-// POST /sessions/:id/resume - Resume a Claude Code session
+// POST /sessions/:id/resume - Resume an agent session in an existing tmux session
 sessions.post('/:id/resume', async (c) => {
   const id = c.req.param('id');
   const body = await c.req.json().catch(() => ({}));
   const parsed = ResumeSessionSchema.safeParse(body);
 
-  const exists = await tmuxService.sessionExists(id);
-  if (!exists) {
+  const tmuxSessions = await tmuxService.listSessions();
+  const session = tmuxSessions.find(s => s.id === id);
+  if (!session) {
     return c.json({ error: 'Session not found' }, 404);
   }
 
   try {
-    // Build the claude resume command
-    const ccSessionId = parsed.success ? parsed.data.ccSessionId : undefined;
-    const command = ccSessionId ? `claude -r ${ccSessionId}` : 'claude -r';
+    const sessionId = parsed.success ? (parsed.data.sessionId ?? parsed.data.ccSessionId) : undefined;
+    const requestedAgent = parsed.success ? parsed.data.agent : undefined;
+    const agent: AgentProvider = requestedAgent ?? session.agent ?? DEFAULT_AGENT_PROVIDER;
+    const command = agentResumeCommand(agent, sessionId);
 
-    // Send the command to the tmux session
     const success = await tmuxService.sendKeys(id, command);
     if (!success) {
       return c.json({ error: 'Failed to send command' }, 500);

--- a/backend/tests/unit/agent-providers.test.ts
+++ b/backend/tests/unit/agent-providers.test.ts
@@ -3,6 +3,7 @@ import {
   AGENT_PROVIDER_IDS,
   AGENT_PROVIDERS,
   CreateSessionSchema,
+  agentResumeCommand,
   agentSupportsConversationMetadata,
   detectAgentProviderFromArgs,
 } from '../../../shared/types';
@@ -74,5 +75,12 @@ describe('Agent provider registry', () => {
     ];
 
     expect(findDuplicateAgentWorkingDirSession(sessions, 'codex', '/repo')?.name).toBe('legacy-codex');
+  });
+
+  test('builds resume commands per agent', () => {
+    expect(agentResumeCommand('claude')).toBe('claude -r');
+    expect(agentResumeCommand('claude', 'abc-123')).toBe('claude -r abc-123');
+    expect(agentResumeCommand('codex')).toBe('codex resume');
+    expect(agentResumeCommand('codex', 'thread-xyz')).toBe('codex resume thread-xyz');
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -549,7 +549,7 @@ export function App() {
           const response = await authFetch(`${API_BASE}/api/sessions/history/resume`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ sessionId: session.ccSessionId, projectPath: session.currentPath }),
+            body: JSON.stringify({ sessionId: session.ccSessionId, projectPath: session.currentPath, agent: session.agent }),
           });
           if (!response.ok) {
             throw new Error('Failed to resume session');

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -1011,7 +1011,7 @@ export function SessionList({ onSelectSession, onSelectPane, onBack, onClose, in
           const response = await authFetch(`${API_BASE}/api/sessions/history/resume`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ sessionId: ccSessionId, projectPath: session.currentPath }),
+            body: JSON.stringify({ sessionId: ccSessionId, projectPath: session.currentPath, agent: session.agent }),
           });
           if (response.ok) {
             const data = await response.json();
@@ -1028,11 +1028,11 @@ export function SessionList({ onSelectSession, onSelectPane, onBack, onClose, in
           if (newSession) onSelectSession(newSession);
         }
       } else {
-        // Active session: resume claude in existing tmux session
+        // Active session: resume the agent in the existing tmux session
         const response = await authFetch(`${API_BASE}/api/sessions/${sessionId}/resume`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ccSessionId }),
+          body: JSON.stringify({ ccSessionId, agent: session?.agent }),
         });
         if (response.ok && session) {
           onSelectSession(session);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -52,6 +52,7 @@ export const AGENT_PROVIDERS = {
   claude: {
     id: 'claude',
     command: 'claude',
+    resumeCommand: 'claude -r',
     labelKey: 'session.agentProvider.claude',
     processPatterns: [/(?:^|\/)claude(?:\s|$)/, /\/claude\/versions\//],
     supportsConversationMetadata: true,
@@ -59,6 +60,7 @@ export const AGENT_PROVIDERS = {
   codex: {
     id: 'codex',
     command: 'codex',
+    resumeCommand: 'codex resume',
     labelKey: 'session.agentProvider.codex',
     processPatterns: [/(?:^|\/)codex(?:\s|$)/, /\/@openai\/codex\//],
     supportsConversationMetadata: false,
@@ -84,6 +86,11 @@ export function detectAgentProviderFromArgs(args: string): AgentProvider | undef
 
 export function agentSupportsConversationMetadata(agent: string | undefined): boolean {
   return !!agent && isAgentProvider(agent) && AGENT_PROVIDERS[agent].supportsConversationMetadata;
+}
+
+export function agentResumeCommand(agent: AgentProvider, sessionId?: string): string {
+  const base = AGENT_PROVIDERS[agent].resumeCommand;
+  return sessionId ? `${base} ${sessionId}` : base;
 }
 
 export interface SessionResponse {


### PR DESCRIPTION
## Summary
- `POST /sessions/:id/resume` と `POST /sessions/history/resume` が `claude -r` 固定だったため、Codex セッションを resume すると Claude が起動してしまう問題を解消
- `AGENT_PROVIDERS` に `resumeCommand` を追加し、`agentResumeCommand(agent, sessionId?)` ヘルパー経由で組み立てる構造に統一
- フロント (App.tsx / SessionList.tsx) は resume API 呼び出し時に `session.agent` を渡す

## Behavior
| Body | 実行コマンド |
|---|---|
| `{"agent":"codex","sessionId":"<uuid>"}` | `codex resume <uuid>` |
| `{"agent":"claude","sessionId":"abc-123"}` | `claude -r abc-123` |
| `{}` | `claude -r`（既存挙動を維持） |

`/history/resume` の conflict check も `findDuplicateAgentWorkingDirSession` に統一し、agent 単位で重複判定するよう変更。

## Test plan
- [x] `bun run test` - backend 144 / frontend 36 全 pass
- [x] `bun run --filter backend build` / `bun run --filter frontend build` 成功
- [x] dev backend (port 3456) で `/api/sessions/:id/resume` を実 tmux ペインに対して叩き、`codex resume <uuid>` / `claude -r abc-123` / `claude -r` がそれぞれ tmux に送信されることを確認
- [x] codex CLI 側で受信したコマンドが正しくパースされ、`No saved session found with ID...` のエラーが返る（= 配線正常）
- [ ] UI から history タブの Codex セッション項目で resume 動作（マージ後の動確で実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)