### PR TITLE
Release v0.1.133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.133] - 2026-05-20
+
+### Added
+- `cchub update` で GitHub トークン認証をサポートし、未認証 60/時のレート制限 (60/hr) を 5000/時 に引き上げ可能に
+  - 検出順: `GITHUB_TOKEN` env → `GH_TOKEN` env → `gh auth token` サブプロセス自動検出
+  - 認証時は `🔑 Using GitHub token from {{source}}` を表示
+  - 403 + `x-ratelimit-remaining: 0` を rate limit として識別し、リセット時刻と認証手順 (`export GITHUB_TOKEN=<token>` / `gh auth login`) を表示
+  - 未設定時は従来通り未認証で動作 (`backend/src/commands/update.ts`, `backend/src/i18n/index.ts`)
+
 ## [0.1.132] - 2026-05-20
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.132",
+  "version": "0.1.133",
   "generated": "2026-05-20",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.132",
+  "version": "0.1.133",
   "generated": "2026-05-20",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/commands/update.ts
+++ b/backend/src/commands/update.ts
@@ -55,26 +55,69 @@ interface GitHubRelease {
   }[];
 }
 
-async function getLatestRelease(): Promise<GitHubRelease | null> {
+interface GitHubTokenInfo {
+  token: string;
+  source: 'GITHUB_TOKEN' | 'GH_TOKEN' | 'gh CLI';
+}
+
+function getGitHubToken(): GitHubTokenInfo | null {
+  if (process.env.GITHUB_TOKEN) {
+    return { token: process.env.GITHUB_TOKEN, source: 'GITHUB_TOKEN' };
+  }
+  if (process.env.GH_TOKEN) {
+    return { token: process.env.GH_TOKEN, source: 'GH_TOKEN' };
+  }
+  try {
+    const proc = Bun.spawnSync(['gh', 'auth', 'token'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    if (proc.exitCode === 0) {
+      const token = new TextDecoder().decode(proc.stdout).trim();
+      if (token) return { token, source: 'gh CLI' };
+    }
+  } catch {
+    // gh not installed — fall through
+  }
+  return null;
+}
+
+async function getLatestRelease(tokenInfo: GitHubTokenInfo | null): Promise<GitHubRelease | null> {
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github.v3+json',
+    'User-Agent': `cchub/${VERSION}`,
+  };
+  if (tokenInfo) {
+    headers.Authorization = `Bearer ${tokenInfo.token}`;
+  }
+
   try {
     const response = await fetch(
       `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
-      {
-        headers: {
-          'Accept': 'application/vnd.github.v3+json',
-          'User-Agent': `cchub/${VERSION}`,
-        },
-      }
+      { headers }
     );
 
-    if (!response.ok) {
-      if (response.status === 404) {
-        return null; // No releases yet
-      }
-      throw new Error(`GitHub API error: ${response.status}`);
+    if (response.ok) {
+      return await response.json();
     }
-
-    return await response.json();
+    if (response.status === 404) {
+      return null;
+    }
+    if (response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0') {
+      console.error(`❌ ${t(tokenInfo ? 'update.rateLimitedAuth' : 'update.rateLimitedAnon')}`);
+      const resetHeader = response.headers.get('x-ratelimit-reset');
+      if (resetHeader) {
+        const resetDate = new Date(parseInt(resetHeader, 10) * 1000);
+        console.error(`   ${t('update.rateLimitResetAt', { time: resetDate.toLocaleString() })}`);
+      }
+      if (!tokenInfo) {
+        console.error(`💡 ${t('update.rateLimitHintAnon')}`);
+        console.error('   - export GITHUB_TOKEN=<token>');
+        console.error('   - gh auth login');
+      }
+      return null;
+    }
+    throw new Error(`GitHub API error: ${response.status}`);
   } catch (_error) {
     console.error(`❌ ${t('update.githubConnectionFailed')}`);
     return null;
@@ -127,7 +170,12 @@ export async function checkAndUpdate(checkOnly: boolean, autoMode: boolean): Pro
     console.log(`🔍 更新を確認中... (現在: v${currentVersion})`);
   }
 
-  const release = await getLatestRelease();
+  const tokenInfo = getGitHubToken();
+  if (tokenInfo && !autoMode) {
+    console.log(`🔑 ${t('update.authUsing', { source: tokenInfo.source })}`);
+  }
+
+  const release = await getLatestRelease(tokenInfo);
 
   if (!release) {
     if (!autoMode) {

--- a/backend/src/i18n/index.ts
+++ b/backend/src/i18n/index.ts
@@ -72,7 +72,12 @@ const translations: Record<string, Translations> = {
     update: {
       githubConnectionFailed: "Failed to connect to GitHub API",
       serviceRestarted: "Service restarted",
-      manualRestartRequired: "Manual restart required: systemctl --user restart cchub"
+      manualRestartRequired: "Manual restart required: systemctl --user restart cchub",
+      authUsing: "Using GitHub token from {{source}}",
+      rateLimitedAnon: "GitHub API rate limit exceeded (60/hr for unauthenticated requests)",
+      rateLimitedAuth: "GitHub API rate limit exceeded",
+      rateLimitHintAnon: "Hint: Authenticate to raise the limit to 5000/hr",
+      rateLimitResetAt: "Resets at: {{time}}"
     },
     usage: {
       limitReached: "Limit reached",
@@ -144,7 +149,12 @@ const translations: Record<string, Translations> = {
     update: {
       githubConnectionFailed: "GitHub APIへの接続に失敗しました",
       serviceRestarted: "サービスを再起動しました",
-      manualRestartRequired: "手動で再起動してください: systemctl --user restart cchub"
+      manualRestartRequired: "手動で再起動してください: systemctl --user restart cchub",
+      authUsing: "GitHub token を使用中 (取得元: {{source}})",
+      rateLimitedAnon: "GitHub API のレート制限に到達しました (未認証時は 60/時)",
+      rateLimitedAuth: "GitHub API のレート制限に到達しました",
+      rateLimitHintAnon: "ヒント: 認証すると上限が 5000/時 に拡大されます",
+      rateLimitResetAt: "リセット時刻: {{time}}"
     },
     usage: {
       limitReached: "リミット到達中",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.132",
+  "version": "0.1.133",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes

### Added
- `cchub update` で GitHub トークン認証をサポート (rate limit: 60/hr → 5000/hr)
  - 検出順: `GITHUB_TOKEN` env → `GH_TOKEN` env → `gh auth token` サブプロセス自動検出
  - 認証時は `🔑 Using GitHub token from {{source}}` を表示
  - 403 + `x-ratelimit-remaining: 0` を rate limit として識別し、リセット時刻と認証手順 (`export GITHUB_TOKEN=<token>` / `gh auth login`) を案内
  - 未設定時は従来通り未認証で動作 (後方互換)

## Test plan
- [x] `gh auth token` 自動検出経由で `update --check` 成功
- [x] `GITHUB_TOKEN` env var を優先 (gh CLI より先) — 検証済
- [x] 未認証 + rate limit 到達時に "rate limit exceeded" / reset time / `GITHUB_TOKEN`・`gh auth login` ヒントが表示
- [x] EN / JA i18n 両方で表示
- [x] `bun run --filter backend lint` clean
- [x] backend test 既存 fail 2 件以外は pass (回帰なし)

## Notes
- バイナリダウンロード (`browser_download_url`) には token 不要 (asset 配信はレート制限対象外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)