### PR TITLE
Release v0.1.104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.104] - 2026-05-09
+
+### Fixed
+- Lost セッションの Resume ボタンを押しても新しい tmux セッションへ自動で切り替わらない問題を修正
+  - `useCallback` クロージャ内で古い `sessions` 配列を `find` していたため、resume API で作成された新セッションが見つからず navigation が呼ばれなかった
+  - API レスポンスと lost セッションのメタデータから直接セッションオブジェクトを組み立てて即座に遷移するよう変更
+- Claude セッションでアクティブな Resume バッジ条件が壊れていた回帰を修正
+  - `d4d570d` (Codex MVP) で `!isClaudeRunning` を `!supportsConversationMetadata` に取り違えていたため、Claude では絶対にバッジが出ない状態だった
+  - agent プロセス検出ベースで条件を再構築
+
+### Added
+- Codex 使用量ダッシュボードに limit 到達予測時刻 (`estimatedHitTime`) を追加
+  - Anthropic と同じ計算ロジックで、現在のペースから 100% 到達時刻を予測
+  - 予測がある場合は status を `danger` に格上げし、チャートのマーカーと文言を一致させる
+
 ## [0.1.103] - 2026-05-08
 
 ### Fixed

--- a/backend/src/services/codex-usage.ts
+++ b/backend/src/services/codex-usage.ts
@@ -52,18 +52,65 @@ function statusFromUtilization(utilization: number): UsageCycleInfo['status'] {
   return 'safe';
 }
 
+/**
+ * Mirrors AnthropicUsageService.estimateHitTime. Returns a formatted hit time
+ * (HH:MM for short windows, M/D for long windows) when current pace projects
+ * to 100% before the cycle resets — otherwise undefined.
+ *
+ * `cycleHours` is the assumed cycle length used to derive cycle start
+ * (resetTime − cycleHours). Codex uses rolling windows but the chart and
+ * status share this approximation so the message and chart projection agree.
+ */
+function estimateHitTime(
+  utilization: number,
+  resetsAtMs: number,
+  cycleHours: number,
+  now: number,
+): string | undefined {
+  if (utilization <= 0 || utilization >= 100) return undefined;
+  const cycleStartMs = resetsAtMs - cycleHours * 60 * 60 * 1000;
+  const elapsedMs = now - cycleStartMs;
+  if (elapsedMs <= 0) return undefined;
+  const ratePerMs = utilization / elapsedMs;
+  const remaining = 100 - utilization;
+  const msToHit = remaining / ratePerMs;
+  const hitMs = now + msToHit;
+  if (hitMs >= resetsAtMs) return undefined;
+  // Ignore predictions that fall in the last 10% of remaining time — those are
+  // basically "won't hit before reset" with rounding noise.
+  const remainingMs = resetsAtMs - now;
+  if (remainingMs > 0 && msToHit > remainingMs * 0.9) return undefined;
+  const hit = new Date(hitMs);
+  if (cycleHours <= 24) {
+    return `${hit.getHours()}:${hit.getMinutes().toString().padStart(2, '0')}`;
+  }
+  return `${hit.getMonth() + 1}/${hit.getDate()}`;
+}
+
 function buildCycleInfo(window: RateLimitWindow | null | undefined, now: number): UsageCycleInfo | undefined {
   if (!window) return undefined;
   const utilization = numberOrUndefined(window.used_percent);
   const resetsAtSec = numberOrUndefined(window.resets_at);
+  const windowMinutes = numberOrUndefined(window.window_minutes);
   if (utilization === undefined || resetsAtSec === undefined) return undefined;
-  const resetsAt = new Date(resetsAtSec * 1000).toISOString();
-  const timeRemaining = formatDuration(resetsAtSec * 1000 - now);
+  const resetsAtMs = resetsAtSec * 1000;
+  const resetsAt = new Date(resetsAtMs).toISOString();
+  const timeRemaining = formatDuration(resetsAtMs - now);
+  const cycleHours = windowMinutes !== undefined ? windowMinutes / 60 : 0;
+  const estimatedHitTime = cycleHours > 0
+    ? estimateHitTime(utilization, resetsAtMs, cycleHours, now)
+    : undefined;
+  // When current pace projects to 100% before reset, the chart shows the
+  // hit-time marker — the status must say "danger" so the wording matches.
+  const status: UsageCycleInfo['status'] = estimatedHitTime
+    ? 'danger'
+    : statusFromUtilization(utilization);
   return {
     utilization,
     resetsAt,
     timeRemaining,
-    status: statusFromUtilization(utilization),
+    estimatedHitTime,
+    status,
     statusMessage: '',
   };
 }

--- a/backend/tests/unit/codex-usage-service.test.ts
+++ b/backend/tests/unit/codex-usage-service.test.ts
@@ -90,9 +90,31 @@ describe('CodexUsageService', () => {
     const svc = new CodexUsageService(sessionsDir);
     const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 9, 47, 35));
     expect(result?.fiveHour?.utilization).toBe(80.0);
-    expect(result?.fiveHour?.status).toBe('warning');
+    // 80% used 47m into a 5h cycle projects to 100% well before reset, so the
+    // status should be `danger` (matches the chart's hit-time marker).
+    expect(result?.fiveHour?.status).toBe('danger');
+    expect(result?.fiveHour?.estimatedHitTime).toBeDefined();
     expect(result?.sevenDay?.utilization).toBe(30.0);
     expect(result?.planType).toBe('plus');
+  });
+
+  test('keeps status safe when current pace will reset before hitting the limit', () => {
+    // 1% used 4 hours into a 5h cycle. Pace projects far past reset → safe.
+    const fiveHourReset = Math.floor(Date.UTC(2026, 4, 7, 14, 0, 0) / 1000);
+    placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
+      makeRolloutLine({
+        rate_limits: {
+          primary: { used_percent: 1.0, window_minutes: 300, resets_at: fiveHourReset },
+          secondary: null,
+          plan_type: 'plus',
+        },
+      }),
+    ]);
+    const svc = new CodexUsageService(sessionsDir);
+    const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 13, 0, 0));
+    expect(result?.fiveHour?.utilization).toBe(1.0);
+    expect(result?.fiveHour?.status).toBe('safe');
+    expect(result?.fiveHour?.estimatedHitTime).toBeUndefined();
   });
 
   test('walks back through older rollouts when newest has no rate_limits', () => {

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -661,8 +661,10 @@ function SessionItem({
       ? extSession.paneTitle.replace(/^[✳★●◆]\s*/, '')  // Remove status icons
       : session.name;
 
-  // Show resume button only when Claude is not running and we have a ccSessionId
-  const showResumeButton = !supportsConversationMetadata && extSession.ccSessionId;
+  // Show resume button only when no agent is currently running and we have a
+  // conversation id we can resume from (Claude → ccSessionId, Codex → agentSessionId).
+  const isAgentRunning = !!extSession.agent;
+  const showResumeButton = !isAgentRunning && (extSession.ccSessionId || extSession.agentSessionId);
 
   const handleResume = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1020,12 +1022,20 @@ export function SessionList({ onSelectSession, onSelectPane, onBack, onClose, in
           });
           if (response.ok) {
             const data = await response.json();
-            const checkNewSession = () => {
-              const newSession = sessions.find(s => s.id === data.tmuxSessionId);
-              if (newSession) onSelectSession(newSession);
-            };
-            checkNewSession();
-            setTimeout(checkNewSession, 2000);
+            // Build a session object from the API response + the lost session's metadata
+            // so we can navigate immediately, instead of waiting for the WS push and
+            // searching `sessions` (which is stale inside this closure).
+            onSelectSession({
+              id: data.tmuxSessionId,
+              name: data.tmuxSessionId,
+              createdAt: '',
+              lastAccessedAt: '',
+              state: 'working',
+              currentPath: session.currentPath,
+              agent: data.agent ?? session.agent,
+              theme: session.theme,
+              customTitle: session.customTitle,
+            });
           }
         } else {
           // Lost session without a conversation id: create a fresh session in the same

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary

- **fix**: Lost セッションの Resume ボタンが新 tmux セッションに navigate しなかった問題を修正（`useCallback` の stale closure）
- **fix**: Claude セッションでアクティブな Resume バッジが絶対に表示されなかった回帰を修正（`d4d570d` での誤リネーム）
- **feat**: Codex 使用量ダッシュボードに limit 到達予測時刻 (`estimatedHitTime`) を追加。予測がある場合は status を `danger` に格上げ
- **chore**: bump version to 0.1.104

## Test plan
- [x] `bun run typecheck` (4/4 packages pass)
- [x] `bun run test` (160 backend + 36 frontend, 全 pass)
- [x] dev 環境で Lost セッション (`pixiv`) の Resume → `claude -r 8accc343...` 実行 + 新セッションへ自動遷移を実機確認
- [x] dev 環境で ccSessionId なしの Lost セッション (`linux`) → fresh session 作成パスでも navigation 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)