### PR TITLE
fix: prepend scrollback for void-bottom + simplify renderer

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -37,6 +37,9 @@ interface MuxSubscription {
   // tmux history-size at the time of the last snapshot, per pane. Used to
   // compute scrollbackDelta on the next capture.
   lastHistorySize: Map<string, number>;
+  // Cached scrollback rows used to pad short snapshots (Claude TUI
+  // workaround). Reusable while historySize is unchanged.
+  lastPadFill: Map<string, import('../services/pane-snapshot').PadFillCache>;
   // Per-pane snapshot debounce timers.
   snapshotTimers: Map<string, Timer>;
   // Pane IDs we've ever sent a snapshot for, so we can recapture them on
@@ -221,6 +224,7 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
     existing.initialized = false;
     existing.serverSnapshots.clear();
     existing.lastHistorySize.clear();
+    existing.lastPadFill.clear();
     for (const t of existing.snapshotTimers.values()) clearTimeout(t);
     existing.snapshotTimers.clear();
     existing.outputSuppressedCount = 0;
@@ -245,6 +249,7 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
       initialized: false,
       serverSnapshots: new Map(),
       lastHistorySize: new Map(),
+      lastPadFill: new Map(),
       snapshotTimers: new Map(),
       knownPanes: new Set(),
       outputSuppressedCount: 0,
@@ -364,22 +369,25 @@ async function emitSnapshot(
   paneId: string,
 ) {
   if (sub.controlSession.isDestroyed) return;
-  let result: { snapshot: PaneSnapshot; historySize: number } | null;
+  let result: Awaited<ReturnType<typeof captureSnapshot>>;
   try {
     result = await captureSnapshot(
       sub.controlSession,
       paneId,
       sub.lastHistorySize.get(paneId),
+      sub.lastPadFill.get(paneId),
     );
   } catch (err) {
     console.warn(`[mux] captureSnapshot failed for ${paneId}:`, err);
     return;
   }
   if (!result) return;
-  const { snapshot, historySize } = result;
+  const { snapshot, historySize, padFill } = result;
 
   sub.knownPanes.add(paneId);
   sub.lastHistorySize.set(paneId, historySize);
+  if (padFill) sub.lastPadFill.set(paneId, padFill);
+  else sub.lastPadFill.delete(paneId);
 
   const prev = sub.serverSnapshots.get(paneId);
   if (!prev) {
@@ -392,24 +400,15 @@ async function emitSnapshot(
 
   const ops = diffSnapshots(prev, snapshot);
   const hasScrollback = (snapshot.scrollbackDelta?.length ?? 0) > 0;
-  // TEMPORARY (Claude Code workaround): When snapshot.lines.length changes,
-  // the bottom-aligned write offset on the client also changes, and diff line
-  // ops (indexed within snapshot.lines, not the grid) can no longer be
-  // applied consistently. Force a full snapshot in that case so the client
-  // re-anchors the offset cleanly. Remove with the rest of the Claude TUI
-  // workaround when the upstream renders the full pane.
-  const linesLenChanged = prev.lines.length !== snapshot.lines.length;
-  // Scrollback can only be carried on a full snapshot (it must be applied
-  // before the visible region is rewritten), and lines-length changes need a
-  // full snapshot so the client can re-anchor the bottom-align offset.
-  const needFullSnapshot = hasScrollback || linesLenChanged;
 
-  if (ops.length === 0 && !needFullSnapshot) {
+  if (ops.length === 0 && !hasScrollback) {
     sub.serverSnapshots.set(paneId, snapshot);
     return;
   }
 
-  if (needFullSnapshot) {
+  // Scrollback can only be carried on a full snapshot (it must be applied
+  // before the visible region is rewritten).
+  if (hasScrollback) {
     console.log(`[mux] state-snapshot pane=${paneId} seq=${snapshot.seq} scrollbackDelta=${snapshot.scrollbackDelta?.length ?? 0} rows=${snapshot.rows}`);
     try {
       ws.send(JSON.stringify({ type: 'state-snapshot', sessionId, snapshot }));
@@ -446,6 +445,7 @@ async function emitInitialSnapshots(
     // clear the history baseline too so scrollbackDelta starts empty.
     sub.serverSnapshots.delete(pane.paneId);
     sub.lastHistorySize.delete(pane.paneId);
+    sub.lastPadFill.delete(pane.paneId);
     await emitSnapshot(ws, sessionId, sub, pane.paneId);
   }
 }

--- a/backend/src/services/pane-snapshot.ts
+++ b/backend/src/services/pane-snapshot.ts
@@ -19,14 +19,12 @@ function allocSeq(): number {
   return nextSeq++;
 }
 
-// Cap how many scrollback rows we ship in a single snapshot. Pathological
-// catch-ups (long disconnect, history-size jump) shouldn't blow the wire.
-const MAX_SCROLLBACK_DELTA = 500;
-
-// On the first snapshot for a pane ship up to this many recent
-// scrollback rows so the client has substantive history available
-// immediately. Subsequent deltas come from real tmux history growth.
-const INITIAL_SCROLLBACK_ROWS = 500;
+// On the first snapshot for a pane, ship up to this many recent scrollback
+// rows in one shot so the client's xterm scrollback has substantive history
+// from the start. tmux history-limit defaults to 10000; cap below that to
+// keep the first-snapshot payload bounded (≈ 400 KB at 200 byte/row with
+// ANSI escapes).
+const INITIAL_SCROLLBACK_ROWS = 2000;
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes by design.
 const ANSI_RE = /\x1b\[[\d;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
@@ -38,6 +36,28 @@ function isVisuallyBlank(s: string): boolean {
 }
 
 /**
+ * Fetch up to `wanted` rows of scrollback ending just above the visible
+ * region (`-S -wanted -E -1`). Returns trimmed rows or [] on failure.
+ */
+async function captureScrollback(
+  cs: TmuxControlSession,
+  paneId: string,
+  wanted: number,
+): Promise<string[]> {
+  if (wanted <= 0) return [];
+  try {
+    const raw = await cs.sendCommand(
+      `capture-pane -e -p -t ${paneId} -S -${wanted} -E -1`,
+    );
+    const sb = raw.split('\n');
+    while (sb.length > 0 && isVisuallyBlank(sb[sb.length - 1])) sb.pop();
+    return sb;
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Capture a snapshot of a pane. Returns null if the pane no longer exists.
  *
  * Captures:
@@ -46,11 +66,17 @@ function isVisuallyBlank(s: string): boolean {
  *   - any new scrollback lines added since `prevHistorySize`, so the client
  *     can grow its own scrollback ring buffer for wheel/touch scrolling
  */
+export interface PadFillCache {
+  historySize: number;
+  rows: string[];
+}
+
 export async function captureSnapshot(
   cs: TmuxControlSession,
   paneId: string,
   prevHistorySize?: number,
-): Promise<{ snapshot: PaneSnapshot; historySize: number } | null> {
+  prevPadFill?: PadFillCache,
+): Promise<{ snapshot: PaneSnapshot; historySize: number; padFill?: PadFillCache } | null> {
   let metaRaw: string;
   try {
     metaRaw = await cs.sendCommand(
@@ -82,67 +108,52 @@ export async function captureSnapshot(
   }
 
   let lines = linesRaw.split('\n');
-  // Trim trailing rows that are visually blank — including rows that contain
-  // only whitespace or ANSI escapes (background-color repaint, SGR resets).
-  // Claude TUI sometimes pads the unused bottom region with spaces while
-  // typing, which `capture-pane` returns as space-only rows. Without this
-  // trim those rows survive into snap.lines and re-create the void.
+  // Trim trailing rows that are visually blank (whitespace / ANSI escapes
+  // only). tmux's capture-pane already returns at most one trailing newline,
+  // but Claude TUI sometimes paints space-only rows in the unused bottom
+  // region — they would otherwise survive into snap.lines as visible blanks.
   while (lines.length > 0 && isVisuallyBlank(lines[lines.length - 1])) lines.pop();
   if (lines.length > rows) {
     lines = lines.slice(0, rows);
   }
   // TEMPORARY WORKAROUND — Claude Code 固有 (TODO: remove when fixed upstream).
   //
-  // Claude TUI (Claude Code) は input area の下に意図的な余白を残す
-  // レイアウトで、 pane の下半分を描画しない。 tmux の `capture-pane`
-  // は描かれた cell の最終行までしか返さないため、 pane height=52 に
-  // 対して lines.length=37 のような短い snapshot になる。
+  // Claude TUI は pane の下半分を描画せず、 capture-pane も描かれた cell
+  // の最終行までしか返さない。 visible 余白を埋めるため、 不足分を
+  // scrollback の末尾 (= 直前まで visible にいた過去履歴) から取って
+  // snap.lines の先頭に prepend する。
+  //   - 上: scrollback 末尾 (= 古い履歴)
+  //   - 下: TUI 描画 (= 新しい履歴 + input area)
+  // Claude TUI が pane を full に描画するようになれば、 この prepend
+  // と空文字 padding を削除して通常の path に戻せる。
   //
-  // 不足分を空文字で padding して pane height に揃えると、 xterm 側で
-  // 末尾の行が黒い void として焼き付き、 旧 byte-stream 時代には
-  // 見えなかった「下半分が空」 の状態が固定表示されてしまう。
-  //
-  // 対策として padding を行わず、 snap.lines は「描画された範囲のみ」
-  // (= lines.length 行) を送る。 snap.rows は pane height のまま維持し、
-  // client 側で snap.lines を grid の下端揃えで描画する。 grid 上端の
-  // 余白は scrollback / 前 frame で自然に埋まる (= 旧 byte-stream の
-  // 「触らない領域は前のまま」 を再現)。
-  //
-  // Claude TUI が pane を画面下まで使う設計に変わったら、 この
-  // workaround は不要になる。 server の trim と client の下端揃え
-  // 描画 (snapshot-render.ts の bottom-aligned write) を削除して
-  // 通常の「snap.lines === pane height」 path に戻す。
+  // padFill は historySize 単位でキャッシュ可能 (= 同じ historySize なら
+  // scrollback の末尾 N 行は同じ)。 reuse することで毎 snapshot tick の
+  // tmux round-trip を減らす。
+  let padFill: PadFillCache | undefined = prevPadFill;
+  const padNeeded = rows - lines.length;
+  if (padNeeded > 0 && !altScreen && historySize > 0) {
+    if (!padFill || padFill.historySize !== historySize || padFill.rows.length < padNeeded) {
+      const fetched = await captureScrollback(cs, paneId, Math.max(padNeeded, padFill?.rows.length ?? 0));
+      if (fetched.length > 0) padFill = { historySize, rows: fetched };
+    }
+    if (padFill && padFill.rows.length > 0) {
+      lines = [...padFill.rows.slice(-padNeeded), ...lines];
+    }
+  }
+  while (lines.length < rows) lines.push('');
 
-  // Capture scrollback. On the first snapshot for a pane (no baseline) we
-  // ship the most recent INITIAL_SCROLLBACK_ROWS so the client has history
-  // available immediately. On subsequent snapshots we send only the rows
-  // pushed into scrollback since the previous capture (delta).
+  // Initial-only scrollback: ship up to INITIAL_SCROLLBACK_ROWS of the most
+  // recent rows once (on the first snapshot for this pane), nothing after.
   let scrollbackDelta: string[] | undefined;
-  if (!altScreen) {
-    let wanted = 0;
-    if (prevHistorySize === undefined) {
-      wanted = Math.min(historySize, INITIAL_SCROLLBACK_ROWS);
-    } else if (historySize > prevHistorySize) {
-      wanted = Math.min(historySize - prevHistorySize, MAX_SCROLLBACK_DELTA);
-    }
-    if (wanted > 0) {
-      try {
-        // -S -N selects N rows above the visible region (the newest scrollback).
-        // -E -1 stops at the row just above the viewport.
-        const sbRaw = await cs.sendCommand(
-          `capture-pane -e -p -t ${paneId} -S -${wanted} -E -1`,
-        );
-        const sb = sbRaw.split('\n');
-        while (sb.length > 0 && sb[sb.length - 1] === '') sb.pop();
-        if (sb.length > 0) scrollbackDelta = sb;
-      } catch {
-        // Ignore scrollback capture failures — visible state is what matters.
-      }
-    }
+  if (!altScreen && prevHistorySize === undefined && historySize > 0) {
+    const sb = await captureScrollback(cs, paneId, Math.min(historySize, INITIAL_SCROLLBACK_ROWS));
+    if (sb.length > 0) scrollbackDelta = sb;
   }
 
   return {
     historySize,
+    padFill,
     snapshot: {
       paneId,
       seq: allocSeq(),
@@ -152,8 +163,6 @@ export async function captureSnapshot(
       scrollbackDelta,
       cursor: {
         x: Math.max(0, Math.min(cols - 1, cx)),
-        // cursor.y is given relative to the pane's grid (0..rows-1). The client
-        // re-anchors it to the bottom-aligned write position when lines.length < rows.
         y: Math.max(0, Math.min(rows - 1, cy)),
         visible: cursorVisible,
       },

--- a/backend/src/services/tmux-control.ts
+++ b/backend/src/services/tmux-control.ts
@@ -664,17 +664,16 @@ export class TmuxControlSession {
    * inherit `window-size manual`, so `refresh-client -C` alone updates the
    * client SIGWINCH but leaves the pane stuck at whichever client attached
    * first (typically desktop) — phones would otherwise get content laid out
-   * at desktop dimensions and clipped. `resize-window` was historically
-   * avoided because its grid re-pack cleared cells that TUIs (Claude Code)
-   * leave unrendered, surfacing as a black void; that's now handled by the
-   * client's bottom-aligned snapshot write, so the re-pack is harmless.
+   * at desktop dimensions and clipped.
    */
   private async applyClientSize(cols: number, rows: number): Promise<void> {
     try {
-      await Promise.all([
-        this.sendCommand(`refresh-client -C ${cols}x${rows}`),
-        this.sendCommand(`resize-window -t ${this.sessionId} -x ${cols} -y ${rows}`),
-      ]);
+      // Sequential, not Promise.all: tmux -CC has a single FIFO for command
+      // responses, and overlapping sends corrupt the parsing (the second
+      // command's bytes can interleave with the first command's response
+      // window, producing "unknown command" errors).
+      await this.sendCommand(`refresh-client -C ${cols}x${rows}`);
+      await this.sendCommand(`resize-window -t ${this.sessionId} -x ${cols} -y ${rows}`);
     } catch {
       // Ignore resize errors
     }

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -9,7 +9,7 @@ import type { SessionTheme } from '../../../shared/types';
 import { filterMouseTrackingInput, shouldInterceptKeyEvent } from '../utils/terminal-filters';
 import { bench } from '../utils/bench';
 import { sendDebugDump, isSelfVerifyEnabled, type DumpTrigger, type PaneRenderEvent } from '../hooks/useMultiplexedTerminal';
-import { snapshotToVTSequence, diffToVTSequence, bottomAlignOffset } from '../utils/snapshot-render';
+import { snapshotToVTSequence, diffToVTSequence } from '../utils/snapshot-render';
 import {
   getTerminalThemes, isLightMode, LIGHT_ANSI_COLORS,
   DEFAULT_FONT_SIZE, MIN_FONT_SIZE, MAX_FONT_SIZE,
@@ -98,18 +98,10 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
   const refreshRef = useRef<() => void>(() => {});
   const dumpForSelfVerifyRef = useRef<((trigger: DumpTrigger) => void) | null>(null);
   // State captured at the moment the last snapshot finished writing, exposed
-  // for dumpForSelfVerify. Tracked together because they're all read at the
-  // same time and must reflect the same snapshot apply.
-  //
-  // - `baseY`: scrollback offset at write-complete. Using buf.baseY at dump
-  //   time would drift if a background scrollback push advanced it between
-  //   apply and dump.
-  // - `linesLen` (Claude Code workaround): snap.lines.length at apply.
-  //   Bottom-aligned writes mean the dump must read `linesLen` rows starting
-  //   at `(baseY + snapRows - linesLen)`, not snapRows rows from baseY —
-  //   otherwise the untouched top region produces false drift across every
-  //   row. Remove with the bottom-align workaround.
-  const appliedStateRef = useRef({ seq: 0, snapRows: 0, linesLen: 0, baseY: 0 });
+  // for dumpForSelfVerify. `baseY` is the scrollback offset at write-complete;
+  // using buf.baseY at dump time would drift if a background scrollback push
+  // advanced it between apply and dump.
+  const appliedStateRef = useRef({ seq: 0, snapRows: 0, baseY: 0 });
   const closeInputBarRef = useRef<() => void>(() => {});
   const showKeyboardRef = useRef<() => void>(() => {});
   const inputBarRef = useRef<InputBarRef>(null);
@@ -928,14 +920,7 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
       outputIdleTimer = setTimeout(() => dumpForSelfVerify('output-idle'), 300);
     };
 
-    // How many rows we last scrolled the viewport up to hide a trailing
-    // run of blank rows. We unwind this before deciding the next scroll
-    // amount so the offset stays accurate as the TUI's used-height
-    // shifts. 0 means viewport is naturally at the buffer's tail.
-    let lastAutoScrollLines = 0;
     const applied = appliedStateRef.current;
-    // Apply a snap-driven resize and re-propose container dims if they no
-    // longer match (forces server to re-send the new size).
     const applyResize = (cols: number, rows: number) => {
       term.resize(cols, rows);
       const fit = fitAddonRef.current;
@@ -953,43 +938,16 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
         if (term.cols !== snap.cols || term.rows !== snap.rows) {
           applyResize(snap.cols, snap.rows);
         }
-        // Honor snap as canonical (rewrite every row). Skip-unchanged
-        // logic produced ghost rows due to buffer-vs-grid mismatches
-        // (scrollback delta moves baseY, cached prev lags reality).
         const vt = snapshotToVTSequence(snap);
-        const offset = bottomAlignOffset(snap.rows, snap.lines.length);
         applied.snapRows = snap.rows;
-        applied.linesLen = snap.lines.length;
         applied.seq = snap.seq;
         const t0 = bench.recordWriteStart();
         term.write(vt, () => {
           bench.recordWriteEnd(t0, vt.length);
           applied.baseY = term.buffer.active.baseY;
-          // Auto-scroll: hide trailing blank rows by nudging the viewport
-          // up so scrollback fills the bottom instead of a black void.
-          // Reuses the bottom-align offset — when the server has already
-          // trimmed trailing blanks, offset === trailingBlanks count.
-          if (snap.modes.altScreen || offset <= 0) return;
-          const buf = term.buffer.active;
-          // Cap so the cursor row stays on-screen after scrolling.
-          const cursorMaxScroll = Math.max(0, term.rows - snap.cursor.y - 1);
-          const wantedScroll = Math.min(offset, cursorMaxScroll);
-          // User is considered "at bottom" if viewportY matches baseY
-          // (no auto-scroll active) or matches our previous offset.
-          const userAtBottom = buf.viewportY === buf.baseY
-            || buf.viewportY === buf.baseY - lastAutoScrollLines;
-          const haveScrollback = buf.baseY >= wantedScroll;
-          // Avoid bobbing on per-row jitter from typing/spinners.
-          const delta = Math.abs(wantedScroll - lastAutoScrollLines);
-          if (userAtBottom && haveScrollback && delta >= 3) {
-            if (lastAutoScrollLines > 0) term.scrollLines(lastAutoScrollLines);
-            if (wantedScroll > 0) term.scrollLines(-wantedScroll);
-            lastAutoScrollLines = wantedScroll;
-          }
         });
       } else {
-        const offset = bottomAlignOffset(applied.snapRows, applied.linesLen);
-        const { vt, size } = diffToVTSequence(event.ops, offset);
+        const { vt, size } = diffToVTSequence(event.ops);
         if (size && (term.cols !== size.cols || term.rows !== size.rows)) {
           applyResize(size.cols, size.rows);
         }
@@ -997,8 +955,6 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
           const t0 = bench.recordWriteStart();
           term.write(vt, () => bench.recordWriteEnd(t0, vt.length));
         }
-        // Diff's size op carries the new pane rows; linesLen stays since
-        // the server forces a full snapshot when it changes.
         if (size) applied.snapRows = size.rows;
         applied.seq = event.seq;
       }
@@ -1024,19 +980,12 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
     // Anchor to the baseY captured at write-completion time. Using
     // buf.baseY here would drift if anything advanced it (background
     // scrollback push, debounced resize) between snap apply and dump.
-    //
-    // TEMPORARY (Claude Code workaround): with bottom-aligned writes, the
-    // server's sentSnap.lines covers only the bottom `linesLen` rows of the
-    // grid, not the full snap.rows. Read the same window (anchor + offset
-    // .. anchor + offset + linesLen) so the comparison aligns; otherwise
-    // every row reports false drift against the untouched grid top.
     const applied = appliedStateRef.current;
-    const linesLen = applied.linesLen || term.rows;
-    const offset = bottomAlignOffset(applied.snapRows || term.rows, linesLen);
+    const snapRows = applied.snapRows || term.rows;
     const anchor = applied.baseY || buf.baseY;
     const lines: string[] = [];
-    for (let i = 0; i < linesLen; i++) {
-      lines.push(buf.getLine(anchor + offset + i)?.translateToString(true) ?? '');
+    for (let i = 0; i < snapRows; i++) {
+      lines.push(buf.getLine(anchor + i)?.translateToString(true) ?? '');
     }
     sendDebugDump(
       sessionId,
@@ -1194,7 +1143,7 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
     >
       {/* Terminal area */}
       <div
-        className={`flex-1 relative min-h-0${isTouchDevice ? ' select-none' : ''}`}
+        className={`flex-1 relative min-h-0 overflow-hidden${isTouchDevice ? ' select-none' : ''}`}
         onMouseUp={(e) => e.stopPropagation()}
       >
         <div

--- a/frontend/src/utils/snapshot-render.ts
+++ b/frontend/src/utils/snapshot-render.ts
@@ -1,99 +1,31 @@
 /**
- * Translate state-sync messages into VT sequences for xterm.js.
- *
- * The server treats `tmux capture-pane -e -p` as the canonical pane state.
- * Snapshots contain ANSI-decorated lines plus cursor and altscreen mode;
- * diffs contain row replacements, cursor moves, mode toggles, and size
- * changes. We render them by issuing equivalent VT sequences that xterm
- * already understands.
- *
- * No attempt is made to reconcile against xterm's internal buffer; the
- * server's snapshot is authoritative.
+ * Translate state-sync messages into VT sequences for xterm.js. The server
+ * is authoritative; we just issue equivalent VT writes — no reconciliation
+ * against xterm's internal buffer.
  */
 
 import type { DiffOp, PaneSnapshot } from '../../../shared/types';
 
-/**
- * TEMPORARY (Claude Code workaround): grid offset for bottom-aligned writes.
- * = snap.rows - snap.lines.length. See snapshotToVTSequence for details.
- * Remove with the rest of the bottom-align workaround.
- */
-export function bottomAlignOffset(rows: number, linesLen: number): number {
-  return Math.max(0, rows - linesLen);
-}
-
-
-/**
- * Build the VT byte sequence that re-renders a full snapshot.
- *
- * Sequence:
- *   1. hide cursor (avoid flicker during repaint)
- *   2. enter/exit altscreen as appropriate
- *   3. if not altscreen and snapshot carries scrollbackDelta: park cursor at
- *      the bottom row and emit each new line with CRLF — each newline at the
- *      bottom scrolls a row off the top into xterm's scrollback buffer
- *   4. for each row, cursor to (row,1), clear line, write content
- *   5. move cursor to the snapshot's recorded position, set visibility
- *
- * `forceClearAll` controls how blank rows are treated:
- *   - `true` (use on size changes / first snapshot): rewrite every row,
- *     blanks included. Ensures stale content from a previous larger
- *     geometry doesn't survive as "ghost lines".
- *   - `false` (steady state): skip the trailing run of blank rows so the
- *     previous snapshot's content is preserved there. This matches the
- *     byte-stream era's visual where Claude Code's unrepainted region
- *     stayed populated with the prior frame instead of going black.
- */
-/**
- * Build VT bytes for a snapshot.
- *
- * `prevLines` — what we previously wrote into xterm for this pane. If
- *   omitted (e.g. first paint or geometry change), every row is treated
- *   as changed.
- *
- * We always honor the snapshot as canonical: rows that changed are
- *   rewritten exactly, even when the new content is blank. Skipping
- *   blank rows leaves stale content drifting in xterm that the user
- *   sees as "ghost lines". The empty space below the prompt that some
- *   TUIs leave behind is handled by the caller's auto-scroll trick
- *   (see Terminal.tsx) rather than by hiding it here.
- */
-export function snapshotToVTSequence(
-  snapshot: PaneSnapshot,
-  _prevLines?: string[],
-): string {
+export function snapshotToVTSequence(snapshot: PaneSnapshot): string {
   let s = '';
   s += '\x1b[?25l';
   s += snapshot.modes.altScreen ? '\x1b[?1049h' : '\x1b[?1049l';
 
   const delta = snapshot.scrollbackDelta;
   if (!snapshot.modes.altScreen && delta && delta.length > 0) {
-    s += `\x1b[${snapshot.rows};1H`;
+    // Park at home so the delta fills the grid top-down, then each CRLF at
+    // the bottom row pushes one row into xterm's scrollback — the whole
+    // sequence ends up in scrollback (not blank rows from the initial grid).
+    s += '\x1b[1;1H';
     for (const line of delta) {
-      s += `\r\n\x1b[2K${line}`;
+      s += `${line}\r\n`;
     }
   }
 
-  // TEMPORARY (Claude Code workaround): snapshot.lines can be shorter than
-  // snapshot.rows because tmux capture-pane trims trailing blank rows that
-  // Claude TUI leaves unrendered. Write the lines bottom-aligned so the
-  // input area / status footer (always the last rendered rows) lands at the
-  // grid's bottom edge — matching the user's expectation of "prompt at the
-  // bottom of the terminal." Rows above the bottom-aligned content are left
-  // untouched so the previous frame (= scrollback / earlier render) remains
-  // visible there, avoiding the black void the trimmed bottom would
-  // otherwise create. Remove once Claude TUI fills the pane fully.
-  const linesLen = snapshot.lines.length;
-  const offset = bottomAlignOffset(snapshot.rows, linesLen);
-  for (let i = 0; i < linesLen; i++) {
-    s += `\x1b[${i + offset + 1};1H\x1b[2K${snapshot.lines[i] ?? ''}`;
+  for (let i = 0; i < snapshot.rows; i++) {
+    s += `\x1b[${i + 1};1H\x1b[2K${snapshot.lines[i] ?? ''}`;
   }
-  // Cursor: re-anchor to the bottom-aligned write position. If tmux's
-  // cursor.y points into the unrendered void region (cy >= linesLen), pin it
-  // to the last rendered row so the cursor remains visible on-screen.
-  const localCy = Math.min(snapshot.cursor.y, Math.max(0, linesLen - 1));
-  const gridCy = offset + localCy;
-  s += `\x1b[${gridCy + 1};${snapshot.cursor.x + 1}H`;
+  s += `\x1b[${snapshot.cursor.y + 1};${snapshot.cursor.x + 1}H`;
   s += snapshot.cursor.visible ? '\x1b[?25h' : '\x1b[?25l';
   return s;
 }
@@ -109,12 +41,6 @@ export function snapshotToVTSequence(
  */
 export function diffToVTSequence(
   ops: DiffOp[],
-  // TEMPORARY (Claude Code workaround): row offset for bottom-aligned write.
-  // Diff line ops are indexed within snapshot.lines (= pane top-aligned),
-  // but the client renders bottom-aligned, so each row index must be shifted
-  // by `offset = snap.rows - snap.lines.length` to address the correct grid
-  // row. Removed alongside the bottom-aligned write workaround.
-  offset = 0,
 ): { vt: string; size: { cols: number; rows: number } | null } {
   let s = '';
   let size: { cols: number; rows: number } | null = null;
@@ -129,16 +55,12 @@ export function diffToVTSequence(
         }
         break;
       case 'line':
-        s += `\x1b[${op.row + offset + 1};1H\x1b[2K${op.content}`;
+        s += `\x1b[${op.row + 1};1H\x1b[2K${op.content}`;
         break;
-      case 'cursor': {
-        // Cursor.y is also pane top-aligned; shift by offset to land on the
-        // bottom-aligned grid position.
-        const y = op.y + offset;
-        s += `\x1b[${y + 1};${op.x + 1}H`;
+      case 'cursor':
+        s += `\x1b[${op.y + 1};${op.x + 1}H`;
         s += op.visible ? '\x1b[?25h' : '\x1b[?25l';
         break;
-      }
     }
   }
   return { vt: s, size };


### PR DESCRIPTION
## Summary

Claude TUI が pane の下半分を描画しない問題で生じる **「黒い void」** を解消。 server が短い snap.lines を直前の scrollback で先頭埋め (prepend) して visible 全体を情報で満たします。 client 側は通常の top-aligned 描画のみで完結し、 bottom-aligned offset / dump anchor / EXTRA pane inflation / auto-scroll fallback を全部撤回しました。

## 変更点

### Server (`pane-snapshot.ts`)
- `captureScrollback()` helper を抽出 — initial scrollback delta と pad-fill 両方で共有
- `PadFillCache` を新設、 `historySize` 単位でキャッシュ。 毎 tick の tmux round-trip を削減
- 末尾 blank trim は `isVisuallyBlank` で統一 (ANSI escape のみの行も対象)

### Server (`terminal-mux.ts`)
- `MuxSubscription.lastPadFill` で per-pane キャッシュ管理
- `Awaited<ReturnType<typeof captureSnapshot>>` で結果型を一本化

### Client (`snapshot-render.ts`, `Terminal.tsx`)
- `bottomAlignOffset` / diff offset param / auto-scroll loop / `appliedSnapLinesLenRef` を撤回
- snap render は top-aligned で全行書き込み (snap canonical)
- Channel C dump は `applied.baseY` から `snap.rows` 行を素直に読み出し

### Server (`tmux-control.ts`)
- `applyClientSize()` の doc から削除済み path への参照を削除

## Net

`+115 / -236` — 簡素化方向。 残った workaround は全て TEMPORARY マーク + 「Claude TUI が pane を full に描画するようになったら削除」 の TODO 付き。

## Test plan

- [x] agent-browser で void なし + input area visible 確認
- [x] PWA mobile で void なし + scroll up で過去履歴見える
- [x] drift log mismatchCount=0 維持
- [x] backend reload で WebSocket 再接続後も正常