### PR TITLE
Release v0.1.125

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.125] - 2026-05-19
+
+### Fixed
+- **慢性的な CPU 高負荷 (平均 73〜108%) を解消**: `sessions-push` のホットループで毎周期に全 jsonl の readdir + stat + 内容読み込みが走り、加えて UI セッション切替のたびに `tmux -CC attach` を再 spawn していた問題を修正。平均 CPU を **77.6% → 23.4% (約70%削減)** に低下 (10分間観測)
+  - `tmux-control.ts`: `GRACE_PERIOD_MS` を 5s → 30s に戻す。idle CPU 削減目的で短縮されていたが、結果として UI 切替のたびに `tmux -CC attach` を再 spawn して逆に負荷を増やしていた
+  - `claude-code.ts`: `SESSION_DATA_CACHE_TTL` を 5s → 30s。`sessions-push` 周期 (5s) と同位相で毎回 cache miss していた問題を解消。mtime チェックは内側に残るのでフレッシュさは維持
+  - `claude-code.ts`: `pathResultCache` (TTL 3s) を追加し、`getSessionForPath` / `getRecentSessionsForPath` / `getSessionByTtyStartTime` の readdir + 全 jsonl stat スイープを同一 `sessions-push` tick 内でショートサーキット
+
 ## [0.1.124] - 2026-05-18
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,8 +113,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.124",
-  "generated": "2026-05-18",
+  "version": "0.1.125",
+  "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.124",
-  "generated": "2026-05-18",
+  "version": "0.1.125",
+  "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/backend/src/services/claude-code.ts
+++ b/backend/src/services/claude-code.ts
@@ -86,9 +86,17 @@ export class ClaudeCodeService {
   private ttySessionCache = new Map<string, { sessionId: string | null; timestamp: number }>();
   private static readonly TTY_SESSION_CACHE_TTL = 10_000; // 10 seconds
 
-  // Cache for session data keyed by file path (avoids re-reading JSONL files)
+  // Cache for session data keyed by file path (avoids re-reading JSONL files).
+  // Longer than the 5s sessions-push interval so back-to-back pushes stay on the
+  // mtime-checked cache instead of re-reading every JSONL each cycle.
   private sessionDataCache = new Map<string, CachedSessionData>();
-  private static readonly SESSION_DATA_CACHE_TTL = 5000; // 5 seconds
+  private static readonly SESSION_DATA_CACHE_TTL = 30_000; // 30 seconds
+
+  // Cache for getSessionForPath / getRecentSessionsForPath / getSessionByTtyStartTime
+  // results keyed by composite cache key. Avoids re-running readdir + stat over
+  // every JSONL on every sessions-push tick.
+  private pathResultCache = new Map<string, { data: unknown; timestamp: number }>();
+  private static readonly PATH_RESULT_CACHE_TTL = 3_000; // 3 seconds
 
   constructor() {
     this.claudeDir = join(homedir(), '.claude', 'projects');
@@ -136,6 +144,16 @@ export class ClaudeCodeService {
    * Used when -r flag is not present
    */
   async getSessionByTtyStartTime(tty: string, workingDir: string): Promise<ClaudeCodeSession | null> {
+    const cacheKey = `tty:${tty}:${workingDir}`;
+    const cached = this.getPathCached<ClaudeCodeSession | null>(cacheKey);
+    if (cached !== undefined) return cached;
+
+    const result = await this.getSessionByTtyStartTimeUncached(tty, workingDir);
+    this.setPathCached(cacheKey, result);
+    return result;
+  }
+
+  private async getSessionByTtyStartTimeUncached(tty: string, workingDir: string): Promise<ClaudeCodeSession | null> {
     try {
       // Get tty name from path (Linux: pts/10, macOS: ttys004)
       const ttyMatch = tty.match(/(pts\/\d+|ttys\d+)$/);
@@ -636,10 +654,32 @@ export class ClaudeCodeService {
     }
   }
 
+  private getPathCached<T>(key: string): T | undefined {
+    const entry = this.pathResultCache.get(key);
+    if (entry && Date.now() - entry.timestamp < ClaudeCodeService.PATH_RESULT_CACHE_TTL) {
+      return entry.data as T;
+    }
+    return undefined;
+  }
+
+  private setPathCached(key: string, data: unknown): void {
+    this.pathResultCache.set(key, { data, timestamp: Date.now() });
+  }
+
   /**
    * Get the latest Claude Code session info for a given working directory
    */
   async getSessionForPath(workingDir: string): Promise<ClaudeCodeSession | null> {
+    const cacheKey = `path:${workingDir}`;
+    const cached = this.getPathCached<ClaudeCodeSession | null>(cacheKey);
+    if (cached !== undefined) return cached;
+
+    const result = await this.getSessionForPathUncached(workingDir);
+    this.setPathCached(cacheKey, result);
+    return result;
+  }
+
+  private async getSessionForPathUncached(workingDir: string): Promise<ClaudeCodeSession | null> {
     try {
       // Try exact path first, then parent directories
       let currentPath = workingDir;
@@ -796,6 +836,16 @@ export class ClaudeCodeService {
    * Used when multiple tmux sessions share the same working directory
    */
   async getRecentSessionsForPath(workingDir: string, count: number): Promise<ClaudeCodeSession[]> {
+    const cacheKey = `recent:${workingDir}:${count}`;
+    const cached = this.getPathCached<ClaudeCodeSession[]>(cacheKey);
+    if (cached !== undefined) return cached;
+
+    const result = await this.getRecentSessionsForPathUncached(workingDir, count);
+    this.setPathCached(cacheKey, result);
+    return result;
+  }
+
+  private async getRecentSessionsForPathUncached(workingDir: string, count: number): Promise<ClaudeCodeSession[]> {
     const sessions: ClaudeCodeSession[] = [];
 
     try {

--- a/backend/src/services/tmux-control.ts
+++ b/backend/src/services/tmux-control.ts
@@ -28,8 +28,11 @@ const SEND_KEYS_CHUNK_SIZE = 4096;
 // Debounce for refresh-client -C
 const RESIZE_DEBOUNCE_MS = 50;
 
-// Grace period before destroying session after all clients disconnect
-const GRACE_PERIOD_MS = 5_000; // 5 seconds (was 30s - reduced to minimize idle CPU)
+// Grace period before destroying session after all clients disconnect.
+// Long enough to absorb typical UI session switches without forcing a `tmux -CC`
+// respawn (re-attach + re-ready cost is several hundred ms and triggers a fresh
+// listSessions / dashboard fan-out).
+const GRACE_PERIOD_MS = 30_000;
 
 interface PendingCommand {
   resolve: (output: string) => void;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.124",
+  "version": "0.1.125",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- `sessions-push` ホットループで毎周期に全 jsonl の readdir + stat + 読み込みが走り、加えて UI セッション切替のたびに `tmux -CC attach` が再 spawn される構造的な問題を修正。実機 (systemd user service) で 10 分観測し、平均 CPU を **77.6% → 23.4% (約70%削減)** に低下することを確認。

## Changes
- fix(perf): reduce idle CPU from sessions-push hot loop
  - `tmux-control.ts`: `GRACE_PERIOD_MS` 5s → 30s
  - `claude-code.ts`: `SESSION_DATA_CACHE_TTL` 5s → 30s（mtime チェックは内側に残るのでフレッシュさ維持）
  - `claude-code.ts`: `pathResultCache` (TTL 3s) を `getSessionForPath` / `getRecentSessionsForPath` / `getSessionByTtyStartTime` に追加
- chore: bump version to 0.1.125

## Test plan
- [x] `bun run lint` / `typecheck` / `test` (frontend 23 / backend 166) すべて pass
- [x] `bun run build:binary` 成功、`~/bin/cchub` に置換して `systemctl --user restart cchub.service`
- [x] 10 分後の CPU 計測: 77.6% → 23.4%
- [ ] `cchub update` 後、Tailscale 経由でセッション切替・dashboard が引き続き動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)