### PR TITLE
Release v0.1.108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.108] - 2026-05-16
+
+### Fixed
+- ファイルビューでファイルを開く / 切替時にファイル一覧のスクロール位置がリセットされる問題を修正
+  - 原因1: `useFileViewer` の `isLoading` フラグが `listDirectory` と `readFile` で共有されており、ファイルを開くと FileBrowser が「読み込み中…」プレースホルダーで置き換わってアンマウントされていた
+  - 原因2: モバイル単一ペインレイアウトでは `viewMode` が `'file'` に切り替わると FileBrowser 自体がアンマウントされていた
+  - 修正: 初回ディレクトリ読み込み時のみプレースホルダー表示、`viewMode` 切替時は display 切替で FileBrowser を常駐させスクロール位置を保持
+- ファイルビューで現在開いているファイルが視覚的に分かるよう、選択中ファイルを青背景＋青ボーダーでハイライト
+  - popstate ハンドラーがブラウザビューに戻る際に `selectedFile` を明示的にクリアしていたため、戻ったタイミングでハイライトが消えていた問題も併せて修正
+
+### Added
+- ファイルビュー回帰テスト (`frontend/tests/e2e/file-viewer-selection.spec.ts`): desktop split layout でのスクロール保持＋選択ハイライト、mobile での browser↔file 往復スクロール保持
+
 ## [0.1.107] - 2026-05-15
 
 ### Fixed

--- a/frontend/playwright.missing-agent.config.ts
+++ b/frontend/playwright.missing-agent.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
 // already running on https://localhost:5173 (started outside playwright).
 export default defineConfig({
   testDir: './tests/e2e',
-  testMatch: 'missing-agent.spec.ts',
+  testMatch: ['missing-agent.spec.ts', 'file-viewer-selection.spec.ts'],
   fullyParallel: false,
   retries: 0,
   workers: 1,
@@ -19,6 +19,13 @@ export default defineConfig({
       name: 'mobile-chromium',
       use: {
         ...devices['Pixel 5'],
+        ignoreHTTPSErrors: true,
+      },
+    },
+    {
+      name: 'desktop-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
         ignoreHTTPSErrors: true,
       },
     },

--- a/frontend/src/components/files/FileBrowser.tsx
+++ b/frontend/src/components/files/FileBrowser.tsx
@@ -12,6 +12,8 @@ interface FileBrowserProps {
   isLoading: boolean;
   onSelectFile: (file: FileInfo) => void;
   showHidden?: boolean;
+  /** Path of the file currently shown in the viewer (highlighted in the tree). */
+  selectedPath?: string;
 }
 
 // File type icons
@@ -70,6 +72,7 @@ interface TreeItemProps {
   onToggleDir: (path: string) => void;
   onSelectFile: (file: FileInfo) => void;
   showHidden: boolean;
+  selectedPath?: string;
 }
 
 function TreeItem({
@@ -81,12 +84,14 @@ function TreeItem({
   onToggleDir,
   onSelectFile,
   showHidden,
+  selectedPath,
 }: TreeItemProps) {
   const isDirectory = file.type === 'directory';
   const isExpanded = expandedDirs.has(file.path);
   const isLoading = loadingDirs.has(file.path);
   const children = dirContents.get(file.path) || [];
   const visibleChildren = showHidden ? children : children.filter(f => !f.isHidden);
+  const isSelected = !isDirectory && selectedPath === file.path;
 
   const handleClick = () => {
     if (isDirectory) {
@@ -100,7 +105,11 @@ function TreeItem({
     <>
       <div
         onClick={handleClick}
-        className="flex items-center gap-2 py-2.5 px-2 hover:bg-th-surface active:bg-th-surface-hover cursor-pointer transition-colors"
+        className={`flex items-center gap-2 py-2.5 px-2 cursor-pointer transition-colors ${
+          isSelected
+            ? 'bg-blue-500/15 text-blue-200 border-l-2 border-blue-400'
+            : 'border-l-2 border-transparent hover:bg-th-surface active:bg-th-surface-hover'
+        }`}
         style={{ paddingLeft: `${depth * 20 + 8}px` }}
       >
         {/* Chevron for directories */}
@@ -142,6 +151,7 @@ function TreeItem({
               onToggleDir={onToggleDir}
               onSelectFile={onSelectFile}
               showHidden={showHidden}
+              selectedPath={selectedPath}
             />
           ))}
         </div>
@@ -157,6 +167,7 @@ export function FileBrowser({
   isLoading,
   onSelectFile,
   showHidden = false,
+  selectedPath,
 }: FileBrowserProps) {
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
   const [dirContents, setDirContents] = useState<Map<string, FileInfo[]>>(new Map());
@@ -216,11 +227,17 @@ export function FileBrowser({
   // Get short path for display
   const shortPath = currentPath.replace(/^\/home\/[^/]+\//, '~/');
 
+  // Show the loading placeholder only on the initial directory load (when no
+  // files have arrived yet). Once we have a tree, keep it mounted so reading
+  // a file's contents doesn't unmount the list and reset the user's scroll
+  // position.
+  const showLoadingPlaceholder = isLoading && visibleFiles.length === 0;
+
   return (
     <div className="flex flex-col h-full bg-th-bg text-th-text">
       {/* File tree */}
       <div className="flex-1 overflow-y-auto">
-        {isLoading ? (
+        {showLoadingPlaceholder ? (
           <div className="flex items-center justify-center h-32">
             <div className="text-th-text-muted">読み込み中...</div>
           </div>
@@ -241,6 +258,7 @@ export function FileBrowser({
                 onToggleDir={handleToggleDir}
                 onSelectFile={onSelectFile}
                 showHidden={showHidden}
+                selectedPath={selectedPath}
               />
             ))}
           </div>

--- a/frontend/src/components/files/FileViewer.tsx
+++ b/frontend/src/components/files/FileViewer.tsx
@@ -105,7 +105,6 @@ export function FileViewer({ sessionWorkingDir, onClose, initialPath, onCopyProm
     getChanges,
     getGitChanges,
     getGitDiff,
-    clearSelectedFile,
   } = useFileViewer(sessionWorkingDir);
 
   const [viewMode, setViewMode] = useState<ViewMode>('browser');
@@ -208,11 +207,9 @@ export function FileViewer({ sessionWorkingDir, onClose, initialPath, onCopyProm
     window.history.pushState({ fileViewer: true }, '', window.location.href);
   }, []);
 
-  // Store onClose and clearSelectedFile in refs so popstate listener always sees latest
+  // Store onClose in a ref so the popstate listener always sees the latest.
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
-  const clearSelectedFileRef = useRef(clearSelectedFile);
-  clearSelectedFileRef.current = clearSelectedFile;
 
   // handleBack for in-app button
   const handleBack = useCallback(() => {
@@ -317,9 +314,8 @@ export function FileViewer({ sessionWorkingDir, onClose, initialPath, onCopyProm
         setListMode(prev.listMode);
         setSelectedChange(prev.selectedChange);
         setSelectedGitDiff(prev.selectedGitDiff);
-        if (prev.viewMode !== 'file') {
-          clearSelectedFileRef.current();
-        }
+        // Keep selectedFile around even when returning to browser view so the
+        // FileBrowser can highlight the most recently opened file.
       } else {
         e.stopImmediatePropagation();
         onCloseRef.current();
@@ -535,6 +531,7 @@ export function FileViewer({ sessionWorkingDir, onClose, initialPath, onCopyProm
                   isLoading={isLoading}
                   onSelectFile={handleSelectFile}
                   showHidden={showHidden}
+                  selectedPath={selectedFile?.path}
                 />
               ) : (
                 <ChangesView
@@ -711,7 +708,9 @@ export function FileViewer({ sessionWorkingDir, onClose, initialPath, onCopyProm
 
         {/* Content */}
         <div className="flex-1 overflow-hidden">
-          {viewMode === 'browser' && (
+          {/* Keep FileBrowser mounted across viewMode changes so its scroll
+              position survives switching to a file view and back. */}
+          <div className={viewMode === 'browser' ? 'h-full' : 'hidden'}>
             <FileBrowser
               files={files}
               currentPath={currentPath}
@@ -719,8 +718,9 @@ export function FileViewer({ sessionWorkingDir, onClose, initialPath, onCopyProm
               isLoading={isLoading}
               onSelectFile={handleSelectFile}
               showHidden={showHidden}
+              selectedPath={selectedFile?.path}
             />
-          )}
+          </div>
 
           {viewMode === 'file' && selectedFile && (
             isImageFile(selectedFile.path) ? (

--- a/frontend/tests/e2e/file-viewer-selection.spec.ts
+++ b/frontend/tests/e2e/file-viewer-selection.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+// Regression test: switching files in the FileViewer must
+//   (a) keep the file-list scroll position
+//   (b) visually highlight the currently selected file
+// Bug repro before fix: clicking a file toggled the shared isLoading flag
+// in useFileViewer, which unmounted the file tree (replaced with a "読み込み中…"
+// placeholder) and reset scroll to the top on next mount.
+
+const FRONTEND_URL = 'https://localhost:5173';
+const BACKEND_URL = 'https://localhost:3456';
+
+test.use({
+  ignoreHTTPSErrors: true,
+  baseURL: FRONTEND_URL,
+});
+
+async function pickFirstClaudeSession(request: APIRequestContext): Promise<string> {
+  const res = await request.get(`${BACKEND_URL}/api/sessions`);
+  const data = await res.json();
+  const target = data.sessions.find(
+    (s: { agent?: string; state?: string }) =>
+      s.agent === 'claude' && (s.state === 'idle' || s.state === 'working'),
+  );
+  if (!target) throw new Error('no claude session — start `claude` in a tmux session');
+  return target.id as string;
+}
+
+test('FileBrowser keeps scroll and shows selection when switching files (desktop split)', async ({ page, request, viewport }) => {
+  // Desktop split layout keeps FileBrowser visible while a file is open in
+  // the right pane, so scrollTop is directly observable. On mobile the
+  // FileBrowser is hidden via display:none while a file is open (browsers
+  // report scrollTop=0 in that state); the round-trip test below covers it.
+  test.skip(!viewport || viewport.width < 768, 'desktop split layout only');
+
+  const sessionId = await pickFirstClaudeSession(request);
+
+  await page.addInitScript(([id]) => {
+    localStorage.setItem('cchub-open-sessions', JSON.stringify([id]));
+    localStorage.setItem('cchub-last-session-id', id);
+    localStorage.setItem('cchub-onboarding-completed', 'true');
+    localStorage.setItem('cchub-onboarding-sessionlist-completed', 'true');
+  }, [sessionId]);
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  // Open the file viewer (FilesIcon button — used in the mobile + desktop bars).
+  // The path bar at the bottom of the FileBrowser shows the current path; once
+  // it appears we know the directory listing has finished.
+  await page.locator('[aria-label="Switch to Files"], [title*="ファイル"], button:has-text("Files")').first().click({ timeout: 15000 });
+
+  const fileTree = page.locator('.flex-1.overflow-y-auto').first();
+  await fileTree.waitFor({ timeout: 15000 });
+
+  // Wait until the tree actually has clickable file rows.
+  const fileRows = page.locator('div.cursor-pointer:not(:has(.text-yellow-400))');
+  await expect(fileRows.first()).toBeVisible({ timeout: 15000 });
+  const rowCount = await fileRows.count();
+  if (rowCount < 2) test.skip(true, `need ≥2 files in tree, found ${rowCount}`);
+
+  // Scroll the list down so we can detect a reset.
+  const scrollContainer = await fileTree.elementHandle();
+  if (!scrollContainer) throw new Error('scroll container not found');
+  await page.evaluate((el) => { (el as HTMLElement).scrollTop = 200; }, scrollContainer);
+  const scrollBefore = await page.evaluate((el) => (el as HTMLElement).scrollTop, scrollContainer);
+
+  // Click first file. Selection highlight should appear, scroll should stay.
+  await fileRows.first().click();
+  await expect(page.locator('div.cursor-pointer.bg-blue-500\\/15')).toHaveCount(1, { timeout: 5000 });
+
+  const scrollAfter = await page.evaluate((el) => (el as HTMLElement).scrollTop, scrollContainer);
+  expect(scrollAfter, `scroll reset after click (before=${scrollBefore} after=${scrollAfter})`).toBeGreaterThan(0);
+
+  // Switch to a different file; selection should move with it.
+  await fileRows.nth(1).click();
+  await page.waitForTimeout(500);
+  const selected = page.locator('div.cursor-pointer.bg-blue-500\\/15');
+  await expect(selected).toHaveCount(1);
+  const scrollFinal = await page.evaluate((el) => (el as HTMLElement).scrollTop, scrollContainer);
+  expect(scrollFinal, `scroll reset after second click`).toBeGreaterThan(0);
+});
+
+test('FileBrowser scroll survives switching to file view and back (mobile flow)', async ({ page, request }) => {
+  // On the mobile flow viewMode toggles between 'browser' and 'file', which
+  // used to unmount the FileBrowser. The fix keeps it mounted via display
+  // toggling so scrollTop survives the round trip.
+  const sessionId = await pickFirstClaudeSession(request);
+
+  await page.addInitScript(([id]) => {
+    localStorage.setItem('cchub-open-sessions', JSON.stringify([id]));
+    localStorage.setItem('cchub-last-session-id', id);
+    localStorage.setItem('cchub-onboarding-completed', 'true');
+    localStorage.setItem('cchub-onboarding-sessionlist-completed', 'true');
+  }, [sessionId]);
+
+  await page.setViewportSize({ width: 393, height: 851 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  await page.locator('[aria-label="Switch to Files"], [title*="ファイル"], button:has-text("Files")').first().click({ timeout: 15000 });
+
+  const fileTree = page.locator('.flex-1.overflow-y-auto').first();
+  await fileTree.waitFor({ timeout: 15000 });
+  const fileRows = page.locator('div.cursor-pointer:not(:has(.text-yellow-400))');
+  await expect(fileRows.first()).toBeVisible({ timeout: 15000 });
+
+  const scrollContainer = await fileTree.elementHandle();
+  if (!scrollContainer) throw new Error('scroll container not found');
+  await page.evaluate((el) => { (el as HTMLElement).scrollTop = 150; }, scrollContainer);
+  const scrollBefore = await page.evaluate((el) => (el as HTMLElement).scrollTop, scrollContainer);
+  if (scrollBefore === 0) test.skip(true, 'not enough rows to scroll');
+
+  // Click a file (transitions to viewMode='file' on mobile).
+  await fileRows.first().click();
+  await page.waitForTimeout(800);
+
+  // Navigate back to file list (browser back).
+  await page.goBack();
+  await page.waitForTimeout(500);
+
+  const scrollAfter = await page.evaluate((el) => (el as HTMLElement).scrollTop, scrollContainer);
+  expect(scrollAfter, `scroll lost across viewMode round trip (before=${scrollBefore} after=${scrollAfter})`).toBe(scrollBefore);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary

ファイルビューでファイルを開く / 切り替える際にファイル一覧のスクロール位置がリセットされ、また現在見ているファイルが視覚的に分からない問題を修正。

## Root cause

1. **Scroll reset (loading-state)**: `useFileViewer` の `isLoading` が `listDirectory` と `readFile` で共有されており、ファイルを開くと `FileBrowser` が「読み込み中…」プレースホルダーで置き換わってアンマウント → DOM scrollTop が失われていた
2. **Scroll reset (mobile viewMode)**: モバイル単一ペインレイアウトでは `viewMode === 'browser'` 時のみ `FileBrowser` を条件レンダリング → ファイルを開くと完全にアンマウント → 戻ったときにスクロールリセット
3. **Highlight が消える**: popstate ハンドラーがブラウザビューに戻る際に `selectedFile` を明示的にクリア → `selectedPath` が `undefined` になりハイライト消失

## Changes

- `FileBrowser` に `selectedPath` prop を追加、該当行を青背景＋青ボーダーでハイライト
- `FileBrowser` のローディングプレースホルダーは初回ディレクトリ読み込み時のみ表示
- モバイルの `FileBrowser` を display 切替の div で常駐させ、`viewMode` 切替で DOM が消えないように
- popstate ハンドラーの `clearSelectedFile()` 呼び出しを削除（不要な `clearSelectedFileRef` も併せて整理）
- Playwright 回帰テスト追加 (`file-viewer-selection.spec.ts`)

## Test plan

- [x] Playwright e2e: desktop split layout でファイル切替、スクロール保持＋選択ハイライト
- [x] Playwright e2e: mobile での browser↔file 往復、スクロール保持
- [x] スマホ実機: スクロール位置保持 ✓、ハイライト表示 ✓
- [x] TypeScript / Lint clean、Production build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)