### PR TITLE
Release v0.1.132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.132] - 2026-05-20
+
+### Added
+- **履歴タブの Codex 対応**: `~/.codex/sessions/**` の rollout JSONL を読み取り、Claude セッションと同じ project バケットに merge して表示する `CodexHistoryService` を追加。各履歴行に `Claude` / `Codex` バッジを表示、再開時は agent に応じて `claude -r` / `codex resume` を自動切り替え。検索 (SSE ストリーミング含む)・会話表示・プロジェクト一覧の全エンドポイントで Codex セッションを統合 (`backend/src/services/codex-history.ts`, `backend/src/routes/sessions.ts`, `frontend/src/components/SessionHistory.tsx`, `frontend/src/hooks/useSessionHistory.ts`, `shared/types.ts`)
+
 ## [0.1.131] - 2026-05-19
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -113,8 +113,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.131",
-  "generated": "2026-05-19",
+  "version": "0.1.132",
+  "generated": "2026-05-20",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.131",
-  "generated": "2026-05-19",
+  "version": "0.1.132",
+  "generated": "2026-05-20",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -8,6 +8,7 @@ import { ClaudeCodeService } from '../services/claude-code';
 import { CodexService } from '../services/codex';
 import { CodexConversationService } from '../services/codex-conversation';
 import { SessionHistoryService } from '../services/session-history';
+import { CodexHistoryService } from '../services/codex-history';
 import { PromptHistoryService } from '../services/prompt-history';
 import { getAllSessionMetadata, setSessionTheme, setSessionTitle, getSessionOrder, setSessionOrder, getLastKnownSessions, saveLastKnownSessions, removeLastKnownSession, type LastKnownSession } from '../services/session-metadata';
 import { computeSessionMetrics } from '../services/session-metrics';
@@ -19,6 +20,7 @@ const claudeCodeService = new ClaudeCodeService();
 const codexService = new CodexService();
 const codexConversationService = new CodexConversationService();
 const sessionHistoryService = new SessionHistoryService();
+const codexHistoryService = new CodexHistoryService(undefined, codexConversationService);
 const promptHistoryService = new PromptHistoryService();
 
 export function shellQuote(value: string): string {
@@ -404,8 +406,27 @@ sessions.post('/', async (c) => {
 });
 
 // GET /sessions/history/projects - Get list of projects (fast, no file content reading)
+// Merges Claude (~/.claude/projects/*) and Codex (~/.codex/sessions/**) buckets
+// by encoded cwd so the same directory shows up once.
 sessions.get('/history/projects', async (c) => {
-  const projects = await sessionHistoryService.getProjects();
+  const [claudeProjects, codexProjects] = await Promise.all([
+    sessionHistoryService.getProjects(),
+    codexHistoryService.getProjects(),
+  ]);
+  const byDir = new Map<string, typeof claudeProjects[number]>();
+  for (const p of claudeProjects) byDir.set(p.dirName, p);
+  for (const p of codexProjects) {
+    const existing = byDir.get(p.dirName);
+    if (existing) {
+      existing.sessionCount += p.sessionCount;
+      if (!existing.latestModified || (p.latestModified && p.latestModified > existing.latestModified)) {
+        existing.latestModified = p.latestModified;
+      }
+    } else {
+      byDir.set(p.dirName, p);
+    }
+  }
+  const projects = Array.from(byDir.values()).sort((a, b) => a.projectName.localeCompare(b.projectName));
   return c.json({ projects });
 });
 
@@ -413,8 +434,15 @@ sessions.get('/history/projects', async (c) => {
 sessions.get('/history/search', async (c) => {
   const query = c.req.query('q') || '';
   const limit = parseInt(c.req.query('limit') || '50', 10);
-  const sessions = await sessionHistoryService.searchSessions(query, limit);
-  return c.json({ sessions });
+  const [claudeMatches, codexMatches] = await Promise.all([
+    sessionHistoryService.searchSessions(query, limit),
+    codexHistoryService.searchSessions(query, limit),
+  ]);
+  const merged = [
+    ...claudeMatches.map(s => ({ ...s, agent: s.agent ?? 'claude' as const })),
+    ...codexMatches,
+  ].sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime()).slice(0, limit);
+  return c.json({ sessions: merged });
 });
 
 // GET /sessions/history/search/stream - Streaming search with SSE
@@ -430,11 +458,22 @@ sessions.get('/history/search/stream', async (c) => {
   const stream = new ReadableStream({
     async start(controller) {
       const encoder = new TextEncoder();
+      let yielded = 0;
 
       try {
-        for await (const session of sessionHistoryService.searchSessionsStream(query, limit)) {
-          const data = `data: ${JSON.stringify(session)}\n\n`;
-          controller.enqueue(encoder.encode(data));
+        // Emit Codex matches up-front (small set, scanned in one pass).
+        const codexMatches = await codexHistoryService.searchSessions(query, limit);
+        for (const session of codexMatches) {
+          if (yielded >= limit) break;
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(session)}\n\n`));
+          yielded++;
+        }
+        // Then stream Claude matches incrementally.
+        for await (const session of sessionHistoryService.searchSessionsStream(query, limit - yielded)) {
+          if (yielded >= limit) break;
+          const tagged = { ...session, agent: session.agent ?? 'claude' as const };
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(tagged)}\n\n`));
+          yielded++;
         }
         // Send done event
         controller.enqueue(encoder.encode('event: done\ndata: {}\n\n'));
@@ -456,18 +495,33 @@ sessions.get('/history/search/stream', async (c) => {
 });
 
 // GET /sessions/history/projects/:dirName - Get sessions for a specific project
+// Returns merged Claude + Codex sessions in the same project bucket.
 sessions.get('/history/projects/:dirName', async (c) => {
   const dirName = c.req.param('dirName');
-  const sessions = await sessionHistoryService.getProjectSessions(dirName);
-  return c.json({ sessions });
+  const [claudeSessions, codexSessions] = await Promise.all([
+    sessionHistoryService.getProjectSessions(dirName),
+    codexHistoryService.getProjectSessions(dirName),
+  ]);
+  const merged = [
+    ...claudeSessions.map(s => ({ ...s, agent: s.agent ?? 'claude' as const })),
+    ...codexSessions,
+  ].sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+  return c.json({ sessions: merged });
 });
 
-// GET /sessions/history - Get past Claude Code session history
+// GET /sessions/history - Get past session history (recent across all projects)
 // NOTE: This must be defined BEFORE /:id to prevent "history" being interpreted as an id
 sessions.get('/history', async (c) => {
   const includeMetadata = c.req.query('metadata') === 'true';
-  const history = await sessionHistoryService.getRecentSessions(30, includeMetadata);
-  return c.json({ sessions: history });
+  const [claudeHistory, codexHistory] = await Promise.all([
+    sessionHistoryService.getRecentSessions(30, includeMetadata),
+    codexHistoryService.getRecentSessions(30),
+  ]);
+  const merged = [
+    ...claudeHistory.map(s => ({ ...s, agent: s.agent ?? 'claude' as const })),
+    ...codexHistory,
+  ].sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime()).slice(0, 30);
+  return c.json({ sessions: merged });
 });
 
 // GET /sessions/history/:sessionId/conversation - Get conversation history for a session
@@ -480,7 +534,7 @@ sessions.get('/history/:sessionId/conversation', async (c) => {
   const last = lastQuery ? parseInt(lastQuery, 10) : undefined;
   const agent = c.req.query('agent');
   const messages = agent === 'codex'
-    ? await codexConversationService.getConversation(sessionId)
+    ? await codexHistoryService.getConversation(sessionId)
     : await sessionHistoryService.getConversation(sessionId, projectDirName);
   return c.json({ messages: last ? messages.slice(-last) : messages });
 });

--- a/backend/src/services/codex-history.ts
+++ b/backend/src/services/codex-history.ts
@@ -1,0 +1,234 @@
+import { createReadStream } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { ConversationMessage, HistorySession } from '../../../shared/types';
+import { CodexConversationService } from './codex-conversation';
+import type { ProjectInfo } from './session-history';
+
+interface RolloutInfo {
+  rolloutPath: string;
+  sessionId: string;
+  cwd: string;
+  firstPrompt?: string;
+  modified: string;
+}
+
+/**
+ * Encode an absolute path into the same dirName key that Claude uses
+ * (`~/.claude/projects/-home-m0a-cchub/...`), so Claude and Codex
+ * sessions for the same project bucket share one ProjectInfo entry.
+ */
+function encodeCwd(cwd: string): string {
+  return cwd.replace(/\//g, '-');
+}
+
+/**
+ * Reads session history from Codex rollout JSONL files.
+ *
+ * Rollouts live under `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`.
+ * The first event in a rollout is `session_meta` with `id` / `cwd`;
+ * subsequent `event_msg/user_message` events carry the prompt text.
+ *
+ * We avoid parsing the whole file for the listing flow — only the
+ * first ~50 lines are scanned to extract metadata + first prompt.
+ */
+export class CodexHistoryService {
+  private sessionsDir: string;
+  private conversationService: CodexConversationService;
+  private cache = new Map<string, { mtimeMs: number; info: RolloutInfo | null }>();
+
+  constructor(
+    sessionsDir = join(homedir(), '.codex', 'sessions'),
+    conversationService = new CodexConversationService(),
+  ) {
+    this.sessionsDir = sessionsDir;
+    this.conversationService = conversationService;
+  }
+
+  /** Walk the date-partitioned tree and return absolute paths of all rollout files. */
+  private async listRolloutPaths(): Promise<string[]> {
+    const results: string[] = [];
+    const walk = async (dir: string, depth: number): Promise<void> => {
+      let entries: string[];
+      try {
+        entries = await readdir(dir);
+      } catch {
+        return;
+      }
+      await Promise.all(entries.map(async (name) => {
+        const full = join(dir, name);
+        try {
+          const s = await stat(full);
+          if (s.isDirectory() && depth < 3) {
+            await walk(full, depth + 1);
+          } else if (s.isFile() && name.endsWith('.jsonl') && name.startsWith('rollout-')) {
+            results.push(full);
+          }
+        } catch {
+          // ignore unreadable entries
+        }
+      }));
+    };
+    await walk(this.sessionsDir, 0);
+    return results;
+  }
+
+  private async readRolloutInfo(rolloutPath: string): Promise<RolloutInfo | null> {
+    let mtimeMs: number;
+    try {
+      mtimeMs = (await stat(rolloutPath)).mtimeMs;
+    } catch {
+      return null;
+    }
+    const cached = this.cache.get(rolloutPath);
+    if (cached && cached.mtimeMs === mtimeMs) return cached.info;
+
+    let sessionId: string | undefined;
+    let cwd: string | undefined;
+    let firstPrompt: string | undefined;
+    let linesRead = 0;
+    const maxLines = 200; // first prompt often appears within the first dozens of events
+
+    try {
+      const fileStream = createReadStream(rolloutPath);
+      const rl = createInterface({ input: fileStream, crlfDelay: Infinity });
+      for await (const line of rl) {
+        linesRead++;
+        if (linesRead > maxLines && firstPrompt) break;
+        if (!line.trim()) continue;
+        let event: {
+          type?: string;
+          payload?: {
+            id?: string;
+            cwd?: string;
+            type?: string;
+            message?: string;
+          };
+        };
+        try {
+          event = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const payload = event.payload;
+        if (!payload) continue;
+        if (event.type === 'session_meta') {
+          if (typeof payload.id === 'string') sessionId = payload.id;
+          if (typeof payload.cwd === 'string') cwd = payload.cwd;
+        } else if (event.type === 'event_msg' && payload.type === 'user_message') {
+          if (!firstPrompt && typeof payload.message === 'string' && payload.message.trim()) {
+            const content = payload.message.trim();
+            firstPrompt = content.length > 100 ? `${content.slice(0, 100)}...` : content;
+          }
+        }
+        if (sessionId && cwd && firstPrompt) break;
+      }
+      rl.close();
+      fileStream.destroy();
+    } catch {
+      // fall through; partial info still usable
+    }
+
+    // Fallback: id encoded in the filename (`rollout-<ts>-<uuid>.jsonl`)
+    if (!sessionId) {
+      const m = rolloutPath.match(/rollout-[\d-T]+-([0-9a-f-]+)\.jsonl$/);
+      if (m) sessionId = m[1];
+    }
+
+    const info: RolloutInfo | null = sessionId && cwd
+      ? { rolloutPath, sessionId, cwd, firstPrompt, modified: new Date(mtimeMs).toISOString() }
+      : null;
+    this.cache.set(rolloutPath, { mtimeMs, info });
+    return info;
+  }
+
+  private async listRollouts(): Promise<RolloutInfo[]> {
+    const paths = await this.listRolloutPaths();
+    const infos = await Promise.all(paths.map((p) => this.readRolloutInfo(p)));
+    return infos.filter((x): x is RolloutInfo => x !== null);
+  }
+
+  /** Group rollouts by cwd → ProjectInfo. dirName matches Claude's encoding. */
+  async getProjects(): Promise<ProjectInfo[]> {
+    const rollouts = await this.listRollouts();
+    const byDir = new Map<string, ProjectInfo>();
+    for (const r of rollouts) {
+      const dirName = encodeCwd(r.cwd);
+      const projectName = r.cwd.replace(/^\/home\/[^/]+\//, '~/');
+      const existing = byDir.get(dirName);
+      if (existing) {
+        existing.sessionCount++;
+        if (!existing.latestModified || r.modified > existing.latestModified) {
+          existing.latestModified = r.modified;
+        }
+      } else {
+        byDir.set(dirName, {
+          dirName,
+          projectPath: r.cwd,
+          projectName,
+          sessionCount: 1,
+          latestModified: r.modified,
+        });
+      }
+    }
+    return Array.from(byDir.values());
+  }
+
+  async getProjectSessions(dirName: string): Promise<HistorySession[]> {
+    const rollouts = await this.listRollouts();
+    const sessions: HistorySession[] = [];
+    for (const r of rollouts) {
+      if (encodeCwd(r.cwd) !== dirName) continue;
+      sessions.push(this.toHistorySession(r));
+    }
+    sessions.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+    return sessions;
+  }
+
+  async getRecentSessions(limit = 30): Promise<HistorySession[]> {
+    const rollouts = await this.listRollouts();
+    rollouts.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+    return rollouts.slice(0, limit).map((r) => this.toHistorySession(r));
+  }
+
+  async searchSessions(query: string, limit = 50): Promise<HistorySession[]> {
+    if (!query.trim()) return [];
+    const needle = query.toLowerCase();
+    const rollouts = await this.listRollouts();
+    const matches: HistorySession[] = [];
+    for (const r of rollouts) {
+      const haystack = `${r.cwd} ${r.firstPrompt ?? ''}`.toLowerCase();
+      if (haystack.includes(needle)) {
+        matches.push(this.toHistorySession(r));
+        if (matches.length >= limit) break;
+      }
+    }
+    matches.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+    return matches;
+  }
+
+  async getConversation(sessionId: string): Promise<ConversationMessage[]> {
+    // First try the active-thread path (state_5.sqlite → rollout_path).
+    const viaDb = await this.conversationService.getConversation(sessionId);
+    if (viaDb.length > 0) return viaDb;
+    // Fallback for archived rollouts that aren't in the active threads table:
+    // locate the rollout file by id and parse directly.
+    const rollouts = await this.listRollouts();
+    const hit = rollouts.find((r) => r.sessionId === sessionId);
+    if (!hit) return [];
+    return this.conversationService.parseRollout(hit.rolloutPath);
+  }
+
+  private toHistorySession(r: RolloutInfo): HistorySession {
+    return {
+      sessionId: r.sessionId,
+      projectPath: r.cwd,
+      projectName: r.cwd.replace(/^\/home\/[^/]+\//, '~/'),
+      firstPrompt: r.firstPrompt,
+      modified: r.modified,
+      agent: 'codex',
+    };
+  }
+}

--- a/backend/src/services/session-history.ts
+++ b/backend/src/services/session-history.ts
@@ -3,23 +3,9 @@ import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import type { HistorySession } from '../../../shared/types';
 
-export interface HistorySession {
-  sessionId: string;
-  projectPath: string;
-  projectName: string;
-  firstPrompt?: string;
-  summary?: string;
-  modified: string;
-  // Phase 2 additions
-  startTime?: string;
-  endTime?: string;
-  durationMinutes?: number;
-  messageCount?: number;
-  gitBranch?: string;
-  // For session matching with active sessions
-  firstMessageUuid?: string;
-}
+export type { HistorySession };
 
 interface SessionMetadata {
   startTime?: string;

--- a/frontend/src/components/SessionHistory.tsx
+++ b/frontend/src/components/SessionHistory.tsx
@@ -74,6 +74,12 @@ function HistoryItem({
 	const messageCount = session.messageCount;
 	const gitBranch = session.gitBranch;
 
+	const agent = session.agent ?? "claude";
+	const agentBadge =
+		agent === "codex"
+			? { label: "Codex", className: "text-cyan-300 bg-cyan-400/10 border-cyan-400/20" }
+			: { label: "Claude", className: "text-violet-300 bg-violet-400/10 border-violet-400/20" };
+
 	return (
 		<div
 			onClick={onTap}
@@ -85,6 +91,11 @@ function HistoryItem({
 						{truncatedText}
 					</p>
 					<div className="flex items-center gap-3 mt-1.5 text-[11px] text-zinc-600">
+						<span
+							className={`inline-flex items-center px-1.5 py-px rounded border text-[10px] font-medium ${agentBadge.className}`}
+						>
+							{agentBadge.label}
+						</span>
 						<span>
 							{formatRelativeTime(session.modified, t, i18n.language)}
 						</span>
@@ -297,6 +308,7 @@ export function SessionHistory({
 			const result = await resumeSession(
 				session.sessionId,
 				session.projectPath,
+				session.agent,
 			);
 
 			if (result) {
@@ -359,6 +371,7 @@ export function SessionHistory({
 			const messages = await fetchConversation(
 				session.sessionId,
 				projectDirName,
+				session.agent,
 			);
 			setConversation(messages);
 		} finally {
@@ -405,7 +418,11 @@ export function SessionHistory({
 		setLoadingConversation(true);
 		setConversation([]);
 		try {
-			const messages = await fetchConversation(session.sessionId);
+			const messages = await fetchConversation(
+				session.sessionId,
+				undefined,
+				session.agent,
+			);
 			setConversation(messages);
 		} finally {
 			setLoadingConversation(false);

--- a/frontend/src/hooks/useSessionHistory.ts
+++ b/frontend/src/hooks/useSessionHistory.ts
@@ -43,10 +43,12 @@ interface UseSessionHistoryResult {
 	resumeSession: (
 		sessionId: string,
 		projectPath: string,
+		agent?: "claude" | "codex",
 	) => Promise<{ tmuxSessionId: string } | null>;
 	fetchConversation: (
 		sessionId: string,
 		projectDirName?: string,
+		agent?: "claude" | "codex",
 	) => Promise<ConversationMessage[]>;
 }
 
@@ -149,14 +151,18 @@ export function useSessionHistory(): UseSessionHistoryResult {
 	}, [sessionsByProject, fetchProjectSessions]);
 
 	const resumeSession = useCallback(
-		async (sessionId: string, projectPath: string) => {
+		async (
+			sessionId: string,
+			projectPath: string,
+			agent?: "claude" | "codex",
+		) => {
 			try {
 				const response = await authFetch(
 					`${API_BASE}/api/sessions/history/resume`,
 					{
 						method: "POST",
 						headers: { "Content-Type": "application/json" },
-						body: JSON.stringify({ sessionId, projectPath }),
+						body: JSON.stringify({ sessionId, projectPath, agent }),
 					},
 				);
 				if (!response.ok) {
@@ -179,6 +185,7 @@ export function useSessionHistory(): UseSessionHistoryResult {
 		async (
 			sessionId: string,
 			projectDirName?: string,
+			agent?: "claude" | "codex",
 		): Promise<ConversationMessage[]> => {
 			try {
 				const url = new URL(
@@ -187,6 +194,9 @@ export function useSessionHistory(): UseSessionHistoryResult {
 				);
 				if (projectDirName) {
 					url.searchParams.set("projectDirName", projectDirName);
+				}
+				if (agent === "codex") {
+					url.searchParams.set("agent", "codex");
 				}
 				const response = await authFetch(url.toString(), {
 					cache: "no-store",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.131",
+  "version": "0.1.132",
   "private": true,
   "workspaces": [
     "backend",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -415,6 +415,9 @@ export interface HistorySession {
   gitBranch?: string;
   // For session matching with active sessions
   firstMessageUuid?: string;
+  // Which agent produced this history entry. Drives the resume command
+  // (`claude -r <id>` vs `codex resume <id>`) and the badge in the UI.
+  agent?: AgentProvider;
 }
 
 export interface HistorySessionsResponse {


### PR DESCRIPTION
## Changes
- feat: 履歴タブで Codex セッションも表示・再開可能に。`~/.codex/sessions/**` の rollout を Claude セッションと同じ project バケットに merge し、各行に agent バッジ + 再開時に `claude -r` / `codex resume` を自動切り替え (`backend/src/services/codex-history.ts`, `backend/src/routes/sessions.ts`, `frontend/src/components/SessionHistory.tsx`, `frontend/src/hooks/useSessionHistory.ts`, `shared/types.ts`)

## Notes
- グルーピング: Codex の `session_meta.cwd` を Claude と同じエンコード (`/` → `-`) で dirName 化し、同じ project に集約
- Conversation 取得: 既存の `?agent=codex` 経路を `CodexHistoryService.getConversation` 経由に変更 (active threads sqlite に無いアーカイブ済み rollout も拾えるようになる)
- バッジ色: Claude = violet, Codex = cyan

🤖 Generated with [Claude Code](https://claude.com/claude-code)