### PR TITLE
Resume lost sessions with the original agent

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -241,7 +241,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       ccRecapAt: undefined,
       indicatorState: undefined,
       ccSessionId: lost.ccSessionId,
-      agentSessionId: undefined,
+      agentSessionId: lost.agentSessionId,
       messageCount: undefined,
       gitBranch: undefined,
       durationMinutes: undefined,
@@ -264,6 +264,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       theme: s.theme,
       customTitle: s.customTitle,
       ccSessionId: s.ccSessionId,
+      agentSessionId: s.agentSessionId,
     })),
     ...lostSessions,
   ];

--- a/backend/src/services/session-metadata.ts
+++ b/backend/src/services/session-metadata.ts
@@ -19,6 +19,8 @@ export interface LastKnownSession {
   theme?: SessionTheme;
   customTitle?: string;
   ccSessionId?: string;
+  /** Codex thread id (rollout). Used to drive `codex resume <id>` after reboot. */
+  agentSessionId?: string;
 }
 
 interface MetadataStore {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -545,17 +545,21 @@ export function App() {
   }, [activeSessionId, isLoading]);
 
   const handleSelectSession = useCallback(async (session: ExtendedSessionResponse) => {
-    // Lost session: resume with claude -r if ccSessionId available, otherwise recreate
+    // Lost session: resume with the original agent's resume command when we have
+    // a conversation id (Claude → ccSessionId, Codex → agentSessionId), otherwise
+    // recreate a fresh session preserving the original agent.
     if (session.state === 'lost') {
       try {
         let newSessionId: string;
         let newSessionName: string;
-        if (session.ccSessionId && session.currentPath) {
-          // Resume with conversation history via claude -r
+        const conversationId = session.agent === 'codex'
+          ? session.agentSessionId
+          : session.ccSessionId;
+        if (conversationId && session.currentPath) {
           const response = await authFetch(`${API_BASE}/api/sessions/history/resume`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ sessionId: session.ccSessionId, projectPath: session.currentPath, agent: session.agent }),
+            body: JSON.stringify({ sessionId: conversationId, projectPath: session.currentPath, agent: session.agent }),
           });
           if (!response.ok) {
             throw new Error('Failed to resume session');
@@ -564,8 +568,8 @@ export function App() {
           newSessionId = data.tmuxSessionId;
           newSessionName = data.tmuxSessionId;
         } else {
-          // No ccSessionId: fallback to new session
-          const newSession = await createSession(session.name, session.currentPath);
+          // No conversation id: fall back to a fresh session in the same agent.
+          const newSession = await createSession(session.name, session.currentPath, session.agent);
           if (!newSession) return;
           newSessionId = newSession.id;
           newSessionName = newSession.name;
@@ -576,6 +580,8 @@ export function App() {
           state: 'working' as const,
           currentPath: session.currentPath,
           ccSessionId: session.ccSessionId,
+          agent: session.agent,
+          agentSessionId: session.agentSessionId,
           theme: session.theme,
         }]);
         setActiveSessionId(newSessionId);

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -998,20 +998,25 @@ export function SessionList({ onSelectSession, onSelectPane, onBack, onClose, in
       .catch(() => {});
   }, [hookBannerDismissed]);
 
-  // Resume a Claude session
+  // Resume an agent session, preserving the original agent (claude / codex / ...)
   const handleResume = useCallback(async (sessionId: string, ccSessionId?: string) => {
     try {
-      // Check if this is a lost session (no tmux session exists)
       const session = sessions.find(s => s.id === sessionId);
       const isLost = session?.state === 'lost';
+      // Per-agent conversation id: Claude → ccSessionId, Codex → agentSessionId.
+      // Pick the one matching the session's agent so we don't accidentally
+      // hand a Codex thread id to `claude -r` (or vice versa).
+      const conversationId = session?.agent === 'codex'
+        ? session.agentSessionId
+        : (ccSessionId ?? session?.ccSessionId);
 
       if (isLost && session?.currentPath) {
-        if (ccSessionId) {
-          // Lost session with ccSessionId: resume via history API
+        if (conversationId) {
+          // Lost session with a known conversation id: resume via history API
           const response = await authFetch(`${API_BASE}/api/sessions/history/resume`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ sessionId: ccSessionId, projectPath: session.currentPath, agent: session.agent }),
+            body: JSON.stringify({ sessionId: conversationId, projectPath: session.currentPath, agent: session.agent }),
           });
           if (response.ok) {
             const data = await response.json();
@@ -1023,8 +1028,9 @@ export function SessionList({ onSelectSession, onSelectPane, onBack, onClose, in
             setTimeout(checkNewSession, 2000);
           }
         } else {
-          // Lost session without ccSessionId: create new session in the same directory
-          const newSession = await createSession(session.name, session.currentPath);
+          // Lost session without a conversation id: create a fresh session in the same
+          // directory using the original agent so a Codex session doesn't come back as Claude.
+          const newSession = await createSession(session.name, session.currentPath, session.agent);
           if (newSession) onSelectSession(newSession);
         }
       } else {
@@ -1032,7 +1038,7 @@ export function SessionList({ onSelectSession, onSelectPane, onBack, onClose, in
         const response = await authFetch(`${API_BASE}/api/sessions/${sessionId}/resume`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ccSessionId, agent: session?.agent }),
+          body: JSON.stringify({ ccSessionId: conversationId, agent: session?.agent }),
         });
         if (response.ok && session) {
           onSelectSession(session);


### PR DESCRIPTION
## Summary
- Lost セッション（再起動後などに tmux から消えた状態）の Resume ボタンが Codex セッションでも Claude として復活していた問題を修正
- `LastKnownSession` に `agentSessionId` を追加して、再起動後も Codex thread id を保持
- フロントの handleResume / handleSelectSession が agent に応じて適切な conversation id を選択

## Implementation
- `backend/src/services/session-metadata.ts`: `LastKnownSession` に `agentSessionId?: string` を追加
- `backend/src/routes/sessions.ts`: snapshot 保存時に `agentSessionId` を含める。lost セッションの API レスポンスにも `agentSessionId` を伝播
- `frontend/src/components/SessionList.tsx`:
  - handleResume が `session.agent === 'codex'` のとき `agentSessionId`、それ以外は `ccSessionId` を conversation id として採用
  - lost で conversation id が無い場合は `createSession(name, workingDir, session.agent)` で元の agent のまま新規作成
- `frontend/src/App.tsx`: handleSelectSession（lost セッションタップ時）も同じロジック。新しく開いた OpenSession に `agent` / `agentSessionId` も保存

## Test plan
- [x] `bun run --filter '*' test` 全 pass (backend 158, frontend 36)
- [x] backend / frontend 双方の build が通ることを確認
- [ ] dev で Codex セッション → 再起動 → lost 状態で Resume → codex resume <thread_id> が走ることを確認（rate limit 解除後に動確）

## Notes
- 既存の last-known-sessions.json には agentSessionId が無いので、初回は無視される（次回 sessions API 呼び出しで再書き込みされて補完される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)