### PR TITLE
Release v0.1.118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.118] - 2026-05-18
+
+### Changed
+- state-snapshot の per-pane emit cap を 100ms (10/sec) → 200ms (5/sec) に変更 (#164)
+  - v0.1.117 でも cchub CPU が ~127% 残存していたため、レート制限を倍に強化
+  - 初回 (idle 後) snapshot は 50ms debounce のままなのでタイピングレイテンシは不変
+  - 連続再描画 (スピナー / log tail) のみ 5fps に頭打ち
+
 ## [0.1.117] - 2026-05-18
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "generated": "2026-05-18",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "generated": "2026-05-18",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- perf: state-snapshot emit cap を 10/sec → 5/sec/pane に変更 (#164)

## Notes
v0.1.117 の rate-limit (10/sec) でも CPU が 127% 残存していたため、上限をさらに半減。スピナーは 5fps に頭打ちだがタイピング応答性は不変。

期待効果: 本番 CPU 127% → 60-70%