### PR TITLE
Release v0.1.117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.117] - 2026-05-18
+
+### Fixed
+- state-snapshot 送信が pane あたり最大 ~20/sec で連続発火し cchub が CPU 150% 以上を消費する問題を修正 (#162)
+  - `SNAPSHOT_MIN_INTERVAL_MS=100` の hard rate-limit を導入し、連続 `%output` 下でも 1 pane あたり最大 ~10/sec に制限
+  - 初回 (idle 後) snapshot は従来通り 50ms debounce 後に送信されるためタイピングレイテンシは維持
+- `[mux] state-snapshot ...` の詳細ログを `DEBUG_MUX=1` 配下に隔離し、journald への書き込み量を削減
+
 ## [0.1.116] - 2026-05-18
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,8 +113,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.115",
-  "generated": "2026-05-17",
+  "version": "0.1.117",
+  "generated": "2026-05-18",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.115",
-  "generated": "2026-05-17",
+  "version": "0.1.117",
+  "generated": "2026-05-18",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: state-snapshot 送信を pane あたり最大 ~10/sec に rate-limit (#162) — cchub の CPU 150%+ 暴走を解消
- chore: `[mux] state-snapshot ...` ログを `DEBUG_MUX=1` 配下に隔離

## Notes
本番 v0.1.116 で報告された「cchub プロセスが 108–158% CPU を消費し state-snapshot ログが 10–15 行/sec で出続ける」問題への対応。