### PR TITLE
Release v0.1.134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.134] - 2026-05-20
+
+### Fixed
+- ターミナルでマウスホイール/トラックパッドのスクロールが効かず、代わりに Claude / Codex の入力履歴が切り替わる問題を修正
+  - 原因: xterm.js は active mouse protocol が WHEEL を含むとき、wheel イベントを直接アプリ (Ink TUI) に転送し、TUI 側で↑/↓キー扱いとなっていた
+  - 対応: `Terminal.tsx` の wheel listener を capture 段階に移し `stopPropagation()` を追加。xterm.js のハンドラに届かないようにして、`scrollTerminal()` だけが走るようにした
+
 ## [0.1.133] - 2026-05-20
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.133",
+  "version": "0.1.134",
   "generated": "2026-05-20",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.133",
+  "version": "0.1.134",
   "generated": "2026-05-20",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1022,18 +1022,23 @@ export const TerminalComponent = memo(
 				e.preventDefault(); // Mobile/tablet: prevent default
 			};
 
-			// Mouse wheel scroll
+			// Mouse wheel scroll — intercept on the capture phase before xterm.js
+			// receives the event. xterm.js forwards wheel events to the application
+			// (e.g. Claude / Codex Ink TUIs interpret wheel as ↑/↓ → input history),
+			// which prevents the user from scrolling tmux's scrollback. Stopping
+			// propagation here keeps the wheel local to our scrollTerminal() call.
 			const handleWheel = (e: WheelEvent) => {
 				const term = terminalRef.current;
 				if (!term) return;
 				e.preventDefault();
+				e.stopPropagation();
 				const lines = Math.ceil(Math.abs(e.deltaY) / 40);
 				scrollTerminal(e.deltaY > 0 ? lines : -lines);
 				updateScrollIndicator();
 			};
 
 			if (container) {
-				container.addEventListener("wheel", handleWheel, { passive: false });
+				container.addEventListener("wheel", handleWheel, { capture: true, passive: false });
 				container.addEventListener("touchstart", handleTouchStart, {
 					passive: true,
 				});
@@ -1061,7 +1066,7 @@ export const TerminalComponent = memo(
 					);
 					container.removeEventListener("mouseup", handleMouseUp);
 					container.removeEventListener("contextmenu", handleContextMenu);
-					container.removeEventListener("wheel", handleWheel);
+					container.removeEventListener("wheel", handleWheel, { capture: true } as EventListenerOptions);
 				}
 				if (resizeTimeout) clearTimeout(resizeTimeout);
 				resizeObserver.disconnect();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.133",
+  "version": "0.1.134",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes

### Fixed
- ターミナルでマウスホイール/トラックパッドのスクロールが効かず、代わりに Claude / Codex の入力履歴が切り替わる問題を修正
  - 原因: xterm.js は active mouse protocol が WHEEL を含むとき、wheel イベントを直接 TUI (Ink) に転送し、↑/↓ キー扱いとなっていた
  - 対応: `frontend/src/components/Terminal.tsx` の wheel listener を **capture 段階** に移し `stopPropagation()` を追加。xterm.js のハンドラに届かないようにして、`scrollTerminal()` (tmux scrollback) だけが走るようにした

## Test plan
- [x] Playwright で `.xterm-screen` に wheel イベント発火 → spy listener は受け取らず (`xtermReceived: false`)、`defaultPrevented: true`
- [x] dev 環境でトラックパッドスクロールが tmux scrollback に効くことを確認 (ユーザー確認済み)
- [x] `bun run --filter frontend lint` clean

## Notes
- vim / less などを tmux 内で使うユースケースは tmux scrollback に切り替わるが、それぞれ独自のスクロールキー (Ctrl+B/Ctrl+F 等) があるので実用上の影響は小さい
- Cmd+= / Cmd+- のフォントサイズ調整は別ハンドラなので影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)