### PR TITLE
Release v0.1.128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.128] - 2026-05-19
+
+### Fixed
+- **lost セッションの再開**: 再起動後に lost 状態で復元されたセッションで、`last-known-sessions.json` のスナップショットを毎回上書きする際 `currentPath` などが一時的に取れなかったタイミングで既存値ごと消えてしまい、フロントの再開フローが履歴 API ではなくアクティブ用エンドポイントに落ちて 404 になる事象を修正。新しい値が無いときだけ前回値を維持する fallback を追加 (`backend/src/routes/sessions.ts`)
+
 ## [0.1.127] - 2026-05-19
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -282,18 +282,25 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     });
   }
 
-  // Save snapshot: active sessions + still-lost sessions (so lost ones persist across refreshes)
+  // Save snapshot: active sessions + still-lost sessions (so lost ones persist across refreshes).
+  // Fall back to previously-known values when tmux didn't report a field this round —
+  // otherwise a transient gap (e.g. currentPath missing on first capture) erases the data
+  // and lost-session resume can't find the project path.
+  const prevById = new Map(lastKnown.map(s => [s.id, s]));
   const snapshot: LastKnownSession[] = [
-    ...results.filter(s => s.state !== 'lost').map(s => ({
-      id: s.id,
-      name: s.name,
-      currentPath: s.currentPath,
-      agent: s.agent,
-      theme: s.theme,
-      customTitle: s.customTitle,
-      ccSessionId: s.ccSessionId,
-      agentSessionId: s.agentSessionId,
-    })),
+    ...results.filter(s => s.state !== 'lost').map(s => {
+      const prev = prevById.get(s.id);
+      return {
+        id: s.id,
+        name: s.name,
+        currentPath: s.currentPath ?? prev?.currentPath,
+        agent: s.agent ?? prev?.agent,
+        theme: s.theme ?? prev?.theme,
+        customTitle: s.customTitle ?? prev?.customTitle,
+        ccSessionId: s.ccSessionId ?? prev?.ccSessionId,
+        agentSessionId: s.agentSessionId ?? prev?.agentSessionId,
+      };
+    }),
     ...lostSessions,
   ];
   // Fire async, don't block response

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: lost セッションの再開で 404 になる問題を修正 — `last-known-sessions.json` 上書き時に `currentPath` などが一時的な欠落で消えないよう、前回値へのフォールバックを追加 (`backend/src/routes/sessions.ts`)

## Notes
症状: 再起動後に lost 状態のセッションで「再開」を押しても無反応 / 404。`currentPath` が落ちると frontend の `handleResume` が history-resume API に分岐できず、アクティブ用エンドポイント (`/api/sessions/:id/resume`) を叩いてしまっていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)