### PR TITLE
Release v0.1.105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.105] - 2026-05-09
+
+### Added
+- ターミナル遅延の end-to-end 計測用 instrumentation を追加（ssh+termux との比較用、本番動作には影響なし）
+  - `CCHUB_BENCH=1` で起動するとバックエンドが WebSocket 送信ごとにフレームサイズ・送信所要時間・タイムスタンプをログ出力
+  - フロントエンドに `window.__cchub_bench` を公開: `start()` で計測開始、受信フレーム数・xterm.js parse 時間 (P50/P95/Max)・スループットを記録
+  - 受信ストリームに `__BENCH_END__` マーカーが現れると自動で集計レポートを `console.table` 出力
+  - `scripts/prepare-bench-data.sh` で 4 種類のベンチ用データ (`/tmp/bench-{plain,color,jp,redraw}.txt`) を生成
+
 ## [0.1.104] - 2026-05-09
 
 ### Fixed

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -6,6 +6,9 @@ import type { ControlClientMessage, MuxClientMessage, ConversationMessage } from
 import { MUX_BINARY_TYPE } from '../../../shared/types';
 import { buildSessionsList } from './sessions';
 
+const BENCH = !!process.env.CCHUB_BENCH;
+const BENCH_T0 = performance.now();
+
 /** Per-session subscription state for a mux client */
 interface MuxSubscription {
   controlSession: TmuxControlSession;
@@ -242,7 +245,12 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
           sessionIdBuf.copy(frame, 1);
           paneIdBuf.copy(frame, 1 + sessionIdBuf.length);
           data.copy(frame, 1 + sessionIdBuf.length + paneIdBuf.length);
+          const sendT = BENCH ? performance.now() : 0;
           const result = ws.send(frame);
+          if (BENCH) {
+            const sendDur = performance.now() - sendT;
+            console.log(`[bench] tx ${sessionId} ${paneId} ${data.length}b send=${sendDur.toFixed(2)}ms t=${(sendT - BENCH_T0).toFixed(2)}`);
+          }
           if (result === 0) {
             sub.sendFailCount++;
           }

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -7,6 +7,7 @@ import '@xterm/xterm/css/xterm.css';
 import { authFetch } from '../services/api';
 import type { SessionTheme } from '../../../shared/types';
 import { filterMouseTrackingInput, filterMouseTrackingOutput, shouldInterceptKeyEvent } from '../utils/terminal-filters';
+import { bench } from '../utils/bench';
 import {
   getTerminalThemes, isLightMode, LIGHT_ANSI_COLORS,
   DEFAULT_FONT_SIZE, MIN_FONT_SIZE, MAX_FONT_SIZE,
@@ -893,7 +894,10 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
     const cleanup = cm.registerOnData((data) => {
       const str = decoder.decode(data, { stream: true });
       const filtered = filterMouseTrackingOutput(str);
-      if (filtered.length > 0) terminalRef.current?.write(filtered);
+      if (filtered.length > 0) {
+        const t0 = bench.recordWriteStart();
+        terminalRef.current?.write(filtered, () => bench.recordWriteEnd(t0, filtered.length));
+      }
     });
     controlCleanupRef.current = cleanup;
     return () => {

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { reportWsLatency } from '../services/latency-store';
 import type { TmuxLayoutNode } from '../../../shared/types';
 import { MUX_BINARY_TYPE } from '../../../shared/types';
+import { bench } from '../utils/bench';
 
 interface UseMultiplexedTerminalOptions {
   sessionId: string;
@@ -195,6 +196,8 @@ function ensureConnection(token?: string | null) {
       const data = view.subarray(idx + 1);
 
       wsOutputCount++;
+      bench.recordFrame(data.length);
+      bench.scanForEndMarker(data);
       cb?.onPaneOutput?.(paneId, data);
       return;
     }

--- a/frontend/src/utils/bench.ts
+++ b/frontend/src/utils/bench.ts
@@ -1,0 +1,174 @@
+/**
+ * End-to-end terminal latency bench.
+ *
+ * Activate by running `__cchub_bench.start()` in DevTools console (or by
+ * setting localStorage 'cchub-bench' = '1' before reload). When active, every
+ * WS frame and every xterm `term.write` is sampled. The bench also watches
+ * the incoming byte stream for the marker `__BENCH_END__` and prints a
+ * summary report when it is seen.
+ *
+ * Recommended usage:
+ *   1. PC で https://localhost:3456 を開いて DevTools コンソールを開く
+ *   2. `__cchub_bench.start()` を実行
+ *   3. 任意のセッションで:
+ *        cat /tmp/bench-color.txt; echo __BENCH_END__
+ *   4. コンソールに集計が出る
+ */
+
+interface FrameSample {
+  /** WebSocket onmessage 受信時刻 (performance.now) */
+  recvT: number;
+  /** バイト数 (ペイロードのみ) */
+  bytes: number;
+}
+
+interface WriteSample {
+  /** term.write 呼び出し直前の時刻 */
+  startT: number;
+  /** xterm の write callback (parse 完了) 時刻 */
+  endT: number;
+  /** 書き込んだバイト数 */
+  bytes: number;
+}
+
+interface BenchState {
+  active: boolean;
+  startT: number;
+  frames: FrameSample[];
+  writes: WriteSample[];
+  endMarkerSeenAt: number | null;
+}
+
+const END_MARKER = '__BENCH_END__';
+const END_MARKER_BYTES = new TextEncoder().encode(END_MARKER);
+
+const state: BenchState = {
+  active: false,
+  startT: 0,
+  frames: [],
+  writes: [],
+  endMarkerSeenAt: null,
+};
+
+function isActive(): boolean {
+  return state.active;
+}
+
+function start(): void {
+  state.active = true;
+  state.startT = performance.now();
+  state.frames = [];
+  state.writes = [];
+  state.endMarkerSeenAt = null;
+  console.log('[bench] started — emit `' + END_MARKER + '` to finalize');
+}
+
+function stop(): void {
+  state.active = false;
+  report();
+}
+
+function recordFrame(bytes: number): void {
+  if (!state.active) return;
+  state.frames.push({ recvT: performance.now(), bytes });
+}
+
+function recordWriteStart(): number {
+  return state.active ? performance.now() : 0;
+}
+
+function recordWriteEnd(startT: number, bytes: number): void {
+  if (!state.active || startT === 0) return;
+  state.writes.push({ startT, endT: performance.now(), bytes });
+}
+
+/**
+ * Scan an incoming byte slice for END_MARKER. When seen, finalize and report.
+ * Uses a small ring of "recent bytes" to handle markers that span frames.
+ */
+let markerScanRing: Uint8Array = new Uint8Array(0);
+function scanForEndMarker(bytes: Uint8Array): void {
+  if (!state.active || state.endMarkerSeenAt !== null) return;
+  // Concat the tail of the previous slice (length = marker - 1) with the new
+  // slice so a marker straddling a frame boundary is still found.
+  const tailLen = Math.min(markerScanRing.length, END_MARKER_BYTES.length - 1);
+  const combined = new Uint8Array(tailLen + bytes.length);
+  combined.set(markerScanRing.subarray(markerScanRing.length - tailLen), 0);
+  combined.set(bytes, tailLen);
+  if (indexOf(combined, END_MARKER_BYTES) !== -1) {
+    state.endMarkerSeenAt = performance.now();
+    // Defer report to next tick so the corresponding write/render is captured.
+    requestAnimationFrame(() => requestAnimationFrame(report));
+  }
+  markerScanRing = bytes;
+}
+
+function indexOf(haystack: Uint8Array, needle: Uint8Array): number {
+  if (needle.length === 0 || haystack.length < needle.length) return -1;
+  outer: for (let i = 0; i <= haystack.length - needle.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+function pct(arr: number[], p: number): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+function report(): void {
+  if (state.frames.length === 0 && state.writes.length === 0) {
+    console.log('[bench] no samples collected');
+    return;
+  }
+  const totalBytes = state.frames.reduce((s, f) => s + f.bytes, 0);
+  const firstFrame = state.frames[0]?.recvT ?? state.startT;
+  const lastFrame = state.frames[state.frames.length - 1]?.recvT ?? state.startT;
+  const lastWriteEnd = state.writes[state.writes.length - 1]?.endT ?? lastFrame;
+  const wallMs = (state.endMarkerSeenAt ?? lastWriteEnd) - firstFrame;
+  const writeDurations = state.writes.map(w => w.endT - w.startT);
+
+  const summary = {
+    frames: state.frames.length,
+    totalBytes,
+    bytesPerFrameAvg: state.frames.length ? Math.round(totalBytes / state.frames.length) : 0,
+    bytesPerFrameP50: pct(state.frames.map(f => f.bytes), 50),
+    bytesPerFrameP95: pct(state.frames.map(f => f.bytes), 95),
+    writes: state.writes.length,
+    writeDurMsP50: pct(writeDurations, 50).toFixed(2),
+    writeDurMsP95: pct(writeDurations, 95).toFixed(2),
+    writeDurMsMax: writeDurations.length ? Math.max(...writeDurations).toFixed(2) : '0',
+    writeDurMsTotal: writeDurations.reduce((s, d) => s + d, 0).toFixed(2),
+    wallMs: wallMs.toFixed(2),
+    throughputKBps: wallMs > 0 ? ((totalBytes / 1024) / (wallMs / 1000)).toFixed(1) : 'n/a',
+    endMarkerSeen: state.endMarkerSeenAt !== null,
+  };
+  console.log('[bench] report', summary);
+  console.table([summary]);
+}
+
+export const bench = {
+  isActive,
+  start,
+  stop,
+  report,
+  recordFrame,
+  recordWriteStart,
+  recordWriteEnd,
+  scanForEndMarker,
+};
+
+// Auto-start if localStorage flag is set
+if (typeof localStorage !== 'undefined' && localStorage.getItem('cchub-bench') === '1') {
+  start();
+}
+
+// Expose on window for DevTools
+if (typeof window !== 'undefined') {
+  (window as unknown as { __cchub_bench: typeof bench }).__cchub_bench = bench;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "private": true,
   "workspaces": [
     "backend",

--- a/scripts/prepare-bench-data.sh
+++ b/scripts/prepare-bench-data.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Prepare bench fixtures used to compare CC Hub vs ssh+tmux throughput.
+#
+# Generates 100KB-class fixtures in /tmp:
+#   bench-plain.txt  100KB ASCII (numeric)
+#   bench-color.txt  100KB ANSI-colored lines (renderer-heavy)
+#   bench-jp.txt     100KB Japanese text (CJK width-heavy)
+#
+# Usage:
+#   bash scripts/prepare-bench-data.sh
+#   # then on each client:
+#   #   cat /tmp/bench-color.txt; echo __BENCH_END__
+set -euo pipefail
+
+OUT_DIR="${1:-/tmp}"
+mkdir -p "$OUT_DIR"
+
+# 1. Plain ASCII
+seq 1 20000 > "$OUT_DIR/bench-plain.txt"
+
+# 2. ANSI color
+{
+  for i in $(seq 1 5000); do
+    printf '\e[3%dm行 %5d: foo bar baz qux quux corge grault garply\e[0m\n' \
+      $((i % 7 + 1)) "$i"
+  done
+} > "$OUT_DIR/bench-color.txt"
+
+# 3. Japanese (CJK). `yes | head -c` triggers SIGPIPE on `yes` which trips
+# pipefail; tolerate that exit code with `|| true`.
+{ yes 'あいうえおかきくけこさしすせそたちつてと日本語テキスト' | head -c 100000; } > "$OUT_DIR/bench-jp.txt" || true
+
+# 4. Full-screen redraw burst (cursor moves + colors, mimics top/htop)
+{
+  for f in $(seq 1 200); do
+    printf '\e[H\e[2J'  # home + clear
+    for r in $(seq 1 24); do
+      printf '\e[%d;1H\e[3%dm%-78s\e[0m\n' \
+        "$r" $((r % 7 + 1)) "frame=$f row=$r $(date +%s%N)"
+    done
+  done
+} > "$OUT_DIR/bench-redraw.txt"
+
+ls -lh "$OUT_DIR"/bench-*.txt
+echo
+echo "Run on each client (ssh-termux / CC Hub):"
+echo "  time (cat $OUT_DIR/bench-color.txt; echo __BENCH_END__)"
+echo
+echo "Frontend bench (DevTools console):"
+echo "  __cchub_bench.start()"
+echo "  // run the cat command in CC Hub"
+echo "  // report prints automatically when __BENCH_END__ is seen"


### PR DESCRIPTION
## Summary

- **feat**: ターミナル遅延の計測 instrumentation を追加（CCHUB_BENCH と `window.__cchub_bench`）。本番動作には影響なし
- **chore**: bump version to 0.1.105

## Test plan
- [x] typecheck (4/4 pass)
- [x] tests (160 backend + 36 frontend pass)
- [x] dev サーバで `CCHUB_BENCH=1` ログ出力を確認 (`[bench] tx ... send=Xms` が流れる)
- [ ] リリース後に Termux ssh と CC Hub で `cat /tmp/bench-color.txt; echo __BENCH_END__` を実機計測比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)