### PR TITLE
perf: lower state-snapshot emit cap to 5/sec/pane

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -30,7 +30,10 @@ const SNAPSHOT_DEBOUNCE_MS = 50;
 // runs tmux display-message + capture-pane and serializes a full snapshot
 // (~10 KB) to JSON, so removing the upper bound let an actively-redrawing
 // pane consume 150% CPU.
-const SNAPSHOT_MIN_INTERVAL_MS = 100;
+// 200ms = 5/sec/pane. The first post-idle snapshot still fires after the
+// 50ms debounce so typing latency is unaffected; only sustained redraws
+// (spinners, log tails) hit this ceiling.
+const SNAPSHOT_MIN_INTERVAL_MS = 200;
 
 // Verbose per-snapshot logging is gated behind DEBUG_MUX=1. At 10+ emits/sec
 // per pane the journald cost is non-trivial; the [tmux-control] perf summary


### PR DESCRIPTION
## Summary

Tune \`SNAPSHOT_MIN_INTERVAL_MS\` from 100ms (10/sec) → 200ms (5/sec) per pane.

## Background

v0.1.117 (#162) capped snapshot emit at 10/sec/pane, bringing cchub CPU from ~158% → ~127% under continuous TUI redraws. Per-emit cost (display-message + capture-pane + 10 KB JSON + WS send) is still significant. Halving the cap should roughly halve the residual CPU.

Typing latency is unchanged (50ms debounce on first post-idle output). Only sustained redraws (spinners, log tails) cap at 5fps.

## Test plan

- [x] \`bun run test\` — 165+23 pass
- [ ] Verify production CPU drop post-release