### PR TITLE
Release v0.1.120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.120] - 2026-05-18
+
+### Added
+- ダッシュボードに UI 拡大率設定を追加 (80% / 90% / 100% / 115% / 130%)
+  - `<html>` の `font-size` を経由して Tailwind の rem ベース要素 (Dashboard / SessionList / FileViewer / アイコン) を一括スケール
+  - xterm.js は独自フォント設定のためターミナル本文には影響せず、Terminal の Cmd+= / Cmd+- とは独立して制御可能
+  - 設定は `localStorage['cchub-ui-scale']` に永続化、FOUC を防ぐため `main.tsx` で early apply
+
+### Fixed
+- Welcome セッション作成時に `cd '~' && claude` が `cd: no such file or directory: ~` で失敗していた問題を修正
+  - `agentStartCommand` / resume command で `shellQuote` 前に `~` / `~/...` を `homedir()` に展開する `expandHome()` ヘルパーを追加
+
 ## [0.1.119] - 2026-05-18
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "generated": "2026-05-18",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "generated": "2026-05-18",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { homedir } from 'node:os';
 import { AGENT_PROVIDERS, AGENT_PROVIDER_IDS, CreateSessionSchema, DEFAULT_AGENT_PROVIDER, PaneIdSchema, agentResumeCommand, agentSupportsConversationMetadata, type AgentProvider, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
 import { TmuxService } from '../services/tmux';
 import { controlSessions, getOrCreateControlSession } from '../services/tmux-control';
@@ -24,8 +25,14 @@ export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+export function expandHome(value: string): string {
+  if (value === '~') return homedir();
+  if (value.startsWith('~/')) return `${homedir()}${value.slice(1)}`;
+  return value;
+}
+
 export function agentStartCommand(agent: AgentProvider, workingDir: string): string {
-  return `cd ${shellQuote(workingDir)} && ${AGENT_PROVIDERS[agent].command}`;
+  return `cd ${shellQuote(expandHome(workingDir))} && ${AGENT_PROVIDERS[agent].command}`;
 }
 
 export function findDuplicateAgentWorkingDirSession<T extends { agent?: string; currentCommand?: string; currentPath?: string }>(
@@ -543,7 +550,7 @@ sessions.post('/history/resume', async (c) => {
     await tmuxService.createSession(tmuxSessionName);
 
     // Change to project directory and run the agent's resume command
-    const command = `cd ${shellQuote(projectPath)} && ${agentResumeCommand(agent, sessionId)}`;
+    const command = `cd ${shellQuote(expandHome(projectPath))} && ${agentResumeCommand(agent, sessionId)}`;
     const success = await tmuxService.sendKeys(tmuxSessionName, command);
 
     if (!success) {

--- a/backend/tests/unit/agent-providers.test.ts
+++ b/backend/tests/unit/agent-providers.test.ts
@@ -7,7 +7,8 @@ import {
   agentSupportsConversationMetadata,
   detectAgentProviderFromArgs,
 } from '../../../shared/types';
-import { agentStartCommand, findDuplicateAgentWorkingDirSession, shellQuote } from '../../src/routes/sessions';
+import { homedir } from 'node:os';
+import { agentStartCommand, expandHome, findDuplicateAgentWorkingDirSession, shellQuote } from '../../src/routes/sessions';
 
 describe('Agent provider registry', () => {
   test('derives provider IDs from the registry', () => {
@@ -57,6 +58,14 @@ describe('Agent provider registry', () => {
     expect(shellQuote('/tmp/plain path')).toBe("'/tmp/plain path'");
     expect(shellQuote("/tmp/it's-here")).toBe("'/tmp/it'\\''s-here'");
     expect(agentStartCommand('codex', "/tmp/it's-here")).toBe("cd '/tmp/it'\\''s-here' && codex");
+  });
+
+  test('expands ~ to the home directory before quoting', () => {
+    expect(expandHome('~')).toBe(homedir());
+    expect(expandHome('~/foo')).toBe(`${homedir()}/foo`);
+    expect(expandHome('/abs/path')).toBe('/abs/path');
+    expect(expandHome('~user/foo')).toBe('~user/foo');
+    expect(agentStartCommand('claude', '~')).toBe(`cd '${homedir()}' && claude`);
   });
 
   test('detects duplicate working directories only for the same agent', () => {

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -9,6 +9,7 @@ import { HourlyHeatmap } from './HourlyHeatmap';
 import { NetworkLatency } from './NetworkLatency';
 import { ServerInfo } from './ServerInfo';
 import { useTheme } from '../../hooks/useTheme';
+import { useUiScale } from '../../hooks/useUiScale';
 
 // Onboarding localStorage keys
 const ONBOARDING_KEY = 'cchub-onboarding-completed';
@@ -25,6 +26,7 @@ export function Dashboard({ className = '', compact = false }: DashboardProps) {
   const { t, i18n } = useTranslation();
   const { data, isLoading, error } = useDashboard(30000);
   const { theme, toggleTheme } = useTheme();
+  const { scale: uiScale, setScale: setUiScale, options: uiScaleOptions } = useUiScale();
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [cacheClearing, setCacheClearing] = useState(false);
   const [agentTab, setAgentTab] = useState<AgentTab>('claude');
@@ -195,6 +197,33 @@ export function Dashboard({ className = '', compact = false }: DashboardProps) {
           >
             {cacheClearing ? t('common.loading') : t('dashboard.clearCache')}
           </button>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2 max-w-lg">
+          <span className="text-[12px] text-zinc-500">{t('appearance.uiScale')}</span>
+          <div
+            className="inline-flex items-center rounded-md bg-white/[0.04] p-0.5"
+            role="group"
+            aria-label={t('appearance.uiScale')}
+          >
+            {uiScaleOptions.map((opt) => {
+              const isActive = Math.abs(uiScale - opt) < 0.001;
+              return (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() => setUiScale(opt)}
+                  aria-pressed={isActive}
+                  className={`px-2.5 py-1 text-[12px] rounded transition-colors ${
+                    isActive
+                      ? 'bg-white/[0.10] text-zinc-200'
+                      : 'text-zinc-500 hover:text-zinc-300'
+                  }`}
+                >
+                  {Math.round(opt * 100)}%
+                </button>
+              );
+            })}
+          </div>
         </div>
         {data?.version && (
           <div className="text-[11px] text-zinc-700 mt-3">

--- a/frontend/src/hooks/useUiScale.ts
+++ b/frontend/src/hooks/useUiScale.ts
@@ -1,0 +1,23 @@
+import { useCallback, useState } from 'react';
+import {
+  UI_SCALE_OPTIONS,
+  UI_SCALE_STORAGE_KEY,
+  applyUiScale,
+  getStoredUiScale,
+} from '../utils/uiScale';
+
+export function useUiScale() {
+  const [scale, setScaleState] = useState<number>(() => getStoredUiScale());
+
+  const setScale = useCallback((next: number) => {
+    applyUiScale(next);
+    try {
+      localStorage.setItem(UI_SCALE_STORAGE_KEY, String(next));
+    } catch {
+      // ignore quota / disabled storage
+    }
+    setScaleState(next);
+  }, []);
+
+  return { scale, setScale, options: UI_SCALE_OPTIONS };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -233,7 +233,8 @@
   },
   "appearance": {
     "dark": "Dark",
-    "light": "Light"
+    "light": "Light",
+    "uiScale": "UI Scale"
   },
   "theme": {
     "red": "Red",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -233,7 +233,8 @@
   },
   "appearance": {
     "dark": "ダーク",
-    "light": "ライト"
+    "light": "ライト",
+    "uiScale": "UI拡大率"
   },
   "theme": {
     "red": "赤",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,12 @@
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import { initRemoteLogger } from './utils/remoteLogger';
+import { applyUiScale, getStoredUiScale } from './utils/uiScale';
 import './i18n';
 import './index.css';
+
+// Apply persisted UI scale before render to avoid flash of unstyled content
+applyUiScale(getStoredUiScale());
 
 // Initialize remote logging first
 initRemoteLogger();

--- a/frontend/src/utils/uiScale.ts
+++ b/frontend/src/utils/uiScale.ts
@@ -1,0 +1,25 @@
+export const UI_SCALE_STORAGE_KEY = 'cchub-ui-scale';
+export const UI_SCALE_OPTIONS = [0.8, 0.9, 1.0, 1.15, 1.3] as const;
+export const DEFAULT_UI_SCALE = 1.0;
+const BASE_FONT_SIZE_PX = 14;
+
+export type UiScale = (typeof UI_SCALE_OPTIONS)[number];
+
+export function getStoredUiScale(): number {
+  try {
+    const stored = localStorage.getItem(UI_SCALE_STORAGE_KEY);
+    if (stored) {
+      const n = parseFloat(stored);
+      if (!Number.isNaN(n) && (UI_SCALE_OPTIONS as readonly number[]).includes(n)) {
+        return n;
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_UI_SCALE;
+}
+
+export function applyUiScale(scale: number): void {
+  document.documentElement.style.fontSize = `${BASE_FONT_SIZE_PX * scale}px`;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes

### Added
- ダッシュボードに UI 拡大率設定を追加 (80% / 90% / 100% / 115% / 130%)
  - `<html>` の `font-size` 経由で Tailwind の rem ベース要素 (Dashboard / SessionList / FileViewer / アイコンの一部) を一括スケール
  - xterm.js は独自フォント設定のため Terminal 本文には影響せず、`Cmd+=` / `Cmd+-` と独立して制御可能
  - 設定は `localStorage['cchub-ui-scale']` に永続化、FOUC 回避のため `main.tsx` で early apply

### Fixed
- Welcome セッション作成時に `cd '~' && claude` が `cd: no such file or directory: ~` で失敗していた問題を修正
  - `agentStartCommand` / resume command で `shellQuote` 前に `~` / `~/...` を `homedir()` に展開する `expandHome()` ヘルパーを追加

## Test plan
- [x] `bun run --filter backend test` (既存の2件 fail は環境依存で main でも再現、新規追加の expand-home テストは pass)
- [x] dev 環境 (`https://localhost:5173`) で Playwright 経由で UI Scale 切替を検証
  - `<html>` font-size が 14px → 18.2px (130%) に変化
  - Terminal canvas の文字サイズは不変 (xterm.js 独立)
  - rem ベースの UI 要素は追従、`w-[18px]` の固定指定箇所は未追従 (既知の制限)

## Notes
- `w-[18px]` で記述された固定ピクセルアイコン (25箇所) は UI Scale に追従しません。将来 `w-[1.25rem]` 等への置換を検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)