### PR TITLE
chore(cchub-profile): bundle profile.ts + analyze/drill helpers

### DIFF
--- a/.claude/skills/cchub-profile/SKILL.md
+++ b/.claude/skills/cchub-profile/SKILL.md
@@ -18,27 +18,50 @@ cchub debug disable                # 通常モードへ戻す
 cchub debug status                 # 現在の状態
 ```
 
-## デフォルトのフロー (短時間の CPU profile)
+## デフォルトのフロー — Claude 側で完結 (推奨)
 
-1. `cchub debug status` で現状確認 (既に有効なら手順スキップ)
-2. `cchub debug profile --seconds 60` を起動 (60 秒の窓を開ける)
-3. journal から WS URL を確認:
-   ```bash
-   journalctl --user -u cchub.service --since "1 minute ago" --no-pager | grep "debug.bun.sh"
-   ```
-   出力例: `https://debug.bun.sh/#0.0.0.0:9229/<token>`
-4. ユーザーに以下を案内 (ローカル Chrome で手作業):
-   - Chrome で `chrome://inspect` を開く
-   - **Configure…** → `<TAILSCALE_IP>:9229` (例: `100.91.210.90:9229`) を追加
-   - Remote Target に **cchub** が出る → **inspect** クリック
-   - Performance タブ → **Record** → 再現操作 → **Stop**
-   - 右クリック → **Save profile** で `.cpuprofile` を保存 (Chrome DevTools / VS Code で開ける)
-5. 60 秒経過で自動的に `disable` 実行され通常モードへ戻る
-6. 戻ったことを `cchub debug status` で確認
+同梱の `scripts/profile.ts` が CDP の WebSocket を直接叩いて `.cpuprofile` を取る。
+**Chrome / DevTools を立ち上げる必要はなく、Claude セッション内で完結する。**
+
+```bash
+# CC Hub プロジェクト内から:
+bun .claude/skills/cchub-profile/scripts/profile.ts profile --seconds 30 --out /tmp/p.json
+```
+
+内部の流れ:
+1. `cchub debug enable` で inspector を起動
+2. journal から WS URL を取得
+3. WebSocket で `ScriptProfiler.startTracking` → `--seconds N` sleep → `ScriptProfiler.stopTracking`
+4. `trackingComplete` のサンプル群を `--out` のパスに JSON で保存
+5. `cchub debug disable` で元に戻す (`try/finally` 保護)
+
+集計:
+
+```bash
+# 全体トップ (self time + total time)
+bun .claude/skills/cchub-profile/scripts/profile.ts analyze /tmp/p.json
+
+# 特定関数を含むスタックの leaf 集計
+bun .claude/skills/cchub-profile/scripts/profile.ts drill /tmp/p.json buildSessionsList
+```
+
+サンプル取得中は **実負荷をかける** こと (curl で `/api/dashboard` や `/api/sessions` をループ叩き、または実 UI 操作)。アイドル時に取っても何も浮かばない。
+
+## ローカル Chrome 経由 (オプション)
+
+`.cpuprofile` を Chrome DevTools / VS Code の Performance / CPU profiler で開きたい場合:
+
+1. `cchub debug profile --seconds 60` を実行
+2. journal から `https://debug.bun.sh/#<IP>:9229/<token>` を取り出す
+3. ローカル Chrome の `chrome://inspect` で Configure に `<TAILSCALE_IP>:9229` を追加 → cchub remote target → inspect
+4. Performance タブ → Record → 操作再現 → Stop → 右クリックで `.cpuprofile` 保存
+5. 60s 経過で自動 disable
+
+> **agent-browser 経由は不可**: HTTPS の debug.bun.sh から `ws://` の mixed-content / WebSocket 接続まわりの制約で Timeline のイベント列が空になる。Claude 側からの取得は必ず上記の `scripts/profile.ts` ルートを使う。
 
 ## 開けっぱなしモード
 
-長く調査したい場合:
+調査を対話的に続けたい場合のみ:
 
 ```bash
 cchub debug enable
@@ -47,12 +70,6 @@ cchub debug disable    # 必ず手動で戻すこと
 ```
 
 `cchub debug status` が `🟢 Inspector enabled` のままなら忘れているサイン。必ず元に戻す。
-
-## Claude 側で UI 状態を確認する場合 (オプション)
-
-`agent-browser` が使えるなら、`https://debug.bun.sh/#0.0.0.0:9229/<token>` を開いて Console / Sources / Timelines タブの存在を確認できる。
-
-**ただし agent-browser (headless Chromium) では Timeline のイベント列が空になる**: HTTPS の `debug.bun.sh` から `ws://` への mixed-content や WebSocket 接続まわりの制約で、UI は表示できるが実イベントが流れない。実プロファイルはユーザーのローカル Chrome での `chrome://inspect` 経由でしか取得できない。Claude 側からは「inspector が listen している」ところまでの動作確認に留める。
 
 ## 接続検証 (UI を使わず)
 
@@ -75,8 +92,10 @@ curl -s http://localhost:9229/json/version
 
 - inspector mode への切替時にサーバを **systemctl restart** する。WebSocket クライアントは一旦切断 → 自動再接続するが、進行中のリクエストは落ちる。アクティブな操作中は避ける
 - inspector port (9229) は `0.0.0.0` で listen する。tailnet 経由でしかアクセスできないなら良いが、もしポート公開設定があるなら enable 中は要注意
-- `profile --seconds N` は Ctrl-C で中断すると drop-in が残る可能性がある。中断したら `cchub debug disable` を手動で実行
+- `profile.ts profile ...` / `cchub debug profile` は途中で Ctrl-C すると drop-in が残る可能性がある。中断したら `cchub debug disable` を手動で実行
 - 仕組み的には `~/.config/systemd/user/cchub.service.d/99-inspect.conf` の有無で切り替わる。直接編集も可能だが、CLI 経由が安全
+- アイドル時に profile を取っても `stackTraces: []` で空になりやすい。**サンプリング中は必ず curl / 実 UI 操作で負荷をかける**こと
+- 🚨 `scripts/profile.ts` の中で `Inspector.enable` / `Debugger.enable` / `Runtime.enable` を呼ばないこと。これらは JSC を debugger-attached 状態にして `ScriptProfiler` のサンプリングを止める。`ScriptProfiler.startTracking` を直接叩くだけで十分
 
 ## 参照
 

--- a/.claude/skills/cchub-profile/scripts/profile.ts
+++ b/.claude/skills/cchub-profile/scripts/profile.ts
@@ -1,0 +1,253 @@
+#!/usr/bin/env bun
+// @ts-nocheck — standalone bun script, lives outside the project tsconfig.
+//
+// End-to-end CPU profile capture against the running cchub.service.
+//
+// Subcommands:
+//   profile [--seconds N] [--out PATH]   Enable inspector → capture → disable.
+//   analyze <profile.json>               Top-N hot functions (self + total).
+//   drill <profile.json> <name>          Leaf frames under any sample touching <name>.
+//
+// Talks directly to Bun's WebKit Inspector over CDP, so no Chrome / DevTools
+// session is needed — the profile JSON ends up on disk ready for `analyze`.
+
+import { spawnSync } from "node:child_process";
+import { writeFile, readFile } from "node:fs/promises";
+
+const [, , cmd, ...rest] = process.argv;
+
+if (cmd === "profile") {
+	await cmdProfile(parseProfileArgs(rest));
+} else if (cmd === "analyze") {
+	await cmdAnalyze(rest[0]);
+} else if (cmd === "drill") {
+	await cmdDrill(rest[0], rest[1]);
+} else {
+	usage();
+	process.exit(1);
+}
+
+function usage(): void {
+	console.error("usage:");
+	console.error("  profile.ts profile [--seconds N] [--out PATH]");
+	console.error("  profile.ts analyze <profile.json>");
+	console.error("  profile.ts drill   <profile.json> <function-name-substring>");
+}
+
+function parseProfileArgs(args: string[]): { seconds: number; out: string } {
+	let seconds = 30;
+	let out = "/tmp/cchub.profile.json";
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--seconds") seconds = Number(args[++i]);
+		else if (args[i] === "--out") out = args[++i];
+	}
+	if (!Number.isFinite(seconds) || seconds < 1) {
+		console.error("--seconds must be a positive integer");
+		process.exit(1);
+	}
+	return { seconds, out };
+}
+
+async function cmdProfile({ seconds, out }: { seconds: number; out: string }) {
+	const enable = spawnSync("cchub", ["debug", "enable"], { stdio: "inherit" });
+	if (enable.status !== 0) {
+		console.error("cchub debug enable failed");
+		process.exit(1);
+	}
+
+	try {
+		// Service just restarted — give Bun time to bind the inspector port and
+		// re-attach its routes before we open the WS. The first 2-3s of a fresh
+		// process are mostly init and don't produce useful samples anyway.
+		await waitForInspector();
+		const wsUrl = await findWsUrl();
+		console.error(`[cdp] using ${wsUrl}`);
+		const profile = await captureProfile(wsUrl, seconds);
+		await writeFile(out, JSON.stringify(profile));
+		console.error(`[cdp] saved ${out}`);
+		console.error("\nrun `bun .../profile.ts analyze " + out + "` to see hot functions.");
+	} finally {
+		spawnSync("cchub", ["debug", "disable"], { stdio: "inherit" });
+	}
+}
+
+async function waitForInspector(): Promise<void> {
+	for (let i = 0; i < 30; i++) {
+		try {
+			const r = await fetch("http://localhost:9229/json/version", { signal: AbortSignal.timeout(500) });
+			if (r.ok) {
+				// Inspector is up. Sleep one more beat so startup work settles.
+				await new Promise((r) => setTimeout(r, 800));
+				return;
+			}
+		} catch {
+			// not ready yet
+		}
+		await new Promise((r) => setTimeout(r, 200));
+	}
+	throw new Error("inspector did not come up within 6s");
+}
+
+async function findWsUrl(): Promise<string> {
+	for (let i = 0; i < 10; i++) {
+		const journal = spawnSync(
+			"journalctl",
+			[
+				"--user",
+				"-u",
+				"cchub.service",
+				"--since",
+				"1 minute ago",
+				"--no-pager",
+				"--output=cat",
+			],
+			{ encoding: "utf8" },
+		);
+		const m = journal.stdout?.match(/(ws:\/\/[^\s]+)/g);
+		if (m && m.length > 0) {
+			// Last match = most recent restart.
+			return m[m.length - 1];
+		}
+		await new Promise((r) => setTimeout(r, 500));
+	}
+	throw new Error("could not find Bun inspector WS URL in journal");
+}
+
+async function captureProfile(wsUrl: string, seconds: number): Promise<unknown> {
+	const ws = new WebSocket(wsUrl);
+	let nextId = 1;
+	const pending = new Map<number, (v: unknown) => void>();
+	let trackingCompleteResolve: ((v: unknown) => void) | null = null;
+	const trackingComplete = new Promise<unknown>((r) => {
+		trackingCompleteResolve = r;
+	});
+
+	ws.addEventListener("message", (ev: MessageEvent) => {
+		const data = JSON.parse(typeof ev.data === "string" ? ev.data : "");
+		if (typeof data.id === "number" && pending.has(data.id)) {
+			const r = pending.get(data.id);
+			pending.delete(data.id);
+			if (data.error) throw new Error(`cdp: ${data.error.message}`);
+			r?.(data.result);
+		} else if (data.method === "ScriptProfiler.trackingComplete") {
+			trackingCompleteResolve?.(data.params);
+		}
+	});
+
+	const call = (method: string, params: Record<string, unknown> = {}) =>
+		new Promise<any>((resolve) => {
+			const id = nextId++;
+			pending.set(id, resolve);
+			ws.send(JSON.stringify({ id, method, params }));
+		});
+
+	await new Promise<void>((resolve, reject) => {
+		ws.addEventListener("open", () => resolve(), { once: true });
+		ws.addEventListener("error", () => reject(new Error("ws connect failed")), { once: true });
+	});
+
+	// Don't call Inspector/Debugger.enable here — they put JSC into a
+	// debugger-attached state that suppresses the sampling tracker. Just start
+	// the profiler directly; Bun's default sampling rate kicks in.
+	await call("ScriptProfiler.startTracking", { includeSamples: true });
+	console.error(`[cdp] tracking for ${seconds}s…`);
+	await new Promise((r) => setTimeout(r, seconds * 1000));
+	const stopResult = await call("ScriptProfiler.stopTracking");
+
+	// Some Bun versions return samples inline; others fire trackingComplete.
+	// Try both.
+	const eventParams: any = await Promise.race([
+		trackingComplete,
+		new Promise<null>((r) => setTimeout(() => r(null), 5000)),
+	]);
+	ws.close();
+
+	const samples = eventParams?.samples ?? stopResult?.samples ?? null;
+	if (!samples || (samples.stackTraces && samples.stackTraces.length === 0)) {
+		const stopKeys = stopResult ? Object.keys(stopResult).join(",") : "(no stopResult)";
+		const evKeys = eventParams ? Object.keys(eventParams).join(",") : "(no event)";
+		throw new Error(
+			`no usable samples — stopTracking returned [${stopKeys}], trackingComplete params [${evKeys}]`,
+		);
+	}
+	return samples;
+}
+
+// --------------------------------------------------------------------------
+// analyze / drill: read the captured profile and surface hot functions.
+
+interface Frame {
+	name: string;
+	url: string;
+	line: number;
+}
+interface Trace {
+	stackFrames: Frame[];
+}
+
+function frameKey(f: Frame): string {
+	const name = f.name || "(anon)";
+	const u = f.url || "?";
+	const short = u.startsWith("/$bunfs/") ? "[bundle]" : u.startsWith("internal:") ? u : "?";
+	return `${name} @ ${short}:${f.line}`;
+}
+
+async function cmdAnalyze(path: string) {
+	if (!path) {
+		usage();
+		process.exit(1);
+	}
+	const raw = await readFile(path, "utf8");
+	const traces: Trace[] = JSON.parse(raw).stackTraces ?? [];
+	console.log(`# samples: ${traces.length}`);
+
+	const self = new Map<string, number>();
+	const total = new Map<string, number>();
+	for (const t of traces) {
+		const f = t.stackFrames ?? [];
+		if (f.length === 0) continue;
+		const leaf = frameKey(f[0]);
+		self.set(leaf, (self.get(leaf) ?? 0) + 1);
+		const seen = new Set<string>();
+		for (const frame of f) {
+			const k = frameKey(frame);
+			if (seen.has(k)) continue;
+			seen.add(k);
+			total.set(k, (total.get(k) ?? 0) + 1);
+		}
+	}
+
+	printTop("Top 15 by self time (where CPU is actually spent)", self, traces.length, 15);
+	printTop(
+		"Top 15 by total (function appears anywhere in call stack)",
+		total,
+		traces.length,
+		15,
+	);
+}
+
+async function cmdDrill(path: string, target: string) {
+	if (!path || !target) {
+		usage();
+		process.exit(1);
+	}
+	const raw = await readFile(path, "utf8");
+	const traces: Trace[] = JSON.parse(raw).stackTraces ?? [];
+	const hits = traces.filter((t) => t.stackFrames.some((f) => f.name?.includes(target)));
+	console.log(`samples containing ${target}: ${hits.length} / ${traces.length}`);
+	const leaf = new Map<string, number>();
+	for (const t of hits) {
+		const k = frameKey(t.stackFrames[0]);
+		leaf.set(k, (leaf.get(k) ?? 0) + 1);
+	}
+	printTop(`Top 20 leaf frames under ${target}`, leaf, hits.length, 20);
+}
+
+function printTop(title: string, map: Map<string, number>, denom: number, n: number) {
+	const top = [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, n);
+	console.log(`\n## ${title}`);
+	for (const [k, v] of top) {
+		const pct = ((v / denom) * 100).toFixed(1);
+		console.log(`  ${pct.padStart(5)}% (${String(v).padStart(4)})  ${k}`);
+	}
+}


### PR DESCRIPTION
## Summary
- Bundle the CDP-driven profile capture + analysis we built during today's investigation into the \`cchub-profile\` skill so future sessions get it for free.
- New \`.claude/skills/cchub-profile/scripts/profile.ts\` with three subcommands:
  - \`profile [--seconds N] [--out PATH]\` — enable inspector → talk CDP → capture → disable (try/finally)
  - \`analyze <profile.json>\` — top-15 self/total time
  - \`drill <profile.json> <name>\` — leaf ranking under any function

## Why
The manual flow (enable / grep journal / hand-write WS client / disable) was effectively today's investigation, twice. Promote it to first-class and avoid teaching the next Claude session the same lessons.

## Notes captured in SKILL.md
- Idle samples come back empty — apply real load during tracking.
- 🚨 Do NOT call \`Inspector.enable\` / \`Debugger.enable\` / \`Runtime.enable\` before \`ScriptProfiler.startTracking\`. They attach JSC to a debugger and silence the sampler. (Confirmed: identical script with those calls returns empty samples, without them returns 720 samples in 12s.)

## Test plan
- [x] \`bun .claude/skills/cchub-profile/scripts/profile.ts profile --seconds 12 --out /tmp/p.json\` under curl load → 720 samples / 572KB
- [x] \`analyze\` reproduces the same top frames seen with the original manual harness
- [x] \`drill buildSessionsList\` shows the same mkdir / spawn / saveLastKnownSessions hot path
- [x] skill validates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)