### PR TITLE
Show Codex usage limits on the dashboard

### DIFF
--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { StatsService } from '../services/stats-service';
 import { AnthropicUsageService } from '../services/anthropic-usage';
+import { CodexUsageService } from '../services/codex-usage';
 import { UsageHistoryService } from '../services/usage-history';
 import { SystemMetricsService } from '../services/system-metrics';
 import { getConnectedClientCount } from './terminal-mux';
@@ -9,6 +10,7 @@ import type { DashboardResponse } from '../../../shared/types';
 
 const statsService = new StatsService();
 const anthropicUsageService = new AnthropicUsageService();
+const codexUsageService = new CodexUsageService();
 const usageHistoryService = new UsageHistoryService();
 const systemMetricsService = new SystemMetricsService();
 
@@ -34,8 +36,9 @@ export const dashboard = new Hono();
 
 // GET /dashboard - Get dashboard data
 dashboard.get('/', async (c) => {
-  const [usageLimits, dailyActivity, modelUsage, hourlyActivity, usageHistory, systemMetrics, diskUsage] = await Promise.all([
+  const [usageLimits, codexUsageLimits, dailyActivity, modelUsage, hourlyActivity, usageHistory, systemMetrics, diskUsage] = await Promise.all([
     anthropicUsageService.getUsageLimits(),
+    codexUsageService.getUsageLimits(),
     statsService.getDailyActivity(14),
     statsService.getModelUsage(),
     statsService.getHourlyActivity(),
@@ -56,6 +59,7 @@ dashboard.get('/', async (c) => {
     limits: null, // Deprecated
     usageLimits,
     usageLimitsStatus: anthropicUsageService.getStatus(),
+    codexUsageLimits,
     usageHistory: usageHistory,
     dailyActivity,
     modelUsage,

--- a/backend/src/services/codex-usage.ts
+++ b/backend/src/services/codex-usage.ts
@@ -1,0 +1,201 @@
+import { existsSync, readdirSync, statSync, openSync, readSync, closeSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { CodexUsageLimits, UsageCycleInfo } from '../../../shared/types';
+
+interface RateLimitWindow {
+  used_percent?: number;
+  window_minutes?: number;
+  resets_at?: number; // unix epoch seconds
+}
+
+interface RateLimitsPayload {
+  limit_id?: string;
+  primary?: RateLimitWindow | null;
+  secondary?: RateLimitWindow | null;
+  plan_type?: string;
+}
+
+interface TokenCountEvent {
+  timestamp?: string;
+  type?: string;
+  payload?: {
+    type?: string;
+    rate_limits?: RateLimitsPayload | null;
+  };
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function formatDuration(diffMs: number): string {
+  if (diffMs <= 0) return 'soon';
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  if (days > 0) return `${days}d ${hours}h${minutes}m`;
+  if (hours > 0) return `${hours}h${minutes}m`;
+  return `${minutes}m`;
+}
+
+function statusFromUtilization(utilization: number): UsageCycleInfo['status'] {
+  if (utilization >= 100) return 'exceeded';
+  if (utilization >= 75) return 'warning';
+  return 'safe';
+}
+
+function buildCycleInfo(window: RateLimitWindow | null | undefined, now: number): UsageCycleInfo | undefined {
+  if (!window) return undefined;
+  const utilization = numberOrUndefined(window.used_percent);
+  const resetsAtSec = numberOrUndefined(window.resets_at);
+  if (utilization === undefined || resetsAtSec === undefined) return undefined;
+  const resetsAt = new Date(resetsAtSec * 1000).toISOString();
+  const timeRemaining = formatDuration(resetsAtSec * 1000 - now);
+  return {
+    utilization,
+    resetsAt,
+    timeRemaining,
+    status: statusFromUtilization(utilization),
+    statusMessage: '',
+  };
+}
+
+function classifyWindow(minutes: number | undefined): 'fiveHour' | 'sevenDay' | undefined {
+  if (minutes === undefined) return undefined;
+  // Free plan: only 7d (10080). Paid plans may include 5h (300).
+  // Allow some tolerance — anything under 24h treated as the short window.
+  if (minutes <= 60 * 24) return 'fiveHour';
+  return 'sevenDay';
+}
+
+function findLatestRateLimitsInText(text: string): { event: TokenCountEvent; rateLimits: RateLimitsPayload } | undefined {
+  const lines = text.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]?.trim();
+    if (!line || !line.includes('"rate_limits"')) continue;
+    let event: TokenCountEvent;
+    try {
+      event = JSON.parse(line) as TokenCountEvent;
+    } catch {
+      continue;
+    }
+    if (event.type !== 'event_msg' || event.payload?.type !== 'token_count') continue;
+    const rateLimits = event.payload?.rate_limits;
+    if (rateLimits) return { event, rateLimits };
+  }
+  return undefined;
+}
+
+function readLatestRateLimits(rolloutPath: string): { event: TokenCountEvent; rateLimits: RateLimitsPayload } | undefined {
+  try {
+    const stat = statSync(rolloutPath);
+    const maxTailBytes = 4 * 1024 * 1024;
+    if (stat.size <= maxTailBytes) {
+      return findLatestRateLimitsInText(readFileSync(rolloutPath, 'utf8'));
+    }
+    const fd = openSync(rolloutPath, 'r');
+    try {
+      const bytesToRead = Math.min(stat.size, maxTailBytes);
+      const buffer = Buffer.alloc(bytesToRead);
+      readSync(fd, buffer, 0, bytesToRead, stat.size - bytesToRead);
+      return findLatestRateLimitsInText(buffer.toString('utf8'));
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+interface RolloutCandidate {
+  path: string;
+  mtimeMs: number;
+}
+
+function findRolloutCandidates(sessionsDir: string, limit: number): RolloutCandidate[] {
+  if (!existsSync(sessionsDir)) return [];
+  const candidates: RolloutCandidate[] = [];
+
+  // Layout: sessionsDir/YYYY/MM/DD/rollout-*.jsonl
+  const years = readdirSync(sessionsDir).filter(name => /^\d{4}$/.test(name)).sort().reverse();
+  outer: for (const year of years) {
+    const yearDir = join(sessionsDir, year);
+    let months: string[] = [];
+    try { months = readdirSync(yearDir).filter(name => /^\d{2}$/.test(name)).sort().reverse(); } catch { continue; }
+    for (const month of months) {
+      const monthDir = join(yearDir, month);
+      let days: string[] = [];
+      try { days = readdirSync(monthDir).filter(name => /^\d{2}$/.test(name)).sort().reverse(); } catch { continue; }
+      for (const day of days) {
+        const dayDir = join(monthDir, day);
+        let files: string[] = [];
+        try { files = readdirSync(dayDir).filter(name => name.startsWith('rollout-') && name.endsWith('.jsonl')); } catch { continue; }
+        for (const file of files) {
+          const fullPath = join(dayDir, file);
+          try {
+            const stat = statSync(fullPath);
+            candidates.push({ path: fullPath, mtimeMs: stat.mtimeMs });
+          } catch { /* skip unreadable */ }
+        }
+        // Once we have enough candidates from the most recent days, stop walking older days.
+        if (candidates.length >= limit * 2) break outer;
+      }
+    }
+  }
+
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates.slice(0, limit);
+}
+
+export class CodexUsageService {
+  private sessionsDir: string;
+  private cache: { data: CodexUsageLimits | null; timestamp: number } | null = null;
+  private static readonly CACHE_TTL_MS = 30_000;
+  // How many recent rollouts to scan when looking for the latest rate_limits event.
+  private static readonly ROLLOUT_SCAN_LIMIT = 8;
+
+  constructor(sessionsDir = join(homedir(), '.codex', 'sessions')) {
+    this.sessionsDir = sessionsDir;
+  }
+
+  async getUsageLimits(): Promise<CodexUsageLimits | null> {
+    const now = Date.now();
+    if (this.cache && now - this.cache.timestamp < CodexUsageService.CACHE_TTL_MS) {
+      return this.cache.data;
+    }
+
+    const result = this.computeUsageLimits(now);
+    this.cache = { data: result, timestamp: now };
+    return result;
+  }
+
+  /** Exposed for tests. */
+  computeUsageLimits(now: number = Date.now()): CodexUsageLimits | null {
+    const candidates = findRolloutCandidates(this.sessionsDir, CodexUsageService.ROLLOUT_SCAN_LIMIT);
+    for (const candidate of candidates) {
+      const found = readLatestRateLimits(candidate.path);
+      if (!found) continue;
+      const { event, rateLimits } = found;
+
+      const result: CodexUsageLimits = {
+        planType: rateLimits.plan_type,
+        capturedAt: event.timestamp,
+      };
+
+      const cycles: Array<{ minutes: number | undefined; window: RateLimitWindow | null | undefined }> = [
+        { minutes: rateLimits.primary?.window_minutes, window: rateLimits.primary },
+        { minutes: rateLimits.secondary?.window_minutes, window: rateLimits.secondary },
+      ];
+      for (const { minutes, window } of cycles) {
+        const slot = classifyWindow(minutes);
+        if (!slot) continue;
+        const info = buildCycleInfo(window, now);
+        if (info && !result[slot]) result[slot] = info;
+      }
+
+      if (result.fiveHour || result.sevenDay) return result;
+    }
+    return null;
+  }
+}

--- a/backend/src/services/codex-usage.ts
+++ b/backend/src/services/codex-usage.ts
@@ -9,10 +9,17 @@ interface RateLimitWindow {
   resets_at?: number; // unix epoch seconds
 }
 
+interface RateLimitsCredits {
+  has_credits?: boolean;
+  unlimited?: boolean;
+  balance?: string;
+}
+
 interface RateLimitsPayload {
   limit_id?: string;
   primary?: RateLimitWindow | null;
   secondary?: RateLimitWindow | null;
+  credits?: RateLimitsCredits | null;
   plan_type?: string;
 }
 
@@ -69,11 +76,26 @@ function classifyWindow(minutes: number | undefined): 'fiveHour' | 'sevenDay' | 
   return 'sevenDay';
 }
 
-function findLatestRateLimitsInText(text: string): { event: TokenCountEvent; rateLimits: RateLimitsPayload } | undefined {
+interface RolloutScan {
+  /** Most recent rate_limits event regardless of populated windows. Carries plan/credits state. */
+  latest?: { event: TokenCountEvent; rateLimits: RateLimitsPayload };
+  /** Most recent rate_limits event with at least one populated window. Carries cycle data. */
+  windowed?: { event: TokenCountEvent; rateLimits: RateLimitsPayload };
+}
+
+/**
+ * Walk events newest-first. Codex keeps emitting rate_limits after a cycle is
+ * exhausted, but with both windows null — those are useful for credits/plan
+ * state but not for the chart. So we collect two views:
+ *  - `latest`: the very newest rate_limits event (any windows)
+ *  - `windowed`: the newest event whose primary or secondary is populated
+ */
+function scanRolloutText(text: string): RolloutScan {
   const lines = text.split('\n');
+  const out: RolloutScan = {};
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i]?.trim();
-    if (!line || !line.includes('"rate_limits"')) continue;
+    if (!line?.includes('"rate_limits"')) continue;
     let event: TokenCountEvent;
     try {
       event = JSON.parse(line) as TokenCountEvent;
@@ -82,29 +104,34 @@ function findLatestRateLimitsInText(text: string): { event: TokenCountEvent; rat
     }
     if (event.type !== 'event_msg' || event.payload?.type !== 'token_count') continue;
     const rateLimits = event.payload?.rate_limits;
-    if (rateLimits) return { event, rateLimits };
+    if (!rateLimits) continue;
+    if (!out.latest) out.latest = { event, rateLimits };
+    if (!out.windowed && (rateLimits.primary || rateLimits.secondary)) {
+      out.windowed = { event, rateLimits };
+    }
+    if (out.latest && out.windowed) return out;
   }
-  return undefined;
+  return out;
 }
 
-function readLatestRateLimits(rolloutPath: string): { event: TokenCountEvent; rateLimits: RateLimitsPayload } | undefined {
+function readRolloutScan(rolloutPath: string): RolloutScan {
   try {
     const stat = statSync(rolloutPath);
     const maxTailBytes = 4 * 1024 * 1024;
     if (stat.size <= maxTailBytes) {
-      return findLatestRateLimitsInText(readFileSync(rolloutPath, 'utf8'));
+      return scanRolloutText(readFileSync(rolloutPath, 'utf8'));
     }
     const fd = openSync(rolloutPath, 'r');
     try {
       const bytesToRead = Math.min(stat.size, maxTailBytes);
       const buffer = Buffer.alloc(bytesToRead);
       readSync(fd, buffer, 0, bytesToRead, stat.size - bytesToRead);
-      return findLatestRateLimitsInText(buffer.toString('utf8'));
+      return scanRolloutText(buffer.toString('utf8'));
     } finally {
       closeSync(fd);
     }
   } catch {
-    return undefined;
+    return {};
   }
 }
 
@@ -173,29 +200,52 @@ export class CodexUsageService {
   /** Exposed for tests. */
   computeUsageLimits(now: number = Date.now()): CodexUsageLimits | null {
     const candidates = findRolloutCandidates(this.sessionsDir, CodexUsageService.ROLLOUT_SCAN_LIMIT);
+
+    let aggregateLatest: { event: TokenCountEvent; rateLimits: RateLimitsPayload } | undefined;
+    let aggregateWindowed: { event: TokenCountEvent; rateLimits: RateLimitsPayload } | undefined;
+
     for (const candidate of candidates) {
-      const found = readLatestRateLimits(candidate.path);
-      if (!found) continue;
-      const { event, rateLimits } = found;
-
-      const result: CodexUsageLimits = {
-        planType: rateLimits.plan_type,
-        capturedAt: event.timestamp,
-      };
-
-      const cycles: Array<{ minutes: number | undefined; window: RateLimitWindow | null | undefined }> = [
-        { minutes: rateLimits.primary?.window_minutes, window: rateLimits.primary },
-        { minutes: rateLimits.secondary?.window_minutes, window: rateLimits.secondary },
-      ];
-      for (const { minutes, window } of cycles) {
-        const slot = classifyWindow(minutes);
-        if (!slot) continue;
-        const info = buildCycleInfo(window, now);
-        if (info && !result[slot]) result[slot] = info;
-      }
-
-      if (result.fiveHour || result.sevenDay) return result;
+      const scan = readRolloutScan(candidate.path);
+      if (!aggregateLatest && scan.latest) aggregateLatest = scan.latest;
+      if (!aggregateWindowed && scan.windowed) aggregateWindowed = scan.windowed;
+      if (aggregateLatest && aggregateWindowed) break;
     }
-    return null;
+
+    if (!aggregateLatest && !aggregateWindowed) return null;
+
+    const windowedSource = aggregateWindowed ?? aggregateLatest;
+    const latestSource = aggregateLatest ?? aggregateWindowed;
+    if (!windowedSource || !latestSource) return null;
+
+    const result: CodexUsageLimits = {
+      planType: latestSource.rateLimits.plan_type ?? windowedSource.rateLimits.plan_type,
+      capturedAt: latestSource.event.timestamp,
+    };
+
+    const cycles: Array<{ minutes: number | undefined; window: RateLimitWindow | null | undefined }> = [
+      { minutes: windowedSource.rateLimits.primary?.window_minutes, window: windowedSource.rateLimits.primary },
+      { minutes: windowedSource.rateLimits.secondary?.window_minutes, window: windowedSource.rateLimits.secondary },
+    ];
+    for (const { minutes, window } of cycles) {
+      const slot = classifyWindow(minutes);
+      if (!slot) continue;
+      const info = buildCycleInfo(window, now);
+      if (info && !result[slot]) result[slot] = info;
+    }
+
+    // Codex stops returning windows once the cycle is exhausted, so the windowed
+    // source can be stale by the time we read this. Detect exhaustion from the
+    // latest event's credits and override the short cycle status accordingly.
+    const credits = latestSource.rateLimits.credits;
+    const exhausted = !!credits && credits.has_credits === false && credits.unlimited !== true;
+    if (exhausted) {
+      result.rateLimitExceeded = true;
+      if (result.fiveHour) {
+        result.fiveHour = { ...result.fiveHour, utilization: 100, status: 'exceeded' };
+      }
+    }
+
+    if (!result.fiveHour && !result.sevenDay && !result.rateLimitExceeded) return null;
+    return result;
   }
 }

--- a/backend/tests/unit/codex-usage-service.test.ts
+++ b/backend/tests/unit/codex-usage-service.test.ts
@@ -119,6 +119,62 @@ describe('CodexUsageService', () => {
     expect(result?.capturedAt).toBe('2026-05-06T09:00:00Z');
   });
 
+  test('marks rate limit exceeded when latest event reports no credits', () => {
+    const fiveHourReset = Math.floor(Date.UTC(2026, 4, 7, 16, 48, 0) / 1000);
+    const sevenDayReset = Math.floor(Date.UTC(2026, 4, 14, 11, 48, 0) / 1000);
+    placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
+      // Older event with populated windows (so we still chart something)
+      makeRolloutLine({
+        timestamp: '2026-05-07T12:21:17Z',
+        rate_limits: {
+          primary: { used_percent: 75.0, window_minutes: 300, resets_at: fiveHourReset },
+          secondary: { used_percent: 12.0, window_minutes: 10080, resets_at: sevenDayReset },
+          plan_type: 'plus',
+        },
+      }),
+      // Newer event after exhaustion: windows null, no credits
+      makeRolloutLine({
+        timestamp: '2026-05-07T14:03:01Z',
+        rate_limits: {
+          primary: null,
+          secondary: null,
+          credits: { has_credits: false, unlimited: false, balance: '0' },
+          plan_type: null,
+        },
+      }),
+    ]);
+
+    const svc = new CodexUsageService(sessionsDir);
+    const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 14, 5, 0));
+    expect(result?.rateLimitExceeded).toBe(true);
+    expect(result?.fiveHour?.utilization).toBe(100);
+    expect(result?.fiveHour?.status).toBe('exceeded');
+    // 7d cycle still reports the last known windowed value
+    expect(result?.sevenDay?.utilization).toBe(12.0);
+    // capturedAt comes from the latest (exhausted) event
+    expect(result?.capturedAt).toBe('2026-05-07T14:03:01Z');
+    // planType falls back to the windowed event when latest reports null
+    expect(result?.planType).toBe('plus');
+  });
+
+  test('does not mark exhaustion when credits are unlimited', () => {
+    const fiveHourReset = Math.floor(Date.UTC(2026, 4, 7, 16, 48, 0) / 1000);
+    placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
+      makeRolloutLine({
+        rate_limits: {
+          primary: { used_percent: 50.0, window_minutes: 300, resets_at: fiveHourReset },
+          secondary: null,
+          credits: { has_credits: false, unlimited: true, balance: '0' },
+          plan_type: 'enterprise',
+        },
+      }),
+    ]);
+    const svc = new CodexUsageService(sessionsDir);
+    const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 14, 5, 0));
+    expect(result?.rateLimitExceeded).toBeUndefined();
+    expect(result?.fiveHour?.utilization).toBe(50.0);
+  });
+
   test('caches results within TTL', async () => {
     const resetsAtSec = Math.floor(Date.UTC(2026, 4, 14, 0, 0, 0) / 1000);
     placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [

--- a/backend/tests/unit/codex-usage-service.test.ts
+++ b/backend/tests/unit/codex-usage-service.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CodexUsageService } from '../../src/services/codex-usage';
+
+function makeRolloutLine(overrides: {
+  rate_limits: unknown;
+  timestamp?: string;
+}): string {
+  return JSON.stringify({
+    timestamp: overrides.timestamp ?? '2026-05-07T09:47:35.877Z',
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: null,
+      rate_limits: overrides.rate_limits,
+    },
+  });
+}
+
+let scratch: string;
+let sessionsDir: string;
+
+function placeRollout(relativeDir: string, fileName: string, lines: string[]): void {
+  const dir = join(sessionsDir, relativeDir);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, fileName);
+  writeFileSync(path, `${lines.join('\n')}\n`);
+}
+
+describe('CodexUsageService', () => {
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'cchub-codex-usage-'));
+    sessionsDir = join(scratch, 'sessions');
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  test('returns null when sessions dir is missing', () => {
+    const svc = new CodexUsageService(join(scratch, 'missing'));
+    expect(svc.computeUsageLimits()).toBeNull();
+  });
+
+  test('returns null when no rollout has rate_limits', () => {
+    placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
+      JSON.stringify({ timestamp: '2026-05-07T09:47:30Z', type: 'session_meta', payload: {} }),
+    ]);
+    const svc = new CodexUsageService(sessionsDir);
+    expect(svc.computeUsageLimits()).toBeNull();
+  });
+
+  test('reads 7-day window from primary on free plan', () => {
+    const resetsAtSec = Math.floor(Date.UTC(2026, 4, 14, 0, 0, 0) / 1000);
+    placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
+      makeRolloutLine({
+        rate_limits: {
+          primary: { used_percent: 5.0, window_minutes: 10080, resets_at: resetsAtSec },
+          secondary: null,
+          plan_type: 'free',
+        },
+      }),
+    ]);
+
+    const svc = new CodexUsageService(sessionsDir);
+    const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 9, 47, 35));
+    expect(result).not.toBeNull();
+    expect(result?.planType).toBe('free');
+    expect(result?.fiveHour).toBeUndefined();
+    expect(result?.sevenDay?.utilization).toBe(5.0);
+    expect(result?.sevenDay?.resetsAt).toBe(new Date(resetsAtSec * 1000).toISOString());
+    expect(result?.sevenDay?.status).toBe('safe');
+  });
+
+  test('classifies 5h and 7d windows when both present', () => {
+    const fiveHourReset = Math.floor(Date.UTC(2026, 4, 7, 14, 0, 0) / 1000);
+    const sevenDayReset = Math.floor(Date.UTC(2026, 4, 14, 0, 0, 0) / 1000);
+    placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
+      makeRolloutLine({
+        rate_limits: {
+          primary: { used_percent: 80.0, window_minutes: 300, resets_at: fiveHourReset },
+          secondary: { used_percent: 30.0, window_minutes: 10080, resets_at: sevenDayReset },
+          plan_type: 'plus',
+        },
+      }),
+    ]);
+
+    const svc = new CodexUsageService(sessionsDir);
+    const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 9, 47, 35));
+    expect(result?.fiveHour?.utilization).toBe(80.0);
+    expect(result?.fiveHour?.status).toBe('warning');
+    expect(result?.sevenDay?.utilization).toBe(30.0);
+    expect(result?.planType).toBe('plus');
+  });
+
+  test('walks back through older rollouts when newest has no rate_limits', () => {
+    const resetsAtSec = Math.floor(Date.UTC(2026, 4, 14, 0, 0, 0) / 1000);
+    // Newer file: no rate_limits
+    placeRollout('2026/05/07', 'rollout-2026-05-07T10-00-00-zzz.jsonl', [
+      JSON.stringify({ timestamp: '2026-05-07T10:00:00Z', type: 'session_meta', payload: {} }),
+    ]);
+    // Older file with rate_limits
+    placeRollout('2026/05/06', 'rollout-2026-05-06T09-00-00-aaa.jsonl', [
+      makeRolloutLine({
+        timestamp: '2026-05-06T09:00:00Z',
+        rate_limits: {
+          primary: { used_percent: 12.5, window_minutes: 10080, resets_at: resetsAtSec },
+          secondary: null,
+          plan_type: 'free',
+        },
+      }),
+    ]);
+
+    const svc = new CodexUsageService(sessionsDir);
+    const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 10, 0, 0));
+    expect(result?.sevenDay?.utilization).toBe(12.5);
+    expect(result?.capturedAt).toBe('2026-05-06T09:00:00Z');
+  });
+
+  test('caches results within TTL', async () => {
+    const resetsAtSec = Math.floor(Date.UTC(2026, 4, 14, 0, 0, 0) / 1000);
+    placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
+      makeRolloutLine({
+        rate_limits: {
+          primary: { used_percent: 5.0, window_minutes: 10080, resets_at: resetsAtSec },
+          secondary: null,
+          plan_type: 'free',
+        },
+      }),
+    ]);
+
+    const svc = new CodexUsageService(sessionsDir);
+    const first = await svc.getUsageLimits();
+    rmSync(scratch, { recursive: true, force: true });
+    const second = await svc.getUsageLimits();
+    expect(first).toEqual(second);
+    expect(second?.sevenDay?.utilization).toBe(5.0);
+  });
+});

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -29,7 +29,22 @@ export function Dashboard({ className = '', compact = false }: DashboardProps) {
   const [cacheClearing, setCacheClearing] = useState(false);
   const [agentTab, setAgentTab] = useState<AgentTab>('claude');
   const codexLimits = data?.codexUsageLimits;
-  const showAgentTabs = !!codexLimits;
+  const codexAvailable = !!codexLimits;
+  // Claude is "available" when we have any actionable Claude data. The endpoint
+  // returns empty arrays / no-credentials errors on a Codex-only machine.
+  const claudeAvailable = !!data && (
+    !!data.usageLimits
+    || (data.dailyActivity?.length ?? 0) > 0
+    || (data.modelUsage?.length ?? 0) > 0
+  );
+  const showAgentTabs = claudeAvailable && codexAvailable;
+  // When only one provider is available we ignore `agentTab` and force the
+  // available one. Otherwise respect the user's tab selection (default Claude).
+  const effectiveTab: AgentTab = showAgentTabs
+    ? agentTab
+    : codexAvailable && !claudeAvailable
+      ? 'codex'
+      : 'claude';
 
   const handleClearCache = useCallback(async () => {
     setCacheClearing(true);
@@ -97,13 +112,19 @@ export function Dashboard({ className = '', compact = false }: DashboardProps) {
         </div>
       )}
 
-      {agentTab === 'codex' ? (
+      {effectiveTab === 'codex' ? (
         <div className={compact ? 'space-y-3' : 'md:grid md:grid-cols-2 md:gap-4 space-y-3 md:space-y-0'}>
           <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06] md:col-span-2">
             <UsageLimits
               data={codexLimits || null}
               history={[]}
               title={t('dashboard.codexUsageLimits')}
+              showMissingCycles
+              badge={codexLimits?.planType}
+              banner={codexLimits?.rateLimitExceeded
+                ? { message: t('dashboard.codexRateLimitExceeded'), tone: 'danger' }
+                : undefined
+              }
             />
           </div>
           <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06] md:col-span-2 text-th-text-muted text-xs">

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -19,12 +19,17 @@ interface DashboardProps {
   compact?: boolean; // true when in narrow side panel
 }
 
+type AgentTab = 'claude' | 'codex';
+
 export function Dashboard({ className = '', compact = false }: DashboardProps) {
   const { t, i18n } = useTranslation();
   const { data, isLoading, error } = useDashboard(30000);
   const { theme, toggleTheme } = useTheme();
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [cacheClearing, setCacheClearing] = useState(false);
+  const [agentTab, setAgentTab] = useState<AgentTab>('claude');
+  const codexLimits = data?.codexUsageLimits;
+  const showAgentTabs = !!codexLimits;
 
   const handleClearCache = useCallback(async () => {
     setCacheClearing(true);
@@ -69,28 +74,66 @@ export function Dashboard({ className = '', compact = false }: DashboardProps) {
 
   return (
     <div className={`overflow-y-auto overscroll-contain px-4 py-4 ${className}`}>
-      <div className={compact ? 'space-y-3' : 'md:grid md:grid-cols-2 md:gap-4 space-y-3 md:space-y-0'}>
-        <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
-          <NetworkLatency />
+      {showAgentTabs && (
+        <div className="flex gap-1 mb-3 text-xs">
+          {(['claude', 'codex'] as const).map(id => {
+            const isActive = agentTab === id;
+            const label = id === 'claude' ? 'Claude' : 'Codex';
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setAgentTab(id)}
+                className={`px-3 py-1.5 rounded-md transition-colors ${
+                  isActive
+                    ? 'bg-white/[0.08] text-th-text'
+                    : 'bg-white/[0.03] text-th-text-muted hover:text-th-text hover:bg-white/[0.05]'
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
         </div>
-        <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
-          <ServerInfo systemMetrics={data?.systemMetrics} diskUsage={data?.diskUsage} connectedClients={data?.connectedClients} />
-        </div>
-        <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
-          <UsageLimits data={data?.usageLimits || null} status={data?.usageLimitsStatus} history={data?.usageHistory || []} />
-        </div>
-        <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
-          <DailyUsageChart data={data?.dailyActivity || []} />
-        </div>
-        <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
-          <ModelUsageChart data={data?.modelUsage || []} />
-        </div>
-        {data?.hourlyActivity && Object.keys(data.hourlyActivity).length > 0 && (
+      )}
+
+      {agentTab === 'codex' ? (
+        <div className={compact ? 'space-y-3' : 'md:grid md:grid-cols-2 md:gap-4 space-y-3 md:space-y-0'}>
           <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06] md:col-span-2">
-            <HourlyHeatmap data={data.hourlyActivity} />
+            <UsageLimits
+              data={codexLimits || null}
+              history={[]}
+              title={t('dashboard.codexUsageLimits')}
+            />
           </div>
-        )}
-      </div>
+          <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06] md:col-span-2 text-th-text-muted text-xs">
+            {t('dashboard.codexOtherMetricsComingSoon')}
+          </div>
+        </div>
+      ) : (
+        <div className={compact ? 'space-y-3' : 'md:grid md:grid-cols-2 md:gap-4 space-y-3 md:space-y-0'}>
+          <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
+            <NetworkLatency />
+          </div>
+          <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
+            <ServerInfo systemMetrics={data?.systemMetrics} diskUsage={data?.diskUsage} connectedClients={data?.connectedClients} />
+          </div>
+          <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
+            <UsageLimits data={data?.usageLimits || null} status={data?.usageLimitsStatus} history={data?.usageHistory || []} />
+          </div>
+          <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
+            <DailyUsageChart data={data?.dailyActivity || []} />
+          </div>
+          <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
+            <ModelUsageChart data={data?.modelUsage || []} />
+          </div>
+          {data?.hourlyActivity && Object.keys(data.hourlyActivity).length > 0 && (
+            <div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06] md:col-span-2">
+              <HourlyHeatmap data={data.hourlyActivity} />
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Settings section */}
       <div className="mt-6 pt-4 border-t border-white/[0.06]">

--- a/frontend/src/components/dashboard/UsageLimits.tsx
+++ b/frontend/src/components/dashboard/UsageLimits.tsx
@@ -12,6 +12,12 @@ interface UsageLimitsProps {
   status?: UsageLimitsStatus;
   history: UsageSnapshot[];
   title?: string;
+  /** Render a placeholder for cycles that are absent from `data` (e.g. Codex free plan has no 5h). */
+  showMissingCycles?: boolean;
+  /** Small badge shown next to the title (e.g. plan name). */
+  badge?: string;
+  /** Optional banner shown above the cycles, e.g. "rate limit exceeded". */
+  banner?: { message: string; tone?: 'info' | 'warning' | 'danger' };
 }
 
 function formatTimeUntil(iso: string): string {
@@ -73,14 +79,49 @@ function getStatusMessage(
   }
 }
 
-export function UsageLimits({ data, status, history, title }: UsageLimitsProps) {
+function MissingCyclePlaceholder({ label, message }: { label: string; message: string }) {
+  return (
+    <div className="mb-3">
+      <div className="flex justify-between text-xs mb-1">
+        <span className="text-th-text-secondary">{label}</span>
+        <span className="text-th-text-muted">—</span>
+      </div>
+      <div className="text-[10px] text-th-text-muted">{message}</div>
+    </div>
+  );
+}
+
+function Banner({ banner }: { banner: NonNullable<UsageLimitsProps['banner']> }) {
+  const toneClass = banner.tone === 'danger'
+    ? 'border-red-500/40 bg-red-500/10 text-red-300'
+    : banner.tone === 'warning'
+      ? 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+      : 'border-blue-500/40 bg-blue-500/10 text-blue-300';
+  return (
+    <div className={`text-[11px] mb-2 px-2 py-1.5 rounded border ${toneClass}`}>
+      {banner.message}
+    </div>
+  );
+}
+
+export function UsageLimits({ data, status, history, title, showMissingCycles = false, badge, banner }: UsageLimitsProps) {
   const { t } = useTranslation();
   const heading = title ?? t('dashboard.usageLimits');
+  const headingNode = (
+    <div className="flex items-center gap-2">
+      <span className="text-sm font-medium text-th-text">{heading}</span>
+      {badge && (
+        <span className="text-[10px] text-th-text-muted uppercase tracking-wide px-1.5 py-0.5 bg-white/[0.06] rounded">
+          {badge}
+        </span>
+      )}
+    </div>
+  );
 
   if (!data || (!data.fiveHour && !data.sevenDay)) {
     return (
       <div className="p-3 bg-th-surface rounded-md">
-        <div className="text-sm font-medium text-th-text mb-2">{heading}</div>
+        <div className="mb-2">{headingNode}</div>
         {status?.errorReason ? (
           <ErrorMessage status={status} />
         ) : (
@@ -90,18 +131,21 @@ export function UsageLimits({ data, status, history, title }: UsageLimitsProps) 
     );
   }
 
+  const missingMessage = t('dashboard.cycleNotInPlan');
+
   return (
     <div className="p-3 bg-th-surface rounded-md">
       <div className="flex items-center justify-between mb-3">
-        <div className="text-sm font-medium text-th-text">{heading}</div>
+        {headingNode}
         {status?.isStale && (
           <div className="text-[10px] text-th-text-muted">{t('dashboard.usageStaleData')}</div>
         )}
       </div>
 
       {status?.errorReason && <ErrorMessage status={status} />}
+      {banner && <Banner banner={banner} />}
 
-      {data.fiveHour && (
+      {data.fiveHour ? (
         <UsageChart
           label={t('dashboard.fiveHourCycle')}
           field="fiveHour"
@@ -111,9 +155,13 @@ export function UsageLimits({ data, status, history, title }: UsageLimitsProps) 
           status={data.fiveHour.status || 'safe'}
           statusMessage={getStatusMessage(t, data.fiveHour.status, data.fiveHour.timeRemaining, data.fiveHour.estimatedHitTime)}
         />
+      ) : (
+        showMissingCycles && (
+          <MissingCyclePlaceholder label={t('dashboard.fiveHourCycle')} message={missingMessage} />
+        )
       )}
 
-      {data.sevenDay && (
+      {data.sevenDay ? (
         <UsageChart
           label={t('dashboard.sevenDayCycle')}
           field="sevenDay"
@@ -123,6 +171,10 @@ export function UsageLimits({ data, status, history, title }: UsageLimitsProps) 
           status={data.sevenDay.status || 'safe'}
           statusMessage={getStatusMessage(t, data.sevenDay.status, data.sevenDay.timeRemaining, data.sevenDay.estimatedHitTime)}
         />
+      ) : (
+        showMissingCycles && (
+          <MissingCyclePlaceholder label={t('dashboard.sevenDayCycle')} message={missingMessage} />
+        )
       )}
     </div>
   );

--- a/frontend/src/components/dashboard/UsageLimits.tsx
+++ b/frontend/src/components/dashboard/UsageLimits.tsx
@@ -1,11 +1,17 @@
 import { useTranslation } from 'react-i18next';
-import type { UsageLimits as UsageLimitsType, UsageLimitsStatus, UsageSnapshot } from '../../../../shared/types';
+import type { UsageCycleInfo, UsageLimitsStatus, UsageSnapshot } from '../../../../shared/types';
 import { UsageChart } from './UsageChart';
 
+interface UsageLimitsData {
+  fiveHour?: UsageCycleInfo;
+  sevenDay?: UsageCycleInfo;
+}
+
 interface UsageLimitsProps {
-  data: UsageLimitsType | null;
+  data: UsageLimitsData | null;
   status?: UsageLimitsStatus;
   history: UsageSnapshot[];
+  title?: string;
 }
 
 function formatTimeUntil(iso: string): string {
@@ -67,13 +73,14 @@ function getStatusMessage(
   }
 }
 
-export function UsageLimits({ data, status, history }: UsageLimitsProps) {
+export function UsageLimits({ data, status, history, title }: UsageLimitsProps) {
   const { t } = useTranslation();
+  const heading = title ?? t('dashboard.usageLimits');
 
-  if (!data) {
+  if (!data || (!data.fiveHour && !data.sevenDay)) {
     return (
       <div className="p-3 bg-th-surface rounded-md">
-        <div className="text-sm font-medium text-th-text mb-2">{t('dashboard.usageLimits')}</div>
+        <div className="text-sm font-medium text-th-text mb-2">{heading}</div>
         {status?.errorReason ? (
           <ErrorMessage status={status} />
         ) : (
@@ -86,7 +93,7 @@ export function UsageLimits({ data, status, history }: UsageLimitsProps) {
   return (
     <div className="p-3 bg-th-surface rounded-md">
       <div className="flex items-center justify-between mb-3">
-        <div className="text-sm font-medium text-th-text">{t('dashboard.usageLimits')}</div>
+        <div className="text-sm font-medium text-th-text">{heading}</div>
         {status?.isStale && (
           <div className="text-[10px] text-th-text-muted">{t('dashboard.usageStaleData')}</div>
         )}
@@ -94,25 +101,29 @@ export function UsageLimits({ data, status, history }: UsageLimitsProps) {
 
       {status?.errorReason && <ErrorMessage status={status} />}
 
-      <UsageChart
-        label={t('dashboard.fiveHourCycle')}
-        field="fiveHour"
-        snapshots={history}
-        currentUtilization={data.fiveHour.utilization}
-        resetsAt={data.fiveHour.resetsAt}
-        status={data.fiveHour.status || 'safe'}
-        statusMessage={getStatusMessage(t, data.fiveHour.status, data.fiveHour.timeRemaining, data.fiveHour.estimatedHitTime)}
-      />
+      {data.fiveHour && (
+        <UsageChart
+          label={t('dashboard.fiveHourCycle')}
+          field="fiveHour"
+          snapshots={history}
+          currentUtilization={data.fiveHour.utilization}
+          resetsAt={data.fiveHour.resetsAt}
+          status={data.fiveHour.status || 'safe'}
+          statusMessage={getStatusMessage(t, data.fiveHour.status, data.fiveHour.timeRemaining, data.fiveHour.estimatedHitTime)}
+        />
+      )}
 
-      <UsageChart
-        label={t('dashboard.sevenDayCycle')}
-        field="sevenDay"
-        snapshots={history}
-        currentUtilization={data.sevenDay.utilization}
-        resetsAt={data.sevenDay.resetsAt}
-        status={data.sevenDay.status || 'safe'}
-        statusMessage={getStatusMessage(t, data.sevenDay.status, data.sevenDay.timeRemaining, data.sevenDay.estimatedHitTime)}
-      />
+      {data.sevenDay && (
+        <UsageChart
+          label={t('dashboard.sevenDayCycle')}
+          field="sevenDay"
+          snapshots={history}
+          currentUtilization={data.sevenDay.utilization}
+          resetsAt={data.sevenDay.resetsAt}
+          status={data.sevenDay.status || 'safe'}
+          statusMessage={getStatusMessage(t, data.sevenDay.status, data.sevenDay.timeRemaining, data.sevenDay.estimatedHitTime)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -82,6 +82,8 @@
   "dashboard": {
     "title": "Dashboard",
     "usageLimits": "Usage Limits",
+    "codexUsageLimits": "Codex Usage Limits",
+    "codexOtherMetricsComingSoon": "Codex daily activity, model usage, and cost estimates are coming soon",
     "resetIn": "Reset in",
     "limitPrediction": "Limit Prediction",
     "dailyStats": "Daily Activity",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -84,6 +84,8 @@
     "usageLimits": "Usage Limits",
     "codexUsageLimits": "Codex Usage Limits",
     "codexOtherMetricsComingSoon": "Codex daily activity, model usage, and cost estimates are coming soon",
+    "cycleNotInPlan": "Not available on current plan",
+    "codexRateLimitExceeded": "Codex rate limit exceeded — wait for reset or purchase credits",
     "resetIn": "Reset in",
     "limitPrediction": "Limit Prediction",
     "dailyStats": "Daily Activity",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -84,6 +84,8 @@
     "usageLimits": "使用量リミット",
     "codexUsageLimits": "Codex 使用量リミット",
     "codexOtherMetricsComingSoon": "Codex の日別アクティビティ・モデル別使用量・コスト推定は準備中です",
+    "cycleNotInPlan": "現在のプランでは未対応",
+    "codexRateLimitExceeded": "Codex のリミット到達中（リセットまで利用不可、もしくは追加クレジット購入が必要）",
     "resetIn": "リセットまで",
     "limitPrediction": "リミット到達予測",
     "dailyStats": "日別アクティビティ",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -82,6 +82,8 @@
   "dashboard": {
     "title": "ダッシュボード",
     "usageLimits": "使用量リミット",
+    "codexUsageLimits": "Codex 使用量リミット",
+    "codexOtherMetricsComingSoon": "Codex の日別アクティビティ・モデル別使用量・コスト推定は準備中です",
     "resetIn": "リセットまで",
     "limitPrediction": "リミット到達予測",
     "dailyStats": "日別アクティビティ",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -311,6 +311,12 @@ export interface CodexUsageLimits {
   sevenDay?: UsageCycleInfo;
   planType?: string;
   capturedAt?: string; // timestamp of the rollout event the limits were read from
+  /**
+   * True when Codex's most recent rate_limits event reports `credits.has_credits === false`.
+   * OpenAI returns null primary/secondary windows once exhausted, so the cycle data
+   * may be from an earlier in-cycle measurement; this flag signals "currently exhausted".
+   */
+  rateLimitExceeded?: boolean;
 }
 
 // Usage history snapshot for line chart

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -304,6 +304,15 @@ export interface UsageLimits {
   sevenDay: UsageCycleInfo;
 }
 
+// Usage limits derived from Codex rollouts (rate_limits in token_count events).
+// Free plan only includes the 7-day window; paid plans may include both.
+export interface CodexUsageLimits {
+  fiveHour?: UsageCycleInfo;
+  sevenDay?: UsageCycleInfo;
+  planType?: string;
+  capturedAt?: string; // timestamp of the rollout event the limits were read from
+}
+
 // Usage history snapshot for line chart
 export interface UsageSnapshot {
   timestamp: string; // ISO 8601
@@ -350,6 +359,7 @@ export interface DashboardResponse {
   limits: LimitsInfo | null; // Deprecated, kept for compatibility
   usageLimits: UsageLimits | null; // New: from Anthropic API
   usageLimitsStatus?: UsageLimitsStatus; // Error/state info for UI
+  codexUsageLimits?: CodexUsageLimits | null; // From Codex rollouts
   usageHistory: UsageSnapshot[]; // Usage history for line chart
   dailyActivity: DailyActivity[];
   modelUsage: ModelUsage[];


### PR DESCRIPTION
## Summary
- Codex rollout (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`) の `token_count` イベントに含まれる `rate_limits` を読み取り、ダッシュボードに Codex 用のリミット表示を追加
- ダッシュボード上部に `Claude` / `Codex` の agent タブを追加（両方のデータが存在するときのみ表示）
- 既存の `UsageLimits` コンポーネントを optional cycle 対応にリファクタ（Claude は 5h+7d、Codex 旧 free plan 等は対応する cycle のみ表示）
- レート制限到達時のバナー表示と、片方しかインストールされていない環境向けのフォールバック

## Implementation
- `backend/src/services/codex-usage.ts` (新規):
  - sessions ツリーを最新日から walk して rollout を新しい順に取得（最大 8 件）
  - 末尾 4MB を tail し、newest-first で 2 つの view を収集:
    - **latest**: plan_type / credits 取得用（windows が null でも採用）
    - **windowed**: 5h/7d グラフ用（primary または secondary が populated）
  - `primary` / `secondary` を `window_minutes` で 5h/7d に振り分け（24h 未満は短期）
  - `credits.has_credits === false` (and not unlimited) で `rateLimitExceeded` をセットし、5h cycle を 100% / exceeded に上書き
  - 30秒キャッシュ
- `shared/types.ts`: `CodexUsageLimits`（cycles optional, planType, capturedAt, rateLimitExceeded）。`DashboardResponse.codexUsageLimits` を追加
- `routes/dashboard.ts`: `CodexUsageService` を組み込みレスポンスに含める
- `frontend/components/dashboard/UsageLimits.tsx`: optional cycle 対応、`badge` (plan_type)、`banner`（rate-limit 到達時の警告）prop を追加
- `frontend/components/dashboard/Dashboard.tsx`:
  - agent タブ。両方のデータが揃うときのみ表示
  - `claudeAvailable` / `codexAvailable` を判定し、片方しか無い環境では自動でそちらを表示
  - Codex タブには UsageLimits + 「他のメトリクスは準備中」プレースホルダ

## Test plan
- [x] `bun run --filter '*' test` 全 pass (backend 152, frontend 36)
- [x] backend `codex-usage-service.test.ts` 8 ケース（基本、5h+7d 同居、古い rollout フォールスルー、キャッシュ、rate-limit-exhausted 検出、unlimited 例外）
- [x] dev backend (3456) で `/api/dashboard` の `codexUsageLimits` を実機データで確認
  - free 期: `{ planType: "free", sevenDay: { utilization: 5, ... } }`
  - plus 期: `{ planType: "plus", fiveHour: { utilization: 75 }, sevenDay: { utilization: 12 } }`
  - exhausted: `{ rateLimitExceeded: true, fiveHour: { utilization: 100, status: "exceeded" }, ... }`
- [x] backend / frontend 双方の build が通ることを確認
- [x] dev UI 上で Codex タブ → グラフ + plan badge + banner の表示を確認

## Notes
- 片方しかインストールされていない環境のシミュレートは未実施（ロジック信頼）。`~/.codex/` または `~/.claude/` を持たない環境で従来挙動が崩れないことは graceful degradation で担保しています
- Codex 用の DailyActivity / ModelUsage / CostEstimate は別タスクで対応予定（Codex タブ内にプレースホルダ表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)