### PR TITLE
chore: gitignore profiles/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ frontend/dev-dist/
 
 # Claude Code user prompt history (local only)
 .claude-user-prompts/
+profiles/


### PR DESCRIPTION
\`bun --cpu-prof\` (used during the v0.1.119 perf investigation) writes \`CPU.*.cpuprofile\` and \`CPU.*.md\` to the cwd. Keep a dedicated \`profiles/\` directory out of source control so future profiling sessions can drop files there without polluting \`git status\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)