### PR TITLE
Release v0.1.110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.110] - 2026-05-17
+
+### Changed
+- ターミナル転送方式を byte-stream から tmux canonical state sync に置換 (#149, #147 Phase 2)
+  - `tmux capture-pane -e -p` の出力を canonical state として扱い、snapshot/diff 形式で client に配信
+  - scrollback delta を snapshot に同梱し、 client 側でも履歴をスクロールできるよう拡張
+  - Channel C (drift detection) を新方式に対応 (state-sync 適用後の grid と canonical を比較)
+
+### Fixed
+- Claude TUI で画面下半分が「黒い void」 として固定表示される問題に暫定対応
+  - server: `capture-pane` が trim する trailing blank 行に空文字 padding しない。 ANSI strip 後に空白のみの行も trim 対象に拡張
+  - client: snapshot.lines を xterm grid の下端揃えで描画 (上端の余白は scrollback / 前 frame が見える)
+  - 全て TEMPORARY マーク付き — Claude TUI が pane を画面下まで使う設計に変わったら削除可能
+- モバイルでアクセスしたときに pane が desktop サイズのまま固定される問題を修正
+  - `refresh-client -C` だけでは `window-size manual` の session で pane が resize されないため、 `resize-window` をペアで発行
+  - 両 tmux コマンドを `Promise.all` で並列化し resize latency を半減
+
 ## [0.1.109] - 2026-05-16
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,8 +113,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.109",
-  "generated": "2026-05-16",
+  "version": "0.1.110",
+  "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.109",
-  "generated": "2026-05-16",
+  "version": "0.1.110",
+  "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary

state-sync (tmux canonical state sync) ベースのターミナル転送への切替と、 それに伴う UX 課題への暫定対応をリリースします。

### 主な変更
- **state-sync 化** (#149): byte-stream → snapshot/diff 配信。 scrollback delta 同梱、 Channel C drift 検知を新方式対応
- **Claude TUI void 対策**: padding 止め + ANSI strip 後の空行 trim + xterm grid 下端揃え描画。 すべて TEMPORARY マーク付き
- **モバイル pane size 連動**: `refresh-client -C` + `resize-window` のペア発行 (Promise.all 並列)

### Test plan
- [x] dev 環境で void 消失確認 (desktop / mobile)
- [x] drift log mismatchCount=0 を継続確認
- [x] モバイル resize 時に pane が追従することを確認
- [x] 既存の active session 含む複数 session 並行操作で挙動安定確認