### PR TITLE
Release v0.1.135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.135] - 2026-05-20
+
+### Changed
+- **セッション削除を「kill のみ・一覧から消さない」挙動に変更**: アクティブセッションを削除しても tmux は kill するが `last-known-sessions.json` のエントリは残し、一覧には Lost として表示され続けるようにした。これにより削除後も「再開」ボタンで会話の続きをワンタップで開ける。完全に一覧から消したい場合は Lost セッションをもう一度削除すると last-known からも除外される (`backend/src/routes/sessions.ts`)
+- 削除確認ダイアログの警告文を実挙動に合わせて更新 (「この操作は取り消せません」→「tmuxセッションを終了します。一覧には Lost として残り、「再開」ボタンで会話を続けられます。」)、トーンを警告赤から中立色に変更 (`frontend/src/App.tsx`, `frontend/src/components/SessionList.tsx`, `frontend/src/i18n/locales/{ja,en}.json`)
+
 ## [0.1.134] - 2026-05-20
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.134",
+  "version": "0.1.135",
   "generated": "2026-05-20",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.134",
+  "version": "0.1.135",
   "generated": "2026-05-20",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -683,14 +683,16 @@ sessions.delete('/:id', async (c) => {
 
   const exists = await tmuxService.sessionExists(id);
   if (!exists) {
-    // May be a lost session — remove from last-known and return success
+    // Already lost — purge from last-known so it disappears from the list.
     await removeLastKnownSession(id).catch(() => {});
     return c.json({ success: true });
   }
 
   try {
     await tmuxService.killSession(id);
-    await removeLastKnownSession(id).catch(() => {});
+    // Keep the entry in last-known so the session shows up as "Lost" and can
+    // be resumed via the Resume button without going to the history tab.
+    // To purge entirely, delete the Lost session again.
     return c.json({ success: true });
   } catch (_error) {
     return c.json({ error: 'Failed to delete session' }, 500);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -140,7 +140,9 @@ function ConfirmDeleteDialog({
 					<span className="font-medium text-th-text">{sessionName}</span>{" "}
 					を削除しますか？
 				</p>
-				<p className="text-sm text-red-400 mb-6">この操作は取り消せません。</p>
+				<p className="text-sm text-th-text-secondary mb-6">
+					tmuxセッションを終了します。一覧には Lost として残り、「再開」ボタンで会話を続けられます。
+				</p>
 				<div className="flex gap-3 justify-end">
 					<button
 						type="button"

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -162,7 +162,7 @@ export function SessionMenuDialog({
 					<p className="text-th-text-secondary mb-4">
 						{t("session.deleteConfirm", { name: session.name })}
 					</p>
-					<p className="text-sm text-red-400 mb-6">
+					<p className="text-sm text-th-text-secondary mb-6">
 						{t("session.deleteWarning")}
 					</p>
 					<div className="flex gap-3 justify-end">

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -43,7 +43,7 @@
 		"clearColor": "Clear Color",
 		"deleteSession": "Delete Session",
 		"deleteConfirm": "Delete {{name}}?",
-		"deleteWarning": "This action cannot be undone.",
+		"deleteWarning": "The tmux session will end. It will remain in the list as \"Lost\" and can be resumed with the Resume button.",
 		"sessionName": "Session Name",
 		"sessionNamePlaceholder": "Leave blank for auto-generation",
 		"agent": "Agent",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -43,7 +43,7 @@
 		"clearColor": "色をクリア",
 		"deleteSession": "セッションを削除",
 		"deleteConfirm": "{{name}} を削除しますか？",
-		"deleteWarning": "この操作は取り消せません。",
+		"deleteWarning": "tmuxセッションを終了します。一覧には Lost として残り、「再開」ボタンで会話を続けられます。",
 		"sessionName": "セッション名",
 		"sessionNamePlaceholder": "空欄で自動生成",
 		"agent": "エージェント",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.134",
+  "version": "0.1.135",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- chore: セッション削除を「kill のみ・一覧から消さない」挙動に変更。tmux は kill するが last-known-sessions に残し、Lost として一覧に残るので「再開」ボタンでワンタップで会話の続きを開ける
- 削除確認ダイアログの警告文を実挙動に合わせて更新、トーンを警告赤から中立色に変更

## Notes
完全に一覧から消したい場合は Lost セッションをもう一度削除すると last-known からも除外される (2段階削除)。