### PR TITLE
docs: update architecture for state-sync transport

### DIFF
--- a/architecture.html
+++ b/architecture.html
@@ -136,7 +136,7 @@
       {
         "name": "captureSnapshot / diffSnapshots",
         "file": "backend/src/services/pane-snapshot.ts",
-        "summary": "tmux capture-pane -e -p を canonical state として PaneSnapshot を生成し、 前回 snap との差分 DiffOp[] を計算。 末尾の visually-blank 行 (ANSI strip 後に空) は trim し、 padding しない (Claude TUI 暫定対応)。 scrollback delta も同梱して client の history を成長させる",
+        "summary": "tmux capture-pane -e -p を canonical state として PaneSnapshot を生成し、 前回 snap との差分 DiffOp[] を計算。 Claude TUI 暫定対応として、 末尾 visually-blank 行を trim した後、 不足分を recent scrollback (capture-pane -S -N -E -1) で prepend pad (= visible 余白を直前履歴で埋める)。 padFill は historySize 単位でキャッシュ (PadFillCache) して毎 tick の tmux round-trip を回避。 初回 snap には INITIAL_SCROLLBACK_ROWS まで scrollback delta も同梱",
         "deps": [
           "shared/types"
         ]
@@ -660,7 +660,7 @@
       {
         "name": "Terminal",
         "file": "frontend/src/components/Terminal.tsx",
-        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から snapshot / diff イベントを受け、snapshotToVTSequence / diffToVTSequence で VT 列に変換して書き込み。snap.lines は xterm grid の下端揃えで描画 (Claude TUI 暫定対応)。Channel C drift dump を baseY + bottom-align offset から読む。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
+        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から snapshot / diff イベントを受け、snapshotToVTSequence / diffToVTSequence で VT 列に変換して上端揃え書き込み (snap canonical)。Channel C drift dump は applied.baseY から snap.rows 行を grid 読出し。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
         "hooks": [
           "useSelectionMode"
         ],
@@ -1158,12 +1158,12 @@
         "tmux プロセス (描画変化)",
         "tmux -CC %output トリガで debounce",
         "captureSnapshot: display-message で cursor/size + capture-pane -e -p で visible 領域取得",
-        "末尾の visually-blank 行を trim (Claude TUI 暫定対応)",
-        "前 snap と diffSnapshots で比較 → DiffOp[] (lines.length が変わる場合は full snapshot を強制)",
+        "末尾 visually-blank 行を trim → 不足分を scrollback の最新行で prepend (Claude TUI 暫定対応、 padFill キャッシュ)",
+        "前 snap と diffSnapshots で比較 → DiffOp[]",
         "/ws/mux JSON { type:'state-snapshot' | 'state-diff', sessionId, snapshot | ops }",
         "ブラウザ WebSocket",
         "useMultiplexedTerminal.registerOnRender",
-        "snapshotToVTSequence / diffToVTSequence (bottom-aligned write、offset = rows - lines.length)",
+        "snapshotToVTSequence / diffToVTSequence (top-aligned write、snap が canonical)",
         "Terminal.tsx xterm.js write"
       ]
     },
@@ -1171,7 +1171,7 @@
       "name": "Channel C drift detection (dev only)",
       "steps": [
         "trigger: resize-done / reconnect-done / output-idle (300ms) / periodic (30s)",
-        "Terminal.tsx dumpForSelfVerify: applied.baseY + bottom-align offset から linesLen 行を grid 読出し",
+        "Terminal.tsx dumpForSelfVerify: applied.baseY から snap.rows 行を grid 読出し",
         "/ws/mux JSON { type:'debug-dump', sessionId, paneId, lines, cursor, appliedSeq }",
         "terminal-mux handleDebugDump: sub.serverSnapshots の sentSnap.lines と比較 (ANSI strip + trimEnd で normalize)",
         "mismatch を /tmp/cchub-drift.log に JSON Lines で追記"

--- a/architecture.html
+++ b/architecture.html
@@ -120,17 +120,25 @@
     "backend": "Bun runtime + Hono",
     "frontend": "React 19 + Vite + Tailwind v4 + xterm.js",
     "shared": "Zod v4 schemas in shared/types.ts",
-    "transport": "Multiplexed WebSocket /ws/mux + tmux -CC control mode"
+    "transport": "Multiplexed WebSocket /ws/mux + tmux -CC control mode。ターミナル表示は state-sync (tmux capture-pane を canonical state として snapshot / diff を JSON で配信)"
   },
   "backend": {
     "services": [
       {
         "name": "TmuxControlSession",
         "file": "backend/src/services/tmux-control.ts",
-        "summary": "tmux -CC (control mode) プロセスを管理するコア。%output / %layout-change / %begin / %end / %error / %exit を処理し、raw byte stream で UTF-8 を保持。client 単位の pane 出力ルーティング、コマンド FIFO キュー、グレースピリオド付きライフサイクル管理を提供",
+        "summary": "tmux -CC (control mode) プロセスを管理するコア。%output / %layout-change / %begin / %end / %error / %exit を処理し、raw byte stream で UTF-8 を保持。client 単位の pane 出力ルーティング、コマンド FIFO キュー、グレースピリオド付きライフサイクル管理を提供。setClientSize() は refresh-client -C と resize-window を Promise.all で並列発行し、window-size manual な session でも client サイズに pane を追従させる",
         "deps": [
           "tmux-octal-decoder",
           "tmux-layout-parser"
+        ]
+      },
+      {
+        "name": "captureSnapshot / diffSnapshots",
+        "file": "backend/src/services/pane-snapshot.ts",
+        "summary": "tmux capture-pane -e -p を canonical state として PaneSnapshot を生成し、 前回 snap との差分 DiffOp[] を計算。 末尾の visually-blank 行 (ANSI strip 後に空) は trim し、 padding しない (Claude TUI 暫定対応)。 scrollback delta も同梱して client の history を成長させる",
+        "deps": [
+          "shared/types"
         ]
       },
       {
@@ -652,7 +660,7 @@
       {
         "name": "Terminal",
         "file": "frontend/src/components/Terminal.tsx",
-        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から pane I/O を受け、tmux レイアウト由来の setExactSize() でサイズ同期。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
+        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から snapshot / diff イベントを受け、snapshotToVTSequence / diffToVTSequence で VT 列に変換して書き込み。snap.lines は xterm grid の下端揃えで描画 (Claude TUI 暫定対応)。Channel C drift dump を baseY + bottom-align offset から読む。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
         "hooks": [
           "useSelectionMode"
         ],
@@ -1029,7 +1037,7 @@
   },
   "websocket": {
     "endpoint": "/ws/mux",
-    "description": "単一の多重化 WebSocket。クライアントは subscribe でセッションごとに購読し、binary フレーム [0x02][sessionId\\0][paneId\\0][data] と JSON 制御メッセージを混在で受信",
+    "description": "単一の多重化 WebSocket。クライアントは subscribe でセッションごとに購読し、ターミナル表示は state-snapshot / state-diff (JSON) で配信。 binary フレームは現在使用していない",
     "client_messages": {
       "mux_level": [
         "subscribe",
@@ -1051,7 +1059,8 @@
         "zoom-pane",
         "respawn-pane",
         "ping",
-        "client-info"
+        "client-info",
+        "debug-dump"
       ]
     },
     "server_messages": {
@@ -1065,7 +1074,8 @@
         "conversation-update"
       ],
       "per_session": [
-        "output (binary)",
+        "state-snapshot",
+        "state-diff",
         "layout",
         "initial-content",
         "ready",
@@ -1076,7 +1086,6 @@
         "hook-event"
       ]
     },
-    "binary_format": "[0x02][sessionId\\0][paneId\\0][raw bytes]",
     "intervals": {
       "sessions-updated push": "5s",
       "zombie connection detection": "60s",
@@ -1144,17 +1153,28 @@
       ]
     },
     {
-      "name": "ターミナル出力表示",
+      "name": "ターミナル出力表示 (state-sync)",
       "steps": [
-        "tmux プロセス",
-        "tmux -CC stdout",
-        "TmuxControlSession (raw buffer)",
-        "%output 行デコード (tmux-octal-decoder)",
-        "OutputListener (paneId 別 callback)",
-        "/ws/mux binary frame [0x02][sessionId\\0][paneId\\0][data]",
+        "tmux プロセス (描画変化)",
+        "tmux -CC %output トリガで debounce",
+        "captureSnapshot: display-message で cursor/size + capture-pane -e -p で visible 領域取得",
+        "末尾の visually-blank 行を trim (Claude TUI 暫定対応)",
+        "前 snap と diffSnapshots で比較 → DiffOp[] (lines.length が変わる場合は full snapshot を強制)",
+        "/ws/mux JSON { type:'state-snapshot' | 'state-diff', sessionId, snapshot | ops }",
         "ブラウザ WebSocket",
-        "useMultiplexedTerminal.onPaneOutput",
+        "useMultiplexedTerminal.registerOnRender",
+        "snapshotToVTSequence / diffToVTSequence (bottom-aligned write、offset = rows - lines.length)",
         "Terminal.tsx xterm.js write"
+      ]
+    },
+    {
+      "name": "Channel C drift detection (dev only)",
+      "steps": [
+        "trigger: resize-done / reconnect-done / output-idle (300ms) / periodic (30s)",
+        "Terminal.tsx dumpForSelfVerify: applied.baseY + bottom-align offset から linesLen 行を grid 読出し",
+        "/ws/mux JSON { type:'debug-dump', sessionId, paneId, lines, cursor, appliedSeq }",
+        "terminal-mux handleDebugDump: sub.serverSnapshots の sentSnap.lines と比較 (ANSI strip + trimEnd で normalize)",
+        "mismatch を /tmp/cchub-drift.log に JSON Lines で追記"
       ]
     },
     {

--- a/architecture.json
+++ b/architecture.json
@@ -23,7 +23,7 @@
       {
         "name": "captureSnapshot / diffSnapshots",
         "file": "backend/src/services/pane-snapshot.ts",
-        "summary": "tmux capture-pane -e -p を canonical state として PaneSnapshot を生成し、 前回 snap との差分 DiffOp[] を計算。 末尾の visually-blank 行 (ANSI strip 後に空) は trim し、 padding しない (Claude TUI 暫定対応)。 scrollback delta も同梱して client の history を成長させる",
+        "summary": "tmux capture-pane -e -p を canonical state として PaneSnapshot を生成し、 前回 snap との差分 DiffOp[] を計算。 Claude TUI 暫定対応として、 末尾 visually-blank 行を trim した後、 不足分を recent scrollback (capture-pane -S -N -E -1) で prepend pad (= visible 余白を直前履歴で埋める)。 padFill は historySize 単位でキャッシュ (PadFillCache) して毎 tick の tmux round-trip を回避。 初回 snap には INITIAL_SCROLLBACK_ROWS まで scrollback delta も同梱",
         "deps": [
           "shared/types"
         ]
@@ -547,7 +547,7 @@
       {
         "name": "Terminal",
         "file": "frontend/src/components/Terminal.tsx",
-        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から snapshot / diff イベントを受け、snapshotToVTSequence / diffToVTSequence で VT 列に変換して書き込み。snap.lines は xterm grid の下端揃えで描画 (Claude TUI 暫定対応)。Channel C drift dump を baseY + bottom-align offset から読む。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
+        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から snapshot / diff イベントを受け、snapshotToVTSequence / diffToVTSequence で VT 列に変換して上端揃え書き込み (snap canonical)。Channel C drift dump は applied.baseY から snap.rows 行を grid 読出し。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
         "hooks": [
           "useSelectionMode"
         ],
@@ -1045,12 +1045,12 @@
         "tmux プロセス (描画変化)",
         "tmux -CC %output トリガで debounce",
         "captureSnapshot: display-message で cursor/size + capture-pane -e -p で visible 領域取得",
-        "末尾の visually-blank 行を trim (Claude TUI 暫定対応)",
-        "前 snap と diffSnapshots で比較 → DiffOp[] (lines.length が変わる場合は full snapshot を強制)",
+        "末尾 visually-blank 行を trim → 不足分を scrollback の最新行で prepend (Claude TUI 暫定対応、 padFill キャッシュ)",
+        "前 snap と diffSnapshots で比較 → DiffOp[]",
         "/ws/mux JSON { type:'state-snapshot' | 'state-diff', sessionId, snapshot | ops }",
         "ブラウザ WebSocket",
         "useMultiplexedTerminal.registerOnRender",
-        "snapshotToVTSequence / diffToVTSequence (bottom-aligned write、offset = rows - lines.length)",
+        "snapshotToVTSequence / diffToVTSequence (top-aligned write、snap が canonical)",
         "Terminal.tsx xterm.js write"
       ]
     },
@@ -1058,7 +1058,7 @@
       "name": "Channel C drift detection (dev only)",
       "steps": [
         "trigger: resize-done / reconnect-done / output-idle (300ms) / periodic (30s)",
-        "Terminal.tsx dumpForSelfVerify: applied.baseY + bottom-align offset から linesLen 行を grid 読出し",
+        "Terminal.tsx dumpForSelfVerify: applied.baseY から snap.rows 行を grid 読出し",
         "/ws/mux JSON { type:'debug-dump', sessionId, paneId, lines, cursor, appliedSeq }",
         "terminal-mux handleDebugDump: sub.serverSnapshots の sentSnap.lines と比較 (ANSI strip + trimEnd で normalize)",
         "mismatch を /tmp/cchub-drift.log に JSON Lines で追記"

--- a/architecture.json
+++ b/architecture.json
@@ -7,17 +7,25 @@
     "backend": "Bun runtime + Hono",
     "frontend": "React 19 + Vite + Tailwind v4 + xterm.js",
     "shared": "Zod v4 schemas in shared/types.ts",
-    "transport": "Multiplexed WebSocket /ws/mux + tmux -CC control mode"
+    "transport": "Multiplexed WebSocket /ws/mux + tmux -CC control mode。ターミナル表示は state-sync (tmux capture-pane を canonical state として snapshot / diff を JSON で配信)"
   },
   "backend": {
     "services": [
       {
         "name": "TmuxControlSession",
         "file": "backend/src/services/tmux-control.ts",
-        "summary": "tmux -CC (control mode) プロセスを管理するコア。%output / %layout-change / %begin / %end / %error / %exit を処理し、raw byte stream で UTF-8 を保持。client 単位の pane 出力ルーティング、コマンド FIFO キュー、グレースピリオド付きライフサイクル管理を提供",
+        "summary": "tmux -CC (control mode) プロセスを管理するコア。%output / %layout-change / %begin / %end / %error / %exit を処理し、raw byte stream で UTF-8 を保持。client 単位の pane 出力ルーティング、コマンド FIFO キュー、グレースピリオド付きライフサイクル管理を提供。setClientSize() は refresh-client -C と resize-window を Promise.all で並列発行し、window-size manual な session でも client サイズに pane を追従させる",
         "deps": [
           "tmux-octal-decoder",
           "tmux-layout-parser"
+        ]
+      },
+      {
+        "name": "captureSnapshot / diffSnapshots",
+        "file": "backend/src/services/pane-snapshot.ts",
+        "summary": "tmux capture-pane -e -p を canonical state として PaneSnapshot を生成し、 前回 snap との差分 DiffOp[] を計算。 末尾の visually-blank 行 (ANSI strip 後に空) は trim し、 padding しない (Claude TUI 暫定対応)。 scrollback delta も同梱して client の history を成長させる",
+        "deps": [
+          "shared/types"
         ]
       },
       {
@@ -539,7 +547,7 @@
       {
         "name": "Terminal",
         "file": "frontend/src/components/Terminal.tsx",
-        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から pane I/O を受け、tmux レイアウト由来の setExactSize() でサイズ同期。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
+        "summary": "xterm.js + WebGL アドオンのターミナル実装。ControlModeConfig から snapshot / diff イベントを受け、snapshotToVTSequence / diffToVTSequence で VT 列に変換して書き込み。snap.lines は xterm grid の下端揃えで描画 (Claude TUI 暫定対応)。Channel C drift dump を baseY + bottom-align offset から読む。タッチ選択モード、フォントサイズ調整、デスクトップ自動コピー",
         "hooks": [
           "useSelectionMode"
         ],
@@ -916,7 +924,7 @@
   },
   "websocket": {
     "endpoint": "/ws/mux",
-    "description": "単一の多重化 WebSocket。クライアントは subscribe でセッションごとに購読し、binary フレーム [0x02][sessionId\\0][paneId\\0][data] と JSON 制御メッセージを混在で受信",
+    "description": "単一の多重化 WebSocket。クライアントは subscribe でセッションごとに購読し、ターミナル表示は state-snapshot / state-diff (JSON) で配信。 binary フレームは現在使用していない",
     "client_messages": {
       "mux_level": [
         "subscribe",
@@ -938,7 +946,8 @@
         "zoom-pane",
         "respawn-pane",
         "ping",
-        "client-info"
+        "client-info",
+        "debug-dump"
       ]
     },
     "server_messages": {
@@ -952,7 +961,8 @@
         "conversation-update"
       ],
       "per_session": [
-        "output (binary)",
+        "state-snapshot",
+        "state-diff",
         "layout",
         "initial-content",
         "ready",
@@ -963,7 +973,6 @@
         "hook-event"
       ]
     },
-    "binary_format": "[0x02][sessionId\\0][paneId\\0][raw bytes]",
     "intervals": {
       "sessions-updated push": "5s",
       "zombie connection detection": "60s",
@@ -1031,17 +1040,28 @@
       ]
     },
     {
-      "name": "ターミナル出力表示",
+      "name": "ターミナル出力表示 (state-sync)",
       "steps": [
-        "tmux プロセス",
-        "tmux -CC stdout",
-        "TmuxControlSession (raw buffer)",
-        "%output 行デコード (tmux-octal-decoder)",
-        "OutputListener (paneId 別 callback)",
-        "/ws/mux binary frame [0x02][sessionId\\0][paneId\\0][data]",
+        "tmux プロセス (描画変化)",
+        "tmux -CC %output トリガで debounce",
+        "captureSnapshot: display-message で cursor/size + capture-pane -e -p で visible 領域取得",
+        "末尾の visually-blank 行を trim (Claude TUI 暫定対応)",
+        "前 snap と diffSnapshots で比較 → DiffOp[] (lines.length が変わる場合は full snapshot を強制)",
+        "/ws/mux JSON { type:'state-snapshot' | 'state-diff', sessionId, snapshot | ops }",
         "ブラウザ WebSocket",
-        "useMultiplexedTerminal.onPaneOutput",
+        "useMultiplexedTerminal.registerOnRender",
+        "snapshotToVTSequence / diffToVTSequence (bottom-aligned write、offset = rows - lines.length)",
         "Terminal.tsx xterm.js write"
+      ]
+    },
+    {
+      "name": "Channel C drift detection (dev only)",
+      "steps": [
+        "trigger: resize-done / reconnect-done / output-idle (300ms) / periodic (30s)",
+        "Terminal.tsx dumpForSelfVerify: applied.baseY + bottom-align offset から linesLen 行を grid 読出し",
+        "/ws/mux JSON { type:'debug-dump', sessionId, paneId, lines, cursor, appliedSeq }",
+        "terminal-mux handleDebugDump: sub.serverSnapshots の sentSnap.lines と比較 (ANSI strip + trimEnd で normalize)",
+        "mismatch を /tmp/cchub-drift.log に JSON Lines で追記"
       ]
     },
     {


### PR DESCRIPTION
## Summary

0.1.110 で landed した byte-stream → state-sync 移行を `architecture.json` / `architecture.html` に反映。

### 変更点
- transport 概要に state-sync 説明追加
- `pane-snapshot.ts` を services エントリとして追加
- `TmuxControlSession` summary に `setClientSize` の resize-window 並列発行を追記
- `Terminal` summary を snapshot/diff 受信 + bottom-aligned write に書き換え
- WebSocket message リストから `output (binary)` を削除、 `state-snapshot` / `state-diff` / `debug-dump` を追加
- data_flows: 「ターミナル出力表示」 を state-sync パイプラインに書き換え、 「Channel C drift detection」 フローを新規追加

### Test plan
- [x] `python3 scripts/build-architecture-html.py` が version 同期メッセージを出力
- [ ] `architecture.html` を開いて表示崩れがないか確認