### PR TITLE
Release v0.1.106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.106] - 2026-05-11
+
+### Fixed
+- スマホで会話ビューを開いた際に「会話を表示できません / セッションのエージェント情報が取得できませんでした」が表示される問題を修正
+  - `App.tsx` の `fetchAndOpenSession()` 内 3 箇所で `OpenSession` を組み立てる際に `agent` と `agentSessionId` フィールドが欠落していた
+  - API は `agent: 'claude'` を返していたが、フロントが受け取った値を捨てていたため `activeSession.agent` が undefined となり ChatView が `missing-agent` エラーを表示
+  - WebSocket が不安定な環境では後追い同期パス（mobile `setOpenSessions` effect）も働かず、エラーが固定化していた
+
 ## [0.1.105] - 2026-05-09
 
 ### Added

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ import { Onboarding, useOnboarding } from './components/Onboarding';
 import { useAuth } from './hooks/useAuth';
 import { useSessions } from './hooks/useSessions';
 import { authFetch, isTransientNetworkError } from './services/api';
-import type { AgentProvider, SessionResponse, ExtendedSessionResponse, SessionState, SessionTheme, PaneInfo, IndicatorState } from '../../shared/types';
+import type { AgentProvider, ExtendedSessionResponse, SessionState, SessionTheme, PaneInfo, IndicatorState } from '../../shared/types';
 
 // Loading screen with phase display and timeout detection
 function LoadingScreen({
@@ -454,6 +454,8 @@ export function App() {
                 state: session.state,
                 currentPath: session.currentPath,
                 ccSessionId: session.ccSessionId,
+                agent: session.agent,
+                agentSessionId: session.agentSessionId,
                 currentCommand: session.currentCommand,
                 theme: session.theme,
               });
@@ -478,6 +480,8 @@ export function App() {
               state: mostRecent.state,
               currentPath: mostRecent.currentPath,
               ccSessionId: mostRecent.ccSessionId,
+              agent: mostRecent.agent,
+              agentSessionId: mostRecent.agentSessionId,
               currentCommand: mostRecent.currentCommand,
               theme: mostRecent.theme,
             }]);
@@ -494,13 +498,15 @@ export function App() {
           }
         } else if (allSessions.length > 0) {
           // No saved sessions, open most recent
-          const mostRecent = allSessions[0] as SessionResponse & { currentPath?: string; ccSessionId?: string; currentCommand?: string; theme?: SessionTheme };
+          const mostRecent = allSessions[0];
           setOpenSessions([{
             id: mostRecent.id,
             name: mostRecent.name,
             state: mostRecent.state,
             currentPath: mostRecent.currentPath,
             ccSessionId: mostRecent.ccSessionId,
+            agent: mostRecent.agent,
+            agentSessionId: mostRecent.agentSessionId,
             currentCommand: mostRecent.currentCommand,
             theme: mostRecent.theme,
           }]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary

スマホで会話ビュー（ChatView）を開いた際に「会話を表示できません / セッションのエージェント情報が取得できませんでした」が固定表示されるバグを修正。

## Root cause

`App.tsx` の `fetchAndOpenSession()` 内 3 箇所で `OpenSession` を組み立てる際に **`agent` と `agentSessionId` フィールドが欠落** していた。API は `agent: 'claude'` を返していたが、フロントがその値を捨てていたため `activeSession.agent === undefined` となり、`useAgentConversation` が `error: 'missing-agent'` を返してエラー画面が表示されていた。

WebSocketの `sessions-updated` push 経由で `agent` を後追い同期する effect (L330) は存在するが、モバイル回線等で WS が不安定な環境では push を受け取れずエラーが固定化していた。

## Changes

- `frontend/src/App.tsx` の OpenSession 組み立て箇所3つに `agent` と `agentSessionId` を追加
- 未使用になった `SessionResponse` 型のキャストを削除

## Test plan

- [x] dev環境（https://100.91.210.90:5173/）で会話ビューにエラーが出ないことをスマホで確認
- [x] TypeScript: App.tsx に新規エラーなし
- [x] Lint: warning のみ（既存）
- [x] Production build成功、bundle に修正反映確認（3箇所）

🤖 Generated with [Claude Code](https://claude.com/claude-code)