### PR TITLE
Release v0.1.111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.111] - 2026-05-17
+
+### Fixed
+- Claude TUI が pane の下半分を描画しないことによる「黒い void」 を解消 (#152)
+  - server が短い snap.lines を直前の scrollback で先頭埋め (prepend) して visible 全体を情報で満たす
+  - `PadFillCache` を historySize 単位でキャッシュし、 毎 tick の追加 tmux round-trip を回避
+  - 末尾 blank trim を `isVisuallyBlank` で統一 (ANSI escape のみの行も対象)
+
+### Changed
+- state-sync renderer を大幅 simplify (#152)
+  - `bottomAlignOffset` / diff offset / auto-scroll fallback / EXTRA pane inflation を撤回
+  - snap render は top-aligned で全行書き込み (snap canonical)
+  - Channel C dump は `applied.baseY` から `snap.rows` 行を素直に読み出し
+  - 差分: `+115 / -236` の縮減
+
+### Docs
+- アーキテクチャドキュメント (architecture.json / .html) を state-sync 化 + scrollback prepend pad に追従 (#151)
+
 ## [0.1.110] - 2026-05-17
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.110",
+  "version": "0.1.111",
   "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.110",
+  "version": "0.1.111",
   "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.110",
+  "version": "0.1.111",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary

void-bottom 解消 + state-sync renderer 大幅 simplify。

### 主な変更
- **fix**: Claude TUI の void-bottom 問題を scrollback prepend pad で解消 (#152)
- **chore**: state-sync renderer simplify (bottom-aligned 系撤回、 `+115/-236`)
- **docs**: architecture を state-sync + scrollback pad に追従 (#151)

### Test plan
- [x] PWA mobile / agent-browser desktop で void なし + input area visible 確認
- [x] drift log mismatchCount=0 維持
- [x] backend reload で再接続正常