### PR TITLE
Release v0.1.131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.131] - 2026-05-19
+
+### Changed
+- **ConversationViewer の可読性向上**: Tool 結果を再びデフォルトで展開状態に (1行サマリだけだと結果が見づらかった)。折りたたみ内部の本文色を `zinc-500` / `th-text-secondary` から `zinc-300` / `zinc-200` に引き上げ、ダーク背景でのコントラストを改善 (`frontend/src/components/ConversationViewer.tsx`)
+
 ## [0.1.130] - 2026-05-19
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.130",
+  "version": "0.1.131",
   "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.130",
+  "version": "0.1.131",
   "generated": "2026-05-19",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/components/ConversationViewer.tsx
+++ b/frontend/src/components/ConversationViewer.tsx
@@ -94,7 +94,7 @@ function CollapsibleSection({
 				<span className="truncate">{title}</span>
 			</button>
 			{isOpen && (
-				<div className="ml-4 pl-2 border-l border-white/[0.06] text-[length:var(--cv-fs-meta,11px)] text-zinc-500 overflow-x-auto">
+				<div className="ml-4 pl-2 border-l border-white/[0.08] text-[length:var(--cv-fs-meta,11px)] text-zinc-300 overflow-x-auto">
 					{children}
 				</div>
 			)}
@@ -181,10 +181,11 @@ function ToolResultDisplay({ results }: { results: ToolResultInfo[] }) {
 						}
 						icon={result.isError ? "❌" : "📋"}
 						variant={result.isError ? "error" : "result"}
+						defaultOpen
 					>
 						{hasOutput && (
 							<pre
-								className={`whitespace-pre-wrap break-all ${result.isError ? "text-red-300" : "text-th-text-secondary"}`}
+								className={`whitespace-pre-wrap break-all ${result.isError ? "text-red-300" : "text-zinc-200"}`}
 							>
 								{isLong ? (
 									<ExpandableText text={result.output} preview={preview} />
@@ -230,7 +231,7 @@ function ToolResultDisplay({ results }: { results: ToolResultInfo[] }) {
 							</div>
 						)}
 						{!hasOutput && !hasImages && (
-							<pre className="whitespace-pre-wrap break-all text-th-text-secondary">
+							<pre className="whitespace-pre-wrap break-all text-zinc-400">
 								{t("conversation.noOutput")}
 							</pre>
 						)}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.130",
+  "version": "0.1.131",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- design: ConversationViewer の Tool 結果デフォルトを「展開」に戻し、折りたたみ内部の文字色をコントラスト高めに (`frontend/src/components/ConversationViewer.tsx`)

## Notes
v0.1.130 で全部畳んだら肝心の結果が読めずに毎回クリックが必要になっていたので展開デフォルトに戻し、加えて中身の文字色がダーク背景と同化していたのを引き上げた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)