### PR TITLE
Experiment: wterm terminal engine alongside xterm.js (do not merge)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "cc-hub",
+      "dependencies": {
+        "@wterm/ghostty": "0.3.0",
+      },
       "devDependencies": {
         "@typescript/native-preview": "^7.0.0-dev.20260421.2",
       },
@@ -29,6 +32,8 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@tanstack/react-virtual": "^3.13.23",
+        "@wterm/dom": "0.3.0",
+        "@wterm/react": "0.3.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-webgl": "^0.19.0",
@@ -624,6 +629,14 @@
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
+
+    "@wterm/core": ["@wterm/core@0.3.0", "", {}, "sha512-aQ73QBP+eyA3kcn31mA7DmAi7qmEsQijZdmvgwxtSjCi2248EAOZgtkGDpjlspfrxyVxQbUl/IF+gCVcXt4nZQ=="],
+
+    "@wterm/dom": ["@wterm/dom@0.3.0", "", { "dependencies": { "@wterm/core": "0.3.0" } }, "sha512-OiUl7reGSlW02yb5wGXMplMZhW2HBkBSFxvbFj15I832UK0QFIHRvhE2l6Xgae8ROn9bNLaALoKDFvcUuz80iQ=="],
+
+    "@wterm/ghostty": ["@wterm/ghostty@0.3.0", "", { "dependencies": { "@wterm/core": "0.3.0" } }, "sha512-TDjEmUSRD7IaFxq31P7+I3Inkp5mHCfBfO6LYj3/vbLbWOkOZOKPhjAcZ36AYFHe9Q0HLCFvLWmrxIO3aGCjDA=="],
+
+    "@wterm/react": ["@wterm/react@0.3.0", "", { "peerDependencies": { "@wterm/dom": "0.3.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-1rua/roQGCIGkNxjs9TVq+EkXJ0n2IK6aCoaGIQJpvzuHv7iU9/lngG3i1SCpX6deOOO/wpfhtjDTI+z9XF0aA=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-virtual": "^3.13.23",
+    "@wterm/dom": "0.3.0",
+    "@wterm/react": "0.3.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-webgl": "^0.19.0",

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -1,7 +1,8 @@
 import { useRef, useCallback, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Terminal as TerminalIcon, MessageSquare } from 'lucide-react';
-import { TerminalComponent, type TerminalRef } from './Terminal';
+import { type TerminalRef } from './Terminal';
+import { TerminalSwitcher } from './TerminalSwitcher';
 import { ChatView } from './chat/ChatView';
 
 import { authFetch } from '../services/api';
@@ -502,7 +503,7 @@ function TerminalPane({
         )}
         {sessionId ? (
           <div className={showConversation ? 'hidden' : 'h-full'}>
-            <TerminalComponent
+            <TerminalSwitcher
               key={`${sessionId}-${reloadKey}-${globalReloadKey}`}
               ref={terminalRef}
               sessionId={sessionId}

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -19,16 +19,9 @@ import { InputBar, type InputMode, type InputBarRef } from './InputBar';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
-// Control mode: terminal data comes from control WebSocket instead of useTerminal
-export interface ControlModeConfig {
-  paneId: string;
-  sendInput: (data: string) => void;
-  registerOnData: (callback: (data: Uint8Array) => void) => () => void;
-  isConnected: boolean;
-  onResize?: (cols: number, rows: number) => void;
-  onScroll?: (lines: number) => void;
-  requestContent?: () => void;
-}
+// Re-export shared terminal interfaces for backwards compatibility.
+export type { ControlModeConfig, TerminalRef } from './terminal-types';
+import type { ControlModeConfig, TerminalRef } from './terminal-types';
 
 interface TerminalProps {
   sessionId: string;
@@ -48,25 +41,6 @@ interface TerminalProps {
   terminalAreaOverlay?: React.ReactNode;
 }
 
-// Ref interface for external keyboard input
-export interface TerminalRef {
-  sendInput: (char: string) => void;
-  focus: () => void;
-  extractUrls: () => string[];
-  getSelection: () => string;
-  clearSelection: () => void;
-  refreshTerminal: () => void;
-  showKeyboard: () => void;
-  hideKeyboard: () => void;
-  getCellDimensions: () => { width: number; height: number } | null;
-  getSize: () => { cols: number; rows: number } | null;
-  getProposedSize: () => { cols: number; rows: number } | null;
-  setExactSize: (cols: number, rows: number) => void;
-  scrollToBottom: () => void;
-  setInputText: (text: string) => void;
-  changeFontSize: (delta: number) => number;
-  getFontSize: () => number;
-}
 
 export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(function TerminalComponent({
   sessionId,

--- a/frontend/src/components/TerminalSwitcher.tsx
+++ b/frontend/src/components/TerminalSwitcher.tsx
@@ -1,0 +1,35 @@
+import { forwardRef, type ComponentProps } from 'react';
+import { TerminalComponent, type TerminalRef } from './Terminal';
+import { TerminalWtermComponent } from './TerminalWterm';
+
+const STORAGE_KEY = 'cchub-terminal-engine';
+
+export type TerminalEngine = 'xterm' | 'wterm';
+
+export function getTerminalEngine(): TerminalEngine {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get('wterm');
+    if (q === '1' || q === 'true') return 'wterm';
+    if (q === '0' || q === 'false') return 'xterm';
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'wterm' || stored === 'xterm') return stored;
+  } catch {}
+  return 'xterm';
+}
+
+export function setTerminalEngine(engine: TerminalEngine): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, engine);
+  } catch {}
+}
+
+type Props = ComponentProps<typeof TerminalComponent>;
+
+export const TerminalSwitcher = forwardRef<TerminalRef, Props>(function TerminalSwitcher(props, ref) {
+  const engine = getTerminalEngine();
+  if (engine === 'wterm') {
+    return <TerminalWtermComponent {...props} ref={ref} />;
+  }
+  return <TerminalComponent {...props} ref={ref} />;
+});

--- a/frontend/src/components/TerminalWterm.tsx
+++ b/frontend/src/components/TerminalWterm.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useRef, useState, memo, useCallback, forwardRef, useImperativeHandle } from 'react';
+import { Terminal as WTermReact, type TerminalHandle } from '@wterm/react';
+import { GhosttyCore } from '@wterm/ghostty';
+import '@wterm/react/css';
+import type { SessionTheme } from '../../../shared/types';
+import { filterMouseTrackingInput, filterMouseTrackingOutput } from '../utils/terminal-filters';
+import {
+  getTerminalThemes,
+  DEFAULT_FONT_SIZE, MIN_FONT_SIZE, MAX_FONT_SIZE,
+  loadFontSize, saveFontSize,
+} from './terminal-themes';
+import type { ControlModeConfig, TerminalRef } from './terminal-types';
+
+// Each WTerm instance needs its own core (it owns terminal state), but
+// loading the WASM module from the same URL is cheap thanks to browser cache.
+// We surface load errors so the UI can fall back to the built-in Zig core.
+type CoreInstance = Awaited<ReturnType<typeof GhosttyCore.load>>;
+
+interface TerminalWtermProps {
+  sessionId: string;
+  onConnect?: () => void;
+  onDisconnect?: () => void;
+  onError?: (error: string) => void;
+  onReady?: (send: (data: string) => void) => void;
+  hideKeyboard?: boolean;
+  overlayContent?: React.ReactNode;
+  onOverlayTap?: () => void;
+  showOverlay?: boolean;
+  theme?: SessionTheme;
+  controlMode?: ControlModeConfig;
+  hideTerminalArea?: boolean;
+  terminalAreaOverlay?: React.ReactNode;
+}
+
+export const TerminalWtermComponent = memo(forwardRef<TerminalRef, TerminalWtermProps>(function TerminalWtermComponent({
+  sessionId,
+  onReady,
+  theme: sessionTheme,
+  controlMode,
+  hideTerminalArea,
+  terminalAreaOverlay,
+}, ref) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const handleRef = useRef<TerminalHandle | null>(null);
+  const sendRef = useRef<(data: string) => void>(() => {});
+  const [size, setSize] = useState<{ cols: number; rows: number }>({ cols: 80, rows: 24 });
+  const [fontSize, setFontSize] = useState(() => loadFontSize(sessionId));
+  const [isReady, setIsReady] = useState(false);
+  // ghostty 0.3.0 has a `spacer tail not following wide` page integrity bug
+  // that crashes the WASM core when wide chars (e.g. Japanese) are scrolled
+  // through. Stay on the built-in Zig core until upstream fixes it.
+  const [ghosttyCore] = useState<CoreInstance | null>(null);
+  const [coreState] = useState<'loading' | 'ghostty' | 'zig'>('zig');
+
+  const controlModeRef = useRef(controlMode);
+  controlModeRef.current = controlMode;
+
+  const isConnected = controlMode?.isConnected ?? false;
+
+  const send = useCallback((data: string) => {
+    const filtered = filterMouseTrackingInput(data);
+    if (filtered.length > 0) controlModeRef.current?.sendInput(filtered);
+  }, []);
+
+  useEffect(() => { sendRef.current = send; }, [send]);
+
+  useImperativeHandle(ref, () => ({
+    sendInput: (char: string) => sendRef.current(char),
+    focus: () => handleRef.current?.focus(),
+    getSelection: () => window.getSelection()?.toString() ?? '',
+    clearSelection: () => window.getSelection()?.removeAllRanges(),
+    refreshTerminal: () => controlModeRef.current?.requestContent?.(),
+    extractUrls: () => {
+      const text = wrapRef.current?.innerText ?? '';
+      const urls = text.match(/https?:\/\/[^\s<>"{}|\\^`[\]]+/g) ?? [];
+      return [...new Set(urls)].reverse();
+    },
+    showKeyboard: () => {},
+    hideKeyboard: () => {},
+    getCellDimensions: () => {
+      const el = wrapRef.current?.querySelector('.wterm') as HTMLElement | null;
+      if (!el) return null;
+      const cs = getComputedStyle(el);
+      const fs = parseFloat(cs.fontSize) || DEFAULT_FONT_SIZE;
+      return { width: fs * 0.6, height: fs * 1.2 };
+    },
+    getSize: () => size,
+    getProposedSize: () => size,
+    setExactSize: (cols: number, rows: number) => {
+      // Under autoResize=true wterm decides cell-precise dimensions itself;
+      // only forward when the requested size is sensible. Skip; wterm onResize
+      // will propagate back the actual cols/rows it picked.
+      if (cols <= 0 || rows <= 0) return;
+    },
+    scrollToBottom: () => {
+      const el = wrapRef.current?.querySelector('.wterm') as HTMLElement | null;
+      if (el) el.scrollTop = el.scrollHeight;
+    },
+    setInputText: () => {},
+    changeFontSize: (delta: number) => {
+      const next = Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, fontSize + delta));
+      if (next === fontSize) return next;
+      setFontSize(next);
+      saveFontSize(sessionId, next);
+      return next;
+    },
+    getFontSize: () => fontSize,
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [size, fontSize, sessionId]);
+
+  // Bridge: control-mode output -> wterm
+  useEffect(() => {
+    const cm = controlModeRef.current;
+    if (!cm || !isReady) return;
+    const decoder = new TextDecoder('utf-8', { fatal: false });
+    const cleanup = cm.registerOnData((data) => {
+      const str = decoder.decode(data, { stream: true });
+      const filtered = filterMouseTrackingOutput(str);
+      if (filtered.length > 0) handleRef.current?.write(filtered);
+    });
+    return () => {
+      decoder.decode(new Uint8Array(0), { stream: false });
+      cleanup();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isReady, controlMode?.paneId]);
+
+  // Notify parent when ready
+  useEffect(() => {
+    if (isConnected && isReady) onReady?.(send);
+  }, [isConnected, isReady, onReady, send]);
+
+  // Wheel + touch scroll. wterm has its own scrollback (via overflow-y:auto on
+  // .has-scrollback), so prefer native scroll first; only escalate to tmux when
+  // the user is already pinned at the top edge.
+  useEffect(() => {
+    const wrap = wrapRef.current;
+    if (!wrap || !isReady) return;
+    const wtermEl = wrap.querySelector('.wterm') as HTMLElement | null;
+    if (!wtermEl) return;
+
+    const linesFromDelta = (deltaY: number) => Math.max(1, Math.ceil(Math.abs(deltaY) / 40));
+
+    const handleWheel = (e: WheelEvent) => {
+      // Native scroll handles the case when wterm has scrollback room.
+      const canScrollUp = wtermEl.scrollTop > 0;
+      const canScrollDown = wtermEl.scrollTop + wtermEl.clientHeight < wtermEl.scrollHeight - 1;
+      if (e.deltaY < 0 && canScrollUp) return;
+      if (e.deltaY > 0 && canScrollDown) return;
+      // Pinned at the edge — push the request through to tmux scrollback.
+      e.preventDefault();
+      const lines = linesFromDelta(e.deltaY);
+      controlModeRef.current?.onScroll?.(e.deltaY > 0 ? lines : -lines);
+    };
+
+    let touchStartY: number | null = null;
+    let lastTouchY = 0;
+    let accumulated = 0;
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) { touchStartY = null; return; }
+      touchStartY = e.touches[0].clientY;
+      lastTouchY = touchStartY;
+      accumulated = 0;
+    };
+    const handleTouchMove = (e: TouchEvent) => {
+      if (touchStartY === null || e.touches.length !== 1) return;
+      const y = e.touches[0].clientY;
+      const dy = lastTouchY - y;
+      lastTouchY = y;
+      accumulated += dy;
+      const canScrollUp = wtermEl.scrollTop > 0;
+      const canScrollDown = wtermEl.scrollTop + wtermEl.clientHeight < wtermEl.scrollHeight - 1;
+      if ((dy < 0 && canScrollUp) || (dy > 0 && canScrollDown)) return; // native handles it
+      e.preventDefault();
+      const cellH = parseFloat(getComputedStyle(wtermEl).getPropertyValue('--term-row-height')) || Math.round(fontSize * 1.2);
+      const lines = Math.trunc(accumulated / cellH);
+      if (lines !== 0) {
+        accumulated -= lines * cellH;
+        controlModeRef.current?.onScroll?.(lines);
+      }
+    };
+    const handleTouchEnd = () => { touchStartY = null; };
+
+    wrap.addEventListener('wheel', handleWheel, { passive: false });
+    wrap.addEventListener('touchstart', handleTouchStart, { passive: true });
+    wrap.addEventListener('touchmove', handleTouchMove, { passive: false });
+    wrap.addEventListener('touchend', handleTouchEnd);
+    return () => {
+      wrap.removeEventListener('wheel', handleWheel);
+      wrap.removeEventListener('touchstart', handleTouchStart);
+      wrap.removeEventListener('touchmove', handleTouchMove);
+      wrap.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [isReady, fontSize]);
+
+  const themeColors = getTerminalThemes()[sessionTheme || 'default'];
+  const containerStyle: React.CSSProperties = {
+    backgroundColor: themeColors.background,
+  };
+
+  // Inject session theme overrides into wterm CSS variables.
+  // Match xterm.tsx font stack. Don't set `overflow` here — wterm toggles
+  // `.has-scrollback` to switch overflow-y between hidden/auto for scrollback.
+  const wtermStyle: React.CSSProperties = {
+    ['--term-bg' as any]: themeColors.background,
+    ['--term-fg' as any]: themeColors.foreground,
+    ['--term-cursor' as any]: themeColors.foreground,
+    ['--term-font-family' as any]: '"JetBrains Mono", "M PLUS 1 Code", Menlo, Monaco, monospace',
+    ['--term-font-size' as any]: `${fontSize}px`,
+    ['--term-line-height' as any]: '1.2',
+    ['--term-row-height' as any]: `${Math.round(fontSize * 1.2)}px`,
+    width: '100%',
+    height: '100%',
+    boxShadow: 'none',
+    borderRadius: 0,
+    padding: 4,
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col overflow-hidden" style={containerStyle}>
+      <div className="flex-1 relative min-h-0">
+        <div
+          ref={wrapRef}
+          className={`absolute inset-0${hideTerminalArea ? ' invisible pointer-events-none' : ''}`}
+          style={{ overflow: 'hidden' }}
+        >
+          {(
+            <WTermReact
+              ref={(h: TerminalHandle | null) => { handleRef.current = h; }}
+              core={ghosttyCore ?? undefined}
+              cols={size.cols}
+              rows={size.rows}
+              autoResize={true}
+              cursorBlink={false}
+              onData={(d: string) => sendRef.current(d)}
+              onResize={(c: number, r: number) => {
+                setSize({ cols: c, rows: r });
+                controlModeRef.current?.onResize?.(c, r);
+              }}
+              onReady={() => setIsReady(true)}
+              onError={(err: unknown) => console.error('[wterm] init error:', err)}
+              style={wtermStyle}
+            />
+          )}
+        </div>
+        {terminalAreaOverlay && (
+          <div
+            className="absolute inset-0 z-20 bg-[#0a0a0a]"
+            style={{ display: hideTerminalArea ? 'block' : 'none' }}
+          >
+            {terminalAreaOverlay}
+          </div>
+        )}
+        {(!isReady || !isConnected) && (
+          <div className="absolute top-2 left-2 z-30 pointer-events-none">
+            <div className="flex items-center gap-2 bg-yellow-900/80 text-yellow-200 text-xs px-2.5 py-1 rounded-lg shadow">
+              <div className="w-3 h-3 border-2 border-yellow-400 border-t-transparent rounded-full animate-spin" />
+              {!isReady ? 'Loading wterm…' : 'Connecting…'}
+            </div>
+          </div>
+        )}
+        <div className="absolute top-2 right-2 z-30 pointer-events-none">
+          <div className="bg-purple-900/80 text-purple-200 text-[10px] px-2 py-0.5 rounded font-mono">
+            wterm v0.3 · {coreState}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}));
+
+export default TerminalWtermComponent;

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Sun, Moon, Globe } from 'lucide-react';
+import { Sun, Moon, Globe, FlaskConical } from 'lucide-react';
 import { useDashboard } from '../../hooks/useDashboard';
 import { UsageLimits } from './UsageLimits';
 import { DailyUsageChart } from './DailyUsageChart';
@@ -9,6 +9,7 @@ import { HourlyHeatmap } from './HourlyHeatmap';
 import { NetworkLatency } from './NetworkLatency';
 import { ServerInfo } from './ServerInfo';
 import { useTheme } from '../../hooks/useTheme';
+import { getTerminalEngine, setTerminalEngine } from '../TerminalSwitcher';
 
 // Onboarding localStorage keys
 const ONBOARDING_KEY = 'cchub-onboarding-completed';
@@ -27,6 +28,7 @@ export function Dashboard({ className = '', compact = false }: DashboardProps) {
   const { theme, toggleTheme } = useTheme();
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [cacheClearing, setCacheClearing] = useState(false);
+  const [terminalEngine, setTerminalEngineState] = useState(() => getTerminalEngine());
   const [agentTab, setAgentTab] = useState<AgentTab>('claude');
   const codexLimits = data?.codexUsageLimits;
   const codexAvailable = !!codexLimits;
@@ -181,6 +183,25 @@ export function Dashboard({ className = '', compact = false }: DashboardProps) {
           >
             <Globe className="w-3.5 h-3.5" />
             {i18n.language === 'ja' ? 'EN' : 'JA'}
+          </button>
+          <button
+            onClick={() => {
+              const next = terminalEngine === 'wterm' ? 'xterm' : 'wterm';
+              setTerminalEngine(next);
+              setTerminalEngineState(next);
+              window.location.reload();
+            }}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] rounded-md transition-colors ${
+              terminalEngine === 'wterm'
+                ? 'text-purple-200 bg-purple-900/40 hover:bg-purple-900/60'
+                : 'text-zinc-500 hover:text-zinc-300 bg-white/[0.04] hover:bg-white/[0.06]'
+            }`}
+            title={i18n.language === 'ja'
+              ? `ターミナルエンジン: ${terminalEngine}（クリックで切替・リロード）`
+              : `Terminal engine: ${terminalEngine} (click to switch & reload)`}
+          >
+            <FlaskConical className="w-3.5 h-3.5" />
+            <span>{terminalEngine === 'wterm' ? 'wterm (beta)' : 'xterm'}</span>
           </button>
           <button
             onClick={() => setShowResetConfirm(true)}

--- a/frontend/src/components/terminal-types.ts
+++ b/frontend/src/components/terminal-types.ts
@@ -1,0 +1,32 @@
+// Shared terminal interfaces. Both the xterm.js and wterm implementations
+// satisfy these so the rest of the app doesn't need to know which engine is
+// in use.
+
+export interface ControlModeConfig {
+  paneId: string;
+  sendInput: (data: string) => void;
+  registerOnData: (callback: (data: Uint8Array) => void) => () => void;
+  isConnected: boolean;
+  onResize?: (cols: number, rows: number) => void;
+  onScroll?: (lines: number) => void;
+  requestContent?: () => void;
+}
+
+export interface TerminalRef {
+  sendInput: (char: string) => void;
+  focus: () => void;
+  extractUrls: () => string[];
+  getSelection: () => string;
+  clearSelection: () => void;
+  refreshTerminal: () => void;
+  showKeyboard: () => void;
+  hideKeyboard: () => void;
+  getCellDimensions: () => { width: number; height: number } | null;
+  getSize: () => { cols: number; rows: number } | null;
+  getProposedSize: () => { cols: number; rows: number } | null;
+  setExactSize: (cols: number, rows: number) => void;
+  scrollToBottom: () => void;
+  setInputText: (text: string) => void;
+  changeFontSize: (delta: number) => number;
+  getFontSize: () => number;
+}

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback, forwardRef, type ReactNode } from 'react';
-import { TerminalComponent, type TerminalRef, type ControlModeConfig } from '../components/Terminal';
+import { type TerminalRef, type ControlModeConfig } from '../components/Terminal';
+import { TerminalSwitcher } from '../components/TerminalSwitcher';
 import { useMultiplexedTerminal } from '../hooks/useMultiplexedTerminal';
 import type { SessionState, SessionTheme, TmuxLayoutNode } from '../../../shared/types';
 import { fireHookNotification } from '../utils/hookNotification';
@@ -304,7 +305,7 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(function 
       {/* Terminal - full screen. mainOverlay (e.g. ChatView) replaces the
           xterm area while the InputBar inside TerminalComponent remains visible. */}
       <main className="flex-1 relative overflow-hidden min-h-0 select-none">
-        <TerminalComponent
+        <TerminalSwitcher
           ref={ref}
           sessionId={sessionId}
           onError={(err) => setError(err)}

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "devDependencies": {
     "@typescript/native-preview": "^7.0.0-dev.20260421.2"
+  },
+  "dependencies": {
+    "@wterm/ghostty": "0.3.0"
   }
 }


### PR DESCRIPTION
## Summary

実験的に [vercel-labs/wterm](https://github.com/vercel-labs/wterm) v0.3.0 をxterm.jsの代替として組み込んだブランチです。**マージはしません。** Issue #99 の調査記録としてPRを残しておきます。

- ダッシュボードのトグル / `?wterm=1` クエリで xterm ⇔ wterm を切り替え
- `terminal-types.ts` に `TerminalRef` / `ControlModeConfig` を抽出して両エンジンが共有
- `TerminalSwitcher.tsx` がフォワードする薄いラッパー
- `TerminalWterm.tsx` が wterm 実装（スクロール、テーマ、フォント、リサイズを実装）

## Findings (Issue #99 のコメント参照)

- ✅ DOMネイティブな選択コピー、scrollback、レンダ品質（特にghostty）
- ❌ ghostty 0.3.0: 日本語などWide charのscrollback時に `error.InvalidSpacerTailLocation` でクラッシュ → Zigコアにフォールバック
- ❌ Zigコア: `Coalescing…` 等のステータス更新で行が重なる描画バグ
- ❌ マウスレポート (SGR/X10)、serialize/headless API、exact-size 制御が未実装

詳細は https://github.com/m0a/cc-hub/issues/99#issuecomment-4414203639

## Decision

現時点で本採用は時期尚早。ghosttyのwide-charバグ修正＋マウスレポート実装後に再評価する。本PRはクローズ、ブランチは参照用に残す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)