### PR TITLE
Release v0.1.121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.121] - 2026-05-18
+
+### Changed
+- ターミナルのスクロールバックを **tmux 単一ソース化** (#170) — フロントエンドの xterm.js scrollback バッファを廃止し、`scrollback: 0` 固定の純粋な描画装置に変更。スクロール時はサーバに `request-viewport { offset }` を送り、tmux から該当範囲を `capture-pane -S/-E` で取得して描画する
+  - 「再接続後に履歴が減る」「タブ間で見える履歴が違う」「出力中スクロール不可」がすべて根本解決
+  - 旧 state-snapshot / state-diff プロトコル、scrollbackDelta、padFill、INITIAL_SCROLLBACK_ROWS、Channel C drift detection (CCHUB_SELF_VERIFY)、debug-dump をすべて削除
+  - 慣性スクロールは保持 — wheel/touch/momentum は `controlMode.scrollBy()` 経由で offset を変えて新 viewport を要求する設計
+  - ネット **481 行削減** (+424 / -905)
+
 ## [0.1.120] - 2026-05-18
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "generated": "2026-05-18",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "generated": "2026-05-18",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- feat: ターミナルのスクロールバックを tmux 単一ソース化 (#170)
  - フロント xterm.js の scrollback バッファ廃止
  - 履歴破損問題と出力中スクロール不可の問題を根本解決
  - 全体で 481 行削減

## Notes
v0.1.119 の応急処置(scroll fix)を超えて、設計レベルで履歴管理を tmux に一元化。