### PR TITLE
Release v0.1.115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.115] - 2026-05-17
+
+### Added
+- デスクトップの選択モード（マウス長押しで起動）に Enter / Esc キーバインドを追加
+  - Enter: 選択範囲を OS クリップボードにコピー＋モード終了
+  - Esc: コピーせずモード終了
+
 ## [0.1.114] - 2026-05-17
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "generated": "2026-05-17",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1075,6 +1075,27 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
     checkAndExitCopyMode();
   }, [inputMode, sessionId]);
 
+  // Desktop selection mode (activated by mouse long-press) — Enter to copy and
+  // exit, Esc to cancel. Touch devices keep using the SelectionOverlay buttons.
+  useEffect(() => {
+    if (!selection.selectionMode) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        selection.handleCopySelection();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        selection.exitSelectionMode();
+      }
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, [selection.selectionMode, selection.handleCopySelection, selection.exitSelectionMode]);
+
   // Show font size indicator
   useEffect(() => {
     if (isInitialized) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- デスクトップ選択モード (マウス長押しで起動) にキーバインド追加
  - Enter: OS クリップボードへコピー & モード終了
  - Esc: モード終了 (コピーなし)

## Changes
- feat: SelectionOverlay の代わりに Enter/Esc で操作可能に

## Test plan
- [x] dev で長押し選択 → Enter でクリップボードコピー確認
- [x] dev で長押し選択 → Esc でキャンセル確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)