### PR TITLE
Release v0.1.129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.129] - 2026-05-19
+
+### Fixed
+- **ConversationViewer の追従スクロール**: ストリーミング中にメッセージが追加されるたび最下部に強制スクロールしてしまい、上にスクロールして読んでいるとその場に留まれなかった問題を修正。ターミナルと同じ挙動 (最下部にいるときだけ追従、上にスクロール中は留まる、最下部に戻すと追従再開) に変更。`atBottomRef` を常時更新するよう内部状態追跡と外部コールバック (キーボード制御) を分離し、auto-scroll を `atBottomRef` でゲート (`frontend/src/components/ConversationViewer.tsx`)
+
 ## [0.1.128] - 2026-05-19
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/components/ConversationViewer.tsx
+++ b/frontend/src/components/ConversationViewer.tsx
@@ -638,20 +638,19 @@ export function ConversationViewer({
 		let gestureFired = false;
 
 		let cooldownUntil = 0;
-		const reportIfChanged = () => {
-			if (Date.now() < cooldownUntil) return;
-			const atBottom = computeAtBottom();
-			if (atBottom === atBottomRef.current) return;
-			atBottomRef.current = atBottom;
-			cooldownUntil = Date.now() + 600; // ignore rapid layout-shift re-toggles
-			onAtBottomChangeRef.current?.(atBottom);
-		};
-
 		const onScroll = () => {
-			// Only react when the user is (or recently was) touching, to avoid
-			// feedback loops with keyboard show/hide layout shifts.
+			const atBottom = computeAtBottom();
+			const prev = atBottomRef.current;
+			// Always keep internal at-bottom state fresh — the auto-scroll
+			// effect reads this to decide whether to follow streaming output.
+			atBottomRef.current = atBottom;
+			// The external onAtBottomChange callback drives keyboard visibility,
+			// so keep it gated to user gestures to avoid show/hide oscillation.
 			if (!userTouching && Date.now() > userTouchedUntil) return;
-			reportIfChanged();
+			if (atBottom === prev) return;
+			if (Date.now() < cooldownUntil) return;
+			cooldownUntil = Date.now() + 600;
+			onAtBottomChangeRef.current?.(atBottom);
 		};
 		const onStart = (e: TouchEvent) => {
 			userTouching = true;
@@ -716,9 +715,13 @@ export function ConversationViewer({
 	useEffect(() => {
 		if (scrollToBottom && messages.length > 0 && !isLoading) {
 			if (messages.length > prevMessageCount) {
-				requestAnimationFrame(() => {
-					scrollToEnd();
-				});
+				// Only follow streaming output if the user is still at the bottom;
+				// otherwise they're reading older content and we'd yank them back.
+				if (atBottomRef.current) {
+					requestAnimationFrame(() => {
+						scrollToEnd();
+					});
+				}
 			}
 			setPrevMessageCount(messages.length);
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: ConversationViewer のストリーミング中の引き戻しスクロールを修正。ターミナルの scrollback と同じ挙動に (`frontend/src/components/ConversationViewer.tsx`)

## Notes
症状: 出力中に上にスクロールして読もうとすると、新メッセージが届く度に最下部へ強制的に戻されて読めなかった。
原因: 自動スクロール effect が `atBottomRef` を見ずに `messages.length > prev` で無条件発火していたうえ、`atBottomRef` の更新がタッチイベント中限定だったのでデスクトップでは常に true 扱いだった。
修正: scroll イベントで常時 `atBottomRef` を更新し、自動スクロールはそれが true のときだけ実行。キーボード oscillation 防止のための touch ゲートは外部コールバック (`onAtBottomChange`) のみに残した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)