### PR TITLE
Fix terminal state sync for continuous output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+Use `CLAUDE.md` as the single source of repository guidance.
+
+Use `.claude/skills/` and `.claude/commands/` as the single source for repository skills and commands. Do not create parallel Codex-specific copies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Codex and other coding agents should use this file as the single source of repository guidance; `AGENTS.md` only points here.
+
 ## Project Overview
 
 CC Hub is a web-based terminal session manager for Claude Code. It runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -354,7 +354,7 @@ function scheduleSnapshot(
   paneId: string,
 ) {
   const existing = sub.snapshotTimers.get(paneId);
-  if (existing) clearTimeout(existing);
+  if (existing) return;
   const timer = setTimeout(() => {
     sub.snapshotTimers.delete(paneId);
     void emitSnapshot(ws, sessionId, sub, paneId);
@@ -406,25 +406,14 @@ async function emitSnapshot(
     return;
   }
 
-  // Scrollback can only be carried on a full snapshot (it must be applied
-  // before the visible region is rewritten).
-  if (hasScrollback) {
-    console.log(`[mux] state-snapshot pane=${paneId} seq=${snapshot.seq} scrollbackDelta=${snapshot.scrollbackDelta?.length ?? 0} rows=${snapshot.rows}`);
-    try {
-      ws.send(JSON.stringify({ type: 'state-snapshot', sessionId, snapshot }));
-    } catch { return; }
-  } else {
-    try {
-      ws.send(JSON.stringify({
-        type: 'state-diff',
-        sessionId,
-        paneId,
-        base: prev.seq,
-        seq: snapshot.seq,
-        ops,
-      }));
-    } catch { return; }
-  }
+  // Send full snapshots for every visible change. Diff application is fragile
+  // when terminal apps redraw partial normal-screen regions while xterm.js has
+  // local scrollback/baseY state; users then see stale content until reload.
+  // A full snapshot is the same recovery path as reload, but applied live.
+  console.log(`[mux] state-snapshot pane=${paneId} seq=${snapshot.seq} scrollbackDelta=${snapshot.scrollbackDelta?.length ?? 0} rows=${snapshot.rows}`);
+  try {
+    ws.send(JSON.stringify({ type: 'state-snapshot', sessionId, snapshot }));
+  } catch { return; }
   sub.serverSnapshots.set(paneId, snapshot);
 }
 

--- a/backend/src/services/pane-snapshot.ts
+++ b/backend/src/services/pane-snapshot.ts
@@ -102,6 +102,9 @@ export async function captureSnapshot(
 
   let linesRaw: string;
   try {
+    // capture-pane without -a captures the pane's currently visible screen,
+    // including full-screen TUIs such as htop and Codex. `-a` reads tmux's
+    // alternate buffer explicitly and may return the screen behind the TUI.
     linesRaw = await cs.sendCommand(`capture-pane -e -p -t ${paneId}`);
   } catch {
     return null;

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -945,6 +945,9 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
         term.write(vt, () => {
           bench.recordWriteEnd(t0, vt.length);
           applied.baseY = term.buffer.active.baseY;
+          term.scrollToBottom();
+          setScrollIndicator(null);
+          if (scrollIndicatorTimerRef.current) clearTimeout(scrollIndicatorTimerRef.current);
         });
       } else {
         const { vt, size } = diffToVTSequence(event.ops);
@@ -953,7 +956,10 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
         }
         if (vt.length > 0) {
           const t0 = bench.recordWriteStart();
-          term.write(vt, () => bench.recordWriteEnd(t0, vt.length));
+          term.write(vt, () => {
+            bench.recordWriteEnd(t0, vt.length);
+            term.scrollToBottom();
+          });
         }
         if (size) applied.snapRows = size.rows;
         applied.seq = event.seq;


### PR DESCRIPTION
## Summary
- throttle tmux state snapshot scheduling so continuous output cannot starve updates
- send full terminal snapshots for visible changes to avoid stale xterm buffers
- keep xterm viewport pinned to the bottom after snapshot writes
- add AGENTS.md as a pointer to CLAUDE.md for Codex/agent guidance

## Tests
- bun run typecheck
- bun run test