### PR TITLE
Fix Codex usage reset handling

### DIFF
--- a/backend/src/services/codex-usage.ts
+++ b/backend/src/services/codex-usage.ts
@@ -236,9 +236,13 @@ export class CodexUsageService {
     // Codex stops returning windows once the cycle is exhausted, so the windowed
     // source can be stale by the time we read this. Detect exhaustion from the
     // latest event's credits and override the short cycle status accordingly.
+    // If the cycle reset time has already passed, do not keep the exhausted
+    // override around; the next cycle should be reflected by a fresh event.
     const credits = latestSource.rateLimits.credits;
     const exhausted = !!credits && credits.has_credits === false && credits.unlimited !== true;
-    if (exhausted) {
+    const fiveHourResetAtMs = result.fiveHour ? Date.parse(result.fiveHour.resetsAt) : Number.NaN;
+    const resetExpired = Number.isFinite(fiveHourResetAtMs) && now >= fiveHourResetAtMs;
+    if (exhausted && !resetExpired) {
       result.rateLimitExceeded = true;
       if (result.fiveHour) {
         result.fiveHour = { ...result.fiveHour, utilization: 100, status: 'exceeded' };

--- a/backend/tests/unit/codex-usage-service.test.ts
+++ b/backend/tests/unit/codex-usage-service.test.ts
@@ -175,6 +175,37 @@ describe('CodexUsageService', () => {
     expect(result?.fiveHour?.utilization).toBe(50.0);
   });
 
+  test('does not keep exhaustion after the cycle reset time has passed', () => {
+    const fiveHourReset = Math.floor(Date.UTC(2026, 4, 7, 10, 0, 0) / 1000);
+    const sevenDayReset = Math.floor(Date.UTC(2026, 4, 14, 0, 0, 0) / 1000);
+    placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
+      makeRolloutLine({
+        timestamp: '2026-05-07T09:30:00Z',
+        rate_limits: {
+          primary: { used_percent: 88.0, window_minutes: 300, resets_at: fiveHourReset },
+          secondary: { used_percent: 15.0, window_minutes: 10080, resets_at: sevenDayReset },
+          plan_type: 'plus',
+        },
+      }),
+      makeRolloutLine({
+        timestamp: '2026-05-07T09:35:00Z',
+        rate_limits: {
+          primary: null,
+          secondary: null,
+          credits: { has_credits: false, unlimited: false, balance: '0' },
+          plan_type: null,
+        },
+      }),
+    ]);
+
+    const svc = new CodexUsageService(sessionsDir);
+    const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 11, 0, 0));
+
+    expect(result?.rateLimitExceeded).toBeUndefined();
+    expect(result?.fiveHour?.utilization).toBe(88.0);
+    expect(result?.fiveHour?.status).toBe('warning');
+  });
+
   test('caches results within TTL', async () => {
     const resetsAtSec = Math.floor(Date.UTC(2026, 4, 14, 0, 0, 0) / 1000);
     placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [

--- a/frontend/src/components/dashboard/UsageChart.tsx
+++ b/frontend/src/components/dashboard/UsageChart.tsx
@@ -69,18 +69,17 @@ export function UsageChart({ label, field, snapshots, currentUtilization, resets
     const cycleStart = resetTime - cycleDuration;
     const nowRatio = (now - cycleStart) / cycleDuration;
 
+    const relevantSnapshots = snapshots
+      .filter(s => {
+        const ts = new Date(s.timestamp).getTime();
+        return ts >= cycleStart && ts <= now;
+      })
+      .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
     // --- Actual usage points ---
-    // Always start from cycle start at 0%
-    const actualPoints: { x: number; y: number }[] = [
-      { x: ratioToX(0), y: utilToY(0) },
-    ];
-
-    const relevantSnapshots = snapshots.filter(s => {
-      const ts = new Date(s.timestamp).getTime();
-      return ts >= cycleStart && ts <= now;
-    });
-
-    // Add snapshot points — gaps between them become straight lines naturally
+    // Use only real samples so empty/low-history cycles do not render an
+    // artificial vertical spike from the cycle start.
+    const actualPoints: { x: number; y: number }[] = [];
     for (const snap of relevantSnapshots) {
       const ts = new Date(snap.timestamp).getTime();
       const ratio = (ts - cycleStart) / cycleDuration;


### PR DESCRIPTION
## Summary
- stop carrying Codex exhaustion state after the 5h cycle reset time has passed
- avoid drawing an artificial 0% usage point at cycle start when rendering Codex usage charts
- add regression coverage for reset-expired exhaustion events

## Tests
- bun test backend/tests/unit/codex-usage-service.test.ts
- bun run --filter frontend test