### PR TITLE
Release v0.1.113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.113] - 2026-05-17
+
+### Fixed
+- WebSocket が `CONNECTING` のまま長時間固まり「WebSocket connection error」+「Connecting...」表示で操作不能になる問題を修正
+  - 10秒の接続 watchdog を追加し、`onopen` が発火しなければ強制クローズして既存の再接続経路を起動
+  - `pong` の応答が25秒以上途絶えた OPEN ソケットを silently dead とみなし強制クローズ
+  - `window` の `online` イベントで stale な socket を強制クローズしてから即時再接続
+  - タブ復帰時 (`visibilitychange`) に `CONNECTING` が3秒超なら即座に強制クローズして再試行
+
+### Changed
+- サーバ側 WebSocket の `idleTimeout` を 120 秒から 60 秒に短縮し、死亡セッションの掃除を倍速化
+
 ## [0.1.112] - 2026-05-17
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -364,7 +364,7 @@ export default {
     close(ws: import('bun').ServerWebSocket<MuxData>, code: number, reason: string) {
       if (ws.data?.mux) return muxClose(ws, code, reason);
     },
-    idleTimeout: 120,
+    idleTimeout: 60,
     sendPings: true,
   },
 };

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -55,8 +55,23 @@ const getAuthToken = (): string | null => {
 let sharedWs: WebSocket | null = null;
 let sharedPingInterval: number | null = null;
 let sharedReconnectTimeout: number | null = null;
+let sharedConnectWatchdog: number | null = null;
+let sharedWsConnectStart = 0;
+let sharedLastPongAt = 0;
 let subscribedSession: string | null = null;
 let wsReady = false;
+
+// Force-close a CONNECTING socket if onopen hasn't fired by this deadline.
+// Mobile networks can leave the TCP handshake in a zombie state — no onopen,
+// no onclose — and the existing `ensureConnection()` would early-return on
+// CONNECTING forever. The watchdog turns the silent hang into an explicit
+// close, letting the onclose reconnect path take over.
+const CONNECT_WATCHDOG_MS = 10_000;
+const PING_INTERVAL_MS = 10_000;
+// Force-close OPEN socket if no pong reply for this long. Catches "silently
+// dead" connections where the OS hasn't yet noticed the TCP is gone (common
+// on mobile when carrier NAT drops the session).
+const PONG_TIMEOUT_MS = 25_000;
 // Channel C: when the server (CCHUB_SELF_VERIFY=1) accepts our subscription,
 // it includes selfVerifyEnabled=true so we know to start streaming debug-dump
 // messages. Stays false on production builds.
@@ -124,13 +139,23 @@ function subscribeToSession(sessionId: string, force = false) {
 }
 
 function ensureConnection(token?: string | null) {
-  if (sharedWs && (sharedWs.readyState === WebSocket.OPEN || sharedWs.readyState === WebSocket.CONNECTING)) {
-    return;
+  if (sharedWs?.readyState === WebSocket.OPEN) return;
+
+  if (sharedWs?.readyState === WebSocket.CONNECTING) {
+    const elapsed = Date.now() - sharedWsConnectStart;
+    if (elapsed < CONNECT_WATCHDOG_MS) return;
+    console.warn(`[MUX] stale CONNECTING (${elapsed}ms); force closing for retry`);
+    try { sharedWs.close(); } catch {}
+    sharedWs = null;
   }
 
   if (sharedReconnectTimeout) {
     clearTimeout(sharedReconnectTimeout);
     sharedReconnectTimeout = null;
+  }
+  if (sharedConnectWatchdog) {
+    clearTimeout(sharedConnectWatchdog);
+    sharedConnectWatchdog = null;
   }
 
   let wsUrl = `${getWsBase()}/ws/mux`;
@@ -142,17 +167,35 @@ function ensureConnection(token?: string | null) {
   const ws = new WebSocket(wsUrl);
   sharedWs = ws;
   wsReady = false;
+  sharedWsConnectStart = Date.now();
+
+  sharedConnectWatchdog = window.setTimeout(() => {
+    if (sharedWs === ws && ws.readyState === WebSocket.CONNECTING) {
+      console.warn('[MUX] connect watchdog timed out; force closing CONNECTING socket');
+      try { ws.close(); } catch {}
+    }
+    sharedConnectWatchdog = null;
+  }, CONNECT_WATCHDOG_MS);
 
   ws.onopen = () => {
     console.log('[MUX] WebSocket opened');
+    if (sharedConnectWatchdog) {
+      clearTimeout(sharedConnectWatchdog);
+      sharedConnectWatchdog = null;
+    }
+    sharedLastPongAt = Date.now();
 
     if (sharedPingInterval) clearInterval(sharedPingInterval);
     sharedPingInterval = window.setInterval(() => {
-      if (ws.readyState === WebSocket.OPEN) {
-        const sid = activeCallbacks?.sessionId || '';
-        ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now(), sessionId: sid }));
+      if (ws.readyState !== WebSocket.OPEN) return;
+      if (Date.now() - sharedLastPongAt > PONG_TIMEOUT_MS) {
+        console.warn(`[MUX] pong timeout (${Date.now() - sharedLastPongAt}ms); force closing socket`);
+        try { ws.close(); } catch {}
+        return;
       }
-    }, 10_000);
+      const sid = activeCallbacks?.sessionId || '';
+      ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now(), sessionId: sid }));
+    }, PING_INTERVAL_MS);
   };
 
   let wsMsgCount = 0;
@@ -236,6 +279,7 @@ function ensureConnection(token?: string | null) {
         break;
       }
       case 'pong': {
+        sharedLastPongAt = Date.now();
         const rtt = Date.now() - (msg.timestamp as number);
         reportWsLatency(rtt);
         break;
@@ -278,6 +322,10 @@ function ensureConnection(token?: string | null) {
   ws.onclose = (event) => {
     console.log(`[MUX] WebSocket closed: code=${event.code} reason=${event.reason} msgs=${wsMsgCount}`);
     clearInterval(bytesTimer);
+    if (sharedConnectWatchdog) {
+      clearTimeout(sharedConnectWatchdog);
+      sharedConnectWatchdog = null;
+    }
     if (sharedWs !== ws) return;
 
     sharedWs = null;
@@ -315,7 +363,33 @@ function registerVisibilityListener() {
         sharedReconnectTimeout = null;
       }
       ensureConnection();
+      return;
     }
+    // Returning to tab: if CONNECTING is older than a short threshold (3s),
+    // assume the handshake stalled while backgrounded and force a fresh attempt
+    // without waiting the full watchdog window.
+    if (sharedWs.readyState === WebSocket.CONNECTING && Date.now() - sharedWsConnectStart > 3000) {
+      console.warn('[MUX] visibility-change: stale CONNECTING, forcing reconnect');
+      try { sharedWs.close(); } catch {}
+    }
+  });
+
+  // Network status: when the OS reports the network came back, force a fresh
+  // connection check. Without this, a stale OPEN socket left over from a
+  // dropped cellular session can sit unnoticed until the next ping/pong fails.
+  window.addEventListener('online', () => {
+    console.log('[MUX] navigator online; refreshing connection');
+    if (sharedWs?.readyState === WebSocket.CONNECTING || sharedWs?.readyState === WebSocket.OPEN) {
+      try { sharedWs.close(); } catch {}
+    }
+    if (sharedReconnectTimeout) {
+      clearTimeout(sharedReconnectTimeout);
+      sharedReconnectTimeout = null;
+    }
+    ensureConnection();
+  });
+  window.addEventListener('offline', () => {
+    console.log('[MUX] navigator offline');
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- WebSocket が CONNECTING のまま固まる問題に対し、接続 watchdog / pong timeout / online listener を追加
- サーバ側 WebSocket `idleTimeout` を 120s → 60s に短縮

## Changes
- fix: 10秒の接続 watchdog で stale CONNECTING を強制復帰
- fix: 25秒の pong タイムアウトで silently dead な OPEN ソケットを撤去
- fix: `online` イベントでネットワーク復帰時に即時再接続
- fix: タブ復帰時 stale CONNECTING (>3s) を強制クローズ
- chore: サーバ idleTimeout 120s → 60s

## Test plan
- [x] dev 環境で初回接続確認
- [x] バックエンド kill → Connecting... 表示確認
- [x] バックエンド復活 → 自動再接続成功
- [x] ターミナル内容の復元確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)