### PR TITLE
Release v0.1.109: Channel C drift detection (Phase 1 of #147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.109] - 2026-05-16
+
+### Added
+- Channel C: クライアント xterm.js と tmux 内部状態の drift 検知機構 (dev-only、#147 Phase 1)
+  - `CCHUB_SELF_VERIFY=1` でサーバ起動時に有効化
+  - クライアントが trigger (`resize-done` / `reconnect-done` / `output-idle` / `periodic`) で xterm の可視範囲を server に送信
+  - サーバが `tmux capture-pane -p` と比較し、差分を `/tmp/cchub-drift.log` に JSON Lines 形式で追記
+  - production 環境では完全 no-op、ユーザに影響なし
+  - 後続の state diff sync (#147 Phase 2-) の正しさ検証 oracle として継続利用
+
 ## [0.1.108] - 2026-05-16
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.108",
+  "version": "0.1.109",
   "generated": "2026-05-16",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
@@ -128,19 +128,27 @@
         "name": "TmuxControlSession",
         "file": "backend/src/services/tmux-control.ts",
         "summary": "tmux -CC (control mode) プロセスを管理するコア。%output / %layout-change / %begin / %end / %error / %exit を処理し、raw byte stream で UTF-8 を保持。client 単位の pane 出力ルーティング、コマンド FIFO キュー、グレースピリオド付きライフサイクル管理を提供",
-        "deps": ["tmux-octal-decoder", "tmux-layout-parser"]
+        "deps": [
+          "tmux-octal-decoder",
+          "tmux-layout-parser"
+        ]
       },
       {
         "name": "TmuxService",
         "file": "backend/src/services/tmux.ts",
         "summary": "tmux セッションの CRUD (listSessions / createSession / sessionExists / sendKeys) と pane 情報収集。ps を 1 回バッチ実行して全 TTY の agent 情報を取得",
-        "deps": ["tmux-octal-decoder", "shared/types"]
+        "deps": [
+          "tmux-octal-decoder",
+          "shared/types"
+        ]
       },
       {
         "name": "TmuxLayoutParser",
         "file": "backend/src/services/tmux-layout-parser.ts",
         "summary": "tmux layout 文字列 (checksum,WxH,X,Y{...}) を TmuxLayoutNode ツリーへ再帰パース",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "TmuxOctalDecoder",
@@ -164,19 +172,26 @@
         "name": "SessionMetadataService",
         "file": "backend/src/services/session-metadata.ts",
         "summary": "session-metadata.json (theme / title / order) と last-known-sessions.json (リブート後復元用) を永続化。旧フォーマット自動マイグレーション付き",
-        "deps": ["utils/storage"]
+        "deps": [
+          "utils/storage"
+        ]
       },
       {
         "name": "SessionMetricsService",
         "file": "backend/src/services/session-metrics.ts",
         "summary": ".jsonl を解析して context token 使用率・累積トークン数、ps を呼び pid ツリーを辿って RSS 使用量を計算",
-        "deps": ["anthropic-models"]
+        "deps": [
+          "anthropic-models"
+        ]
       },
       {
         "name": "SessionsService",
         "file": "backend/src/services/sessions.ts",
         "summary": "セッションエンティティの CRUD (ファイルベース永続化、UUID ベース ID 生成)",
-        "deps": ["utils/storage", "shared/types"]
+        "deps": [
+          "utils/storage",
+          "shared/types"
+        ]
       },
       {
         "name": "PromptHistoryService",
@@ -188,55 +203,79 @@
         "name": "FileService",
         "file": "backend/src/services/file-service.ts",
         "summary": "パストラバーサル防止付きセキュアファイル操作 (listDirectory / readFile / getParentPath)。MIME タイプ判定・サイズ制限、メディアはメタデータのみ",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "FileChangeTracker",
         "file": "backend/src/services/file-change-tracker.ts",
         "summary": "Claude Code .jsonl の tool_use (Write/Edit) ブロックを解析してどのファイルが変更されたかを追跡",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "AnthropicUsageService",
         "file": "backend/src/services/anthropic-usage.ts",
         "summary": "Anthropic API (/v1/usage) から 5 時間 / 7 日間の usage 利用率を取得。60 秒キャッシュ、429 時 5 分バックオフ、in-flight request coalescing",
-        "deps": ["anthropic-models", "utils/claude-credentials", "i18n", "cli"]
+        "deps": [
+          "anthropic-models",
+          "utils/claude-credentials",
+          "i18n",
+          "cli"
+        ]
       },
       {
         "name": "AnthropicModelsService",
         "file": "backend/src/services/anthropic-models.ts",
         "summary": "Anthropic /v1/models API から model の max_input_tokens を取得し 24 時間キャッシュ",
-        "deps": ["utils/claude-credentials", "cli"]
+        "deps": [
+          "utils/claude-credentials",
+          "cli"
+        ]
       },
       {
         "name": "StatsService",
         "file": "backend/src/services/stats-service.ts",
         "summary": "~/.claude/stats-cache.json から dailyActivity / modelUsage / hourlyActivity / CostEstimate を読み取り / 計算",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "UsageHistoryService",
         "file": "backend/src/services/usage-history.ts",
         "summary": "/tmp/cchub-usage-history.json に usage スナップショットを 30 秒スロットリングで記録し、8 日を超えた古いデータを削除",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "SystemMetricsService",
         "file": "backend/src/services/system-metrics.ts",
         "summary": "CPU / メモリ / スワップ / ロードアベレージを 3 秒ごと最大 60 スナップショット履歴で収集",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "AuthService",
         "file": "backend/src/services/auth.ts",
         "summary": "パスワードベース認証と JWT トークン生成。users.json にユーザーを永続化",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "ConversationWatcher",
         "file": "backend/src/services/conversation-watcher.ts",
         "summary": "Claude Code .jsonl ファイルを fs.watch で監視し、新メッセージを増分パースして WebSocket クライアントへ push",
-        "deps": ["session-history", "claude-code", "shared/types"]
+        "deps": [
+          "session-history",
+          "claude-code",
+          "shared/types"
+        ]
       },
       {
         "name": "CodexService",
@@ -248,127 +287,794 @@
         "name": "CodexConversationService",
         "file": "backend/src/services/codex-conversation.ts",
         "summary": "Codex の rollout JSONL (event_msg/* イベント列) を解析して Claude 形状の ConversationMessage に変換",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "CodexUsageService",
         "file": "backend/src/services/codex-usage.ts",
         "summary": "Codex の最新 rollout ファイルの token_count / rate_limits イベントから 5 時間 / 7 日 UsageLimits を抽出",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       }
     ],
     "routes": [
-      { "group": "sessions", "method": "GET", "path": "/api/sessions", "file": "backend/src/routes/sessions.ts", "description": "全 tmux セッション一覧。WS push 対応なので HTTP 版はデバッグ/フォールバック用途" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions", "file": "backend/src/routes/sessions.ts", "description": "tmux セッション新規作成。workingDir / agent / initialPrompt をサポート。重複 workingDir 時 409" },
-      { "group": "sessions", "method": "GET", "path": "/api/sessions/:id", "file": "backend/src/routes/sessions.ts", "description": "単一セッション詳細" },
-      { "group": "sessions", "method": "DELETE", "path": "/api/sessions/:id", "file": "backend/src/routes/sessions.ts", "description": "セッション削除 (tmux kill-session)" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/resume", "file": "backend/src/routes/sessions.ts", "description": "claude -r または codex resume でセッション再開" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/panes/focus", "file": "backend/src/routes/sessions.ts", "description": "指定 paneId をフォーカス" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/panes/close", "file": "backend/src/routes/sessions.ts", "description": "pane 閉鎖 (最後の pane は拒否)" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/panes/split", "file": "backend/src/routes/sessions.ts", "description": "pane 分割 (h/v)" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/panes/respawn", "file": "backend/src/routes/sessions.ts", "description": "死亡 pane 再起動" },
-      { "group": "sessions", "method": "GET", "path": "/api/sessions/:id/copy-mode", "file": "backend/src/routes/sessions.ts", "description": "tmux copy モードの選択テキスト取得" },
-      { "group": "sessions", "method": "PUT", "path": "/api/sessions/:id/theme", "file": "backend/src/routes/sessions.ts", "description": "セッションカラーテーマ設定" },
-      { "group": "sessions", "method": "PUT", "path": "/api/sessions/:id/title", "file": "backend/src/routes/sessions.ts", "description": "セッションカスタムタイトル設定" },
-      { "group": "sessions", "method": "PUT", "path": "/api/sessions/order", "file": "backend/src/routes/sessions.ts", "description": "セッション表示順序設定" },
-      { "group": "sessions", "method": "GET", "path": "/api/sessions/clipboard", "file": "backend/src/routes/sessions.ts", "description": "クリップボード内容取得" },
-      { "group": "sessions", "method": "GET", "path": "/api/sessions/prompts/search", "file": "backend/src/routes/sessions.ts", "description": "~/.claude/history.jsonl からプロンプト履歴検索" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history", "file": "backend/src/routes/sessions.ts", "description": "過去 Claude Code セッション一覧 (最近 30 件)" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/projects", "file": "backend/src/routes/sessions.ts", "description": "プロジェクト一覧 (高速、ファイル内容読まず)" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/projects/:dirName", "file": "backend/src/routes/sessions.ts", "description": "特定プロジェクトのセッション一覧" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/search", "file": "backend/src/routes/sessions.ts", "description": "全プロジェクト横断セッション検索" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/search/stream", "file": "backend/src/routes/sessions.ts", "description": "ストリーミング検索結果 (SSE)" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/:sessionId/conversation", "file": "backend/src/routes/sessions.ts", "description": "セッションの会話履歴 (?agent=codex で Codex ルーティング、?last=N で末尾 N 件)" },
-      { "group": "history", "method": "POST", "path": "/api/sessions/history/metadata", "file": "backend/src/routes/sessions.ts", "description": "複数セッションのメタデータを一括取得 (lazy load 用)" },
-      { "group": "history", "method": "POST", "path": "/api/sessions/history/resume", "file": "backend/src/routes/sessions.ts", "description": "過去セッションを新 tmux セッションとして再開" },
-      { "group": "dashboard", "method": "GET", "path": "/api/dashboard", "file": "backend/src/routes/dashboard.ts", "description": "usageLimits / codexUsageLimits / dailyActivity / modelUsage / systemMetrics / diskUsage / usageHistory を並列取得して DashboardResponse を返す" },
-      { "group": "files", "method": "GET", "path": "/api/files/list", "file": "backend/src/routes/files.ts", "description": "ディレクトリ内容一覧 (path + sessionWorkingDir 必須、パストラバーサル防止)" },
-      { "group": "files", "method": "GET", "path": "/api/files/read", "file": "backend/src/routes/files.ts", "description": "ファイル内容読み取り (1MB 制限デフォルト、メディアはメタデータのみ)" },
-      { "group": "files", "method": "GET", "path": "/api/files/raw", "file": "backend/src/routes/files.ts", "description": "img/video/audio 用インラインストリーム (Range request / 206 対応)" },
-      { "group": "files", "method": "GET", "path": "/api/files/download", "file": "backend/src/routes/files.ts", "description": "ファイルを attachment としてダウンロード" },
-      { "group": "files", "method": "POST", "path": "/api/files/upload", "file": "backend/src/routes/files.ts", "description": "multipart/form-data でファイルアップロード" },
-      { "group": "files", "method": "GET", "path": "/api/files/browse", "file": "backend/src/routes/files.ts", "description": "ディレクトリツリーブラウズ" },
-      { "group": "files", "method": "GET", "path": "/api/files/changes/:sessionWorkingDir", "file": "backend/src/routes/files.ts", "description": "Claude Code .jsonl から変更ファイル一覧" },
-      { "group": "files", "method": "GET", "path": "/api/files/git-changes/:workingDir", "file": "backend/src/routes/files.ts", "description": "git status --porcelain から変更ファイル一覧" },
-      { "group": "files", "method": "GET", "path": "/api/files/git-diff/:workingDir", "file": "backend/src/routes/files.ts", "description": "git diff で特定ファイルの unified diff" },
-      { "group": "files", "method": "GET", "path": "/api/files/images/:filename", "file": "backend/src/routes/files.ts", "description": "会話画像のサーブ" },
-      { "group": "files", "method": "GET", "path": "/api/files/language", "file": "backend/src/routes/files.ts", "description": "ファイル言語検出" },
-      { "group": "files", "method": "POST", "path": "/api/files/mkdir", "file": "backend/src/routes/files.ts", "description": "ディレクトリ作成" },
-      { "group": "misc", "method": "POST", "path": "/api/upload/image", "file": "backend/src/routes/upload.ts", "description": "画像アップロード (PNG / JPEG / GIF / WebP、10MB 上限、/tmp/cchub-images/ に保存)" },
-      { "group": "misc", "method": "POST", "path": "/api/notify", "file": "backend/src/routes/notify.ts", "description": "Claude Code hook イベントを stdin から受け取り IndicatorState 更新 + WebSocket ブロードキャスト + スマート通知メッセージ生成" },
-      { "group": "auth", "method": "POST", "path": "/api/auth/login", "file": "backend/src/routes/auth.ts", "description": "サーバーパスワード照合して JWT トークン発行" },
-      { "group": "auth", "method": "POST", "path": "/api/auth/logout", "file": "backend/src/routes/auth.ts", "description": "ログアウト (ステートレス JWT、クライアント側トークン破棄)" },
-      { "group": "auth", "method": "GET", "path": "/api/auth/me", "file": "backend/src/routes/auth.ts", "description": "現在のユーザー情報" },
-      { "group": "auth", "method": "GET", "path": "/api/auth/required", "file": "backend/src/routes/auth.ts", "description": "認証が必要かどうかの確認" },
-      { "group": "logs", "method": "POST", "path": "/api/logs", "file": "backend/src/routes/logs.ts", "description": "フロントエンド console 出力を受け取り /tmp/cc-hub-browser.log に書き込む" },
-      { "group": "logs", "method": "GET", "path": "/api/logs", "file": "backend/src/routes/logs.ts", "description": "ブラウザログ取得" },
-      { "group": "logs", "method": "DELETE", "path": "/api/logs", "file": "backend/src/routes/logs.ts", "description": "ブラウザログクリア" },
-      { "group": "websocket", "method": "WS", "path": "/ws/mux", "file": "backend/src/routes/terminal-mux.ts", "description": "多重化 WebSocket。subscribe / unsubscribe + セッション別 terminal I/O。5 秒間隔 sessions-updated push、60 秒無応答 zombie 検出" }
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "全 tmux セッション一覧。WS push 対応なので HTTP 版はデバッグ/フォールバック用途"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "tmux セッション新規作成。workingDir / agent / initialPrompt をサポート。重複 workingDir 時 409"
+      },
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions/:id",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "単一セッション詳細"
+      },
+      {
+        "group": "sessions",
+        "method": "DELETE",
+        "path": "/api/sessions/:id",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッション削除 (tmux kill-session)"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/resume",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "claude -r または codex resume でセッション再開"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/focus",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "指定 paneId をフォーカス"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/close",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "pane 閉鎖 (最後の pane は拒否)"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/split",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "pane 分割 (h/v)"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/respawn",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "死亡 pane 再起動"
+      },
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions/:id/copy-mode",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "tmux copy モードの選択テキスト取得"
+      },
+      {
+        "group": "sessions",
+        "method": "PUT",
+        "path": "/api/sessions/:id/theme",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッションカラーテーマ設定"
+      },
+      {
+        "group": "sessions",
+        "method": "PUT",
+        "path": "/api/sessions/:id/title",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッションカスタムタイトル設定"
+      },
+      {
+        "group": "sessions",
+        "method": "PUT",
+        "path": "/api/sessions/order",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッション表示順序設定"
+      },
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions/clipboard",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "クリップボード内容取得"
+      },
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions/prompts/search",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "~/.claude/history.jsonl からプロンプト履歴検索"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "過去 Claude Code セッション一覧 (最近 30 件)"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/projects",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "プロジェクト一覧 (高速、ファイル内容読まず)"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/projects/:dirName",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "特定プロジェクトのセッション一覧"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/search",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "全プロジェクト横断セッション検索"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/search/stream",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "ストリーミング検索結果 (SSE)"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/:sessionId/conversation",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッションの会話履歴 (?agent=codex で Codex ルーティング、?last=N で末尾 N 件)"
+      },
+      {
+        "group": "history",
+        "method": "POST",
+        "path": "/api/sessions/history/metadata",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "複数セッションのメタデータを一括取得 (lazy load 用)"
+      },
+      {
+        "group": "history",
+        "method": "POST",
+        "path": "/api/sessions/history/resume",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "過去セッションを新 tmux セッションとして再開"
+      },
+      {
+        "group": "dashboard",
+        "method": "GET",
+        "path": "/api/dashboard",
+        "file": "backend/src/routes/dashboard.ts",
+        "description": "usageLimits / codexUsageLimits / dailyActivity / modelUsage / systemMetrics / diskUsage / usageHistory を並列取得して DashboardResponse を返す"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/list",
+        "file": "backend/src/routes/files.ts",
+        "description": "ディレクトリ内容一覧 (path + sessionWorkingDir 必須、パストラバーサル防止)"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/read",
+        "file": "backend/src/routes/files.ts",
+        "description": "ファイル内容読み取り (1MB 制限デフォルト、メディアはメタデータのみ)"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/raw",
+        "file": "backend/src/routes/files.ts",
+        "description": "img/video/audio 用インラインストリーム (Range request / 206 対応)"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/download",
+        "file": "backend/src/routes/files.ts",
+        "description": "ファイルを attachment としてダウンロード"
+      },
+      {
+        "group": "files",
+        "method": "POST",
+        "path": "/api/files/upload",
+        "file": "backend/src/routes/files.ts",
+        "description": "multipart/form-data でファイルアップロード"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/browse",
+        "file": "backend/src/routes/files.ts",
+        "description": "ディレクトリツリーブラウズ"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/changes/:sessionWorkingDir",
+        "file": "backend/src/routes/files.ts",
+        "description": "Claude Code .jsonl から変更ファイル一覧"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/git-changes/:workingDir",
+        "file": "backend/src/routes/files.ts",
+        "description": "git status --porcelain から変更ファイル一覧"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/git-diff/:workingDir",
+        "file": "backend/src/routes/files.ts",
+        "description": "git diff で特定ファイルの unified diff"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/images/:filename",
+        "file": "backend/src/routes/files.ts",
+        "description": "会話画像のサーブ"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/language",
+        "file": "backend/src/routes/files.ts",
+        "description": "ファイル言語検出"
+      },
+      {
+        "group": "files",
+        "method": "POST",
+        "path": "/api/files/mkdir",
+        "file": "backend/src/routes/files.ts",
+        "description": "ディレクトリ作成"
+      },
+      {
+        "group": "misc",
+        "method": "POST",
+        "path": "/api/upload/image",
+        "file": "backend/src/routes/upload.ts",
+        "description": "画像アップロード (PNG / JPEG / GIF / WebP、10MB 上限、/tmp/cchub-images/ に保存)"
+      },
+      {
+        "group": "misc",
+        "method": "POST",
+        "path": "/api/notify",
+        "file": "backend/src/routes/notify.ts",
+        "description": "Claude Code hook イベントを stdin から受け取り IndicatorState 更新 + WebSocket ブロードキャスト + スマート通知メッセージ生成"
+      },
+      {
+        "group": "auth",
+        "method": "POST",
+        "path": "/api/auth/login",
+        "file": "backend/src/routes/auth.ts",
+        "description": "サーバーパスワード照合して JWT トークン発行"
+      },
+      {
+        "group": "auth",
+        "method": "POST",
+        "path": "/api/auth/logout",
+        "file": "backend/src/routes/auth.ts",
+        "description": "ログアウト (ステートレス JWT、クライアント側トークン破棄)"
+      },
+      {
+        "group": "auth",
+        "method": "GET",
+        "path": "/api/auth/me",
+        "file": "backend/src/routes/auth.ts",
+        "description": "現在のユーザー情報"
+      },
+      {
+        "group": "auth",
+        "method": "GET",
+        "path": "/api/auth/required",
+        "file": "backend/src/routes/auth.ts",
+        "description": "認証が必要かどうかの確認"
+      },
+      {
+        "group": "logs",
+        "method": "POST",
+        "path": "/api/logs",
+        "file": "backend/src/routes/logs.ts",
+        "description": "フロントエンド console 出力を受け取り /tmp/cc-hub-browser.log に書き込む"
+      },
+      {
+        "group": "logs",
+        "method": "GET",
+        "path": "/api/logs",
+        "file": "backend/src/routes/logs.ts",
+        "description": "ブラウザログ取得"
+      },
+      {
+        "group": "logs",
+        "method": "DELETE",
+        "path": "/api/logs",
+        "file": "backend/src/routes/logs.ts",
+        "description": "ブラウザログクリア"
+      },
+      {
+        "group": "websocket",
+        "method": "WS",
+        "path": "/ws/mux",
+        "file": "backend/src/routes/terminal-mux.ts",
+        "description": "多重化 WebSocket。subscribe / unsubscribe + セッション別 terminal I/O。5 秒間隔 sessions-updated push、60 秒無応答 zombie 検出"
+      }
     ]
   },
   "frontend": {
     "components": [
-      { "name": "DesktopLayout", "file": "frontend/src/components/DesktopLayout.tsx", "summary": "デスクトップ / タブレット用メインレイアウト。PaneNode ツリー管理、tmux control mode 統合、キーボードショートカット、FloatingKeyboard / SessionModal / DashboardPanel のオーケストレーション", "hooks": ["useSessions", "useMultiplexedTerminal"], "parents": ["App"] },
-      { "name": "PaneContainer", "file": "frontend/src/components/PaneContainer.tsx", "summary": "PaneNode ツリーを再帰レンダリング。ControlModeContext を通じて tmux 操作 (split / close / zoom / resize) と Terminal / ChatView の表示切替を提供", "hooks": [], "parents": ["DesktopLayout", "TerminalPage"] },
-      { "name": "Terminal", "file": "frontend/src/components/Terminal.tsx", "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から pane I/O を受け、tmux レイアウト由来の setExactSize() でサイズ同期。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー", "hooks": ["useSelectionMode"], "parents": ["PaneContainer", "TerminalPage"] },
-      { "name": "TerminalPage", "file": "frontend/src/pages/TerminalPage.tsx", "summary": "セッション単位で useMultiplexedTerminal を使い、layout に基づく pane 一覧管理と TerminalComponent への controlConfig 配線を行うページコンポーネント", "hooks": ["useMultiplexedTerminal"], "parents": ["DesktopLayout"] },
-      { "name": "SessionList", "file": "frontend/src/components/SessionList.tsx", "summary": "アクティブセッション一覧 (Active / History / Dashboard タブ)。ドラッグ&ドロップ並び替え、pane 一覧展開、インジケーターステータス表示、テーマ設定", "hooks": ["useSessions"], "parents": ["SessionModal", "DesktopLayout"] },
-      { "name": "SessionModal", "file": "frontend/src/components/SessionModal.tsx", "summary": "Ctrl+B で開くセッション選択モーダル。SessionList をラップして ESC で閉じる", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "SessionHistory", "file": "frontend/src/components/SessionHistory.tsx", "summary": "過去セッションをプロジェクト別にグループ表示。会話ビュー表示、セッション再開アクション", "hooks": ["useSessionHistory"], "parents": ["SessionList"] },
-      { "name": "ConversationViewer", "file": "frontend/src/components/ConversationViewer.tsx", "summary": "ConversationMessage を ReactMarkdown + 仮想スクロールでレンダリング。ピンチズーム対応フォントサイズ調整", "hooks": ["useVirtualizer"], "parents": ["ChatView", "SessionHistory"] },
-      { "name": "ChatView", "file": "frontend/src/components/chat/ChatView.tsx", "summary": "ConversationViewer + ChatComposer を組み合わせた会話 UI。Claude (WebSocket) と Codex (ポーリング) を統一的に扱う useAgentConversation を利用", "hooks": ["useAgentConversation", "useInputEcho"], "parents": ["PaneContainer"] },
-      { "name": "ChatComposer", "file": "frontend/src/components/chat/ChatComposer.tsx", "summary": "デスクトップ向け会話入力フォーム。sendTerminalInput 経由で tmux にブラケットペーストとして送信", "hooks": [], "parents": ["ChatView"] },
-      { "name": "FloatingKeyboard", "file": "frontend/src/components/FloatingKeyboard.tsx", "summary": "タブレット向けドラッグ可能フローティングキーボード。最小化・透明化・向き/モード別位置保存", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "Keyboard", "file": "frontend/src/components/Keyboard.tsx", "summary": "モバイル向けバーチャルキーボード (長押しシンボル入力)", "hooks": [], "parents": ["FloatingKeyboard", "InputBar"] },
-      { "name": "InputBar", "file": "frontend/src/components/InputBar.tsx", "summary": "モバイル/タブレット向け入力バー (hidden / shortcuts / input モード切替、プロンプト履歴、画像添付)", "hooks": [], "parents": ["Terminal"] },
-      { "name": "DashboardPanel", "file": "frontend/src/components/DashboardPanel.tsx", "summary": "Ctrl+Shift+B で開くサイドパネルラッパー。Dashboard コンポーネントを compact モードで包む", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "Dashboard", "file": "frontend/src/components/dashboard/Dashboard.tsx", "summary": "ダッシュボードメインコンテナ。Claude / Codex エージェントタブ切替、UsageLimits / DailyUsageChart / ModelUsageChart / HourlyHeatmap / NetworkLatency / ServerInfo を組み合わせる", "hooks": ["useDashboard", "useTheme"], "parents": ["DashboardPanel"] },
-      { "name": "UsageLimits", "file": "frontend/src/components/dashboard/UsageLimits.tsx", "summary": "5 時間 / 7 日間使用率をプログレスバーと UsageChart で表示。警告状態の色分けと resetsAt 残り時間表示", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "UsageChart", "file": "frontend/src/components/dashboard/UsageChart.tsx", "summary": "UsageSnapshot の時系列折れ線グラフ (SVG 手書き)", "hooks": [], "parents": ["UsageLimits"] },
-      { "name": "DailyUsageChart", "file": "frontend/src/components/dashboard/DailyUsageChart.tsx", "summary": "過去 7 日のメッセージ数 / セッション数棒グラフ", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "ModelUsageChart", "file": "frontend/src/components/dashboard/ModelUsageChart.tsx", "summary": "Opus / Sonnet トークン使用量比較チャート", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "HourlyHeatmap", "file": "frontend/src/components/dashboard/HourlyHeatmap.tsx", "summary": "時間帯別 (0-6 / 6-12 / 12-18 / 18-24) 活動ヒートマップ", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "NetworkLatency", "file": "frontend/src/components/dashboard/NetworkLatency.tsx", "summary": "WebSocket / API レイテンシのリアルタイム表示 (緑 / 黄 / 赤色分け)", "hooks": ["useNetworkLatency"], "parents": ["Dashboard"] },
-      { "name": "ServerInfo", "file": "frontend/src/components/dashboard/ServerInfo.tsx", "summary": "サーバー情報・CPU / メモリ / スワップの SVG ミニチャート・接続クライアント数表示", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "FileViewer", "file": "frontend/src/components/files/FileViewer.tsx", "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude 変更 / Git 変更トグル、ブラウザ履歴ナビ、アップロード / ダウンロード、動画 / 音声再生。v0.1.108 で選択ファイル highlight + スクロール保持を実装", "hooks": ["useFileViewer"], "parents": ["DesktopLayout", "PaneContainer"] },
-      { "name": "FileBrowser", "file": "frontend/src/components/files/FileBrowser.tsx", "summary": "ディレクトリツリーナビゲーション。選択中ファイルを selectedPath prop で受け取り青背景 + 青ボーダーでハイライト", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "CodeViewer", "file": "frontend/src/components/files/CodeViewer.tsx", "summary": "シンタックスハイライト付きコード表示", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "DiffViewer", "file": "frontend/src/components/files/DiffViewer.tsx", "summary": "ファイル変更のサイドバイサイド diff 表示", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "ImageViewer", "file": "frontend/src/components/files/ImageViewer.tsx", "summary": "画像プレビュー + ズーム (/files/raw ストリーミング利用)", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "MarkdownViewer", "file": "frontend/src/components/files/MarkdownViewer.tsx", "summary": "Markdown レンダリング", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "HtmlViewer", "file": "frontend/src/components/files/HtmlViewer.tsx", "summary": "HTML ファイルを iframe でレンダリング", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "PromptComposer", "file": "frontend/src/components/files/PromptComposer.tsx", "summary": "コードビューアで選択した行をプロンプトとしてフォーマットして送信する UI パネル", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "LoginForm", "file": "frontend/src/components/LoginForm.tsx", "summary": "パスワード認証フォーム", "hooks": [], "parents": ["App"] },
-      { "name": "Onboarding", "file": "frontend/src/components/Onboarding.tsx", "summary": "新規ユーザー向け spotlight スタイルウォークスルー (localStorage 完了フラグ管理)", "hooks": [], "parents": ["App"] },
-      { "name": "SelectionOverlay", "file": "frontend/src/components/SelectionOverlay.tsx", "summary": "xterm.js 上にタッチ選択ハンドル + コピーボタンを重ねる SVG オーバーレイ", "hooks": [], "parents": ["Terminal"] }
+      {
+        "name": "DesktopLayout",
+        "file": "frontend/src/components/DesktopLayout.tsx",
+        "summary": "デスクトップ / タブレット用メインレイアウト。PaneNode ツリー管理、tmux control mode 統合、キーボードショートカット、FloatingKeyboard / SessionModal / DashboardPanel のオーケストレーション",
+        "hooks": [
+          "useSessions",
+          "useMultiplexedTerminal"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "PaneContainer",
+        "file": "frontend/src/components/PaneContainer.tsx",
+        "summary": "PaneNode ツリーを再帰レンダリング。ControlModeContext を通じて tmux 操作 (split / close / zoom / resize) と Terminal / ChatView の表示切替を提供",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "Terminal",
+        "file": "frontend/src/components/Terminal.tsx",
+        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から pane I/O を受け、tmux レイアウト由来の setExactSize() でサイズ同期。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
+        "hooks": [
+          "useSelectionMode"
+        ],
+        "parents": [
+          "PaneContainer",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "TerminalPage",
+        "file": "frontend/src/pages/TerminalPage.tsx",
+        "summary": "セッション単位で useMultiplexedTerminal を使い、layout に基づく pane 一覧管理と TerminalComponent への controlConfig 配線を行うページコンポーネント",
+        "hooks": [
+          "useMultiplexedTerminal"
+        ],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "SessionList",
+        "file": "frontend/src/components/SessionList.tsx",
+        "summary": "アクティブセッション一覧 (Active / History / Dashboard タブ)。ドラッグ&ドロップ並び替え、pane 一覧展開、インジケーターステータス表示、テーマ設定",
+        "hooks": [
+          "useSessions"
+        ],
+        "parents": [
+          "SessionModal",
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "SessionModal",
+        "file": "frontend/src/components/SessionModal.tsx",
+        "summary": "Ctrl+B で開くセッション選択モーダル。SessionList をラップして ESC で閉じる",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "SessionHistory",
+        "file": "frontend/src/components/SessionHistory.tsx",
+        "summary": "過去セッションをプロジェクト別にグループ表示。会話ビュー表示、セッション再開アクション",
+        "hooks": [
+          "useSessionHistory"
+        ],
+        "parents": [
+          "SessionList"
+        ]
+      },
+      {
+        "name": "ConversationViewer",
+        "file": "frontend/src/components/ConversationViewer.tsx",
+        "summary": "ConversationMessage を ReactMarkdown + 仮想スクロールでレンダリング。ピンチズーム対応フォントサイズ調整",
+        "hooks": [
+          "useVirtualizer"
+        ],
+        "parents": [
+          "ChatView",
+          "SessionHistory"
+        ]
+      },
+      {
+        "name": "ChatView",
+        "file": "frontend/src/components/chat/ChatView.tsx",
+        "summary": "ConversationViewer + ChatComposer を組み合わせた会話 UI。Claude (WebSocket) と Codex (ポーリング) を統一的に扱う useAgentConversation を利用",
+        "hooks": [
+          "useAgentConversation",
+          "useInputEcho"
+        ],
+        "parents": [
+          "PaneContainer"
+        ]
+      },
+      {
+        "name": "ChatComposer",
+        "file": "frontend/src/components/chat/ChatComposer.tsx",
+        "summary": "デスクトップ向け会話入力フォーム。sendTerminalInput 経由で tmux にブラケットペーストとして送信",
+        "hooks": [],
+        "parents": [
+          "ChatView"
+        ]
+      },
+      {
+        "name": "FloatingKeyboard",
+        "file": "frontend/src/components/FloatingKeyboard.tsx",
+        "summary": "タブレット向けドラッグ可能フローティングキーボード。最小化・透明化・向き/モード別位置保存",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "Keyboard",
+        "file": "frontend/src/components/Keyboard.tsx",
+        "summary": "モバイル向けバーチャルキーボード (長押しシンボル入力)",
+        "hooks": [],
+        "parents": [
+          "FloatingKeyboard",
+          "InputBar"
+        ]
+      },
+      {
+        "name": "InputBar",
+        "file": "frontend/src/components/InputBar.tsx",
+        "summary": "モバイル/タブレット向け入力バー (hidden / shortcuts / input モード切替、プロンプト履歴、画像添付)",
+        "hooks": [],
+        "parents": [
+          "Terminal"
+        ]
+      },
+      {
+        "name": "DashboardPanel",
+        "file": "frontend/src/components/DashboardPanel.tsx",
+        "summary": "Ctrl+Shift+B で開くサイドパネルラッパー。Dashboard コンポーネントを compact モードで包む",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "Dashboard",
+        "file": "frontend/src/components/dashboard/Dashboard.tsx",
+        "summary": "ダッシュボードメインコンテナ。Claude / Codex エージェントタブ切替、UsageLimits / DailyUsageChart / ModelUsageChart / HourlyHeatmap / NetworkLatency / ServerInfo を組み合わせる",
+        "hooks": [
+          "useDashboard",
+          "useTheme"
+        ],
+        "parents": [
+          "DashboardPanel"
+        ]
+      },
+      {
+        "name": "UsageLimits",
+        "file": "frontend/src/components/dashboard/UsageLimits.tsx",
+        "summary": "5 時間 / 7 日間使用率をプログレスバーと UsageChart で表示。警告状態の色分けと resetsAt 残り時間表示",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "UsageChart",
+        "file": "frontend/src/components/dashboard/UsageChart.tsx",
+        "summary": "UsageSnapshot の時系列折れ線グラフ (SVG 手書き)",
+        "hooks": [],
+        "parents": [
+          "UsageLimits"
+        ]
+      },
+      {
+        "name": "DailyUsageChart",
+        "file": "frontend/src/components/dashboard/DailyUsageChart.tsx",
+        "summary": "過去 7 日のメッセージ数 / セッション数棒グラフ",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "ModelUsageChart",
+        "file": "frontend/src/components/dashboard/ModelUsageChart.tsx",
+        "summary": "Opus / Sonnet トークン使用量比較チャート",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "HourlyHeatmap",
+        "file": "frontend/src/components/dashboard/HourlyHeatmap.tsx",
+        "summary": "時間帯別 (0-6 / 6-12 / 12-18 / 18-24) 活動ヒートマップ",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "NetworkLatency",
+        "file": "frontend/src/components/dashboard/NetworkLatency.tsx",
+        "summary": "WebSocket / API レイテンシのリアルタイム表示 (緑 / 黄 / 赤色分け)",
+        "hooks": [
+          "useNetworkLatency"
+        ],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "ServerInfo",
+        "file": "frontend/src/components/dashboard/ServerInfo.tsx",
+        "summary": "サーバー情報・CPU / メモリ / スワップの SVG ミニチャート・接続クライアント数表示",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "FileViewer",
+        "file": "frontend/src/components/files/FileViewer.tsx",
+        "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude 変更 / Git 変更トグル、ブラウザ履歴ナビ、アップロード / ダウンロード、動画 / 音声再生。v0.1.108 で選択ファイル highlight + スクロール保持を実装",
+        "hooks": [
+          "useFileViewer"
+        ],
+        "parents": [
+          "DesktopLayout",
+          "PaneContainer"
+        ]
+      },
+      {
+        "name": "FileBrowser",
+        "file": "frontend/src/components/files/FileBrowser.tsx",
+        "summary": "ディレクトリツリーナビゲーション。選択中ファイルを selectedPath prop で受け取り青背景 + 青ボーダーでハイライト",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "CodeViewer",
+        "file": "frontend/src/components/files/CodeViewer.tsx",
+        "summary": "シンタックスハイライト付きコード表示",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "DiffViewer",
+        "file": "frontend/src/components/files/DiffViewer.tsx",
+        "summary": "ファイル変更のサイドバイサイド diff 表示",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "ImageViewer",
+        "file": "frontend/src/components/files/ImageViewer.tsx",
+        "summary": "画像プレビュー + ズーム (/files/raw ストリーミング利用)",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "MarkdownViewer",
+        "file": "frontend/src/components/files/MarkdownViewer.tsx",
+        "summary": "Markdown レンダリング",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "HtmlViewer",
+        "file": "frontend/src/components/files/HtmlViewer.tsx",
+        "summary": "HTML ファイルを iframe でレンダリング",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "PromptComposer",
+        "file": "frontend/src/components/files/PromptComposer.tsx",
+        "summary": "コードビューアで選択した行をプロンプトとしてフォーマットして送信する UI パネル",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "LoginForm",
+        "file": "frontend/src/components/LoginForm.tsx",
+        "summary": "パスワード認証フォーム",
+        "hooks": [],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "Onboarding",
+        "file": "frontend/src/components/Onboarding.tsx",
+        "summary": "新規ユーザー向け spotlight スタイルウォークスルー (localStorage 完了フラグ管理)",
+        "hooks": [],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "SelectionOverlay",
+        "file": "frontend/src/components/SelectionOverlay.tsx",
+        "summary": "xterm.js 上にタッチ選択ハンドル + コピーボタンを重ねる SVG オーバーレイ",
+        "hooks": [],
+        "parents": [
+          "Terminal"
+        ]
+      }
     ],
     "hooks": [
-      { "name": "useMultiplexedTerminal", "file": "frontend/src/hooks/useMultiplexedTerminal.ts", "summary": "/ws/mux へのモジュールレベル singleton WebSocket 管理。subscribe / unsubscribe、入力送信 (base64)、resize / split / close / zoom / scroll / adjustPane / equalizePanes、自動再接続・keepalive ping を提供" },
-      { "name": "useSessions", "file": "frontend/src/hooks/useSessions.ts", "summary": "モジュールレベルキャッシュ (WS sessions-updated で更新) 付きセッション状態管理。hook イベントによる indicatorState 即時更新" },
-      { "name": "useSessionHistory", "file": "frontend/src/hooks/useSessionHistory.ts", "summary": "過去セッション履歴のブラウズ (プロジェクト一覧 → セッション遅延ロード → SSE ストリーム検索)" },
-      { "name": "useDashboard", "file": "frontend/src/hooks/useDashboard.ts", "summary": "/api/dashboard をポーリング (デフォルト 60 秒間隔)" },
-      { "name": "useFileViewer", "file": "frontend/src/hooks/useFileViewer.ts", "summary": "ファイルビューア状態管理 (listDirectory / readFile / getGitDiff 等の API 呼び出しラップ)" },
-      { "name": "useAuth", "file": "frontend/src/hooks/useAuth.ts", "summary": "JWT 認証状態管理 (localStorage cc-hub-token、認証不要モード対応)" },
-      { "name": "useTheme", "file": "frontend/src/hooks/useTheme.ts", "summary": "light / dark テーマの localStorage 永続化と document.documentElement 属性適用" },
-      { "name": "useNetworkLatency", "file": "frontend/src/hooks/useNetworkLatency.ts", "summary": "/health への 30 秒間隔 HTTP ping で API レイテンシ計測、latency-store を useSyncExternalStore で購読" },
-      { "name": "useLineSelection", "file": "frontend/src/hooks/useLineSelection.ts", "summary": "クリックで行範囲選択 (1 回目=start, 2 回目=end)" },
-      { "name": "useSelectionMode", "file": "frontend/src/hooks/useSelectionMode.ts", "summary": "xterm.js 上のタッチ / マウス選択モード管理 (SelectionRange、コピーボタン位置計算)" },
-      { "name": "useConversationStream", "file": "frontend/src/hooks/useConversationStream.ts", "summary": "/ws/mux の conversation-subscribe を通じて Claude 会話をリアルタイム受信" },
-      { "name": "useCodexConversation", "file": "frontend/src/hooks/useCodexConversation.ts", "summary": "Codex セッションの会話を HTTP ポーリング (デフォルト 5 秒) で取得" },
-      { "name": "useAgentConversation", "file": "frontend/src/hooks/useAgentConversation.ts", "summary": "agent 種別 (claude / codex) に応じて useConversationStream / useCodexConversation を切り替える統合 hook" },
-      { "name": "useInputEcho", "file": "frontend/src/hooks/useInputEcho.ts", "summary": "端末への入力文字を 4 秒間エコー表示 (バックスペース / エスケープなど特殊キーをビジュアル化)" }
+      {
+        "name": "useMultiplexedTerminal",
+        "file": "frontend/src/hooks/useMultiplexedTerminal.ts",
+        "summary": "/ws/mux へのモジュールレベル singleton WebSocket 管理。subscribe / unsubscribe、入力送信 (base64)、resize / split / close / zoom / scroll / adjustPane / equalizePanes、自動再接続・keepalive ping を提供"
+      },
+      {
+        "name": "useSessions",
+        "file": "frontend/src/hooks/useSessions.ts",
+        "summary": "モジュールレベルキャッシュ (WS sessions-updated で更新) 付きセッション状態管理。hook イベントによる indicatorState 即時更新"
+      },
+      {
+        "name": "useSessionHistory",
+        "file": "frontend/src/hooks/useSessionHistory.ts",
+        "summary": "過去セッション履歴のブラウズ (プロジェクト一覧 → セッション遅延ロード → SSE ストリーム検索)"
+      },
+      {
+        "name": "useDashboard",
+        "file": "frontend/src/hooks/useDashboard.ts",
+        "summary": "/api/dashboard をポーリング (デフォルト 60 秒間隔)"
+      },
+      {
+        "name": "useFileViewer",
+        "file": "frontend/src/hooks/useFileViewer.ts",
+        "summary": "ファイルビューア状態管理 (listDirectory / readFile / getGitDiff 等の API 呼び出しラップ)"
+      },
+      {
+        "name": "useAuth",
+        "file": "frontend/src/hooks/useAuth.ts",
+        "summary": "JWT 認証状態管理 (localStorage cc-hub-token、認証不要モード対応)"
+      },
+      {
+        "name": "useTheme",
+        "file": "frontend/src/hooks/useTheme.ts",
+        "summary": "light / dark テーマの localStorage 永続化と document.documentElement 属性適用"
+      },
+      {
+        "name": "useNetworkLatency",
+        "file": "frontend/src/hooks/useNetworkLatency.ts",
+        "summary": "/health への 30 秒間隔 HTTP ping で API レイテンシ計測、latency-store を useSyncExternalStore で購読"
+      },
+      {
+        "name": "useLineSelection",
+        "file": "frontend/src/hooks/useLineSelection.ts",
+        "summary": "クリックで行範囲選択 (1 回目=start, 2 回目=end)"
+      },
+      {
+        "name": "useSelectionMode",
+        "file": "frontend/src/hooks/useSelectionMode.ts",
+        "summary": "xterm.js 上のタッチ / マウス選択モード管理 (SelectionRange、コピーボタン位置計算)"
+      },
+      {
+        "name": "useConversationStream",
+        "file": "frontend/src/hooks/useConversationStream.ts",
+        "summary": "/ws/mux の conversation-subscribe を通じて Claude 会話をリアルタイム受信"
+      },
+      {
+        "name": "useCodexConversation",
+        "file": "frontend/src/hooks/useCodexConversation.ts",
+        "summary": "Codex セッションの会話を HTTP ポーリング (デフォルト 5 秒) で取得"
+      },
+      {
+        "name": "useAgentConversation",
+        "file": "frontend/src/hooks/useAgentConversation.ts",
+        "summary": "agent 種別 (claude / codex) に応じて useConversationStream / useCodexConversation を切り替える統合 hook"
+      },
+      {
+        "name": "useInputEcho",
+        "file": "frontend/src/hooks/useInputEcho.ts",
+        "summary": "端末への入力文字を 4 秒間エコー表示 (バックスペース / エスケープなど特殊キーをビジュアル化)"
+      }
     ]
   },
   "websocket": {
     "endpoint": "/ws/mux",
     "description": "単一の多重化 WebSocket。クライアントは subscribe でセッションごとに購読し、binary フレーム [0x02][sessionId\\0][paneId\\0][data] と JSON 制御メッセージを混在で受信",
     "client_messages": {
-      "mux_level": ["subscribe", "unsubscribe", "subscribe-conversation", "unsubscribe-conversation"],
-      "per_session": ["input", "resize", "split", "close-pane", "resize-pane", "select-pane", "scroll", "adjust-pane", "equalize-panes", "request-content", "zoom-pane", "respawn-pane", "ping", "client-info"]
+      "mux_level": [
+        "subscribe",
+        "unsubscribe",
+        "subscribe-conversation",
+        "unsubscribe-conversation"
+      ],
+      "per_session": [
+        "input",
+        "resize",
+        "split",
+        "close-pane",
+        "resize-pane",
+        "select-pane",
+        "scroll",
+        "adjust-pane",
+        "equalize-panes",
+        "request-content",
+        "zoom-pane",
+        "respawn-pane",
+        "ping",
+        "client-info"
+      ]
     },
     "server_messages": {
-      "mux_level": ["subscribed", "unsubscribed", "sessions-updated", "conversation-subscribed", "conversation-unsubscribed", "initial-conversation", "conversation-update"],
-      "per_session": ["output (binary)", "layout", "initial-content", "ready", "pong", "error", "new-session", "pane-dead", "hook-event"]
+      "mux_level": [
+        "subscribed",
+        "unsubscribed",
+        "sessions-updated",
+        "conversation-subscribed",
+        "conversation-unsubscribed",
+        "initial-conversation",
+        "conversation-update"
+      ],
+      "per_session": [
+        "output (binary)",
+        "layout",
+        "initial-content",
+        "ready",
+        "pong",
+        "error",
+        "new-session",
+        "pane-dead",
+        "hook-event"
+      ]
     },
     "binary_format": "[0x02][sessionId\\0][paneId\\0][raw bytes]",
     "intervals": {
@@ -378,17 +1084,50 @@
     }
   },
   "types": [
-    { "name": "SessionResponse", "fields": "id, name, createdAt, lastAccessedAt, state, currentPath, agent, theme, customTitle" },
-    { "name": "ExtendedSessionResponse", "fields": "extends SessionResponse + indicatorState, ccSessionId, agentSessionId, currentCommand, paneTitle, ccSummary, ccFirstPrompt, ccRecap, waitingToolName, panes, messageCount, gitBranch, durationMinutes, metrics" },
-    { "name": "PaneInfo", "fields": "paneId, currentCommand, currentPath, title, agentName, agentColor, isActive, isDead, indicatorState, pid" },
-    { "name": "TmuxLayoutNode", "fields": "type ('leaf' | 'horizontal' | 'vertical'), width, height, x, y, paneId?, children?" },
-    { "name": "SessionMetrics", "fields": "contextTokens, contextMaxTokens, contextPercent, totalInputTokens, totalCacheCreationTokens, totalCacheReadTokens, totalOutputTokens, totalTokens, memoryRssBytes" },
-    { "name": "DashboardResponse", "fields": "usageLimits, usageLimitsStatus, codexUsageLimits, usageHistory, dailyActivity, modelUsage, costEstimates, hourlyActivity, version, systemMetrics, diskUsage, connectedClients" },
-    { "name": "ConversationMessage", "fields": "role, content, timestamp, thinking, toolUse, toolResult" },
-    { "name": "UsageLimits", "fields": "fiveHour (UsageCycleInfo), sevenDay (UsageCycleInfo)" },
-    { "name": "SessionState", "fields": "'idle' | 'working' | 'waiting_input' | 'waiting_permission' | 'disconnected' | 'lost'" },
-    { "name": "IndicatorState", "fields": "'processing' | 'waiting_input' | 'idle' | 'completed'" },
-    { "name": "AgentProvider", "fields": "'claude' | 'codex'" }
+    {
+      "name": "SessionResponse",
+      "fields": "id, name, createdAt, lastAccessedAt, state, currentPath, agent, theme, customTitle"
+    },
+    {
+      "name": "ExtendedSessionResponse",
+      "fields": "extends SessionResponse + indicatorState, ccSessionId, agentSessionId, currentCommand, paneTitle, ccSummary, ccFirstPrompt, ccRecap, waitingToolName, panes, messageCount, gitBranch, durationMinutes, metrics"
+    },
+    {
+      "name": "PaneInfo",
+      "fields": "paneId, currentCommand, currentPath, title, agentName, agentColor, isActive, isDead, indicatorState, pid"
+    },
+    {
+      "name": "TmuxLayoutNode",
+      "fields": "type ('leaf' | 'horizontal' | 'vertical'), width, height, x, y, paneId?, children?"
+    },
+    {
+      "name": "SessionMetrics",
+      "fields": "contextTokens, contextMaxTokens, contextPercent, totalInputTokens, totalCacheCreationTokens, totalCacheReadTokens, totalOutputTokens, totalTokens, memoryRssBytes"
+    },
+    {
+      "name": "DashboardResponse",
+      "fields": "usageLimits, usageLimitsStatus, codexUsageLimits, usageHistory, dailyActivity, modelUsage, costEstimates, hourlyActivity, version, systemMetrics, diskUsage, connectedClients"
+    },
+    {
+      "name": "ConversationMessage",
+      "fields": "role, content, timestamp, thinking, toolUse, toolResult"
+    },
+    {
+      "name": "UsageLimits",
+      "fields": "fiveHour (UsageCycleInfo), sevenDay (UsageCycleInfo)"
+    },
+    {
+      "name": "SessionState",
+      "fields": "'idle' | 'working' | 'waiting_input' | 'waiting_permission' | 'disconnected' | 'lost'"
+    },
+    {
+      "name": "IndicatorState",
+      "fields": "'processing' | 'waiting_input' | 'idle' | 'completed'"
+    },
+    {
+      "name": "AgentProvider",
+      "fields": "'claude' | 'codex'"
+    }
   ],
   "data_flows": [
     {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.108",
+  "version": "0.1.109",
   "generated": "2026-05-16",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
@@ -15,19 +15,27 @@
         "name": "TmuxControlSession",
         "file": "backend/src/services/tmux-control.ts",
         "summary": "tmux -CC (control mode) プロセスを管理するコア。%output / %layout-change / %begin / %end / %error / %exit を処理し、raw byte stream で UTF-8 を保持。client 単位の pane 出力ルーティング、コマンド FIFO キュー、グレースピリオド付きライフサイクル管理を提供",
-        "deps": ["tmux-octal-decoder", "tmux-layout-parser"]
+        "deps": [
+          "tmux-octal-decoder",
+          "tmux-layout-parser"
+        ]
       },
       {
         "name": "TmuxService",
         "file": "backend/src/services/tmux.ts",
         "summary": "tmux セッションの CRUD (listSessions / createSession / sessionExists / sendKeys) と pane 情報収集。ps を 1 回バッチ実行して全 TTY の agent 情報を取得",
-        "deps": ["tmux-octal-decoder", "shared/types"]
+        "deps": [
+          "tmux-octal-decoder",
+          "shared/types"
+        ]
       },
       {
         "name": "TmuxLayoutParser",
         "file": "backend/src/services/tmux-layout-parser.ts",
         "summary": "tmux layout 文字列 (checksum,WxH,X,Y{...}) を TmuxLayoutNode ツリーへ再帰パース",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "TmuxOctalDecoder",
@@ -51,19 +59,26 @@
         "name": "SessionMetadataService",
         "file": "backend/src/services/session-metadata.ts",
         "summary": "session-metadata.json (theme / title / order) と last-known-sessions.json (リブート後復元用) を永続化。旧フォーマット自動マイグレーション付き",
-        "deps": ["utils/storage"]
+        "deps": [
+          "utils/storage"
+        ]
       },
       {
         "name": "SessionMetricsService",
         "file": "backend/src/services/session-metrics.ts",
         "summary": ".jsonl を解析して context token 使用率・累積トークン数、ps を呼び pid ツリーを辿って RSS 使用量を計算",
-        "deps": ["anthropic-models"]
+        "deps": [
+          "anthropic-models"
+        ]
       },
       {
         "name": "SessionsService",
         "file": "backend/src/services/sessions.ts",
         "summary": "セッションエンティティの CRUD (ファイルベース永続化、UUID ベース ID 生成)",
-        "deps": ["utils/storage", "shared/types"]
+        "deps": [
+          "utils/storage",
+          "shared/types"
+        ]
       },
       {
         "name": "PromptHistoryService",
@@ -75,55 +90,79 @@
         "name": "FileService",
         "file": "backend/src/services/file-service.ts",
         "summary": "パストラバーサル防止付きセキュアファイル操作 (listDirectory / readFile / getParentPath)。MIME タイプ判定・サイズ制限、メディアはメタデータのみ",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "FileChangeTracker",
         "file": "backend/src/services/file-change-tracker.ts",
         "summary": "Claude Code .jsonl の tool_use (Write/Edit) ブロックを解析してどのファイルが変更されたかを追跡",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "AnthropicUsageService",
         "file": "backend/src/services/anthropic-usage.ts",
         "summary": "Anthropic API (/v1/usage) から 5 時間 / 7 日間の usage 利用率を取得。60 秒キャッシュ、429 時 5 分バックオフ、in-flight request coalescing",
-        "deps": ["anthropic-models", "utils/claude-credentials", "i18n", "cli"]
+        "deps": [
+          "anthropic-models",
+          "utils/claude-credentials",
+          "i18n",
+          "cli"
+        ]
       },
       {
         "name": "AnthropicModelsService",
         "file": "backend/src/services/anthropic-models.ts",
         "summary": "Anthropic /v1/models API から model の max_input_tokens を取得し 24 時間キャッシュ",
-        "deps": ["utils/claude-credentials", "cli"]
+        "deps": [
+          "utils/claude-credentials",
+          "cli"
+        ]
       },
       {
         "name": "StatsService",
         "file": "backend/src/services/stats-service.ts",
         "summary": "~/.claude/stats-cache.json から dailyActivity / modelUsage / hourlyActivity / CostEstimate を読み取り / 計算",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "UsageHistoryService",
         "file": "backend/src/services/usage-history.ts",
         "summary": "/tmp/cchub-usage-history.json に usage スナップショットを 30 秒スロットリングで記録し、8 日を超えた古いデータを削除",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "SystemMetricsService",
         "file": "backend/src/services/system-metrics.ts",
         "summary": "CPU / メモリ / スワップ / ロードアベレージを 3 秒ごと最大 60 スナップショット履歴で収集",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "AuthService",
         "file": "backend/src/services/auth.ts",
         "summary": "パスワードベース認証と JWT トークン生成。users.json にユーザーを永続化",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "ConversationWatcher",
         "file": "backend/src/services/conversation-watcher.ts",
         "summary": "Claude Code .jsonl ファイルを fs.watch で監視し、新メッセージを増分パースして WebSocket クライアントへ push",
-        "deps": ["session-history", "claude-code", "shared/types"]
+        "deps": [
+          "session-history",
+          "claude-code",
+          "shared/types"
+        ]
       },
       {
         "name": "CodexService",
@@ -135,127 +174,794 @@
         "name": "CodexConversationService",
         "file": "backend/src/services/codex-conversation.ts",
         "summary": "Codex の rollout JSONL (event_msg/* イベント列) を解析して Claude 形状の ConversationMessage に変換",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       },
       {
         "name": "CodexUsageService",
         "file": "backend/src/services/codex-usage.ts",
         "summary": "Codex の最新 rollout ファイルの token_count / rate_limits イベントから 5 時間 / 7 日 UsageLimits を抽出",
-        "deps": ["shared/types"]
+        "deps": [
+          "shared/types"
+        ]
       }
     ],
     "routes": [
-      { "group": "sessions", "method": "GET", "path": "/api/sessions", "file": "backend/src/routes/sessions.ts", "description": "全 tmux セッション一覧。WS push 対応なので HTTP 版はデバッグ/フォールバック用途" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions", "file": "backend/src/routes/sessions.ts", "description": "tmux セッション新規作成。workingDir / agent / initialPrompt をサポート。重複 workingDir 時 409" },
-      { "group": "sessions", "method": "GET", "path": "/api/sessions/:id", "file": "backend/src/routes/sessions.ts", "description": "単一セッション詳細" },
-      { "group": "sessions", "method": "DELETE", "path": "/api/sessions/:id", "file": "backend/src/routes/sessions.ts", "description": "セッション削除 (tmux kill-session)" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/resume", "file": "backend/src/routes/sessions.ts", "description": "claude -r または codex resume でセッション再開" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/panes/focus", "file": "backend/src/routes/sessions.ts", "description": "指定 paneId をフォーカス" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/panes/close", "file": "backend/src/routes/sessions.ts", "description": "pane 閉鎖 (最後の pane は拒否)" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/panes/split", "file": "backend/src/routes/sessions.ts", "description": "pane 分割 (h/v)" },
-      { "group": "sessions", "method": "POST", "path": "/api/sessions/:id/panes/respawn", "file": "backend/src/routes/sessions.ts", "description": "死亡 pane 再起動" },
-      { "group": "sessions", "method": "GET", "path": "/api/sessions/:id/copy-mode", "file": "backend/src/routes/sessions.ts", "description": "tmux copy モードの選択テキスト取得" },
-      { "group": "sessions", "method": "PUT", "path": "/api/sessions/:id/theme", "file": "backend/src/routes/sessions.ts", "description": "セッションカラーテーマ設定" },
-      { "group": "sessions", "method": "PUT", "path": "/api/sessions/:id/title", "file": "backend/src/routes/sessions.ts", "description": "セッションカスタムタイトル設定" },
-      { "group": "sessions", "method": "PUT", "path": "/api/sessions/order", "file": "backend/src/routes/sessions.ts", "description": "セッション表示順序設定" },
-      { "group": "sessions", "method": "GET", "path": "/api/sessions/clipboard", "file": "backend/src/routes/sessions.ts", "description": "クリップボード内容取得" },
-      { "group": "sessions", "method": "GET", "path": "/api/sessions/prompts/search", "file": "backend/src/routes/sessions.ts", "description": "~/.claude/history.jsonl からプロンプト履歴検索" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history", "file": "backend/src/routes/sessions.ts", "description": "過去 Claude Code セッション一覧 (最近 30 件)" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/projects", "file": "backend/src/routes/sessions.ts", "description": "プロジェクト一覧 (高速、ファイル内容読まず)" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/projects/:dirName", "file": "backend/src/routes/sessions.ts", "description": "特定プロジェクトのセッション一覧" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/search", "file": "backend/src/routes/sessions.ts", "description": "全プロジェクト横断セッション検索" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/search/stream", "file": "backend/src/routes/sessions.ts", "description": "ストリーミング検索結果 (SSE)" },
-      { "group": "history", "method": "GET", "path": "/api/sessions/history/:sessionId/conversation", "file": "backend/src/routes/sessions.ts", "description": "セッションの会話履歴 (?agent=codex で Codex ルーティング、?last=N で末尾 N 件)" },
-      { "group": "history", "method": "POST", "path": "/api/sessions/history/metadata", "file": "backend/src/routes/sessions.ts", "description": "複数セッションのメタデータを一括取得 (lazy load 用)" },
-      { "group": "history", "method": "POST", "path": "/api/sessions/history/resume", "file": "backend/src/routes/sessions.ts", "description": "過去セッションを新 tmux セッションとして再開" },
-      { "group": "dashboard", "method": "GET", "path": "/api/dashboard", "file": "backend/src/routes/dashboard.ts", "description": "usageLimits / codexUsageLimits / dailyActivity / modelUsage / systemMetrics / diskUsage / usageHistory を並列取得して DashboardResponse を返す" },
-      { "group": "files", "method": "GET", "path": "/api/files/list", "file": "backend/src/routes/files.ts", "description": "ディレクトリ内容一覧 (path + sessionWorkingDir 必須、パストラバーサル防止)" },
-      { "group": "files", "method": "GET", "path": "/api/files/read", "file": "backend/src/routes/files.ts", "description": "ファイル内容読み取り (1MB 制限デフォルト、メディアはメタデータのみ)" },
-      { "group": "files", "method": "GET", "path": "/api/files/raw", "file": "backend/src/routes/files.ts", "description": "img/video/audio 用インラインストリーム (Range request / 206 対応)" },
-      { "group": "files", "method": "GET", "path": "/api/files/download", "file": "backend/src/routes/files.ts", "description": "ファイルを attachment としてダウンロード" },
-      { "group": "files", "method": "POST", "path": "/api/files/upload", "file": "backend/src/routes/files.ts", "description": "multipart/form-data でファイルアップロード" },
-      { "group": "files", "method": "GET", "path": "/api/files/browse", "file": "backend/src/routes/files.ts", "description": "ディレクトリツリーブラウズ" },
-      { "group": "files", "method": "GET", "path": "/api/files/changes/:sessionWorkingDir", "file": "backend/src/routes/files.ts", "description": "Claude Code .jsonl から変更ファイル一覧" },
-      { "group": "files", "method": "GET", "path": "/api/files/git-changes/:workingDir", "file": "backend/src/routes/files.ts", "description": "git status --porcelain から変更ファイル一覧" },
-      { "group": "files", "method": "GET", "path": "/api/files/git-diff/:workingDir", "file": "backend/src/routes/files.ts", "description": "git diff で特定ファイルの unified diff" },
-      { "group": "files", "method": "GET", "path": "/api/files/images/:filename", "file": "backend/src/routes/files.ts", "description": "会話画像のサーブ" },
-      { "group": "files", "method": "GET", "path": "/api/files/language", "file": "backend/src/routes/files.ts", "description": "ファイル言語検出" },
-      { "group": "files", "method": "POST", "path": "/api/files/mkdir", "file": "backend/src/routes/files.ts", "description": "ディレクトリ作成" },
-      { "group": "misc", "method": "POST", "path": "/api/upload/image", "file": "backend/src/routes/upload.ts", "description": "画像アップロード (PNG / JPEG / GIF / WebP、10MB 上限、/tmp/cchub-images/ に保存)" },
-      { "group": "misc", "method": "POST", "path": "/api/notify", "file": "backend/src/routes/notify.ts", "description": "Claude Code hook イベントを stdin から受け取り IndicatorState 更新 + WebSocket ブロードキャスト + スマート通知メッセージ生成" },
-      { "group": "auth", "method": "POST", "path": "/api/auth/login", "file": "backend/src/routes/auth.ts", "description": "サーバーパスワード照合して JWT トークン発行" },
-      { "group": "auth", "method": "POST", "path": "/api/auth/logout", "file": "backend/src/routes/auth.ts", "description": "ログアウト (ステートレス JWT、クライアント側トークン破棄)" },
-      { "group": "auth", "method": "GET", "path": "/api/auth/me", "file": "backend/src/routes/auth.ts", "description": "現在のユーザー情報" },
-      { "group": "auth", "method": "GET", "path": "/api/auth/required", "file": "backend/src/routes/auth.ts", "description": "認証が必要かどうかの確認" },
-      { "group": "logs", "method": "POST", "path": "/api/logs", "file": "backend/src/routes/logs.ts", "description": "フロントエンド console 出力を受け取り /tmp/cc-hub-browser.log に書き込む" },
-      { "group": "logs", "method": "GET", "path": "/api/logs", "file": "backend/src/routes/logs.ts", "description": "ブラウザログ取得" },
-      { "group": "logs", "method": "DELETE", "path": "/api/logs", "file": "backend/src/routes/logs.ts", "description": "ブラウザログクリア" },
-      { "group": "websocket", "method": "WS", "path": "/ws/mux", "file": "backend/src/routes/terminal-mux.ts", "description": "多重化 WebSocket。subscribe / unsubscribe + セッション別 terminal I/O。5 秒間隔 sessions-updated push、60 秒無応答 zombie 検出" }
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "全 tmux セッション一覧。WS push 対応なので HTTP 版はデバッグ/フォールバック用途"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "tmux セッション新規作成。workingDir / agent / initialPrompt をサポート。重複 workingDir 時 409"
+      },
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions/:id",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "単一セッション詳細"
+      },
+      {
+        "group": "sessions",
+        "method": "DELETE",
+        "path": "/api/sessions/:id",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッション削除 (tmux kill-session)"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/resume",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "claude -r または codex resume でセッション再開"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/focus",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "指定 paneId をフォーカス"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/close",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "pane 閉鎖 (最後の pane は拒否)"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/split",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "pane 分割 (h/v)"
+      },
+      {
+        "group": "sessions",
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/respawn",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "死亡 pane 再起動"
+      },
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions/:id/copy-mode",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "tmux copy モードの選択テキスト取得"
+      },
+      {
+        "group": "sessions",
+        "method": "PUT",
+        "path": "/api/sessions/:id/theme",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッションカラーテーマ設定"
+      },
+      {
+        "group": "sessions",
+        "method": "PUT",
+        "path": "/api/sessions/:id/title",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッションカスタムタイトル設定"
+      },
+      {
+        "group": "sessions",
+        "method": "PUT",
+        "path": "/api/sessions/order",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッション表示順序設定"
+      },
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions/clipboard",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "クリップボード内容取得"
+      },
+      {
+        "group": "sessions",
+        "method": "GET",
+        "path": "/api/sessions/prompts/search",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "~/.claude/history.jsonl からプロンプト履歴検索"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "過去 Claude Code セッション一覧 (最近 30 件)"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/projects",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "プロジェクト一覧 (高速、ファイル内容読まず)"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/projects/:dirName",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "特定プロジェクトのセッション一覧"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/search",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "全プロジェクト横断セッション検索"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/search/stream",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "ストリーミング検索結果 (SSE)"
+      },
+      {
+        "group": "history",
+        "method": "GET",
+        "path": "/api/sessions/history/:sessionId/conversation",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "セッションの会話履歴 (?agent=codex で Codex ルーティング、?last=N で末尾 N 件)"
+      },
+      {
+        "group": "history",
+        "method": "POST",
+        "path": "/api/sessions/history/metadata",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "複数セッションのメタデータを一括取得 (lazy load 用)"
+      },
+      {
+        "group": "history",
+        "method": "POST",
+        "path": "/api/sessions/history/resume",
+        "file": "backend/src/routes/sessions.ts",
+        "description": "過去セッションを新 tmux セッションとして再開"
+      },
+      {
+        "group": "dashboard",
+        "method": "GET",
+        "path": "/api/dashboard",
+        "file": "backend/src/routes/dashboard.ts",
+        "description": "usageLimits / codexUsageLimits / dailyActivity / modelUsage / systemMetrics / diskUsage / usageHistory を並列取得して DashboardResponse を返す"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/list",
+        "file": "backend/src/routes/files.ts",
+        "description": "ディレクトリ内容一覧 (path + sessionWorkingDir 必須、パストラバーサル防止)"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/read",
+        "file": "backend/src/routes/files.ts",
+        "description": "ファイル内容読み取り (1MB 制限デフォルト、メディアはメタデータのみ)"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/raw",
+        "file": "backend/src/routes/files.ts",
+        "description": "img/video/audio 用インラインストリーム (Range request / 206 対応)"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/download",
+        "file": "backend/src/routes/files.ts",
+        "description": "ファイルを attachment としてダウンロード"
+      },
+      {
+        "group": "files",
+        "method": "POST",
+        "path": "/api/files/upload",
+        "file": "backend/src/routes/files.ts",
+        "description": "multipart/form-data でファイルアップロード"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/browse",
+        "file": "backend/src/routes/files.ts",
+        "description": "ディレクトリツリーブラウズ"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/changes/:sessionWorkingDir",
+        "file": "backend/src/routes/files.ts",
+        "description": "Claude Code .jsonl から変更ファイル一覧"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/git-changes/:workingDir",
+        "file": "backend/src/routes/files.ts",
+        "description": "git status --porcelain から変更ファイル一覧"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/git-diff/:workingDir",
+        "file": "backend/src/routes/files.ts",
+        "description": "git diff で特定ファイルの unified diff"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/images/:filename",
+        "file": "backend/src/routes/files.ts",
+        "description": "会話画像のサーブ"
+      },
+      {
+        "group": "files",
+        "method": "GET",
+        "path": "/api/files/language",
+        "file": "backend/src/routes/files.ts",
+        "description": "ファイル言語検出"
+      },
+      {
+        "group": "files",
+        "method": "POST",
+        "path": "/api/files/mkdir",
+        "file": "backend/src/routes/files.ts",
+        "description": "ディレクトリ作成"
+      },
+      {
+        "group": "misc",
+        "method": "POST",
+        "path": "/api/upload/image",
+        "file": "backend/src/routes/upload.ts",
+        "description": "画像アップロード (PNG / JPEG / GIF / WebP、10MB 上限、/tmp/cchub-images/ に保存)"
+      },
+      {
+        "group": "misc",
+        "method": "POST",
+        "path": "/api/notify",
+        "file": "backend/src/routes/notify.ts",
+        "description": "Claude Code hook イベントを stdin から受け取り IndicatorState 更新 + WebSocket ブロードキャスト + スマート通知メッセージ生成"
+      },
+      {
+        "group": "auth",
+        "method": "POST",
+        "path": "/api/auth/login",
+        "file": "backend/src/routes/auth.ts",
+        "description": "サーバーパスワード照合して JWT トークン発行"
+      },
+      {
+        "group": "auth",
+        "method": "POST",
+        "path": "/api/auth/logout",
+        "file": "backend/src/routes/auth.ts",
+        "description": "ログアウト (ステートレス JWT、クライアント側トークン破棄)"
+      },
+      {
+        "group": "auth",
+        "method": "GET",
+        "path": "/api/auth/me",
+        "file": "backend/src/routes/auth.ts",
+        "description": "現在のユーザー情報"
+      },
+      {
+        "group": "auth",
+        "method": "GET",
+        "path": "/api/auth/required",
+        "file": "backend/src/routes/auth.ts",
+        "description": "認証が必要かどうかの確認"
+      },
+      {
+        "group": "logs",
+        "method": "POST",
+        "path": "/api/logs",
+        "file": "backend/src/routes/logs.ts",
+        "description": "フロントエンド console 出力を受け取り /tmp/cc-hub-browser.log に書き込む"
+      },
+      {
+        "group": "logs",
+        "method": "GET",
+        "path": "/api/logs",
+        "file": "backend/src/routes/logs.ts",
+        "description": "ブラウザログ取得"
+      },
+      {
+        "group": "logs",
+        "method": "DELETE",
+        "path": "/api/logs",
+        "file": "backend/src/routes/logs.ts",
+        "description": "ブラウザログクリア"
+      },
+      {
+        "group": "websocket",
+        "method": "WS",
+        "path": "/ws/mux",
+        "file": "backend/src/routes/terminal-mux.ts",
+        "description": "多重化 WebSocket。subscribe / unsubscribe + セッション別 terminal I/O。5 秒間隔 sessions-updated push、60 秒無応答 zombie 検出"
+      }
     ]
   },
   "frontend": {
     "components": [
-      { "name": "DesktopLayout", "file": "frontend/src/components/DesktopLayout.tsx", "summary": "デスクトップ / タブレット用メインレイアウト。PaneNode ツリー管理、tmux control mode 統合、キーボードショートカット、FloatingKeyboard / SessionModal / DashboardPanel のオーケストレーション", "hooks": ["useSessions", "useMultiplexedTerminal"], "parents": ["App"] },
-      { "name": "PaneContainer", "file": "frontend/src/components/PaneContainer.tsx", "summary": "PaneNode ツリーを再帰レンダリング。ControlModeContext を通じて tmux 操作 (split / close / zoom / resize) と Terminal / ChatView の表示切替を提供", "hooks": [], "parents": ["DesktopLayout", "TerminalPage"] },
-      { "name": "Terminal", "file": "frontend/src/components/Terminal.tsx", "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から pane I/O を受け、tmux レイアウト由来の setExactSize() でサイズ同期。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー", "hooks": ["useSelectionMode"], "parents": ["PaneContainer", "TerminalPage"] },
-      { "name": "TerminalPage", "file": "frontend/src/pages/TerminalPage.tsx", "summary": "セッション単位で useMultiplexedTerminal を使い、layout に基づく pane 一覧管理と TerminalComponent への controlConfig 配線を行うページコンポーネント", "hooks": ["useMultiplexedTerminal"], "parents": ["DesktopLayout"] },
-      { "name": "SessionList", "file": "frontend/src/components/SessionList.tsx", "summary": "アクティブセッション一覧 (Active / History / Dashboard タブ)。ドラッグ&ドロップ並び替え、pane 一覧展開、インジケーターステータス表示、テーマ設定", "hooks": ["useSessions"], "parents": ["SessionModal", "DesktopLayout"] },
-      { "name": "SessionModal", "file": "frontend/src/components/SessionModal.tsx", "summary": "Ctrl+B で開くセッション選択モーダル。SessionList をラップして ESC で閉じる", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "SessionHistory", "file": "frontend/src/components/SessionHistory.tsx", "summary": "過去セッションをプロジェクト別にグループ表示。会話ビュー表示、セッション再開アクション", "hooks": ["useSessionHistory"], "parents": ["SessionList"] },
-      { "name": "ConversationViewer", "file": "frontend/src/components/ConversationViewer.tsx", "summary": "ConversationMessage を ReactMarkdown + 仮想スクロールでレンダリング。ピンチズーム対応フォントサイズ調整", "hooks": ["useVirtualizer"], "parents": ["ChatView", "SessionHistory"] },
-      { "name": "ChatView", "file": "frontend/src/components/chat/ChatView.tsx", "summary": "ConversationViewer + ChatComposer を組み合わせた会話 UI。Claude (WebSocket) と Codex (ポーリング) を統一的に扱う useAgentConversation を利用", "hooks": ["useAgentConversation", "useInputEcho"], "parents": ["PaneContainer"] },
-      { "name": "ChatComposer", "file": "frontend/src/components/chat/ChatComposer.tsx", "summary": "デスクトップ向け会話入力フォーム。sendTerminalInput 経由で tmux にブラケットペーストとして送信", "hooks": [], "parents": ["ChatView"] },
-      { "name": "FloatingKeyboard", "file": "frontend/src/components/FloatingKeyboard.tsx", "summary": "タブレット向けドラッグ可能フローティングキーボード。最小化・透明化・向き/モード別位置保存", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "Keyboard", "file": "frontend/src/components/Keyboard.tsx", "summary": "モバイル向けバーチャルキーボード (長押しシンボル入力)", "hooks": [], "parents": ["FloatingKeyboard", "InputBar"] },
-      { "name": "InputBar", "file": "frontend/src/components/InputBar.tsx", "summary": "モバイル/タブレット向け入力バー (hidden / shortcuts / input モード切替、プロンプト履歴、画像添付)", "hooks": [], "parents": ["Terminal"] },
-      { "name": "DashboardPanel", "file": "frontend/src/components/DashboardPanel.tsx", "summary": "Ctrl+Shift+B で開くサイドパネルラッパー。Dashboard コンポーネントを compact モードで包む", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "Dashboard", "file": "frontend/src/components/dashboard/Dashboard.tsx", "summary": "ダッシュボードメインコンテナ。Claude / Codex エージェントタブ切替、UsageLimits / DailyUsageChart / ModelUsageChart / HourlyHeatmap / NetworkLatency / ServerInfo を組み合わせる", "hooks": ["useDashboard", "useTheme"], "parents": ["DashboardPanel"] },
-      { "name": "UsageLimits", "file": "frontend/src/components/dashboard/UsageLimits.tsx", "summary": "5 時間 / 7 日間使用率をプログレスバーと UsageChart で表示。警告状態の色分けと resetsAt 残り時間表示", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "UsageChart", "file": "frontend/src/components/dashboard/UsageChart.tsx", "summary": "UsageSnapshot の時系列折れ線グラフ (SVG 手書き)", "hooks": [], "parents": ["UsageLimits"] },
-      { "name": "DailyUsageChart", "file": "frontend/src/components/dashboard/DailyUsageChart.tsx", "summary": "過去 7 日のメッセージ数 / セッション数棒グラフ", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "ModelUsageChart", "file": "frontend/src/components/dashboard/ModelUsageChart.tsx", "summary": "Opus / Sonnet トークン使用量比較チャート", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "HourlyHeatmap", "file": "frontend/src/components/dashboard/HourlyHeatmap.tsx", "summary": "時間帯別 (0-6 / 6-12 / 12-18 / 18-24) 活動ヒートマップ", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "NetworkLatency", "file": "frontend/src/components/dashboard/NetworkLatency.tsx", "summary": "WebSocket / API レイテンシのリアルタイム表示 (緑 / 黄 / 赤色分け)", "hooks": ["useNetworkLatency"], "parents": ["Dashboard"] },
-      { "name": "ServerInfo", "file": "frontend/src/components/dashboard/ServerInfo.tsx", "summary": "サーバー情報・CPU / メモリ / スワップの SVG ミニチャート・接続クライアント数表示", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "FileViewer", "file": "frontend/src/components/files/FileViewer.tsx", "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude 変更 / Git 変更トグル、ブラウザ履歴ナビ、アップロード / ダウンロード、動画 / 音声再生。v0.1.108 で選択ファイル highlight + スクロール保持を実装", "hooks": ["useFileViewer"], "parents": ["DesktopLayout", "PaneContainer"] },
-      { "name": "FileBrowser", "file": "frontend/src/components/files/FileBrowser.tsx", "summary": "ディレクトリツリーナビゲーション。選択中ファイルを selectedPath prop で受け取り青背景 + 青ボーダーでハイライト", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "CodeViewer", "file": "frontend/src/components/files/CodeViewer.tsx", "summary": "シンタックスハイライト付きコード表示", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "DiffViewer", "file": "frontend/src/components/files/DiffViewer.tsx", "summary": "ファイル変更のサイドバイサイド diff 表示", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "ImageViewer", "file": "frontend/src/components/files/ImageViewer.tsx", "summary": "画像プレビュー + ズーム (/files/raw ストリーミング利用)", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "MarkdownViewer", "file": "frontend/src/components/files/MarkdownViewer.tsx", "summary": "Markdown レンダリング", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "HtmlViewer", "file": "frontend/src/components/files/HtmlViewer.tsx", "summary": "HTML ファイルを iframe でレンダリング", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "PromptComposer", "file": "frontend/src/components/files/PromptComposer.tsx", "summary": "コードビューアで選択した行をプロンプトとしてフォーマットして送信する UI パネル", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "LoginForm", "file": "frontend/src/components/LoginForm.tsx", "summary": "パスワード認証フォーム", "hooks": [], "parents": ["App"] },
-      { "name": "Onboarding", "file": "frontend/src/components/Onboarding.tsx", "summary": "新規ユーザー向け spotlight スタイルウォークスルー (localStorage 完了フラグ管理)", "hooks": [], "parents": ["App"] },
-      { "name": "SelectionOverlay", "file": "frontend/src/components/SelectionOverlay.tsx", "summary": "xterm.js 上にタッチ選択ハンドル + コピーボタンを重ねる SVG オーバーレイ", "hooks": [], "parents": ["Terminal"] }
+      {
+        "name": "DesktopLayout",
+        "file": "frontend/src/components/DesktopLayout.tsx",
+        "summary": "デスクトップ / タブレット用メインレイアウト。PaneNode ツリー管理、tmux control mode 統合、キーボードショートカット、FloatingKeyboard / SessionModal / DashboardPanel のオーケストレーション",
+        "hooks": [
+          "useSessions",
+          "useMultiplexedTerminal"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "PaneContainer",
+        "file": "frontend/src/components/PaneContainer.tsx",
+        "summary": "PaneNode ツリーを再帰レンダリング。ControlModeContext を通じて tmux 操作 (split / close / zoom / resize) と Terminal / ChatView の表示切替を提供",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "Terminal",
+        "file": "frontend/src/components/Terminal.tsx",
+        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から pane I/O を受け、tmux レイアウト由来の setExactSize() でサイズ同期。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
+        "hooks": [
+          "useSelectionMode"
+        ],
+        "parents": [
+          "PaneContainer",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "TerminalPage",
+        "file": "frontend/src/pages/TerminalPage.tsx",
+        "summary": "セッション単位で useMultiplexedTerminal を使い、layout に基づく pane 一覧管理と TerminalComponent への controlConfig 配線を行うページコンポーネント",
+        "hooks": [
+          "useMultiplexedTerminal"
+        ],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "SessionList",
+        "file": "frontend/src/components/SessionList.tsx",
+        "summary": "アクティブセッション一覧 (Active / History / Dashboard タブ)。ドラッグ&ドロップ並び替え、pane 一覧展開、インジケーターステータス表示、テーマ設定",
+        "hooks": [
+          "useSessions"
+        ],
+        "parents": [
+          "SessionModal",
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "SessionModal",
+        "file": "frontend/src/components/SessionModal.tsx",
+        "summary": "Ctrl+B で開くセッション選択モーダル。SessionList をラップして ESC で閉じる",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "SessionHistory",
+        "file": "frontend/src/components/SessionHistory.tsx",
+        "summary": "過去セッションをプロジェクト別にグループ表示。会話ビュー表示、セッション再開アクション",
+        "hooks": [
+          "useSessionHistory"
+        ],
+        "parents": [
+          "SessionList"
+        ]
+      },
+      {
+        "name": "ConversationViewer",
+        "file": "frontend/src/components/ConversationViewer.tsx",
+        "summary": "ConversationMessage を ReactMarkdown + 仮想スクロールでレンダリング。ピンチズーム対応フォントサイズ調整",
+        "hooks": [
+          "useVirtualizer"
+        ],
+        "parents": [
+          "ChatView",
+          "SessionHistory"
+        ]
+      },
+      {
+        "name": "ChatView",
+        "file": "frontend/src/components/chat/ChatView.tsx",
+        "summary": "ConversationViewer + ChatComposer を組み合わせた会話 UI。Claude (WebSocket) と Codex (ポーリング) を統一的に扱う useAgentConversation を利用",
+        "hooks": [
+          "useAgentConversation",
+          "useInputEcho"
+        ],
+        "parents": [
+          "PaneContainer"
+        ]
+      },
+      {
+        "name": "ChatComposer",
+        "file": "frontend/src/components/chat/ChatComposer.tsx",
+        "summary": "デスクトップ向け会話入力フォーム。sendTerminalInput 経由で tmux にブラケットペーストとして送信",
+        "hooks": [],
+        "parents": [
+          "ChatView"
+        ]
+      },
+      {
+        "name": "FloatingKeyboard",
+        "file": "frontend/src/components/FloatingKeyboard.tsx",
+        "summary": "タブレット向けドラッグ可能フローティングキーボード。最小化・透明化・向き/モード別位置保存",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "Keyboard",
+        "file": "frontend/src/components/Keyboard.tsx",
+        "summary": "モバイル向けバーチャルキーボード (長押しシンボル入力)",
+        "hooks": [],
+        "parents": [
+          "FloatingKeyboard",
+          "InputBar"
+        ]
+      },
+      {
+        "name": "InputBar",
+        "file": "frontend/src/components/InputBar.tsx",
+        "summary": "モバイル/タブレット向け入力バー (hidden / shortcuts / input モード切替、プロンプト履歴、画像添付)",
+        "hooks": [],
+        "parents": [
+          "Terminal"
+        ]
+      },
+      {
+        "name": "DashboardPanel",
+        "file": "frontend/src/components/DashboardPanel.tsx",
+        "summary": "Ctrl+Shift+B で開くサイドパネルラッパー。Dashboard コンポーネントを compact モードで包む",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "Dashboard",
+        "file": "frontend/src/components/dashboard/Dashboard.tsx",
+        "summary": "ダッシュボードメインコンテナ。Claude / Codex エージェントタブ切替、UsageLimits / DailyUsageChart / ModelUsageChart / HourlyHeatmap / NetworkLatency / ServerInfo を組み合わせる",
+        "hooks": [
+          "useDashboard",
+          "useTheme"
+        ],
+        "parents": [
+          "DashboardPanel"
+        ]
+      },
+      {
+        "name": "UsageLimits",
+        "file": "frontend/src/components/dashboard/UsageLimits.tsx",
+        "summary": "5 時間 / 7 日間使用率をプログレスバーと UsageChart で表示。警告状態の色分けと resetsAt 残り時間表示",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "UsageChart",
+        "file": "frontend/src/components/dashboard/UsageChart.tsx",
+        "summary": "UsageSnapshot の時系列折れ線グラフ (SVG 手書き)",
+        "hooks": [],
+        "parents": [
+          "UsageLimits"
+        ]
+      },
+      {
+        "name": "DailyUsageChart",
+        "file": "frontend/src/components/dashboard/DailyUsageChart.tsx",
+        "summary": "過去 7 日のメッセージ数 / セッション数棒グラフ",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "ModelUsageChart",
+        "file": "frontend/src/components/dashboard/ModelUsageChart.tsx",
+        "summary": "Opus / Sonnet トークン使用量比較チャート",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "HourlyHeatmap",
+        "file": "frontend/src/components/dashboard/HourlyHeatmap.tsx",
+        "summary": "時間帯別 (0-6 / 6-12 / 12-18 / 18-24) 活動ヒートマップ",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "NetworkLatency",
+        "file": "frontend/src/components/dashboard/NetworkLatency.tsx",
+        "summary": "WebSocket / API レイテンシのリアルタイム表示 (緑 / 黄 / 赤色分け)",
+        "hooks": [
+          "useNetworkLatency"
+        ],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "ServerInfo",
+        "file": "frontend/src/components/dashboard/ServerInfo.tsx",
+        "summary": "サーバー情報・CPU / メモリ / スワップの SVG ミニチャート・接続クライアント数表示",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "FileViewer",
+        "file": "frontend/src/components/files/FileViewer.tsx",
+        "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude 変更 / Git 変更トグル、ブラウザ履歴ナビ、アップロード / ダウンロード、動画 / 音声再生。v0.1.108 で選択ファイル highlight + スクロール保持を実装",
+        "hooks": [
+          "useFileViewer"
+        ],
+        "parents": [
+          "DesktopLayout",
+          "PaneContainer"
+        ]
+      },
+      {
+        "name": "FileBrowser",
+        "file": "frontend/src/components/files/FileBrowser.tsx",
+        "summary": "ディレクトリツリーナビゲーション。選択中ファイルを selectedPath prop で受け取り青背景 + 青ボーダーでハイライト",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "CodeViewer",
+        "file": "frontend/src/components/files/CodeViewer.tsx",
+        "summary": "シンタックスハイライト付きコード表示",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "DiffViewer",
+        "file": "frontend/src/components/files/DiffViewer.tsx",
+        "summary": "ファイル変更のサイドバイサイド diff 表示",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "ImageViewer",
+        "file": "frontend/src/components/files/ImageViewer.tsx",
+        "summary": "画像プレビュー + ズーム (/files/raw ストリーミング利用)",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "MarkdownViewer",
+        "file": "frontend/src/components/files/MarkdownViewer.tsx",
+        "summary": "Markdown レンダリング",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "HtmlViewer",
+        "file": "frontend/src/components/files/HtmlViewer.tsx",
+        "summary": "HTML ファイルを iframe でレンダリング",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "PromptComposer",
+        "file": "frontend/src/components/files/PromptComposer.tsx",
+        "summary": "コードビューアで選択した行をプロンプトとしてフォーマットして送信する UI パネル",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "LoginForm",
+        "file": "frontend/src/components/LoginForm.tsx",
+        "summary": "パスワード認証フォーム",
+        "hooks": [],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "Onboarding",
+        "file": "frontend/src/components/Onboarding.tsx",
+        "summary": "新規ユーザー向け spotlight スタイルウォークスルー (localStorage 完了フラグ管理)",
+        "hooks": [],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "SelectionOverlay",
+        "file": "frontend/src/components/SelectionOverlay.tsx",
+        "summary": "xterm.js 上にタッチ選択ハンドル + コピーボタンを重ねる SVG オーバーレイ",
+        "hooks": [],
+        "parents": [
+          "Terminal"
+        ]
+      }
     ],
     "hooks": [
-      { "name": "useMultiplexedTerminal", "file": "frontend/src/hooks/useMultiplexedTerminal.ts", "summary": "/ws/mux へのモジュールレベル singleton WebSocket 管理。subscribe / unsubscribe、入力送信 (base64)、resize / split / close / zoom / scroll / adjustPane / equalizePanes、自動再接続・keepalive ping を提供" },
-      { "name": "useSessions", "file": "frontend/src/hooks/useSessions.ts", "summary": "モジュールレベルキャッシュ (WS sessions-updated で更新) 付きセッション状態管理。hook イベントによる indicatorState 即時更新" },
-      { "name": "useSessionHistory", "file": "frontend/src/hooks/useSessionHistory.ts", "summary": "過去セッション履歴のブラウズ (プロジェクト一覧 → セッション遅延ロード → SSE ストリーム検索)" },
-      { "name": "useDashboard", "file": "frontend/src/hooks/useDashboard.ts", "summary": "/api/dashboard をポーリング (デフォルト 60 秒間隔)" },
-      { "name": "useFileViewer", "file": "frontend/src/hooks/useFileViewer.ts", "summary": "ファイルビューア状態管理 (listDirectory / readFile / getGitDiff 等の API 呼び出しラップ)" },
-      { "name": "useAuth", "file": "frontend/src/hooks/useAuth.ts", "summary": "JWT 認証状態管理 (localStorage cc-hub-token、認証不要モード対応)" },
-      { "name": "useTheme", "file": "frontend/src/hooks/useTheme.ts", "summary": "light / dark テーマの localStorage 永続化と document.documentElement 属性適用" },
-      { "name": "useNetworkLatency", "file": "frontend/src/hooks/useNetworkLatency.ts", "summary": "/health への 30 秒間隔 HTTP ping で API レイテンシ計測、latency-store を useSyncExternalStore で購読" },
-      { "name": "useLineSelection", "file": "frontend/src/hooks/useLineSelection.ts", "summary": "クリックで行範囲選択 (1 回目=start, 2 回目=end)" },
-      { "name": "useSelectionMode", "file": "frontend/src/hooks/useSelectionMode.ts", "summary": "xterm.js 上のタッチ / マウス選択モード管理 (SelectionRange、コピーボタン位置計算)" },
-      { "name": "useConversationStream", "file": "frontend/src/hooks/useConversationStream.ts", "summary": "/ws/mux の conversation-subscribe を通じて Claude 会話をリアルタイム受信" },
-      { "name": "useCodexConversation", "file": "frontend/src/hooks/useCodexConversation.ts", "summary": "Codex セッションの会話を HTTP ポーリング (デフォルト 5 秒) で取得" },
-      { "name": "useAgentConversation", "file": "frontend/src/hooks/useAgentConversation.ts", "summary": "agent 種別 (claude / codex) に応じて useConversationStream / useCodexConversation を切り替える統合 hook" },
-      { "name": "useInputEcho", "file": "frontend/src/hooks/useInputEcho.ts", "summary": "端末への入力文字を 4 秒間エコー表示 (バックスペース / エスケープなど特殊キーをビジュアル化)" }
+      {
+        "name": "useMultiplexedTerminal",
+        "file": "frontend/src/hooks/useMultiplexedTerminal.ts",
+        "summary": "/ws/mux へのモジュールレベル singleton WebSocket 管理。subscribe / unsubscribe、入力送信 (base64)、resize / split / close / zoom / scroll / adjustPane / equalizePanes、自動再接続・keepalive ping を提供"
+      },
+      {
+        "name": "useSessions",
+        "file": "frontend/src/hooks/useSessions.ts",
+        "summary": "モジュールレベルキャッシュ (WS sessions-updated で更新) 付きセッション状態管理。hook イベントによる indicatorState 即時更新"
+      },
+      {
+        "name": "useSessionHistory",
+        "file": "frontend/src/hooks/useSessionHistory.ts",
+        "summary": "過去セッション履歴のブラウズ (プロジェクト一覧 → セッション遅延ロード → SSE ストリーム検索)"
+      },
+      {
+        "name": "useDashboard",
+        "file": "frontend/src/hooks/useDashboard.ts",
+        "summary": "/api/dashboard をポーリング (デフォルト 60 秒間隔)"
+      },
+      {
+        "name": "useFileViewer",
+        "file": "frontend/src/hooks/useFileViewer.ts",
+        "summary": "ファイルビューア状態管理 (listDirectory / readFile / getGitDiff 等の API 呼び出しラップ)"
+      },
+      {
+        "name": "useAuth",
+        "file": "frontend/src/hooks/useAuth.ts",
+        "summary": "JWT 認証状態管理 (localStorage cc-hub-token、認証不要モード対応)"
+      },
+      {
+        "name": "useTheme",
+        "file": "frontend/src/hooks/useTheme.ts",
+        "summary": "light / dark テーマの localStorage 永続化と document.documentElement 属性適用"
+      },
+      {
+        "name": "useNetworkLatency",
+        "file": "frontend/src/hooks/useNetworkLatency.ts",
+        "summary": "/health への 30 秒間隔 HTTP ping で API レイテンシ計測、latency-store を useSyncExternalStore で購読"
+      },
+      {
+        "name": "useLineSelection",
+        "file": "frontend/src/hooks/useLineSelection.ts",
+        "summary": "クリックで行範囲選択 (1 回目=start, 2 回目=end)"
+      },
+      {
+        "name": "useSelectionMode",
+        "file": "frontend/src/hooks/useSelectionMode.ts",
+        "summary": "xterm.js 上のタッチ / マウス選択モード管理 (SelectionRange、コピーボタン位置計算)"
+      },
+      {
+        "name": "useConversationStream",
+        "file": "frontend/src/hooks/useConversationStream.ts",
+        "summary": "/ws/mux の conversation-subscribe を通じて Claude 会話をリアルタイム受信"
+      },
+      {
+        "name": "useCodexConversation",
+        "file": "frontend/src/hooks/useCodexConversation.ts",
+        "summary": "Codex セッションの会話を HTTP ポーリング (デフォルト 5 秒) で取得"
+      },
+      {
+        "name": "useAgentConversation",
+        "file": "frontend/src/hooks/useAgentConversation.ts",
+        "summary": "agent 種別 (claude / codex) に応じて useConversationStream / useCodexConversation を切り替える統合 hook"
+      },
+      {
+        "name": "useInputEcho",
+        "file": "frontend/src/hooks/useInputEcho.ts",
+        "summary": "端末への入力文字を 4 秒間エコー表示 (バックスペース / エスケープなど特殊キーをビジュアル化)"
+      }
     ]
   },
   "websocket": {
     "endpoint": "/ws/mux",
     "description": "単一の多重化 WebSocket。クライアントは subscribe でセッションごとに購読し、binary フレーム [0x02][sessionId\\0][paneId\\0][data] と JSON 制御メッセージを混在で受信",
     "client_messages": {
-      "mux_level": ["subscribe", "unsubscribe", "subscribe-conversation", "unsubscribe-conversation"],
-      "per_session": ["input", "resize", "split", "close-pane", "resize-pane", "select-pane", "scroll", "adjust-pane", "equalize-panes", "request-content", "zoom-pane", "respawn-pane", "ping", "client-info"]
+      "mux_level": [
+        "subscribe",
+        "unsubscribe",
+        "subscribe-conversation",
+        "unsubscribe-conversation"
+      ],
+      "per_session": [
+        "input",
+        "resize",
+        "split",
+        "close-pane",
+        "resize-pane",
+        "select-pane",
+        "scroll",
+        "adjust-pane",
+        "equalize-panes",
+        "request-content",
+        "zoom-pane",
+        "respawn-pane",
+        "ping",
+        "client-info"
+      ]
     },
     "server_messages": {
-      "mux_level": ["subscribed", "unsubscribed", "sessions-updated", "conversation-subscribed", "conversation-unsubscribed", "initial-conversation", "conversation-update"],
-      "per_session": ["output (binary)", "layout", "initial-content", "ready", "pong", "error", "new-session", "pane-dead", "hook-event"]
+      "mux_level": [
+        "subscribed",
+        "unsubscribed",
+        "sessions-updated",
+        "conversation-subscribed",
+        "conversation-unsubscribed",
+        "initial-conversation",
+        "conversation-update"
+      ],
+      "per_session": [
+        "output (binary)",
+        "layout",
+        "initial-content",
+        "ready",
+        "pong",
+        "error",
+        "new-session",
+        "pane-dead",
+        "hook-event"
+      ]
     },
     "binary_format": "[0x02][sessionId\\0][paneId\\0][raw bytes]",
     "intervals": {
@@ -265,17 +971,50 @@
     }
   },
   "types": [
-    { "name": "SessionResponse", "fields": "id, name, createdAt, lastAccessedAt, state, currentPath, agent, theme, customTitle" },
-    { "name": "ExtendedSessionResponse", "fields": "extends SessionResponse + indicatorState, ccSessionId, agentSessionId, currentCommand, paneTitle, ccSummary, ccFirstPrompt, ccRecap, waitingToolName, panes, messageCount, gitBranch, durationMinutes, metrics" },
-    { "name": "PaneInfo", "fields": "paneId, currentCommand, currentPath, title, agentName, agentColor, isActive, isDead, indicatorState, pid" },
-    { "name": "TmuxLayoutNode", "fields": "type ('leaf' | 'horizontal' | 'vertical'), width, height, x, y, paneId?, children?" },
-    { "name": "SessionMetrics", "fields": "contextTokens, contextMaxTokens, contextPercent, totalInputTokens, totalCacheCreationTokens, totalCacheReadTokens, totalOutputTokens, totalTokens, memoryRssBytes" },
-    { "name": "DashboardResponse", "fields": "usageLimits, usageLimitsStatus, codexUsageLimits, usageHistory, dailyActivity, modelUsage, costEstimates, hourlyActivity, version, systemMetrics, diskUsage, connectedClients" },
-    { "name": "ConversationMessage", "fields": "role, content, timestamp, thinking, toolUse, toolResult" },
-    { "name": "UsageLimits", "fields": "fiveHour (UsageCycleInfo), sevenDay (UsageCycleInfo)" },
-    { "name": "SessionState", "fields": "'idle' | 'working' | 'waiting_input' | 'waiting_permission' | 'disconnected' | 'lost'" },
-    { "name": "IndicatorState", "fields": "'processing' | 'waiting_input' | 'idle' | 'completed'" },
-    { "name": "AgentProvider", "fields": "'claude' | 'codex'" }
+    {
+      "name": "SessionResponse",
+      "fields": "id, name, createdAt, lastAccessedAt, state, currentPath, agent, theme, customTitle"
+    },
+    {
+      "name": "ExtendedSessionResponse",
+      "fields": "extends SessionResponse + indicatorState, ccSessionId, agentSessionId, currentCommand, paneTitle, ccSummary, ccFirstPrompt, ccRecap, waitingToolName, panes, messageCount, gitBranch, durationMinutes, metrics"
+    },
+    {
+      "name": "PaneInfo",
+      "fields": "paneId, currentCommand, currentPath, title, agentName, agentColor, isActive, isDead, indicatorState, pid"
+    },
+    {
+      "name": "TmuxLayoutNode",
+      "fields": "type ('leaf' | 'horizontal' | 'vertical'), width, height, x, y, paneId?, children?"
+    },
+    {
+      "name": "SessionMetrics",
+      "fields": "contextTokens, contextMaxTokens, contextPercent, totalInputTokens, totalCacheCreationTokens, totalCacheReadTokens, totalOutputTokens, totalTokens, memoryRssBytes"
+    },
+    {
+      "name": "DashboardResponse",
+      "fields": "usageLimits, usageLimitsStatus, codexUsageLimits, usageHistory, dailyActivity, modelUsage, costEstimates, hourlyActivity, version, systemMetrics, diskUsage, connectedClients"
+    },
+    {
+      "name": "ConversationMessage",
+      "fields": "role, content, timestamp, thinking, toolUse, toolResult"
+    },
+    {
+      "name": "UsageLimits",
+      "fields": "fiveHour (UsageCycleInfo), sevenDay (UsageCycleInfo)"
+    },
+    {
+      "name": "SessionState",
+      "fields": "'idle' | 'working' | 'waiting_input' | 'waiting_permission' | 'disconnected' | 'lost'"
+    },
+    {
+      "name": "IndicatorState",
+      "fields": "'processing' | 'waiting_input' | 'idle' | 'completed'"
+    },
+    {
+      "name": "AgentProvider",
+      "fields": "'claude' | 'codex'"
+    }
   ],
   "data_flows": [
     {

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -1,3 +1,4 @@
+import { appendFile } from 'node:fs/promises';
 import type { ServerWebSocket } from 'bun';
 import { TmuxService } from '../services/tmux';
 import { getOrCreateControlSession, type TmuxControlSession } from '../services/tmux-control';
@@ -8,6 +9,14 @@ import { buildSessionsList } from './sessions';
 
 const BENCH = !!process.env.CCHUB_BENCH;
 const BENCH_T0 = performance.now();
+
+// Channel C: client→server self-verification feedback (dev-only).
+// When enabled, clients send their xterm.js buffer snapshot via `debug-dump`
+// messages; the server compares them against `tmux capture-pane -p` output
+// and logs any drift to /tmp/cchub-drift.log for later analysis.
+const SELF_VERIFY = !!process.env.CCHUB_SELF_VERIFY;
+const DRIFT_LOG_PATH = '/tmp/cchub-drift.log';
+const DRIFT_MAX_MISMATCH_SAMPLES = 3;
 
 /** Per-session subscription state for a mux client */
 interface MuxSubscription {
@@ -164,6 +173,16 @@ export async function muxMessage(ws: ServerWebSocket<MuxData>, message: string |
     return;
   }
 
+  if (msg.type === 'debug-dump') {
+    // Channel C: silently no-op unless self-verify is enabled. Even when
+    // disabled we accept the message format to avoid version mismatch errors.
+    if (SELF_VERIFY) {
+      const sub = ws.data.subscriptions.get(msg.sessionId);
+      if (sub) await handleDebugDump(ws, sub, msg);
+    }
+    return;
+  }
+
   // All other messages need sessionId
   const sessionId = (msg as { sessionId?: string }).sessionId;
   if (!sessionId) return;
@@ -205,7 +224,7 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
     existing.initialContentSent = false;
     existing.readyForOutput = false;
     existing.outputSuppressedCount = 0;
-    ws.send(JSON.stringify({ type: 'subscribed', sessionId }));
+    ws.send(JSON.stringify({ type: 'subscribed', sessionId, selfVerifyEnabled: SELF_VERIFY }));
     return;
   }
 
@@ -315,7 +334,7 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
       console.error(`[mux] Failed to send initial layout for ${sessionId}:`, err);
     }
 
-    ws.send(JSON.stringify({ type: 'subscribed', sessionId }));
+    ws.send(JSON.stringify({ type: 'subscribed', sessionId, selfVerifyEnabled: SELF_VERIFY }));
   } catch (error) {
     console.error(`[mux] Failed to subscribe to ${sessionId}:`, error);
     ws.send(JSON.stringify({ type: 'error', message: 'Failed to subscribe', sessionId }));
@@ -407,6 +426,86 @@ function handleUnsubscribeConversation(ws: ServerWebSocket<MuxData>, sessionId: 
   try {
     ws.send(JSON.stringify({ type: 'conversation-unsubscribed', sessionId }));
   } catch { /* disconnected */ }
+}
+
+// =============================================================================
+// Channel C: self-verification drift detection (dev-only)
+// =============================================================================
+
+/** Right-trim trailing whitespace; we compare canonical text only, so trailing
+ *  spaces from tmux's grid padding vs xterm's actual cells must not register
+ *  as drift. */
+function rtrim(s: string): string {
+  let end = s.length;
+  while (end > 0 && (s.charCodeAt(end - 1) === 0x20 || s.charCodeAt(end - 1) === 0x09)) {
+    end--;
+  }
+  return s.slice(0, end);
+}
+
+interface DriftSample {
+  row: number;
+  canonical: string;
+  client: string;
+}
+
+function diffLines(canonical: string[], client: string[]): { count: number; samples: DriftSample[] } {
+  const len = Math.max(canonical.length, client.length);
+  const samples: DriftSample[] = [];
+  let count = 0;
+  for (let i = 0; i < len; i++) {
+    const c = rtrim(canonical[i] ?? '');
+    const x = rtrim(client[i] ?? '');
+    if (c !== x) {
+      count++;
+      if (samples.length < DRIFT_MAX_MISMATCH_SAMPLES) {
+        samples.push({ row: i, canonical: c, client: x });
+      }
+    }
+  }
+  return { count, samples };
+}
+
+async function handleDebugDump(
+  ws: ServerWebSocket<MuxData>,
+  sub: MuxSubscription,
+  msg: Extract<MuxClientMessage, { type: 'debug-dump' }>,
+) {
+  try {
+    // capture-pane -p (text only, no -e attributes) for fair text comparison.
+    // capturePane() unconditionally includes -e, so issue the command directly.
+    const canonicalRaw = await sub.controlSession.sendCommand(`capture-pane -p -t ${msg.paneId}`);
+    const canonicalLines = canonicalRaw.split(/\r?\n/);
+    const { count, samples } = diffLines(canonicalLines, msg.lines);
+
+    const record = {
+      ts: msg.ts,
+      visitorId: ws.data.visitorId,
+      sessionId: msg.sessionId,
+      paneId: msg.paneId,
+      trigger: msg.trigger,
+      clientRows: msg.lines.length,
+      canonicalRows: canonicalLines.length,
+      mismatchCount: count,
+      cursor: msg.cursor,
+      suppressedOutputCount: sub.outputSuppressedCount,
+      sendFailCount: sub.sendFailCount,
+      samples,
+    };
+
+    if (count > 0) {
+      console.warn(
+        `[drift] sess=${msg.sessionId} pane=${msg.paneId} trigger=${msg.trigger} ` +
+        `mismatch=${count}/${Math.max(canonicalLines.length, msg.lines.length)} ` +
+        `suppressed=${sub.outputSuppressedCount}`,
+      );
+    }
+
+    // Always append the record (mismatch=0 entries are useful as denominator).
+    await appendFile(DRIFT_LOG_PATH, `${JSON.stringify(record)}\n`, 'utf8');
+  } catch (err) {
+    console.warn(`[drift] handleDebugDump error for ${msg.paneId}:`, err);
+  }
 }
 
 async function handleControlMessage(

--- a/frontend/playwright.missing-agent.config.ts
+++ b/frontend/playwright.missing-agent.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
 // already running on https://localhost:5173 (started outside playwright).
 export default defineConfig({
   testDir: './tests/e2e',
-  testMatch: ['missing-agent.spec.ts', 'file-viewer-selection.spec.ts'],
+  testMatch: ['missing-agent.spec.ts', 'file-viewer-selection.spec.ts', 'self-verify-channel-c.spec.ts'],
   fullyParallel: false,
   retries: 0,
   workers: 1,

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -8,6 +8,7 @@ import { authFetch } from '../services/api';
 import type { SessionTheme } from '../../../shared/types';
 import { filterMouseTrackingInput, filterMouseTrackingOutput, shouldInterceptKeyEvent } from '../utils/terminal-filters';
 import { bench } from '../utils/bench';
+import { sendDebugDump, isSelfVerifyEnabled } from '../hooks/useMultiplexedTerminal';
 import {
   getTerminalThemes, isLightMode, LIGHT_ANSI_COLORS,
   DEFAULT_FONT_SIZE, MIN_FONT_SIZE, MAX_FONT_SIZE,
@@ -90,6 +91,7 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
   const sendRef = useRef<(data: string) => void>(() => {});
   const resizeRef = useRef<(cols: number, rows: number) => void>(() => {});
   const refreshRef = useRef<() => void>(() => {});
+  const dumpForSelfVerifyRef = useRef<((trigger: 'resize-done' | 'reconnect-done' | 'output-idle' | 'periodic' | 'user') => void) | null>(null);
   const closeInputBarRef = useRef<() => void>(() => {});
   const showKeyboardRef = useRef<() => void>(() => {});
   const inputBarRef = useRef<InputBarRef>(null);
@@ -253,6 +255,11 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
           term.resize(dims.cols, dims.rows);
         }
         resizeRef.current(dims.cols, dims.rows);
+        // Channel C: capture state ~1s after resize so the server's
+        // capture-pane + initial-content round trip has settled.
+        if (isSelfVerifyEnabled()) {
+          setTimeout(() => dumpForSelfVerifyRef.current?.('resize-done'), 1000);
+        }
       }
     }
   }, []);
@@ -891,22 +898,77 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
       term.write('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l');
     }
 
+    // Channel C: schedule a debug-dump 300ms after output stops, so we
+    // observe steady-state drift rather than mid-render snapshots.
+    let outputIdleTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleOutputIdleDump = () => {
+      if (!isSelfVerifyEnabled()) return;
+      if (outputIdleTimer) clearTimeout(outputIdleTimer);
+      outputIdleTimer = setTimeout(() => dumpForSelfVerify('output-idle'), 300);
+    };
+
     const cleanup = cm.registerOnData((data) => {
       const str = decoder.decode(data, { stream: true });
       const filtered = filterMouseTrackingOutput(str);
       if (filtered.length > 0) {
         const t0 = bench.recordWriteStart();
         terminalRef.current?.write(filtered, () => bench.recordWriteEnd(t0, filtered.length));
+        scheduleOutputIdleDump();
       }
     });
     controlCleanupRef.current = cleanup;
     return () => {
       decoder.decode(new Uint8Array(0), { stream: false });
+      if (outputIdleTimer) clearTimeout(outputIdleTimer);
       cleanup();
       controlCleanupRef.current = null;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [!!controlMode, controlMode?.paneId]);
+
+  // Channel C: client→server self-verification trigger orchestration.
+  // No-op unless the server has CCHUB_SELF_VERIFY=1, in which case the
+  // initial subscribed message flips `isSelfVerifyEnabled()` to true.
+  const dumpForSelfVerify = useCallback((trigger: 'resize-done' | 'reconnect-done' | 'output-idle' | 'periodic' | 'user') => {
+    const term = terminalRef.current;
+    const cm = controlModeRef.current;
+    if (!term || !cm || !isSelfVerifyEnabled()) return;
+    const buf = term.buffer.active;
+    // Compare only the currently-visible area against `tmux capture-pane -p`
+    // (which also returns only the visible region). Including scrollback here
+    // would produce huge false-positive mismatch counts.
+    const visibleStart = Math.max(0, buf.length - term.rows);
+    const lines: string[] = [];
+    for (let i = visibleStart; i < buf.length; i++) {
+      lines.push(buf.getLine(i)?.translateToString(true) ?? '');
+    }
+    sendDebugDump(
+      sessionId,
+      cm.paneId,
+      lines,
+      { x: buf.cursorX, y: buf.cursorY },
+      trigger,
+    );
+  }, [sessionId]);
+
+  useEffect(() => { dumpForSelfVerifyRef.current = dumpForSelfVerify; }, [dumpForSelfVerify]);
+
+  // Fire after a fresh (re)connect once everything has settled. isConnected
+  // alone fires too early — the initial-content write hasn't drained — so we
+  // wait one tick + an output-idle window.
+  useEffect(() => {
+    if (!isConnected || !isSelfVerifyEnabled()) return;
+    const t = setTimeout(() => dumpForSelfVerify('reconnect-done'), 500);
+    return () => clearTimeout(t);
+  }, [isConnected, dumpForSelfVerify]);
+
+  // Periodic safety-net dump every 30s while connected, regardless of
+  // recent activity. Catches slow drifts that other triggers miss.
+  useEffect(() => {
+    if (!isConnected || !isSelfVerifyEnabled()) return;
+    const interval = setInterval(() => dumpForSelfVerify('periodic'), 30_000);
+    return () => clearInterval(interval);
+  }, [isConnected, dumpForSelfVerify]);
 
   // Track visual viewport for soft keyboard offset
   useEffect(() => {

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -56,6 +56,10 @@ let sharedPingInterval: number | null = null;
 let sharedReconnectTimeout: number | null = null;
 let subscribedSession: string | null = null;
 let wsReady = false; // true after server sends 'ready'
+// Channel C: when the server (CCHUB_SELF_VERIFY=1) accepts our subscription,
+// it includes selfVerifyEnabled=true so we know to start streaming debug-dump
+// messages. Stays false on production builds.
+let selfVerifyEnabled = false;
 
 // Conversation subscriptions (multiple sessions can be subscribed at once)
 const subscribedConversations = new Set<string>();
@@ -228,6 +232,10 @@ function ensureConnection(token?: string | null) {
         break;
       }
       case 'subscribed': {
+        if (msg.selfVerifyEnabled === true && !selfVerifyEnabled) {
+          selfVerifyEnabled = true;
+          console.log('[MUX] self-verify enabled by server');
+        }
         if (msgSessionId === currentSession) {
           cb?.setIsConnected?.(true);
           cb?.onConnect?.();
@@ -386,6 +394,37 @@ export function sendTerminalInput(sessionId: string, paneId: string, data: strin
   const base64 = uint8ArrayToBase64(bytes);
   sharedWs.send(JSON.stringify({ type: 'input', sessionId, paneId, data: base64 }));
   dispatchInputEcho(sessionId, paneId, data);
+  return true;
+}
+
+export function isSelfVerifyEnabled(): boolean {
+  return selfVerifyEnabled;
+}
+
+/**
+ * Channel C: send a client-side xterm.js snapshot for server-side drift
+ * detection. No-op unless the server has self-verify enabled (so production
+ * builds incur zero overhead). The caller is responsible for assembling
+ * `lines` from the xterm buffer.
+ */
+export function sendDebugDump(
+  sessionId: string,
+  paneId: string,
+  lines: string[],
+  cursor: { x: number; y: number },
+  trigger: 'resize-done' | 'reconnect-done' | 'output-idle' | 'periodic' | 'user',
+): boolean {
+  if (!selfVerifyEnabled) return false;
+  if (sharedWs?.readyState !== WebSocket.OPEN || !wsReady) return false;
+  sharedWs.send(JSON.stringify({
+    type: 'debug-dump',
+    sessionId,
+    paneId,
+    lines,
+    cursor,
+    trigger,
+    ts: Date.now(),
+  }));
   return true;
 }
 

--- a/frontend/tests/e2e/self-verify-channel-c.spec.ts
+++ b/frontend/tests/e2e/self-verify-channel-c.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { readFileSync, existsSync } from 'node:fs';
+
+// Channel C smoke test. Requires the dev server to be started with
+// CCHUB_SELF_VERIFY=1. Drives a brief session and asserts the server wrote
+// drift records to /tmp/cchub-drift.log.
+
+const FRONTEND_URL = 'https://localhost:5173';
+const BACKEND_URL = 'https://localhost:3456';
+const DRIFT_LOG = '/tmp/cchub-drift.log';
+
+test.use({
+  ignoreHTTPSErrors: true,
+  baseURL: FRONTEND_URL,
+});
+
+async function pickFirstClaudeSession(request: APIRequestContext): Promise<string> {
+  const res = await request.get(`${BACKEND_URL}/api/sessions`);
+  const data = await res.json();
+  const target = data.sessions.find(
+    (s: { agent?: string; state?: string }) =>
+      s.agent === 'claude' && (s.state === 'idle' || s.state === 'working'),
+  );
+  if (!target) throw new Error('no claude session — start `claude` in a tmux session');
+  return target.id as string;
+}
+
+test('Channel C writes drift records to log under CCHUB_SELF_VERIFY=1', async ({ page, request }) => {
+  const sessionId = await pickFirstClaudeSession(request);
+
+  await page.addInitScript(([id]) => {
+    localStorage.setItem('cchub-open-sessions', JSON.stringify([id]));
+    localStorage.setItem('cchub-last-session-id', id);
+    localStorage.setItem('cchub-onboarding-completed', 'true');
+    localStorage.setItem('cchub-onboarding-sessionlist-completed', 'true');
+  }, [sessionId]);
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  // Wait long enough for the reconnect-done trigger (500ms) + a periodic-ish
+  // round trip. Output-idle also fires after any startup chatter.
+  await page.waitForTimeout(2500);
+
+  expect(existsSync(DRIFT_LOG), `${DRIFT_LOG} should exist`).toBe(true);
+  const lines = readFileSync(DRIFT_LOG, 'utf8').trim().split('\n').filter(Boolean);
+  expect(lines.length, 'at least one drift record should be appended').toBeGreaterThan(0);
+
+  const records = lines.map(l => JSON.parse(l));
+  console.log(`[diagnostic] drift records: ${records.length}, sample:`, JSON.stringify(records[0]).slice(0, 200));
+
+  // Every record must have the expected shape.
+  for (const r of records) {
+    expect(typeof r.ts).toBe('number');
+    expect(typeof r.paneId).toBe('string');
+    expect(['resize-done', 'reconnect-done', 'output-idle', 'periodic', 'user']).toContain(r.trigger);
+    expect(typeof r.mismatchCount).toBe('number');
+    expect(typeof r.clientRows).toBe('number');
+    expect(typeof r.canonicalRows).toBe('number');
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.108",
+  "version": "0.1.109",
   "private": true,
   "workspaces": [
     "backend",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -501,17 +501,34 @@ export type ControlServerMessage =
 // Multiplexed WebSocket Types (single WS per client)
 // =============================================================================
 
+// Triggers for client-side self-verification dumps (Channel C, dev-only).
+export type DebugDumpTrigger = 'resize-done' | 'reconnect-done' | 'output-idle' | 'periodic' | 'user';
+
 // Client → Server messages for /ws/mux
 export type MuxClientMessage =
   | { type: 'subscribe'; sessionId: string }
   | { type: 'unsubscribe'; sessionId: string }
   | { type: 'subscribe-conversation'; sessionId: string }
   | { type: 'unsubscribe-conversation'; sessionId: string }
+  // Channel C: client sends its xterm.js buffer snapshot for server-side
+  // comparison against the canonical tmux state. Only used when the server
+  // reports `selfVerifyEnabled: true` in the `subscribed` response.
+  | {
+      type: 'debug-dump';
+      sessionId: string;
+      paneId: string;
+      lines: string[];                // xterm buffer.active rows, rtrim()'d on server
+      cursor: { x: number; y: number };
+      trigger: DebugDumpTrigger;
+      ts: number;
+    }
   | (ControlClientMessage & { sessionId: string });
 
 // Server → Client messages for /ws/mux
 export type MuxServerMessage =
-  | { type: 'subscribed'; sessionId: string }
+  // `selfVerifyEnabled` is true when CCHUB_SELF_VERIFY=1 on the server,
+  // signaling clients to start streaming `debug-dump` messages.
+  | { type: 'subscribed'; sessionId: string; selfVerifyEnabled?: boolean }
   | { type: 'unsubscribed'; sessionId: string }
   | { type: 'sessions-updated'; sessions: SessionResponse[] }
   | { type: 'conversation-subscribed'; sessionId: string; ccSessionId: string | null }


### PR DESCRIPTION
## Summary

#147 の Phase 1: dev-mode 限定の Channel C (client→server self-verification feedback) を実装。クライアント xterm.js の可視範囲を定期的にサーバへ送信し、サーバ側で \`tmux capture-pane -p\` と比較して drift を \`/tmp/cchub-drift.log\` に追記する。

## Why

ターミナル表示の乱れが継続課題だが、定量データが無いため優先順位が付けられない状況だった。tmux pane は完全な VT 端末状態 (canonical truth) を持っているので、それと xterm.js の状態を比較すれば drift を機械検知できる。本 PR で **「いつ・どんなときに・どれくらい乱れているか」のデータを取れる土台** を入れる。

また、この feedback は #147 の Phase 2-7 で実装する state diff sync の **正しさ検証 oracle** としてそのまま継続利用する。

## How

- \`CCHUB_SELF_VERIFY=1\` でサーバ起動 → subscribe handshake に \`selfVerifyEnabled: true\` を含めて返す
- クライアントが flag を見て debug-dump 送信開始
- 4 つのトリガー: resize-done (1s)、reconnect-done (500ms)、output-idle (300ms debounce)、periodic (30s)
- サーバが受信 → tmux capture-pane -p → 行単位 rtrim 比較 → JSON Lines で append
- production 環境 (flag 無し) では subscribe handshake が \`selfVerifyEnabled: false\` を返し、クライアントは debug-dump を一切送らない → **完全 no-op**

## Test plan

- [x] Playwright e2e (\`self-verify-channel-c.spec.ts\`): \`CCHUB_SELF_VERIFY=1\` 起動 → ページ load → \`/tmp/cchub-drift.log\` に記録される、JSON 構造が想定通り
- [x] flag 無し起動時に何も記録されない (手動確認)
- [x] TypeScript clean / Biome lint warning 新規ゼロ
- [x] Production build 成功、bundle に self-verify ロジックを含む (production 動作では trigger されない)

## Files

- \`shared/types.ts\` — \`debug-dump\` メッセージ + \`selfVerifyEnabled\` ハンドシェイクフィールド
- \`backend/src/routes/terminal-mux.ts\` — \`CCHUB_SELF_VERIFY\` 読み取り、handleDebugDump、capture-pane 比較、ファイル追記
- \`frontend/src/hooks/useMultiplexedTerminal.ts\` — \`isSelfVerifyEnabled()\` / \`sendDebugDump()\` 公開、subscribed handler 拡張
- \`frontend/src/components/Terminal.tsx\` — dump 抽出 helper + 4 trigger の useEffect
- \`frontend/tests/e2e/self-verify-channel-c.spec.ts\` — 回帰テスト

## Notes / 既知の制約

- 現状の比較は **テキスト一致のみ** (色・属性は除外)。色の false positive が多いため意図的
- xterm.js の可視範囲 \`last term.rows lines\` と \`capture-pane -p\` を比較。scrollback drift は今は対象外
- DEC private modes (mouse tracking 等) は #147 Phase 2 で snapshot に含める予定

## 次にすべきこと (Phase 2 への引継ぎ)

数日〜数週間運用してログを集計し:
- どの trigger で drift が多いか → 後続 Phase の優先順位判断
- mismatch 率の baseline → Phase 2 (state diff sync) 投入後の改善効果の客観評価

🤖 Generated with [Claude Code](https://claude.com/claude-code)