### PR TITLE
Release v0.1.114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.114] - 2026-05-17
+
+### Changed
+- デスクトップのセッションモーダル (Ctrl+B) とダッシュボードパネル (Ctrl+Shift+B) を 1.25 倍に拡大し、Mac などの高 DPI モニタでも読みやすく
+  - タブレットには影響なし (`isTablet` 時は zoom 適用なし)
+
 ## [0.1.113] - 2026-05-17
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/components/DashboardPanel.tsx
+++ b/frontend/src/components/DashboardPanel.tsx
@@ -5,15 +5,24 @@ import { Dashboard } from "./dashboard/Dashboard";
 interface DashboardPanelProps {
 	isOpen: boolean;
 	onClose: () => void;
+	isTablet?: boolean;
 }
 
-export function DashboardPanel({ isOpen, onClose }: DashboardPanelProps) {
+export function DashboardPanel({ isOpen, onClose, isTablet }: DashboardPanelProps) {
 	const { t } = useTranslation();
 
 	if (!isOpen) return null;
 
+	// Desktop typography is too small for monitor viewing distance — scale the
+	// panel up. Tablets stay at native size so finger reach areas aren't
+	// distorted.
+	const desktopZoom = isTablet ? undefined : { zoom: 1.25 };
+
 	return (
-		<div className="w-[360px] xl:w-[420px] 2xl:w-[480px] shrink-0 flex flex-col bg-th-bg border-l border-th-border z-[60]">
+		<div
+			className="w-[360px] xl:w-[420px] 2xl:w-[480px] shrink-0 flex flex-col bg-th-bg border-l border-th-border z-[60]"
+			style={desktopZoom}
+		>
 			{/* Header */}
 			<div className="shrink-0 px-4 pt-3 pb-3 border-b border-white/[0.06]">
 				<div className="flex items-center justify-between max-w-lg">

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -1239,6 +1239,7 @@ export function DesktopLayout({
       <DashboardPanel
         isOpen={showDashboard}
         onClose={() => setShowDashboard(false)}
+        isTablet={isTablet}
       />
 
       {/* Session modal */}
@@ -1246,6 +1247,7 @@ export function DesktopLayout({
         isOpen={showSessionModal}
         onClose={() => setShowSessionModal(false)}
         onSelectSession={handleModalSelectSession}
+        isTablet={isTablet}
       />
 
       {/* File Viewer Modal - per-session instances kept mounted */}

--- a/frontend/src/components/SessionModal.tsx
+++ b/frontend/src/components/SessionModal.tsx
@@ -6,12 +6,14 @@ interface SessionModalProps {
 	isOpen: boolean;
 	onClose: () => void;
 	onSelectSession: (session: SessionResponse) => void;
+	isTablet?: boolean;
 }
 
 export function SessionModal({
 	isOpen,
 	onClose,
 	onSelectSession,
+	isTablet,
 }: SessionModalProps) {
 	// Close on Escape
 	useEffect(() => {
@@ -37,8 +39,12 @@ export function SessionModal({
 
 	if (!isOpen) return null;
 
+	// Desktop only: scale up. Tablet keeps native size so touch targets are
+	// unchanged.
+	const desktopZoom = isTablet ? undefined : { zoom: 1.25 };
+
 	return (
-		<div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0a]">
+		<div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0a]" style={desktopZoom}>
 			<div className="flex-1 min-h-0 overflow-hidden w-full h-full">
 				<SessionList
 					onSelectSession={handleSelectSession}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- デスクトップのセッションモーダル/ダッシュボードパネルが高DPIで小さく見える問題に対応
- 1.25 倍に拡大、タブレットには影響なし

## Changes
- chore: SessionModal / DashboardPanel を desktop 時のみ zoom 1.25

## Test plan
- [x] dev でセッションモーダル拡大確認
- [x] dev でダッシュボード拡大確認
- [x] タブレットには未適用 (`isTablet` ガード)

🤖 Generated with [Claude Code](https://claude.com/claude-code)