### PR TITLE
Release v0.1.126

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.126] - 2026-05-19
+
+### Added
+- **スクロール体験の刷新**: server-side scrollback でスクロール時にサーバ応答待ちで画面が止まる問題を解消
+  - `viewport-pseudo.ts` 新設。`makePseudoViewport(viewport, delta)` で現フレームを delta 行ぶんずらし露出側を空行で埋めた疑似 viewport を生成。`scrollBy` / `scrollToLive` のキャッシュミス時にこの疑似フレームを即時描画し、サーバから本物が届いたら上書き。応答待ち中でも画面が実際にずれて動く
+  - クライアント側 viewport キャッシュ (`Map<offset, {viewport, historySize}>`、pane あたり LRU 20件)。同じ offset への往復スクロールはサーバラウンドトリップなしで即時描画。`historySize` を一緒に保存し、tmux 出力で履歴が変わった場合は自動で stale 扱い。`layout-change` で全キャッシュ破棄
+  - 右上のスクロール位置インジケータを `{ text, loading }` に拡張。応答待ち中は青色の `[N/M] ⏳`、本物着弾で黄色の `[N/M]` に切替＋3秒フェード。今どのくらいスクロール中で、サーバが追いついているかが視認できる
+
+### Fixed
+- 連続 wheel / touch スクロールで `scrollBy` が秒間 50回以上発火し、毎回 viewport 再取得＋全画面 VT 再描画が走って小刻みな揺れに見えていた問題を rAF coalesce で解消 (フレームに 1 回だけ scrollBy を flush)
+- 高速スクロール中に in-flight な複数の `request-viewport` 応答が前後して届いて画面が一瞬戻る現象に対し、`onPaneViewport` で現在の期待 offset と応答 offset を照合して不一致なら repaint をスキップする stale guard を追加 (キャッシュには保存)
+
 ## [0.1.125] - 2026-05-19
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -23,6 +23,7 @@ import {
 } from "../hooks/useSessions";
 import { authFetch } from "../services/api";
 import { fireHookNotification } from "../utils/hookNotification";
+import { makePseudoViewport } from "../utils/viewport-pseudo";
 import { DashboardPanel } from "./DashboardPanel";
 import { FloatingKeyboard, type FloatingKeyboardRef } from "./FloatingKeyboard";
 import { FileViewer } from "./files/FileViewer";
@@ -437,9 +438,11 @@ export function DesktopLayout({
 	const zoomedPaneIdRef = useRef<string | null>(null);
 	zoomedPaneIdRef.current = zoomedPaneId;
 
-	// Per-pane viewport callbacks (paneId -> Set<callbacks>).
+	// Per-pane viewport callbacks (paneId -> Set<callbacks>). Second arg
+	// `isPseudo`: true when frame is a client-stitched preview while the real
+	// server reply is in flight.
 	const paneCallbacksRef = useRef<
-		Map<string, Set<(viewport: PaneViewport) => void>>
+		Map<string, Set<(viewport: PaneViewport, isPseudo?: boolean) => void>>
 	>(new Map());
 
 	// Last viewport per pane. Replayed when a Terminal mounts after the
@@ -449,6 +452,12 @@ export function DesktopLayout({
 	// Current scroll offset per pane (0 = live edge, N = N rows scrolled up
 	// into history). Updated by Terminal.scrollBy and by viewport responses.
 	const paneOffsetRef = useRef<Map<string, number>>(new Map());
+
+	// Per-pane viewport cache keyed by offset.
+	const paneViewportCacheRef = useRef<
+		Map<string, Map<number, { viewport: PaneViewport; historySize: number }>>
+	>(new Map());
+	const VIEWPORT_CACHE_LIMIT = 20;
 
 	const desktopStateRef = useRef(desktopState);
 	desktopStateRef.current = desktopState;
@@ -464,6 +473,25 @@ export function DesktopLayout({
 		sessionId: controlSessionId || "",
 		onPaneViewport: (paneId, viewport) => {
 			lastViewportRef.current.set(paneId, viewport);
+			let perPane = paneViewportCacheRef.current.get(paneId);
+			if (!perPane) {
+				perPane = new Map();
+				paneViewportCacheRef.current.set(paneId, perPane);
+			}
+			perPane.delete(viewport.offset);
+			perPane.set(viewport.offset, {
+				viewport,
+				historySize: viewport.historySize,
+			});
+			if (perPane.size > VIEWPORT_CACHE_LIMIT) {
+				const oldest = perPane.keys().next().value;
+				if (oldest !== undefined) perPane.delete(oldest);
+			}
+			// Drop stale responses (out-of-order viewport reply after the user has
+			// scrolled past it). Cache it but don't repaint unless it matches the
+			// current expected offset.
+			const expected = paneOffsetRef.current.get(paneId);
+			if (expected !== undefined && expected !== viewport.offset) return;
 			// Server clamps the requested offset to historySize; reflect that
 			// back so subsequent scrollBy / getScrollState see the canonical value.
 			paneOffsetRef.current.set(paneId, viewport.offset);
@@ -473,11 +501,14 @@ export function DesktopLayout({
 				return;
 			}
 			for (const cb of callbacks) {
-				cb(viewport);
+				cb(viewport, false);
 			}
 		},
 		onLayoutChange: (layout) => {
 			setControlLayout(layout);
+			// Pane sizes may have changed; drop the viewport cache (line widths
+			// in cached frames no longer match).
+			paneViewportCacheRef.current.clear();
 			// "Last-write-wins": if the tmux window size (from layout root) differs
 			// significantly from what we last sent, another client changed it.
 			// Clear lastSentSizeRef so the next user interaction re-sends our size.
@@ -726,10 +757,19 @@ export function DesktopLayout({
 					// lines = scroll UP into history (increase offset).
 					if (!controlTerminalRef.current.isConnected) return;
 					const cur = paneOffsetRef.current.get(paneId) ?? 0;
-					const history = lastViewportRef.current.get(paneId)?.historySize ?? 0;
+					const last = lastViewportRef.current.get(paneId);
+					const history = last?.historySize ?? 0;
 					const next = Math.max(0, Math.min(history, cur - lines));
 					if (next === cur) return;
 					paneOffsetRef.current.set(paneId, next);
+					const cbs = paneCallbacksRef.current.get(paneId);
+					const cached = paneViewportCacheRef.current.get(paneId)?.get(next);
+					if (cached && cached.historySize === history) {
+						if (cbs) for (const cb of cbs) cb(cached.viewport, false);
+					} else if (last && cbs) {
+						const pseudo = makePseudoViewport(last, next - last.offset);
+						for (const cb of cbs) cb(pseudo, true);
+					}
 					controlTerminalRef.current.requestViewport(paneId, next);
 				},
 				scrollToLive: () => {
@@ -737,6 +777,16 @@ export function DesktopLayout({
 					const cur = paneOffsetRef.current.get(paneId) ?? 0;
 					if (cur === 0) return;
 					paneOffsetRef.current.set(paneId, 0);
+					const last = lastViewportRef.current.get(paneId);
+					const history = last?.historySize ?? 0;
+					const cbs = paneCallbacksRef.current.get(paneId);
+					const cached = paneViewportCacheRef.current.get(paneId)?.get(0);
+					if (cached && cached.historySize === history) {
+						if (cbs) for (const cb of cbs) cb(cached.viewport, false);
+					} else if (last && cbs) {
+						const pseudo = makePseudoViewport(last, 0 - last.offset);
+						for (const cb of cbs) cb(pseudo, true);
+					}
 					controlTerminalRef.current.requestViewport(paneId, 0);
 				},
 				refreshViewport: () => {

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -47,8 +47,11 @@ export interface ControlModeConfig {
 	sendInput: (data: string) => void;
 	/** Subscribe for viewport updates pushed by the server (offset=0 stream)
 	 *  or returned in response to scroll. Returns an unsubscribe fn. */
+	/** `isPseudo=true` marks a client-side stitched frame produced while the
+	 *  real server reply is still in flight — Terminal uses this to show a
+	 *  "loading" badge until the real viewport lands and clears it. */
 	registerOnViewport: (
-		callback: (viewport: PaneViewport) => void,
+		callback: (viewport: PaneViewport, isPseudo?: boolean) => void,
 	) => () => void;
 	isConnected: boolean;
 	onResize?: (cols: number, rows: number) => void;
@@ -144,7 +147,10 @@ export const TerminalComponent = memo(
 		const [fontSize, setFontSize] = useState(() => loadFontSize(sessionId));
 		const [keyboardOffset, setKeyboardOffset] = useState(0);
 		const [showFontSizeIndicator, setShowFontSizeIndicator] = useState(false);
-		const [scrollIndicator, setScrollIndicator] = useState<string | null>(null);
+		const [scrollIndicator, setScrollIndicator] = useState<{
+			text: string;
+			loading: boolean;
+		} | null>(null);
 		const scrollIndicatorTimerRef = useRef<number | null>(null);
 
 		const [isTouchDevice] = useState(() => {
@@ -563,16 +569,34 @@ export const TerminalComponent = memo(
 			let longPressTriggered = false;
 			const LONG_PRESS_DURATION = 400;
 
+			// rAF-coalesce scrollBy: a single wheel notch can fire several wheel
+			// events back-to-back, and touch momentum produces 50+ scroll ticks/sec.
+			// Sum deltas inside a frame and emit one scrollBy at frame boundary so
+			// we issue one viewport refetch per frame instead of many tiny ones.
+			let pendingScrollDelta = 0;
+			let pendingScrollRafId: number | null = null;
+			const flushPendingScroll = () => {
+				pendingScrollRafId = null;
+				const delta = pendingScrollDelta;
+				pendingScrollDelta = 0;
+				if (delta !== 0) controlModeRef.current?.scrollBy?.(delta);
+			};
 			const scrollTerminal = (lines: number) => {
 				// Server-side scrollback: tmux holds the authoritative history; the
 				// control mode adjusts the viewport offset and re-fetches.
-				controlModeRef.current?.scrollBy?.(lines);
+				pendingScrollDelta += lines;
+				if (pendingScrollRafId === null) {
+					pendingScrollRafId = requestAnimationFrame(flushPendingScroll);
+				}
 			};
 
 			const updateScrollIndicator = () => {
 				const state = controlModeRef.current?.getScrollState?.();
 				if (state && state.offset > 0) {
-					setScrollIndicator(`[${state.offset}/${state.historySize}]`);
+					setScrollIndicator((prev) => ({
+						text: `[${state.offset}/${state.historySize}]`,
+						loading: prev?.loading ?? false,
+					}));
 					if (scrollIndicatorTimerRef.current)
 						clearTimeout(scrollIndicatorTimerRef.current);
 					scrollIndicatorTimerRef.current = window.setTimeout(
@@ -1096,7 +1120,7 @@ export const TerminalComponent = memo(
 					cm.forceResize?.(dims.cols, dims.rows);
 				}
 			};
-			const cleanup = cm.registerOnViewport((viewport) => {
+			const cleanup = cm.registerOnViewport((viewport, isPseudo) => {
 				const term = terminalRef.current;
 				if (!term) return;
 				if (term.cols !== viewport.cols || term.rows !== viewport.rows) {
@@ -1109,13 +1133,20 @@ export const TerminalComponent = memo(
 				});
 				const state = cm.getScrollState?.();
 				if (state && state.offset > 0) {
-					setScrollIndicator(`[${state.offset}/${state.historySize}]`);
+					setScrollIndicator({
+						text: `[${state.offset}/${state.historySize}]`,
+						loading: !!isPseudo,
+					});
 					if (scrollIndicatorTimerRef.current)
 						clearTimeout(scrollIndicatorTimerRef.current);
-					scrollIndicatorTimerRef.current = window.setTimeout(
-						() => setScrollIndicator(null),
-						3000,
-					);
+					// Pin the badge while waiting for the real reply; only auto-fade
+					// once the real (non-pseudo) viewport has landed.
+					if (!isPseudo) {
+						scrollIndicatorTimerRef.current = window.setTimeout(
+							() => setScrollIndicator(null),
+							3000,
+						);
+					}
 				} else {
 					setScrollIndicator(null);
 				}
@@ -1352,8 +1383,17 @@ export const TerminalComponent = memo(
 						</div>
 					)}
 					{scrollIndicator && (
-						<div className="absolute top-2 right-2 z-30 bg-[var(--color-overlay)] px-2 py-1 rounded text-xs text-yellow-400/80 pointer-events-none font-mono">
-							{scrollIndicator}
+						<div
+							className={`absolute top-2 right-2 z-30 bg-[var(--color-overlay)] px-2 py-1 rounded text-xs pointer-events-none font-mono ${
+								scrollIndicator.loading
+									? "text-blue-300/90"
+									: "text-yellow-400/80"
+							}`}
+						>
+							{scrollIndicator.text}
+							{scrollIndicator.loading && (
+								<span className="ml-1 opacity-70">⏳</span>
+							)}
 						</div>
 					)}
 					{/* Selection mode controls */}

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "../components/Terminal";
 import { useMultiplexedTerminal } from "../hooks/useMultiplexedTerminal";
 import { fireHookNotification } from "../utils/hookNotification";
+import { makePseudoViewport } from "../utils/viewport-pseudo";
 
 interface PaneLeafInfo {
 	paneId: string;
@@ -71,14 +72,22 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 		// Derive effective active pane: external takes priority
 		const effectiveActivePaneId = externalActivePaneId ?? activePaneId;
 
-		// Per-pane viewport callbacks
+		// Per-pane viewport callbacks. Second arg `isPseudo`: true when the frame
+		// is a client-stitched preview while the real server reply is in flight.
 		const paneCallbacksRef = useRef<
-			Map<string, Set<(viewport: PaneViewport) => void>>
+			Map<string, Set<(viewport: PaneViewport, isPseudo?: boolean) => void>>
 		>(new Map());
 		// Last viewport per pane, replayed when a Terminal mounts late.
 		const lastViewportRef = useRef<Map<string, PaneViewport>>(new Map());
 		// Current scroll offset per pane (0 = live edge).
 		const paneOffsetRef = useRef<Map<string, number>>(new Map());
+
+		// Per-pane viewport cache keyed by offset. Lets a return-trip to a
+		// previously-visited offset paint instantly while the real refresh fetches.
+		const paneViewportCacheRef = useRef<
+			Map<string, Map<number, { viewport: PaneViewport; historySize: number }>>
+		>(new Map());
+		const VIEWPORT_CACHE_LIMIT = 20;
 
 		const onPanesChangeRef = useRef(onPanesChange);
 		onPanesChangeRef.current = onPanesChange;
@@ -97,15 +106,38 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 			token,
 			onPaneViewport: (paneId, viewport) => {
 				lastViewportRef.current.set(paneId, viewport);
+				let perPane = paneViewportCacheRef.current.get(paneId);
+				if (!perPane) {
+					perPane = new Map();
+					paneViewportCacheRef.current.set(paneId, perPane);
+				}
+				perPane.delete(viewport.offset);
+				perPane.set(viewport.offset, {
+					viewport,
+					historySize: viewport.historySize,
+				});
+				if (perPane.size > VIEWPORT_CACHE_LIMIT) {
+					const oldest = perPane.keys().next().value;
+					if (oldest !== undefined) perPane.delete(oldest);
+				}
+				// Drop stale responses (rapid wheel scroll fires many requests in
+				// flight; an older offset's reply arriving late would snap the
+				// screen back). Cache it but don't repaint unless it matches the
+				// current expected offset.
+				const expected = paneOffsetRef.current.get(paneId);
+				if (expected !== undefined && expected !== viewport.offset) return;
 				paneOffsetRef.current.set(paneId, viewport.offset);
 				const callbacks = paneCallbacksRef.current.get(paneId);
 				if (callbacks) {
 					for (const cb of callbacks) {
-						cb(viewport);
+						cb(viewport, false);
 					}
 				}
 			},
 			onLayoutChange: (layout: TmuxLayoutNode) => {
+				// Pane sizes may have changed; cached viewport `lines` no longer
+				// match the new column width, so drop the viewport cache.
+				paneViewportCacheRef.current.clear();
 				// Extract all leaf panes from the layout
 				const leaves = collectLeaves(layout);
 				console.log(
@@ -275,11 +307,23 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 						// edge (decrease offset), negative = into history (increase offset).
 						if (!controlTerminal.isConnected) return;
 						const cur = paneOffsetRef.current.get(currentPaneId) ?? 0;
-						const history =
-							lastViewportRef.current.get(currentPaneId)?.historySize ?? 0;
+						const last = lastViewportRef.current.get(currentPaneId);
+						const history = last?.historySize ?? 0;
 						const next = Math.max(0, Math.min(history, cur - lines));
 						if (next === cur) return;
 						paneOffsetRef.current.set(currentPaneId, next);
+						const cbs = paneCallbacksRef.current.get(currentPaneId);
+						const cached = paneViewportCacheRef.current
+							.get(currentPaneId)
+							?.get(next);
+						if (cached && cached.historySize === history) {
+							if (cbs) for (const cb of cbs) cb(cached.viewport, false);
+						} else if (last && cbs) {
+							// Pseudo-scroll: keep the screen moving while the real
+							// viewport is fetched. Real reply overwrites this frame.
+							const pseudo = makePseudoViewport(last, next - last.offset);
+							for (const cb of cbs) cb(pseudo, true);
+						}
 						controlTerminal.requestViewport(currentPaneId, next);
 					},
 					scrollToLive: () => {
@@ -287,6 +331,18 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 						const cur = paneOffsetRef.current.get(currentPaneId) ?? 0;
 						if (cur === 0) return;
 						paneOffsetRef.current.set(currentPaneId, 0);
+						const last = lastViewportRef.current.get(currentPaneId);
+						const history = last?.historySize ?? 0;
+						const cbs = paneCallbacksRef.current.get(currentPaneId);
+						const cached = paneViewportCacheRef.current
+							.get(currentPaneId)
+							?.get(0);
+						if (cached && cached.historySize === history) {
+							if (cbs) for (const cb of cbs) cb(cached.viewport, false);
+						} else if (last && cbs) {
+							const pseudo = makePseudoViewport(last, 0 - last.offset);
+							for (const cb of cbs) cb(pseudo, true);
+						}
 						controlTerminal.requestViewport(currentPaneId, 0);
 					},
 					refreshViewport: () => {

--- a/frontend/src/utils/viewport-pseudo.ts
+++ b/frontend/src/utils/viewport-pseudo.ts
@@ -1,0 +1,43 @@
+/**
+ * Pseudo-scroll helpers.
+ *
+ * The server-side scrollback model has the canonical history sitting on tmux —
+ * every offset change normally requires a round-trip. While that round-trip is
+ * in flight we still want the screen to *move* in response to wheel / touch so
+ * the user has continuous feedback. `makePseudoViewport` produces a synthetic
+ * viewport by shifting the most recent real viewport by `deltaOffset` rows and
+ * padding the exposed edge with blank rows. The server's real reply will
+ * overwrite it as soon as it arrives.
+ */
+
+import type { PaneViewport } from "../../../shared/types";
+
+export function makePseudoViewport(
+	source: PaneViewport,
+	deltaOffset: number,
+): PaneViewport {
+	if (deltaOffset === 0) return source;
+	const blank = " ".repeat(source.cols);
+	let lines: string[];
+	if (deltaOffset > 0) {
+		// Scrolled UP into history → new blank rows at the top, drop rows from the bottom.
+		const d = Math.min(deltaOffset, source.rows);
+		lines = Array<string>(d)
+			.fill(blank)
+			.concat(source.lines.slice(0, source.rows - d));
+	} else {
+		// Scrolled DOWN toward live → new blank rows at the bottom, drop rows from the top.
+		const d = Math.min(-deltaOffset, source.rows);
+		lines = source.lines.slice(d).concat(Array<string>(d).fill(blank));
+	}
+	const newOffset = source.offset + deltaOffset;
+	return {
+		...source,
+		lines,
+		offset: newOffset,
+		atTail: newOffset === 0,
+		// Hide the cursor while we're showing a stitched frame. The real viewport
+		// will restore it.
+		cursor: { ...source.cursor, visible: false },
+	};
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- Server-side scrollback の根本的体験を改善。スクロール時にサーバ応答を待つ間も画面が実際にずれて動き、応答着弾で本物に置き換わる。
- 右上に `[N/M] ⏳` のスクロール位置インジケータを追加（応答待ち中は ⏳ 付き青、本物着弾で黄→3秒フェード）。
- 副次的に rAF coalesce / stale 応答破棄も入って、高速スクロール中の小刻みな振動・スナップバックも軽減。

## Changes
- feat(scroll): pseudo-viewport rendering + client-side viewport cache + loading indicator
- fix: rAF-coalesce `scrollBy` so wheel/touch ticks issue one viewport refetch per frame
- fix: drop stale viewport responses whose offset no longer matches the user's current offset
- chore: bump version to 0.1.126

## Test plan
- [x] `bun run lint` / `typecheck` / `test` (frontend 23 / backend 166) すべて pass
- [x] dev (`https://100.91.210.90:5173/`) でホイール・タッチ両方でスクロール体感確認、ユーザー OK
- [ ] `cchub update` 後、実機でスクロールバックを大量持つペインを開いて挙動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)