### PR TITLE
perf: hook hot-path + fix: terminal scroll lockup during output

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -53,6 +53,12 @@ app.use('*', logger((message, ...rest) => {
   if (message.includes('GET') && message.includes('/api/sessions') && !message.includes('/api/sessions/')) {
     return;
   }
+  // Skip POST /api/notify hook traffic — fires on every Claude/Codex hook
+  // event (Stop, PreToolUse, PostToolUse, UserPromptSubmit, ...). At ~1/sec
+  // during active sessions the logger middleware itself was ~5% of CPU.
+  if (message.includes('/api/notify') && !message.includes('/api/notify/')) {
+    return;
+  }
   console.log(message, ...rest);
 }));
 app.use('*', cors({

--- a/backend/src/routes/notify.ts
+++ b/backend/src/routes/notify.ts
@@ -1,19 +1,37 @@
 import { Hono } from 'hono';
-import { readFile } from 'node:fs/promises';
 import { broadcastToMuxClients } from './terminal-mux';
 import type { IndicatorState } from '../../../shared/types';
 import { getHookStatus } from '../services/hook-status';
 
+// Read only the trailing slice of a transcript instead of the whole file.
+// Active Claude sessions produce multi-MB .jsonl transcripts; the previous
+// "readFile + split('\\n')" path showed up at ~16% of CPU in profiling
+// because every hook event re-parsed the entire history.
+// 256 KB is enough to comfortably contain 50 trailing JSONL entries even
+// for entries with large tool_result blocks.
+const TRANSCRIPT_TAIL_BYTES = 256 * 1024;
+
+async function readTrailingLines(path: string, lineCount: number): Promise<string[]> {
+  const file = Bun.file(path);
+  const size = file.size;
+  if (size === 0) return [];
+  const offset = Math.max(0, size - TRANSCRIPT_TAIL_BYTES);
+  const slice = offset === 0 ? file : file.slice(offset);
+  const content = await slice.text();
+  const lines = content.split('\n');
+  // The first line may be a partial JSONL record when we sliced mid-file;
+  // drop it so JSON.parse below doesn't fail on a truncated entry.
+  if (offset > 0) lines.shift();
+  return lines.slice(-lineCount);
+}
+
 /** transcriptファイルからコンテキストに応じた通知メッセージを生成する */
 async function generateSmartMessage(transcriptPath: string, _event: string): Promise<string | undefined> {
   try {
-    const content = await readFile(transcriptPath, 'utf-8');
-    const lines = content.trim().split('\n');
-
-    // 最後の50行を解析（パフォーマンスのため）
-    const recentLines = lines.slice(-50);
+    const recentLines = await readTrailingLines(transcriptPath, 50);
     const entries = [];
     for (const line of recentLines) {
+      if (!line) continue;
       try { entries.push(JSON.parse(line)); } catch {}
     }
 

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -933,6 +933,12 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
     const cleanup = cm.registerOnRender((event) => {
       const term = terminalRef.current;
       if (!term) return;
+      // Capture scroll position BEFORE writing the new state. If the user
+      // has scrolled up to read history, snapshot writes should not yank
+      // them back to the bottom — only auto-scroll if they were already
+      // pinned to the live edge.
+      const preBuf = term.buffer.active;
+      const wasAtBottom = preBuf.viewportY >= preBuf.baseY;
       if (event.type === 'snapshot') {
         const snap = event.snapshot;
         if (term.cols !== snap.cols || term.rows !== snap.rows) {
@@ -945,9 +951,11 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
         term.write(vt, () => {
           bench.recordWriteEnd(t0, vt.length);
           applied.baseY = term.buffer.active.baseY;
-          term.scrollToBottom();
-          setScrollIndicator(null);
-          if (scrollIndicatorTimerRef.current) clearTimeout(scrollIndicatorTimerRef.current);
+          if (wasAtBottom) {
+            term.scrollToBottom();
+            setScrollIndicator(null);
+            if (scrollIndicatorTimerRef.current) clearTimeout(scrollIndicatorTimerRef.current);
+          }
         });
       } else {
         const { vt, size } = diffToVTSequence(event.ops);
@@ -958,7 +966,7 @@ export const TerminalComponent = memo(forwardRef<TerminalRef, TerminalProps>(fun
           const t0 = bench.recordWriteStart();
           term.write(vt, () => {
             bench.recordWriteEnd(t0, vt.length);
-            term.scrollToBottom();
+            if (wasAtBottom) term.scrollToBottom();
           });
         }
         if (size) applied.snapRows = size.rows;


### PR DESCRIPTION
## Summary

Three fixes addressing the same root user complaint: cchub at ~124% CPU **and** un-scrollable terminal during active sessions.

| # | Fix | File | Effect |
|---|-----|------|--------|
| A | \`generateSmartMessage\` reads only last 256 KB of transcript via \`Bun.file().slice()\` | \`backend/src/routes/notify.ts\` | -~15% CPU (\`stringSplitFast\` 17.1% → near 0) |
| B | Hono logger skips \`POST /api/notify\` like it already skips \`/api/sessions\` | \`backend/src/index.ts\` | -~5% CPU (\`async log\` 5.1% → near 0) |
| C | Auto-scroll-to-bottom only when user was already at the live edge | \`frontend/src/components/Terminal.tsx\` | terminal becomes scrollable while output is streaming |

## Background

After v0.1.118 snapshot rate-limit (5/sec) cchub stayed at ~124% CPU. CPU profiling (\`bun --cpu-prof\`) identified hook handling as the dominant cost: every Claude/Codex hook event POSTs to \`/api/notify\` → \`generateSmartMessage\` was reading the full multi-MB transcript JSONL and splitting on '\\n', plus the Hono request logger formatted every \"<-- POST / --> POST\" pair.

Separately, with snapshots now arriving at 5/sec, \`term.scrollToBottom()\` was firing on every snapshot apply — so any user scroll-up was reverted within 200ms.

## Expected impact

- CPU: ~124% → ~95-105%
- UX: scrolling up to read history works even during active TUI output

## Test plan

- [x] \`bunx tsc -p backend --noEmit\` — clean
- [x] \`bun run test\` — backend 165 pass / frontend 23 pass
- [ ] Post-release: re-profile to confirm hooks drop out of top 10
- [ ] Post-release: manually scroll up in active terminal, verify it stays scrolled