### PR TITLE
feat: multi-server peer support

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import { upload } from './routes/upload';
 import { files } from './routes/files';
 import { dashboard } from './routes/dashboard';
 import { notify } from './routes/notify';
+import { peers } from './routes/peers';
 import { muxOpen, muxMessage, muxClose, type MuxData } from './routes/terminal-mux';
 import { parseArgs, runCli, VERSION } from './cli';
 import { conditionalAuthMiddleware, isAuthRequired, getJwtSecret } from './middleware/auth';
@@ -149,6 +150,8 @@ app.use('/api/sessions', conditionalAuthMiddleware);
 app.use('/api/upload/*', conditionalAuthMiddleware);
 app.use('/api/files/*', conditionalAuthMiddleware);
 app.use('/api/dashboard', conditionalAuthMiddleware);
+app.use('/api/peers', conditionalAuthMiddleware);
+app.use('/api/peers/*', conditionalAuthMiddleware);
 
 app.route('/api/logs', logs);
 app.route('/api/sessions', sessions);
@@ -156,6 +159,7 @@ app.route('/api/upload', upload);
 app.route('/api/files', files);
 app.route('/api/dashboard', dashboard);
 app.route('/api/notify', notify);
+app.route('/api/peers', peers);
 
 // Static files handling
 const staticRoot = process.env.STATIC_ROOT || '../frontend/dist';

--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -21,6 +21,7 @@ import {
   type StoredPeer,
 } from '../services/peer-registry';
 import { loginToPeer, verifyPeer, peerFetch, PeerAuthError } from '../services/peer-auth';
+import { discoverPeers } from '../services/peer-discovery';
 import { buildSessionsList } from './sessions';
 
 export const peers = new Hono();
@@ -56,6 +57,12 @@ function toClientView(peer: StoredPeer & {
 peers.get('/', async (c) => {
   const all = await listPeers();
   return c.json({ peers: all.map(toClientView) });
+});
+
+// GET /api/peers/discover - Tailscale tailnet 内で cchub が動いている peer を検出
+peers.get('/discover', async (c) => {
+  const discovered = await discoverPeers();
+  return c.json({ discovered });
 });
 
 // POST /api/peers - peer を追加

--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -1,0 +1,188 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import {
+  PeerCreateSchema,
+  PeerUpdateSchema,
+  PeerOrderSchema,
+  LOCAL_PEER_ID,
+  SELF_PEER_URL,
+  type PeerClientView,
+  type PeerStatus,
+  type PeerSession,
+  type PeerSessionsResponse,
+  type ExtendedSessionResponse,
+} from '../../../shared/types';
+import {
+  listPeers,
+  createPeer,
+  updatePeer,
+  deletePeer,
+  setPeerOrder,
+  type StoredPeer,
+} from '../services/peer-registry';
+import { loginToPeer, verifyPeer, peerFetch, PeerAuthError } from '../services/peer-auth';
+import { buildSessionsList } from './sessions';
+
+export const peers = new Hono();
+
+function toClientView(peer: StoredPeer & {
+  wsToken?: string;
+  lastSeenAt?: string;
+  lastErrorAt?: string;
+  lastErrorMessage?: string;
+}): PeerClientView {
+  const status: PeerStatus = peer.id === LOCAL_PEER_ID
+    ? 'online'
+    : peer.lastErrorMessage
+      ? (peer.lastErrorMessage === 'unauthorized' ? 'unauthorized' : 'offline')
+      : peer.lastSeenAt
+        ? 'online'
+        : 'unknown';
+
+  return {
+    id: peer.id,
+    nickname: peer.nickname,
+    url: peer.url,
+    color: peer.color,
+    order: peer.order,
+    wsToken: peer.id === LOCAL_PEER_ID ? undefined : peer.wsToken,
+    status,
+    lastSeenAt: peer.lastSeenAt,
+    errorMessage: peer.lastErrorMessage,
+  };
+}
+
+// GET /api/peers - peer 一覧 (selfを含む)
+peers.get('/', async (c) => {
+  const all = await listPeers();
+  return c.json({ peers: all.map(toClientView) });
+});
+
+// POST /api/peers - peer を追加
+peers.post('/', zValidator('json', PeerCreateSchema), async (c) => {
+  const { nickname, url, password, color } = c.req.valid('json');
+
+  // 追加前に必ず疎通＆ログインを試す
+  let token: string;
+  try {
+    token = await loginToPeer(url, password);
+  } catch (err) {
+    if (err instanceof PeerAuthError) {
+      return c.json({ error: err.message, code: 'PEER_AUTH_FAILED' }, 400);
+    }
+    return c.json({ error: err instanceof Error ? err.message : 'Unknown error' }, 500);
+  }
+
+  const peer = await createPeer({ nickname, url, color, wsToken: token });
+  return c.json({ peer: toClientView(peer) });
+});
+
+// PATCH /api/peers/:id - nickname/color/password 更新
+peers.patch('/:id', zValidator('json', PeerUpdateSchema), async (c) => {
+  const id = c.req.param('id');
+  const { nickname, color, password } = c.req.valid('json');
+
+  let wsToken: string | undefined;
+  if (password) {
+    const peer = (await listPeers()).find(p => p.id === id);
+    if (!peer || peer.id === LOCAL_PEER_ID) {
+      return c.json({ error: 'Peer not found or is local' }, 404);
+    }
+    try {
+      wsToken = await loginToPeer(peer.url, password);
+    } catch (err) {
+      if (err instanceof PeerAuthError) {
+        return c.json({ error: err.message, code: 'PEER_AUTH_FAILED' }, 400);
+      }
+      return c.json({ error: err instanceof Error ? err.message : 'Unknown error' }, 500);
+    }
+  }
+
+  const peer = await updatePeer(id, { nickname, color, wsToken });
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+  return c.json({ peer: toClientView(peer) });
+});
+
+// DELETE /api/peers/:id
+peers.delete('/:id', async (c) => {
+  const id = c.req.param('id');
+  if (id === LOCAL_PEER_ID) {
+    return c.json({ error: 'Cannot delete local peer' }, 400);
+  }
+  const deleted = await deletePeer(id);
+  if (!deleted) return c.json({ error: 'Peer not found' }, 404);
+  return c.json({ success: true });
+});
+
+// PUT /api/peers/order - peer 並び替え
+peers.put('/order', zValidator('json', PeerOrderSchema), async (c) => {
+  const { order } = c.req.valid('json');
+  await setPeerOrder(order);
+  return c.json({ success: true });
+});
+
+// POST /api/peers/:id/verify - 疎通確認
+peers.post('/:id/verify', async (c) => {
+  const id = c.req.param('id');
+  const peer = await listPeers().then(ps => ps.find(p => p.id === id));
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+  if (peer.id === LOCAL_PEER_ID) {
+    return c.json({ status: 'online', latencyMs: 0 });
+  }
+  const result = await verifyPeer(peer.id, peer.url, peer.wsToken);
+  if (result.ok) {
+    return c.json({ status: 'online', latencyMs: result.latencyMs });
+  }
+  return c.json({
+    status: result.status === 401 ? 'unauthorized' : 'offline',
+    message: result.message,
+  });
+});
+
+// GET /api/peers/sessions - 全 peer のセッション一覧をマージして返す
+peers.get('/sessions', async (c) => {
+  const allPeers = await listPeers();
+  const errors: { peerId: string; message: string }[] = [];
+
+  const results = await Promise.all(allPeers.map(async (peer): Promise<PeerSession[]> => {
+    const enrich = (s: ExtendedSessionResponse): PeerSession => ({
+      ...s,
+      peerId: peer.id,
+      peerNickname: peer.nickname,
+      peerColor: peer.color,
+    });
+
+    if (peer.url === SELF_PEER_URL) {
+      try {
+        const local = await buildSessionsList();
+        return local.map(enrich);
+      } catch (err) {
+        errors.push({ peerId: peer.id, message: err instanceof Error ? err.message : 'Local sessions failed' });
+        return [];
+      }
+    }
+
+    try {
+      const res = await peerFetch(peer.id, peer.url, peer.wsToken, '/api/sessions');
+      if (!res.ok) {
+        errors.push({ peerId: peer.id, message: `HTTP ${res.status}` });
+        return [];
+      }
+      const data = (await res.json()) as { sessions?: ExtendedSessionResponse[] };
+      if (!data || !Array.isArray(data.sessions)) {
+        errors.push({ peerId: peer.id, message: 'Invalid response' });
+        return [];
+      }
+      return data.sessions.map(enrich);
+    } catch (err) {
+      errors.push({ peerId: peer.id, message: err instanceof Error ? err.message : 'Fetch failed' });
+      return [];
+    }
+  }));
+
+  const merged = results.flat();
+  const response: PeerSessionsResponse = errors.length > 0
+    ? { sessions: merged, errors }
+    : { sessions: merged };
+  return c.json(response);
+});

--- a/backend/src/services/peer-auth.ts
+++ b/backend/src/services/peer-auth.ts
@@ -1,0 +1,156 @@
+/**
+ * peer-auth: peer (Worker) への代理ログインを行うサービス。
+ *
+ * - Hub が peer 追加時にユーザーから受け取ったパスワードで POST /api/auth/login
+ * - 得られた JWT トークンを保存して以降の API/WS に使う
+ * - 401 が返ってきたら "unauthorized" 状態として記録（ユーザーに再認証を促す）
+ */
+
+import { recordPeerFailure, recordPeerSuccess } from './peer-registry';
+
+const VERIFY_TIMEOUT_MS = 5_000;
+
+export class PeerAuthError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+    this.name = 'PeerAuthError';
+  }
+}
+
+function normalizePeerUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+/**
+ * peer に対してパスワードログインを行い JWT トークンを取得する。
+ *
+ * peer 側が auth disabled (password なし) の場合、401 ではなく 400 が返るので
+ * その時は「トークン不要」とみなして空文字列を返す。
+ */
+export async function loginToPeer(url: string, password: string): Promise<string> {
+  const base = normalizePeerUrl(url);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(`${base}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new PeerAuthError(0, `peer に接続できません: ${msg}`);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (response.status === 400) {
+    // peer 側で auth が無効。トークン不要で動く
+    return '';
+  }
+  if (response.status === 401) {
+    throw new PeerAuthError(401, 'パスワードが正しくありません');
+  }
+  if (!response.ok) {
+    throw new PeerAuthError(response.status, `peer ログイン失敗: HTTP ${response.status}`);
+  }
+
+  const json = (await response.json().catch(() => ({}))) as { token?: string };
+  if (!json.token && response.status !== 400) {
+    // auth 無効の peer なら 400 で抜けているので、ここに来てトークン無しは異常
+    throw new PeerAuthError(500, 'peer の応答に token がありません');
+  }
+  return json.token ?? '';
+}
+
+/**
+ * peer に対して /api/auth/me (or /health) を叩いて到達性を確認する。
+ * 結果は peer-registry に記録される。
+ */
+export async function verifyPeer(
+  peerId: string,
+  url: string,
+  token: string | undefined,
+): Promise<{ ok: true; latencyMs: number } | { ok: false; status: number; message: string }> {
+  const base = normalizePeerUrl(url);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+
+  const start = Date.now();
+  let response: Response;
+  try {
+    // 認証無効 peer でも 200 を返す /health を使う
+    response = await fetch(`${base}/health`, {
+      method: 'GET',
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await recordPeerFailure(peerId, `unreachable: ${msg}`);
+    return { ok: false, status: 0, message: msg };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const latency = Date.now() - start;
+
+  if (!response.ok) {
+    const msg = `HTTP ${response.status}`;
+    await recordPeerFailure(peerId, msg);
+    return { ok: false, status: response.status, message: msg };
+  }
+
+  await recordPeerSuccess(peerId);
+  return { ok: true, latencyMs: latency };
+}
+
+/**
+ * peer に対して認証付きで任意の API パスを叩く。
+ * 401 が返ったら failure を記録するので、呼び出し側はそれを見て unauthorized 扱いにできる。
+ */
+export async function peerFetch(
+  peerId: string,
+  url: string,
+  token: string | undefined,
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const base = normalizePeerUrl(url);
+
+  const headers = new Headers(init?.headers);
+  if (token && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(`${base}${path}`, {
+      ...init,
+      headers,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await recordPeerFailure(peerId, `unreachable: ${msg}`);
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (response.status === 401) {
+    await recordPeerFailure(peerId, 'unauthorized');
+  } else if (response.ok) {
+    await recordPeerSuccess(peerId);
+  }
+
+  return response;
+}

--- a/backend/src/services/peer-auth.ts
+++ b/backend/src/services/peer-auth.ts
@@ -22,13 +22,54 @@ function normalizePeerUrl(url: string): string {
 }
 
 /**
+ * peer の /api/auth/required を叩いて、認証が有効か確認する。
+ * 接続失敗時は throw する (PeerAuthError)。
+ */
+async function isPeerAuthRequired(url: string): Promise<boolean> {
+  const base = normalizePeerUrl(url);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(`${base}/api/auth/required`, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new PeerAuthError(0, `peer に接続できません: ${msg}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!response.ok) {
+    throw new PeerAuthError(response.status, `peer 確認失敗: HTTP ${response.status}`);
+  }
+  const body = (await response.json().catch(() => ({}))) as { required?: boolean };
+  return body.required === true;
+}
+
+/**
  * peer に対してパスワードログインを行い JWT トークンを取得する。
  *
- * peer 側が auth disabled (password なし) の場合、401 ではなく 400 が返るので
- * その時は「トークン不要」とみなして空文字列を返す。
+ * password が undefined/空文字の場合:
+ *   - peer 側 auth 無効 → 空トークンを返す (OK)
+ *   - peer 側 auth 有効 → "password 必須" エラー
+ *
+ * password が指定されている場合:
+ *   - 通常通り /api/auth/login へ POST
+ *   - peer 側 auth 無効なら 400 が返るので空トークンとして扱う
  */
-export async function loginToPeer(url: string, password: string): Promise<string> {
+export async function loginToPeer(url: string, password?: string): Promise<string> {
   const base = normalizePeerUrl(url);
+
+  // password 未指定: まず peer 側の auth 設定を確認
+  if (!password) {
+    const required = await isPeerAuthRequired(url);
+    if (required) {
+      throw new PeerAuthError(401, 'この peer はパスワード認証が有効です。パスワードを入力してください');
+    }
+    return '';
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
@@ -60,11 +101,10 @@ export async function loginToPeer(url: string, password: string): Promise<string
   }
 
   const json = (await response.json().catch(() => ({}))) as { token?: string };
-  if (!json.token && response.status !== 400) {
-    // auth 無効の peer なら 400 で抜けているので、ここに来てトークン無しは異常
+  if (!json.token) {
     throw new PeerAuthError(500, 'peer の応答に token がありません');
   }
-  return json.token ?? '';
+  return json.token;
 }
 
 /**

--- a/backend/src/services/peer-discovery.ts
+++ b/backend/src/services/peer-discovery.ts
@@ -1,0 +1,110 @@
+/**
+ * peer-discovery: Tailscale tailnet をスキャンして cchub が動いてる peer を検出する。
+ *
+ * - `tailscale status --json` で online な peer 一覧を取得
+ * - 各 peer の :5923/health に並列 fetch（タイムアウト 3秒）
+ * - 200 が返れば cchub あり、version を読む
+ * - 自分自身は除外（DNSName マッチで判定）
+ */
+
+import { listPeers } from './peer-registry';
+import { SELF_PEER_URL, type DiscoveredPeer } from '../../../shared/types';
+
+const DISCOVERY_TIMEOUT_MS = 3_000;
+const DEFAULT_PORT = 5923;
+
+interface TailscaleStatus {
+  Self?: { DNSName?: string };
+  Peer?: Record<string, {
+    HostName?: string;
+    DNSName?: string;
+    Online?: boolean;
+    OS?: string;
+  }>;
+}
+
+function normalizeDns(dns: string | undefined): string {
+  if (!dns) return '';
+  // 末尾の "." を取り除く
+  return dns.replace(/\.$/, '');
+}
+
+async function fetchTailscaleStatus(): Promise<TailscaleStatus | null> {
+  try {
+    const proc = Bun.spawnSync(['tailscale', 'status', '--json']);
+    if (proc.exitCode !== 0) return null;
+    return JSON.parse(proc.stdout.toString()) as TailscaleStatus;
+  } catch {
+    return null;
+  }
+}
+
+async function probeCchub(url: string): Promise<{ ok: true; version?: string } | { ok: false }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DISCOVERY_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${url}/health`, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+    if (!res.ok) return { ok: false };
+    const body = (await res.json().catch(() => ({}))) as { status?: string; version?: string };
+    if (body.status !== 'ok') return { ok: false };
+    return { ok: true, version: body.version };
+  } catch {
+    return { ok: false };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function discoverPeers(): Promise<DiscoveredPeer[]> {
+  const status = await fetchTailscaleStatus();
+  if (!status) return [];
+
+  const selfDns = normalizeDns(status.Self?.DNSName);
+  const existingPeers = await listPeers();
+
+  // 既存 peer の URL を hostname:port キーで引けるようにする
+  const existingByHost = new Map<string, { nickname: string }>();
+  for (const p of existingPeers) {
+    if (p.url === SELF_PEER_URL) continue;
+    try {
+      const u = new URL(p.url);
+      existingByHost.set(`${u.hostname}:${u.port || '443'}`, { nickname: p.nickname });
+    } catch {
+      /* skip malformed */
+    }
+  }
+
+  const candidates: { displayName: string; hostname: string }[] = [];
+  for (const peer of Object.values(status.Peer ?? {})) {
+    if (!peer.Online) continue;
+    const dns = normalizeDns(peer.DNSName);
+    if (!dns || dns === selfDns) continue;
+    candidates.push({
+      displayName: peer.HostName ?? dns,
+      hostname: dns,
+    });
+  }
+
+  // 並列 probe
+  const results = await Promise.all(candidates.map(async (c) => {
+    const url = `https://${c.hostname}:${DEFAULT_PORT}`;
+    const probe = await probeCchub(url);
+    if (!probe.ok) return null;
+    const existing = existingByHost.get(`${c.hostname}:${DEFAULT_PORT}`);
+    const discovered: DiscoveredPeer = {
+      displayName: c.displayName,
+      hostname: c.hostname,
+      url,
+      version: probe.version,
+      alreadyRegistered: !!existing,
+      registeredAs: existing?.nickname,
+    };
+    return discovered;
+  }));
+
+  return results.filter((r): r is DiscoveredPeer => r !== null);
+}

--- a/backend/src/services/peer-registry.ts
+++ b/backend/src/services/peer-registry.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, chmod } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import { ensureDataDir } from '../utils/storage';
 import {
@@ -59,7 +59,15 @@ async function load(): Promise<PeersStore> {
 
 async function save(store: PeersStore): Promise<void> {
   const filePath = await getFilePath();
-  await writeFile(filePath, JSON.stringify(store, null, 2));
+  // wsToken を含むので owner read/write のみに制限。
+  // writeFile の mode は新規作成時のみ適用される ─ 既存ファイル上書き時は
+  // umask の名残で 0644 のままになりうるので、毎回 chmod で強制する。
+  await writeFile(filePath, JSON.stringify(store, null, 2), { mode: 0o600 });
+  try {
+    await chmod(filePath, 0o600);
+  } catch {
+    /* permissions might already be correct, or fs doesn't support chmod */
+  }
 }
 
 function generateId(): string {

--- a/backend/src/services/peer-registry.ts
+++ b/backend/src/services/peer-registry.ts
@@ -1,0 +1,213 @@
+import { join } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { ensureDataDir } from '../utils/storage';
+import {
+  type Peer,
+  LOCAL_PEER_ID,
+  SELF_PEER_URL,
+} from '../../../shared/types';
+
+const PEERS_FILE = 'peers.json';
+
+// peer 追加時にラウンドロビンで割り当てる palette。
+// ユーザーが手動で色を選ばなければ、追加順に PALETTE から拾う。
+const COLOR_PALETTE = [
+  '#10b981', // emerald
+  '#3b82f6', // blue
+  '#f59e0b', // amber
+  '#ec4899', // pink
+  '#8b5cf6', // violet
+  '#06b6d4', // cyan
+  '#f97316', // orange
+  '#84cc16', // lime
+];
+
+// peer のトークンは disk に平文保存（家庭内マシン前提）。
+// 必要なら将来 OS keychain 連携に差し替える。
+interface StoredPeer extends Peer {
+  // peer 自身のログインで得たトークン。selfには持たない
+  wsToken?: string;
+  // 最後の verify 時刻と結果
+  lastSeenAt?: string;
+  lastErrorAt?: string;
+  lastErrorMessage?: string;
+}
+
+interface PeersStore {
+  peers: StoredPeer[];
+}
+
+async function getFilePath(): Promise<string> {
+  const dataDir = await ensureDataDir();
+  return join(dataDir, PEERS_FILE);
+}
+
+async function load(): Promise<PeersStore> {
+  const filePath = await getFilePath();
+  try {
+    const data = await readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(data) as PeersStore;
+    if (!Array.isArray(parsed.peers)) {
+      return { peers: [] };
+    }
+    return parsed;
+  } catch {
+    return { peers: [] };
+  }
+}
+
+async function save(store: PeersStore): Promise<void> {
+  const filePath = await getFilePath();
+  await writeFile(filePath, JSON.stringify(store, null, 2));
+}
+
+function generateId(): string {
+  return `p_${randomBytes(4).toString('hex')}`;
+}
+
+function pickColor(existing: StoredPeer[]): string {
+  const used = new Set(existing.map(p => p.color.toLowerCase()));
+  for (const c of COLOR_PALETTE) {
+    if (!used.has(c.toLowerCase())) return c;
+  }
+  // 全部使い切ったらランダム
+  return COLOR_PALETTE[existing.length % COLOR_PALETTE.length] ?? '#64748b';
+}
+
+function localPeer(): StoredPeer {
+  return {
+    id: LOCAL_PEER_ID,
+    nickname: '🏠 Local',
+    url: SELF_PEER_URL,
+    color: COLOR_PALETTE[0] ?? '#10b981',
+    order: 0,
+  };
+}
+
+/**
+ * 全 peer を取得（self を必ず先頭に含めて返す）。
+ * order 昇順でソート済み。
+ */
+export async function listPeers(): Promise<StoredPeer[]> {
+  const store = await load();
+  const hasLocal = store.peers.some(p => p.id === LOCAL_PEER_ID);
+  const peers = hasLocal ? [...store.peers] : [localPeer(), ...store.peers];
+  return peers.sort((a, b) => a.order - b.order);
+}
+
+export async function getPeer(id: string): Promise<StoredPeer | null> {
+  const peers = await listPeers();
+  return peers.find(p => p.id === id) ?? null;
+}
+
+export interface CreatePeerArgs {
+  nickname: string;
+  url: string;
+  color?: string;
+  wsToken?: string;
+}
+
+export async function createPeer(args: CreatePeerArgs): Promise<StoredPeer> {
+  const store = await load();
+  const id = generateId();
+  const existing = await listPeers();
+  const order = existing.reduce((max, p) => Math.max(max, p.order), 0) + 1;
+
+  const peer: StoredPeer = {
+    id,
+    nickname: args.nickname,
+    url: args.url,
+    color: args.color ?? pickColor(existing),
+    order,
+    wsToken: args.wsToken,
+    lastSeenAt: new Date().toISOString(),
+  };
+
+  store.peers.push(peer);
+  await save(store);
+  return peer;
+}
+
+export interface UpdatePeerArgs {
+  nickname?: string;
+  color?: string;
+  wsToken?: string;
+}
+
+export async function updatePeer(id: string, args: UpdatePeerArgs): Promise<StoredPeer | null> {
+  if (id === LOCAL_PEER_ID) {
+    // local peer は nickname/color のみ編集可。 token は持たない
+    const store = await load();
+    let local = store.peers.find(p => p.id === LOCAL_PEER_ID);
+    if (!local) {
+      local = localPeer();
+      store.peers.push(local);
+    }
+    if (args.nickname !== undefined) local.nickname = args.nickname;
+    if (args.color !== undefined) local.color = args.color;
+    await save(store);
+    return local;
+  }
+
+  const store = await load();
+  const peer = store.peers.find(p => p.id === id);
+  if (!peer) return null;
+
+  if (args.nickname !== undefined) peer.nickname = args.nickname;
+  if (args.color !== undefined) peer.color = args.color;
+  if (args.wsToken !== undefined) {
+    peer.wsToken = args.wsToken;
+    peer.lastSeenAt = new Date().toISOString();
+    peer.lastErrorAt = undefined;
+    peer.lastErrorMessage = undefined;
+  }
+
+  await save(store);
+  return peer;
+}
+
+export async function deletePeer(id: string): Promise<boolean> {
+  if (id === LOCAL_PEER_ID) return false; // self は削除不可
+  const store = await load();
+  const before = store.peers.length;
+  store.peers = store.peers.filter(p => p.id !== id);
+  if (store.peers.length === before) return false;
+  await save(store);
+  return true;
+}
+
+export async function setPeerOrder(orderedIds: string[]): Promise<void> {
+  const store = await load();
+  const indexById = new Map(orderedIds.map((id, i) => [id, i]));
+  // 配列に含まれない peer は末尾に追いやる
+  const maxIndex = orderedIds.length;
+  for (const peer of store.peers) {
+    const idx = indexById.get(peer.id);
+    peer.order = idx !== undefined ? idx : maxIndex + peer.order;
+  }
+  await save(store);
+}
+
+export async function recordPeerSuccess(id: string): Promise<void> {
+  if (id === LOCAL_PEER_ID) return;
+  const store = await load();
+  const peer = store.peers.find(p => p.id === id);
+  if (!peer) return;
+  peer.lastSeenAt = new Date().toISOString();
+  peer.lastErrorAt = undefined;
+  peer.lastErrorMessage = undefined;
+  await save(store);
+}
+
+export async function recordPeerFailure(id: string, message: string): Promise<void> {
+  if (id === LOCAL_PEER_ID) return;
+  const store = await load();
+  const peer = store.peers.find(p => p.id === id);
+  if (!peer) return;
+  peer.lastErrorAt = new Date().toISOString();
+  peer.lastErrorMessage = message;
+  await save(store);
+}
+
+export type { StoredPeer };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -200,6 +200,8 @@ function getSavedOpenSessionIds(): string[] {
 
 export function App() {
 	const { t } = useTranslation();
+	const tRef = useRef(t);
+	tRef.current = t;
 	// Auth state
 	const auth = useAuth();
 	// Onboarding state
@@ -494,7 +496,10 @@ export function App() {
 	}, [showSessionList, fileViewerVisible, showConversation]);
 
 	// Create initial session for first-time users
-	const createInitialSession = async (): Promise<OpenSession | null> => {
+	// 毎 render で新インスタンスが作られると fetchAndOpenSession の useEffect が
+	// 無限に再実行されて activeSessionId を localStorage から巻き戻す。
+	// useCallback で安定化し、t は ref 経由で参照する。
+	const createInitialSession = useCallback(async (): Promise<OpenSession | null> => {
 		try {
 			const response = await authFetch(`${API_BASE}/api/sessions`, {
 				method: "POST",
@@ -502,7 +507,7 @@ export function App() {
 				body: JSON.stringify({
 					name: "Welcome",
 					workingDir: "~",
-					initialPrompt: t("onboarding.welcomePrompt"),
+					initialPrompt: tRef.current("onboarding.welcomePrompt"),
 				}),
 			});
 			if (response.ok) {
@@ -513,7 +518,7 @@ export function App() {
 			console.error("Failed to create initial session:", err);
 		}
 		return null;
-	};
+	}, []);
 
 	// Retry handler for loading screen
 	const handleRetry = useCallback(() => {
@@ -565,7 +570,7 @@ export function App() {
 				}
 			} catch (err) {
 				if (isTransientNetworkError(err)) {
-					setLoadError(t("loading.connectionFailed"));
+					setLoadError(tRef.current("loading.connectionFailed"));
 				} else {
 					setShowSessionList(true);
 				}
@@ -575,7 +580,11 @@ export function App() {
 		};
 
 		fetchAndOpenSession();
-	}, [createInitialSession, retryCount, t]);
+		// `t` (useTranslation) は i18n の hydration で参照が変わることがあり、
+		// それで fetchAndOpenSession が再実行されると saveLastSession() より前の
+		// localStorage を読んで activeSessionId が意図せず巻き戻る。
+		// t は ref 経由で参照し、ここの deps からは外す。
+	}, [createInitialSession, retryCount]);
 
 	// Save to localStorage when sessions change
 	useEffect(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import {
 	FileText,
 	MessageSquare,
 	RotateCw,
+	Server,
 	Terminal as TerminalIcon,
 	X as XIcon,
 } from "lucide-react";
@@ -23,6 +24,7 @@ import { DesktopLayout } from "./components/DesktopLayout";
 import { Dashboard } from "./components/dashboard/Dashboard";
 import { FileViewer } from "./components/files/FileViewer";
 import { LoginForm } from "./components/LoginForm";
+import { PeerManager } from "./components/PeerManager";
 import { Onboarding, useOnboarding } from "./components/Onboarding";
 import { SessionList } from "./components/SessionList";
 import type { TerminalRef } from "./components/Terminal";
@@ -258,6 +260,9 @@ export function App() {
 	const [retryCount, setRetryCount] = useState(0);
 	const [showSessionList, setShowSessionList] = useState(false);
 	const [showMobileDashboard, setShowMobileDashboard] = useState(false);
+	const [mobileDashboardTab, setMobileDashboardTab] = useState<
+		"dashboard" | "peers"
+	>("dashboard");
 	const [sessionToDelete, setSessionToDelete] = useState<OpenSession | null>(
 		null,
 	);
@@ -1222,10 +1227,33 @@ export function App() {
 			{showMobileDashboard && (
 				<div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0a] animate-modal-in">
 					<div className="shrink-0 px-4 pt-3 pb-3 border-b border-white/[0.06]">
-						<div className="flex items-center justify-between">
-							<h1 className="text-[18px] font-semibold tracking-[-0.02em] text-white">
-								Dashboard
-							</h1>
+						<div className="flex items-center justify-between gap-2">
+							<div className="flex items-center gap-1 bg-white/[0.04] rounded-lg p-0.5">
+								<button
+									type="button"
+									onClick={() => setMobileDashboardTab("dashboard")}
+									className={`px-3 py-1.5 rounded-md text-sm font-medium inline-flex items-center gap-1.5 transition-colors ${
+										mobileDashboardTab === "dashboard"
+											? "bg-white/[0.08] text-white"
+											: "text-zinc-400 hover:text-zinc-200"
+									}`}
+								>
+									<BarChart3 className="w-4 h-4" />
+									Dashboard
+								</button>
+								<button
+									type="button"
+									onClick={() => setMobileDashboardTab("peers")}
+									className={`px-3 py-1.5 rounded-md text-sm font-medium inline-flex items-center gap-1.5 transition-colors ${
+										mobileDashboardTab === "peers"
+											? "bg-white/[0.08] text-white"
+											: "text-zinc-400 hover:text-zinc-200"
+									}`}
+								>
+									<Server className="w-4 h-4" />
+									Servers
+								</button>
+							</div>
 							<button
 								type="button"
 								onClick={() => setShowMobileDashboard(false)}
@@ -1236,7 +1264,11 @@ export function App() {
 						</div>
 					</div>
 					<div className="flex-1 min-h-0 overflow-y-auto">
-						<Dashboard className="h-full" />
+						{mobileDashboardTab === "dashboard" ? (
+							<Dashboard className="h-full" />
+						) : (
+							<PeerManager />
+						)}
 					</div>
 				</div>
 			)}

--- a/frontend/src/components/DashboardPanel.tsx
+++ b/frontend/src/components/DashboardPanel.tsx
@@ -1,6 +1,8 @@
-import { X } from "lucide-react";
+import { X, Server, BarChart3 } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Dashboard } from "./dashboard/Dashboard";
+import { PeerManager } from "./PeerManager";
 
 interface DashboardPanelProps {
 	isOpen: boolean;
@@ -8,12 +10,15 @@ interface DashboardPanelProps {
 	isTablet?: boolean;
 }
 
+type PanelTab = "dashboard" | "peers";
+
 export function DashboardPanel({
 	isOpen,
 	onClose,
 	isTablet,
 }: DashboardPanelProps) {
 	const { t } = useTranslation();
+	const [tab, setTab] = useState<PanelTab>("dashboard");
 
 	if (!isOpen) return null;
 
@@ -30,9 +35,32 @@ export function DashboardPanel({
 			{/* Header */}
 			<div className="shrink-0 px-4 pt-3 pb-3 border-b border-white/[0.06]">
 				<div className="flex items-center justify-between max-w-lg">
-					<h1 className="text-[18px] font-semibold tracking-[-0.02em] text-white">
-						{t("dashboard.title")}
-					</h1>
+					<div className="flex items-center gap-1 bg-white/[0.04] rounded-lg p-0.5">
+						<button
+							type="button"
+							onClick={() => setTab("dashboard")}
+							className={`px-3 py-1.5 rounded-md text-sm font-medium inline-flex items-center gap-1.5 transition-colors ${
+								tab === "dashboard"
+									? "bg-white/[0.08] text-white"
+									: "text-zinc-400 hover:text-zinc-200"
+							}`}
+						>
+							<BarChart3 className="w-4 h-4" />
+							{t("dashboard.title")}
+						</button>
+						<button
+							type="button"
+							onClick={() => setTab("peers")}
+							className={`px-3 py-1.5 rounded-md text-sm font-medium inline-flex items-center gap-1.5 transition-colors ${
+								tab === "peers"
+									? "bg-white/[0.08] text-white"
+									: "text-zinc-400 hover:text-zinc-200"
+							}`}
+						>
+							<Server className="w-4 h-4" />
+							Servers
+						</button>
+					</div>
 					<div className="flex items-center gap-1">
 						<button
 							type="button"
@@ -45,9 +73,13 @@ export function DashboardPanel({
 				</div>
 			</div>
 
-			{/* Dashboard content */}
+			{/* Content */}
 			<div className="flex-1 min-h-0 overflow-y-auto">
-				<Dashboard className="h-full" compact />
+				{tab === "dashboard" ? (
+					<Dashboard className="h-full" compact />
+				) : (
+					<PeerManager />
+				)}
 			</div>
 		</div>
 	);

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -17,6 +17,8 @@ import type {
 	TmuxLayoutNode,
 } from "../../../shared/types";
 import { useMultiplexedTerminal } from "../hooks/useMultiplexedTerminal";
+import { usePeerConnection } from "../hooks/usePeerConnection";
+import { usePeers } from "../hooks/usePeers";
 import {
 	updateCachedSessionsByHookEvent,
 	useSessions,
@@ -433,6 +435,10 @@ export function DesktopLayout({
 		null,
 	);
 
+	// Multi-server: アクティブセッションが remote peer の場合、そっちの WS に切り替える
+	const { peers } = usePeers();
+	const peerConn = usePeerConnection(controlSessionId || "", apiSessions, peers);
+
 	// Zoom state: when a pane is zoomed, show only that pane full-screen
 	const [zoomedPaneId, setZoomedPaneId] = useState<string | null>(null);
 	const zoomedPaneIdRef = useRef<string | null>(null);
@@ -471,6 +477,8 @@ export function DesktopLayout({
 
 	const controlTerminal = useMultiplexedTerminal({
 		sessionId: controlSessionId || "",
+		peerWsBase: peerConn.wsBase,
+		token: peerConn.token,
 		onPaneViewport: (paneId, viewport) => {
 			lastViewportRef.current.set(paneId, viewport);
 			let perPane = paneViewportCacheRef.current.get(paneId);

--- a/frontend/src/components/PeerManager.tsx
+++ b/frontend/src/components/PeerManager.tsx
@@ -1,0 +1,385 @@
+import { Plus, Trash2, RefreshCw, Pencil, Server, Wifi, WifiOff, AlertTriangle, X } from "lucide-react";
+import { type FormEvent, useState } from "react";
+import { LOCAL_PEER_ID, type PeerClientView } from "../../../shared/types";
+import { usePeers } from "../hooks/usePeers";
+
+const COLOR_OPTIONS = [
+	"#10b981", "#3b82f6", "#f59e0b", "#ec4899",
+	"#8b5cf6", "#06b6d4", "#f97316", "#84cc16",
+	"#ef4444", "#a855f7", "#14b8a6", "#eab308",
+];
+
+function StatusBadge({ peer }: { peer: PeerClientView }) {
+	if (peer.id === LOCAL_PEER_ID) {
+		return (
+			<span className="text-xs px-2 py-0.5 rounded-full bg-emerald-900/40 text-emerald-300 inline-flex items-center gap-1">
+				<Server className="w-3 h-3" /> local
+			</span>
+		);
+	}
+	switch (peer.status) {
+		case "online":
+			return (
+				<span className="text-xs px-2 py-0.5 rounded-full bg-emerald-900/40 text-emerald-300 inline-flex items-center gap-1">
+					<Wifi className="w-3 h-3" /> online
+				</span>
+			);
+		case "offline":
+			return (
+				<span className="text-xs px-2 py-0.5 rounded-full bg-red-900/40 text-red-300 inline-flex items-center gap-1">
+					<WifiOff className="w-3 h-3" /> offline
+				</span>
+			);
+		case "unauthorized":
+			return (
+				<span className="text-xs px-2 py-0.5 rounded-full bg-amber-900/40 text-amber-300 inline-flex items-center gap-1">
+					<AlertTriangle className="w-3 h-3" /> auth required
+				</span>
+			);
+		default:
+			return <span className="text-xs px-2 py-0.5 rounded-full bg-th-surface-hover text-th-text-muted">unknown</span>;
+	}
+}
+
+function ColorSwatch({ color, selected, onClick }: { color: string; selected: boolean; onClick: () => void }) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={`w-7 h-7 rounded-full border-2 transition-transform ${
+				selected ? "border-th-text scale-110" : "border-transparent hover:scale-105"
+			}`}
+			style={{ backgroundColor: color }}
+			aria-label={`色 ${color}`}
+		/>
+	);
+}
+
+interface AddFormProps {
+	onSubmit: (input: { nickname: string; url: string; password: string; color?: string }) => Promise<void>;
+	onCancel: () => void;
+}
+
+function AddPeerForm({ onSubmit, onCancel }: AddFormProps) {
+	const [nickname, setNickname] = useState("");
+	const [url, setUrl] = useState("https://");
+	const [password, setPassword] = useState("");
+	const [color, setColor] = useState<string | undefined>(undefined);
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		setSubmitting(true);
+		setError(null);
+		try {
+			await onSubmit({ nickname, url, password, color });
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "登録に失敗しました");
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<form onSubmit={handleSubmit} className="bg-th-surface-hover border border-th-border rounded-md p-4 space-y-3">
+			<div className="flex items-center justify-between mb-2">
+				<h3 className="font-semibold text-th-text">サーバーを追加</h3>
+				<button type="button" onClick={onCancel} className="text-th-text-muted hover:text-th-text">
+					<X className="w-4 h-4" />
+				</button>
+			</div>
+			<div>
+				<label htmlFor="peer-nickname" className="block text-xs text-th-text-secondary mb-1">ニックネーム (絵文字OK)</label>
+				<input
+					id="peer-nickname"
+					type="text"
+					value={nickname}
+					onChange={(e) => setNickname(e.target.value)}
+					placeholder="💻 MacBook Air"
+					required
+					className="w-full px-3 py-2 bg-th-surface border border-th-border rounded-md text-th-text"
+				/>
+			</div>
+			<div>
+				<label htmlFor="peer-url" className="block text-xs text-th-text-secondary mb-1">URL</label>
+				<input
+					id="peer-url"
+					type="url"
+					value={url}
+					onChange={(e) => setUrl(e.target.value)}
+					placeholder="https://mac.tailnet.ts.net:5923"
+					required
+					className="w-full px-3 py-2 bg-th-surface border border-th-border rounded-md text-th-text font-mono text-sm"
+				/>
+			</div>
+			<div>
+				<label htmlFor="peer-password" className="block text-xs text-th-text-secondary mb-1">そのサーバーのパスワード</label>
+				<input
+					id="peer-password"
+					type="password"
+					value={password}
+					onChange={(e) => setPassword(e.target.value)}
+					required
+					className="w-full px-3 py-2 bg-th-surface border border-th-border rounded-md text-th-text"
+				/>
+			</div>
+			<div>
+				<div className="block text-xs text-th-text-secondary mb-1">識別色 (省略可: 自動割当)</div>
+				<div className="flex flex-wrap gap-2">
+					{COLOR_OPTIONS.map((c) => (
+						<ColorSwatch key={c} color={c} selected={color === c} onClick={() => setColor(c === color ? undefined : c)} />
+					))}
+				</div>
+			</div>
+			{error && <div className="text-red-400 text-sm bg-red-900/20 p-2 rounded">{error}</div>}
+			<div className="flex gap-2">
+				<button
+					type="submit"
+					disabled={submitting}
+					className="flex-1 py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 text-white font-medium rounded-md transition-colors"
+				>
+					{submitting ? "確認中…" : "追加"}
+				</button>
+				<button
+					type="button"
+					onClick={onCancel}
+					className="py-2 px-4 bg-th-surface hover:bg-th-surface-hover border border-th-border text-th-text rounded-md"
+				>
+					キャンセル
+				</button>
+			</div>
+		</form>
+	);
+}
+
+interface EditFormProps {
+	peer: PeerClientView;
+	onSubmit: (input: { nickname?: string; color?: string; password?: string }) => Promise<void>;
+	onCancel: () => void;
+}
+
+function EditPeerForm({ peer, onSubmit, onCancel }: EditFormProps) {
+	const [nickname, setNickname] = useState(peer.nickname);
+	const [color, setColor] = useState(peer.color);
+	const [password, setPassword] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		setSubmitting(true);
+		setError(null);
+		try {
+			const input: { nickname?: string; color?: string; password?: string } = {};
+			if (nickname !== peer.nickname) input.nickname = nickname;
+			if (color !== peer.color) input.color = color;
+			if (password) input.password = password;
+			await onSubmit(input);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "更新に失敗しました");
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const isLocal = peer.id === LOCAL_PEER_ID;
+
+	return (
+		<form onSubmit={handleSubmit} className="bg-th-surface-hover border border-th-border rounded-md p-4 space-y-3">
+			<div className="flex items-center justify-between mb-2">
+				<h3 className="font-semibold text-th-text">サーバー編集</h3>
+				<button type="button" onClick={onCancel} className="text-th-text-muted hover:text-th-text">
+					<X className="w-4 h-4" />
+				</button>
+			</div>
+			<div>
+				<label htmlFor="edit-nickname" className="block text-xs text-th-text-secondary mb-1">ニックネーム</label>
+				<input
+					id="edit-nickname"
+					type="text"
+					value={nickname}
+					onChange={(e) => setNickname(e.target.value)}
+					required
+					className="w-full px-3 py-2 bg-th-surface border border-th-border rounded-md text-th-text"
+				/>
+			</div>
+			<div>
+				<div className="block text-xs text-th-text-secondary mb-1">識別色</div>
+				<div className="flex flex-wrap gap-2">
+					{COLOR_OPTIONS.map((c) => (
+						<ColorSwatch key={c} color={c} selected={color === c} onClick={() => setColor(c)} />
+					))}
+				</div>
+			</div>
+			{!isLocal && (
+				<div>
+					<label htmlFor="edit-password" className="block text-xs text-th-text-secondary mb-1">
+						パスワード (再認証する場合のみ)
+					</label>
+					<input
+						id="edit-password"
+						type="password"
+						value={password}
+						onChange={(e) => setPassword(e.target.value)}
+						className="w-full px-3 py-2 bg-th-surface border border-th-border rounded-md text-th-text"
+					/>
+				</div>
+			)}
+			{error && <div className="text-red-400 text-sm bg-red-900/20 p-2 rounded">{error}</div>}
+			<div className="flex gap-2">
+				<button
+					type="submit"
+					disabled={submitting}
+					className="flex-1 py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 text-white font-medium rounded-md transition-colors"
+				>
+					{submitting ? "保存中…" : "保存"}
+				</button>
+				<button
+					type="button"
+					onClick={onCancel}
+					className="py-2 px-4 bg-th-surface hover:bg-th-surface-hover border border-th-border text-th-text rounded-md"
+				>
+					キャンセル
+				</button>
+			</div>
+		</form>
+	);
+}
+
+export function PeerManager() {
+	const { peers, isLoading, error, refresh, addPeer, updatePeer, deletePeer, verifyPeer } = usePeers();
+	const [adding, setAdding] = useState(false);
+	const [editingId, setEditingId] = useState<string | null>(null);
+	const [verifyingId, setVerifyingId] = useState<string | null>(null);
+
+	const handleAdd = async (input: { nickname: string; url: string; password: string; color?: string }) => {
+		await addPeer(input);
+		setAdding(false);
+	};
+
+	const handleEdit = async (id: string, input: { nickname?: string; color?: string; password?: string }) => {
+		await updatePeer(id, input);
+		setEditingId(null);
+	};
+
+	const handleDelete = async (peer: PeerClientView) => {
+		if (peer.id === LOCAL_PEER_ID) return;
+		if (!confirm(`${peer.nickname} を削除しますか？`)) return;
+		await deletePeer(peer.id);
+	};
+
+	const handleVerify = async (peer: PeerClientView) => {
+		setVerifyingId(peer.id);
+		try {
+			await verifyPeer(peer.id);
+		} catch {
+			/* error 表示は peer.status に反映される */
+		} finally {
+			setVerifyingId(null);
+		}
+	};
+
+	return (
+		<div className="space-y-4 p-4">
+			<div className="flex items-center justify-between">
+				<h2 className="text-lg font-semibold text-th-text">サーバー (Peers)</h2>
+				<div className="flex gap-2">
+					<button
+						type="button"
+						onClick={() => void refresh()}
+						className="p-2 rounded-md bg-th-surface-hover hover:bg-th-surface text-th-text-secondary"
+						title="再読み込み"
+					>
+						<RefreshCw className="w-4 h-4" />
+					</button>
+					<button
+						type="button"
+						onClick={() => setAdding(true)}
+						disabled={adding}
+						className="px-3 py-2 rounded-md bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 text-white text-sm font-medium inline-flex items-center gap-1"
+					>
+						<Plus className="w-4 h-4" /> サーバー追加
+					</button>
+				</div>
+			</div>
+
+			{error && <div className="text-red-400 text-sm bg-red-900/20 p-3 rounded">{error}</div>}
+
+			{adding && <AddPeerForm onSubmit={handleAdd} onCancel={() => setAdding(false)} />}
+
+			{isLoading ? (
+				<div className="text-th-text-muted text-sm">読み込み中…</div>
+			) : (
+				<ul className="space-y-2">
+					{peers.map((peer) => (
+						<li
+							key={peer.id}
+							className="bg-th-surface border-l-4 border border-th-border rounded-md overflow-hidden"
+							style={{ borderLeftColor: peer.color }}
+						>
+							{editingId === peer.id ? (
+								<EditPeerForm
+									peer={peer}
+									onSubmit={(input) => handleEdit(peer.id, input)}
+									onCancel={() => setEditingId(null)}
+								/>
+							) : (
+								<div className="p-3 flex items-center justify-between gap-3">
+									<div className="flex-1 min-w-0">
+										<div className="flex items-center gap-2">
+											<span className="font-medium text-th-text truncate">{peer.nickname}</span>
+											<StatusBadge peer={peer} />
+										</div>
+										<div className="text-xs text-th-text-muted font-mono truncate mt-0.5">
+											{peer.url === "self" ? "(this server)" : peer.url}
+										</div>
+										{peer.errorMessage && (
+											<div className="text-xs text-red-400 mt-0.5">{peer.errorMessage}</div>
+										)}
+									</div>
+									<div className="flex items-center gap-1 shrink-0">
+										{peer.id !== LOCAL_PEER_ID && (
+											<button
+												type="button"
+												onClick={() => handleVerify(peer)}
+												disabled={verifyingId === peer.id}
+												className="p-2 rounded hover:bg-th-surface-hover text-th-text-muted"
+												title="疎通確認"
+											>
+												<RefreshCw className={`w-4 h-4 ${verifyingId === peer.id ? "animate-spin" : ""}`} />
+											</button>
+										)}
+										<button
+											type="button"
+											onClick={() => setEditingId(peer.id)}
+											className="p-2 rounded hover:bg-th-surface-hover text-th-text-muted"
+											title="編集"
+										>
+											<Pencil className="w-4 h-4" />
+										</button>
+										{peer.id !== LOCAL_PEER_ID && (
+											<button
+												type="button"
+												onClick={() => handleDelete(peer)}
+												className="p-2 rounded hover:bg-red-900/30 text-red-400"
+												title="削除"
+											>
+												<Trash2 className="w-4 h-4" />
+											</button>
+										)}
+									</div>
+								</div>
+							)}
+						</li>
+					))}
+				</ul>
+			)}
+
+			<p className="text-xs text-th-text-muted">
+				※ 追加した peer は Hub から代理ログインしてトークンを保存します。<br />
+				※ peer 側のサーバーは変更不要です。
+			</p>
+		</div>
+	);
+}

--- a/frontend/src/components/PeerManager.tsx
+++ b/frontend/src/components/PeerManager.tsx
@@ -276,6 +276,14 @@ export function PeerManager() {
 	};
 
 	const handleDiscover = async () => {
+		// 社内ネットワークなど Tailscale 以外の環境で意図せずポートスキャンに
+		// 見えてしまうのを避けるため、毎回ユーザーに確認を取る。
+		const ok = confirm(
+			"Tailscale tailnet 内の各ホストの :5923 (cchub の既定ポート) に HTTP リクエストを送信して、cchub の有無を確認します。\n\n" +
+				"Tailscale 外のホストには送信しません。実行しますか？",
+		);
+		if (!ok) return;
+
 		setDiscovering(true);
 		setDiscoverError(null);
 		try {

--- a/frontend/src/components/PeerManager.tsx
+++ b/frontend/src/components/PeerManager.tsx
@@ -124,13 +124,15 @@ function AddPeerForm({ onSubmit, onCancel, initialNickname, initialUrl }: AddFor
 				/>
 			</div>
 			<div>
-				<label htmlFor="peer-password" className="block text-xs text-th-text-secondary mb-1">そのサーバーのパスワード</label>
+				<label htmlFor="peer-password" className="block text-xs text-th-text-secondary mb-1">
+					そのサーバーのパスワード
+					<span className="ml-1 text-th-text-muted">(peer 側が認証無効なら空でOK)</span>
+				</label>
 				<input
 					id="peer-password"
 					type="password"
 					value={password}
 					onChange={(e) => setPassword(e.target.value)}
-					required
 					className="w-full px-3 py-2 bg-th-surface border border-th-border rounded-md text-th-text"
 				/>
 			</div>

--- a/frontend/src/components/PeerManager.tsx
+++ b/frontend/src/components/PeerManager.tsx
@@ -1,7 +1,15 @@
-import { Plus, Trash2, RefreshCw, Pencil, Server, Wifi, WifiOff, AlertTriangle, X } from "lucide-react";
+import { Plus, Trash2, RefreshCw, Pencil, Server, Wifi, WifiOff, AlertTriangle, X, Search, CheckCircle2 } from "lucide-react";
 import { type FormEvent, useState } from "react";
-import { LOCAL_PEER_ID, type PeerClientView } from "../../../shared/types";
+import {
+	LOCAL_PEER_ID,
+	type DiscoveredPeer,
+	type PeerClientView,
+	type PeerDiscoverResponse,
+} from "../../../shared/types";
 import { usePeers } from "../hooks/usePeers";
+import { authFetch } from "../services/api";
+
+const API_BASE = import.meta.env.VITE_API_URL || "";
 
 const COLOR_OPTIONS = [
 	"#10b981", "#3b82f6", "#f59e0b", "#ec4899",
@@ -58,11 +66,13 @@ function ColorSwatch({ color, selected, onClick }: { color: string; selected: bo
 interface AddFormProps {
 	onSubmit: (input: { nickname: string; url: string; password: string; color?: string }) => Promise<void>;
 	onCancel: () => void;
+	initialNickname?: string;
+	initialUrl?: string;
 }
 
-function AddPeerForm({ onSubmit, onCancel }: AddFormProps) {
-	const [nickname, setNickname] = useState("");
-	const [url, setUrl] = useState("https://");
+function AddPeerForm({ onSubmit, onCancel, initialNickname, initialUrl }: AddFormProps) {
+	const [nickname, setNickname] = useState(initialNickname ?? "");
+	const [url, setUrl] = useState(initialUrl ?? "https://");
 	const [password, setPassword] = useState("");
 	const [color, setColor] = useState<string | undefined>(undefined);
 	const [submitting, setSubmitting] = useState(false);
@@ -250,12 +260,39 @@ function EditPeerForm({ peer, onSubmit, onCancel }: EditFormProps) {
 export function PeerManager() {
 	const { peers, isLoading, error, refresh, addPeer, updatePeer, deletePeer, verifyPeer } = usePeers();
 	const [adding, setAdding] = useState(false);
+	const [addPrefill, setAddPrefill] = useState<{ nickname: string; url: string } | null>(null);
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [verifyingId, setVerifyingId] = useState<string | null>(null);
+	const [discovering, setDiscovering] = useState(false);
+	const [discovered, setDiscovered] = useState<DiscoveredPeer[] | null>(null);
+	const [discoverError, setDiscoverError] = useState<string | null>(null);
 
 	const handleAdd = async (input: { nickname: string; url: string; password: string; color?: string }) => {
 		await addPeer(input);
 		setAdding(false);
+		setAddPrefill(null);
+	};
+
+	const handleDiscover = async () => {
+		setDiscovering(true);
+		setDiscoverError(null);
+		try {
+			const res = await authFetch(`${API_BASE}/api/peers/discover`);
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
+			const data = (await res.json()) as PeerDiscoverResponse;
+			setDiscovered(data.discovered);
+		} catch (err) {
+			setDiscoverError(err instanceof Error ? err.message : "検索に失敗しました");
+		} finally {
+			setDiscovering(false);
+		}
+	};
+
+	const handlePickDiscovered = (d: DiscoveredPeer) => {
+		if (d.alreadyRegistered) return;
+		setAddPrefill({ nickname: d.displayName, url: d.url });
+		setAdding(true);
+		setDiscovered(null);
 	};
 
 	const handleEdit = async (id: string, input: { nickname?: string; color?: string; password?: string }) => {
@@ -282,7 +319,7 @@ export function PeerManager() {
 
 	return (
 		<div className="space-y-4 p-4">
-			<div className="flex items-center justify-between">
+			<div className="flex items-center justify-between flex-wrap gap-2">
 				<h2 className="text-lg font-semibold text-th-text">サーバー (Peers)</h2>
 				<div className="flex gap-2">
 					<button
@@ -295,7 +332,17 @@ export function PeerManager() {
 					</button>
 					<button
 						type="button"
-						onClick={() => setAdding(true)}
+						onClick={() => void handleDiscover()}
+						disabled={discovering}
+						className="px-3 py-2 rounded-md bg-th-surface-hover hover:bg-th-surface text-th-text text-sm font-medium inline-flex items-center gap-1 disabled:opacity-50"
+						title="Tailscale ネットワーク内を検索"
+					>
+						<Search className={`w-4 h-4 ${discovering ? "animate-pulse" : ""}`} />
+						{discovering ? "検索中…" : "検索"}
+					</button>
+					<button
+						type="button"
+						onClick={() => { setAddPrefill(null); setAdding(true); }}
 						disabled={adding}
 						className="px-3 py-2 rounded-md bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 text-white text-sm font-medium inline-flex items-center gap-1"
 					>
@@ -305,8 +352,91 @@ export function PeerManager() {
 			</div>
 
 			{error && <div className="text-red-400 text-sm bg-red-900/20 p-3 rounded">{error}</div>}
+			{discoverError && (
+				<div className="text-red-400 text-sm bg-red-900/20 p-3 rounded">
+					検索エラー: {discoverError}
+				</div>
+			)}
 
-			{adding && <AddPeerForm onSubmit={handleAdd} onCancel={() => setAdding(false)} />}
+			{discovered !== null && (
+				<div className="bg-th-surface-hover border border-th-border rounded-md p-3 space-y-2">
+					<div className="flex items-center justify-between mb-2">
+						<h3 className="font-semibold text-th-text inline-flex items-center gap-1">
+							<Search className="w-4 h-4" /> ネットワーク内の cchub ({discovered.length})
+						</h3>
+						<button
+							type="button"
+							onClick={() => setDiscovered(null)}
+							className="text-th-text-muted hover:text-th-text"
+						>
+							<X className="w-4 h-4" />
+						</button>
+					</div>
+					{discovered.length === 0 ? (
+						<p className="text-sm text-th-text-muted py-2">
+							未登録の cchub は見つかりませんでした。<br />
+							<span className="text-xs">tailscale で online な peer のみ対象、ポート 5923 を確認します。</span>
+						</p>
+					) : (
+						<ul className="space-y-1">
+							{discovered.map((d) => (
+								<li
+									key={d.hostname}
+									className={`flex items-center justify-between gap-2 p-2 rounded ${
+										d.alreadyRegistered ? "opacity-50" : "hover:bg-th-surface cursor-pointer"
+									}`}
+									onClick={() => handlePickDiscovered(d)}
+									onKeyDown={(e) => {
+										if (e.key === "Enter" || e.key === " ") {
+											e.preventDefault();
+											handlePickDiscovered(d);
+										}
+									}}
+								>
+									<div className="flex-1 min-w-0">
+										<div className="flex items-center gap-2">
+											<span className="font-medium text-th-text truncate">{d.displayName}</span>
+											{d.version && (
+												<span className="text-xs px-1.5 py-0.5 rounded bg-th-surface text-th-text-muted">
+													v{d.version}
+												</span>
+											)}
+											{d.alreadyRegistered && (
+												<span className="text-xs px-1.5 py-0.5 rounded bg-emerald-900/40 text-emerald-300 inline-flex items-center gap-1">
+													<CheckCircle2 className="w-3 h-3" /> 登録済み
+												</span>
+											)}
+										</div>
+										<div className="text-xs text-th-text-muted font-mono truncate mt-0.5">
+											{d.hostname}
+											{d.alreadyRegistered && d.registeredAs && (
+												<span className="ml-2">→ {d.registeredAs}</span>
+											)}
+										</div>
+									</div>
+									{!d.alreadyRegistered && (
+										<button
+											type="button"
+											className="shrink-0 px-3 py-1 rounded-md bg-blue-600 hover:bg-blue-700 text-white text-xs font-medium inline-flex items-center gap-1"
+										>
+											<Plus className="w-3 h-3" /> 追加
+										</button>
+									)}
+								</li>
+							))}
+						</ul>
+					)}
+				</div>
+			)}
+
+			{adding && (
+				<AddPeerForm
+					onSubmit={handleAdd}
+					onCancel={() => { setAdding(false); setAddPrefill(null); }}
+					initialNickname={addPrefill?.nickname}
+					initialUrl={addPrefill?.url}
+				/>
+			)}
 
 			{isLoading ? (
 				<div className="text-th-text-muted text-sm">読み込み中…</div>

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -800,7 +800,19 @@ function SessionItem({
 	const isLive =
 		!isLost &&
 		(cardIndicator === "processing" || cardIndicator === "waiting_input");
-	const accentColor = session.theme ? ACCENT_HEX[session.theme] : undefined;
+	// peer 色は theme より優先度が低い。peer はマルチサーバー時の所属表示なので、
+	// ユーザーが明示的に theme をつけていればそちらを尊重する。
+	const peerAccentColor =
+		extSession.peerId && extSession.peerId !== "local"
+			? extSession.peerColor
+			: undefined;
+	const accentColor = session.theme
+		? ACCENT_HEX[session.theme]
+		: peerAccentColor;
+	const peerBadge =
+		extSession.peerNickname && extSession.peerId && extSession.peerId !== "local"
+			? { nickname: extSession.peerNickname, color: extSession.peerColor ?? "#64748b" }
+			: null;
 
 	// Lost session: show recreate UI
 	if (isLost) {
@@ -968,8 +980,23 @@ function SessionItem({
 					)}
 
 				{/* Metadata row: agent / context / memory / tokens */}
-				{(agentLabel || extSession.metrics) && (
+				{(agentLabel || extSession.metrics || peerBadge) && (
 					<div className="mt-1.5 flex items-center gap-3 flex-wrap text-[11px] text-zinc-500">
+						{peerBadge && (
+							<span
+								className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full font-medium"
+								style={{
+									backgroundColor: `${peerBadge.color}26`,
+									color: peerBadge.color,
+								}}
+							>
+								<span
+									className="w-1.5 h-1.5 rounded-full"
+									style={{ backgroundColor: peerBadge.color }}
+								/>
+								{peerBadge.nickname}
+							</span>
+						)}
 						{agentLabel && (
 							<span className="inline-flex items-center px-2 py-0.5 rounded-full font-medium bg-zinc-500/15 text-zinc-400">
 								{agentLabel}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -32,7 +32,9 @@ import {
 	type SessionResponse,
 	type SessionTheme,
 } from "../../../shared/types";
+import { usePeers } from "../hooks/usePeers";
 import { useSessions } from "../hooks/useSessions";
+import { sessionFetch } from "../services/peer-fetch";
 import { formatRelativeTime } from "../utils/format";
 
 // Theme color mapping
@@ -1200,6 +1202,7 @@ export function SessionList({
 		deleteSession,
 		updateSessionTheme,
 	} = useSessions();
+	const { peers } = usePeers();
 	const { fetchConversation } = useSessionHistory();
 
 	const [sessionForMenu, setSessionForMenu] = useState<SessionResponse | null>(
@@ -1464,11 +1467,16 @@ export function SessionList({
 	const handleMenuChangeTitle = async (title: string | null) => {
 		if (sessionForMenu) {
 			try {
-				await authFetch(`${API_BASE}/api/sessions/${sessionForMenu.id}/title`, {
-					method: "PUT",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ title }),
-				});
+				await sessionFetch(
+					sessionForMenu as ExtendedSessionResponse,
+					peers,
+					`/api/sessions/${sessionForMenu.id}/title`,
+					{
+						method: "PUT",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ title }),
+					},
+				);
 				setSessionForMenu(null);
 			} catch (err) {
 				console.error("Failed to update title:", err);

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -306,11 +306,18 @@ function ensureConnection(token?: string | null, wsBase?: string | null) {
 			case "unsubscribed":
 				break;
 			case "sessions-updated": {
-				window.dispatchEvent(
-					new CustomEvent("cchub-sessions-push", {
-						detail: msg.sessions,
-					}),
-				);
+				// Multi-server: peer 接続中の sessions-updated はその peer 単独の
+				// セッション一覧で、Hub が返すマージ済みリストと整合しない。
+				// Hub に向いている時 (or 初期接続) のみ受け取る。
+				const isHubConnection =
+					currentWsBase === null || currentWsBase === getWsBase();
+				if (isHubConnection) {
+					window.dispatchEvent(
+						new CustomEvent("cchub-sessions-push", {
+							detail: msg.sessions,
+						}),
+					);
+				}
 				break;
 			}
 			case "viewport": {

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -5,6 +5,9 @@ import { reportWsLatency } from "../services/latency-store";
 interface UseMultiplexedTerminalOptions {
 	sessionId: string;
 	token?: string | null;
+	// Multi-server: アクティブな peer の WS base URL ("wss://host:port") を指定。
+	// 省略時は Hub (window.location.host) を使う。
+	peerWsBase?: string | null;
 	onPaneViewport?: (paneId: string, viewport: PaneViewport) => void;
 	onLayoutChange?: (layout: TmuxLayoutNode) => void;
 	onNewSession?: (sessionId: string, sessionName: string) => void;
@@ -69,6 +72,10 @@ let sharedWsConnectStart = 0;
 let sharedLastPongAt = 0;
 let subscribedSession: string | null = null;
 let wsReady = false;
+// Multi-server: 現在の WS 接続が向いている base URL。
+// 接続先が切り替わったら force close して新しい URL に再接続する。
+let currentWsBase: string | null = null;
+let currentWsToken: string | null = null;
 
 // Force-close a CONNECTING socket if onopen hasn't fired by this deadline.
 // Mobile networks can leave the TCP handshake in a zombie state — no onopen,
@@ -153,7 +160,29 @@ function subscribeToSession(sessionId: string, force = false) {
 	sendRaw({ type: "subscribe", sessionId });
 }
 
-function ensureConnection(token?: string | null) {
+function ensureConnection(token?: string | null, wsBase?: string | null) {
+	const desiredBase = wsBase ?? getWsBase();
+	const desiredToken = (token ?? getAuthToken()) || null;
+
+	// 接続先 (URL or token) が変わったら force close して再接続させる
+	const baseChanged =
+		(currentWsBase !== null && currentWsBase !== desiredBase) ||
+		(currentWsToken !== null && currentWsToken !== desiredToken);
+	if (baseChanged && sharedWs) {
+		console.log(
+			`[MUX] target changed (${currentWsBase} → ${desiredBase}); reconnecting`,
+		);
+		try {
+			sharedWs.close();
+		} catch {}
+		sharedWs = null;
+		subscribedSession = null;
+		wsReady = false;
+	}
+
+	currentWsBase = desiredBase;
+	currentWsToken = desiredToken;
+
 	if (sharedWs?.readyState === WebSocket.OPEN) return;
 
 	if (sharedWs?.readyState === WebSocket.CONNECTING) {
@@ -177,10 +206,9 @@ function ensureConnection(token?: string | null) {
 		sharedConnectWatchdog = null;
 	}
 
-	let wsUrl = `${getWsBase()}/ws/mux`;
-	const authToken = token || getAuthToken();
-	if (authToken) {
-		wsUrl += `?token=${encodeURIComponent(authToken)}`;
+	let wsUrl = `${desiredBase}/ws/mux`;
+	if (desiredToken) {
+		wsUrl += `?token=${encodeURIComponent(desiredToken)}`;
 	}
 
 	const ws = new WebSocket(wsUrl);
@@ -364,7 +392,7 @@ function ensureConnection(token?: string | null) {
 
 		if (event.code !== 1000) {
 			sharedReconnectTimeout = window.setTimeout(() => {
-				ensureConnection();
+				ensureConnection(currentWsToken, currentWsBase);
 			}, 2000);
 		}
 	};
@@ -390,7 +418,7 @@ function registerVisibilityListener() {
 				clearTimeout(sharedReconnectTimeout);
 				sharedReconnectTimeout = null;
 			}
-			ensureConnection();
+			ensureConnection(currentWsToken, currentWsBase);
 			return;
 		}
 		// Returning to tab: if CONNECTING is older than a short threshold (3s),
@@ -426,7 +454,7 @@ function registerVisibilityListener() {
 			clearTimeout(sharedReconnectTimeout);
 			sharedReconnectTimeout = null;
 		}
-		ensureConnection();
+		ensureConnection(currentWsToken, currentWsBase);
 	});
 	window.addEventListener("offline", () => {
 		console.log("[MUX] navigator offline");
@@ -509,7 +537,7 @@ export function dispatchInputEcho(
 export function useMultiplexedTerminal(
 	options: UseMultiplexedTerminalOptions,
 ): UseMultiplexedTerminalReturn {
-	const { sessionId, token } = options;
+	const { sessionId, token, peerWsBase } = options;
 	const [isConnected, setIsConnected] = useState(false);
 	const [deadPanes, setDeadPanes] = useState<Set<string>>(new Set());
 
@@ -549,18 +577,23 @@ export function useMultiplexedTerminal(
 	});
 
 	useEffect(() => {
+		// peer 切替時は ensureConnection が force close + 再接続するので、
+		// 接続復帰後 (onopen/ready) で subscribeToSession が呼ばれる
+		if (peerWsBase !== undefined) {
+			ensureConnection(token, peerWsBase);
+		}
 		if (sharedWs?.readyState === WebSocket.OPEN && wsReady) {
 			subscribeToSession(sessionId);
 		}
-	}, [sessionId]);
+	}, [sessionId, token, peerWsBase]);
 
 	const connect = useCallback(() => {
 		registerVisibilityListener();
-		ensureConnection(token);
+		ensureConnection(token, peerWsBase);
 		if (sharedWs?.readyState === WebSocket.OPEN && wsReady) {
 			subscribeToSession(sessionId);
 		}
-	}, [sessionId, token]);
+	}, [sessionId, token, peerWsBase]);
 
 	const disconnect = useCallback(() => {
 		if (subscribedSession) {

--- a/frontend/src/hooks/usePeerConnection.ts
+++ b/frontend/src/hooks/usePeerConnection.ts
@@ -1,0 +1,50 @@
+import { useMemo } from "react";
+import {
+	type ExtendedSessionResponse,
+	LOCAL_PEER_ID,
+	type PeerClientView,
+} from "../../../shared/types";
+
+export interface PeerConnectionInfo {
+	peerId: string;
+	wsBase: string | null; // null = use Hub default (window.location.host)
+	token: string | null;
+	apiBase: string; // REST API base URL ("" for Hub, "https://host:port" for remote peer)
+}
+
+/**
+ * 指定したセッションが属する peer の WS接続情報を返す。
+ * - sessionId が見つからない / peerId が local / 不明: Hub の接続情報を返す
+ * - peerId が remote: peer.url から wsBase + apiBase を導出
+ */
+export function usePeerConnection(
+	sessionId: string,
+	sessions: ExtendedSessionResponse[],
+	peers: PeerClientView[],
+): PeerConnectionInfo {
+	return useMemo(() => {
+		const hubInfo: PeerConnectionInfo = {
+			peerId: LOCAL_PEER_ID,
+			wsBase: null,
+			token: null,
+			apiBase: "",
+		};
+
+		if (!sessionId) return hubInfo;
+
+		const session = sessions.find((s) => s.id === sessionId);
+		const peerId = session?.peerId;
+		if (!peerId || peerId === LOCAL_PEER_ID) return hubInfo;
+
+		const peer = peers.find((p) => p.id === peerId);
+		if (!peer || peer.url === "self") return hubInfo;
+
+		const wsBase = peer.url.replace(/^http(s?):/, (_match, s) => `ws${s}:`).replace(/\/+$/, "");
+		return {
+			peerId,
+			wsBase,
+			token: peer.wsToken ?? null,
+			apiBase: peer.url.replace(/\/+$/, ""),
+		};
+	}, [sessionId, sessions, peers]);
+}

--- a/frontend/src/hooks/usePeers.ts
+++ b/frontend/src/hooks/usePeers.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+	PeerClientView,
+	PeerCreateInput,
+	PeerUpdateInput,
+} from "../../../shared/types";
+import { authFetch } from "../services/api";
+
+const API_BASE = import.meta.env.VITE_API_URL || "";
+
+interface UsePeersReturn {
+	peers: PeerClientView[];
+	isLoading: boolean;
+	error: string | null;
+	refresh: () => Promise<void>;
+	addPeer: (input: PeerCreateInput) => Promise<PeerClientView>;
+	updatePeer: (id: string, input: PeerUpdateInput) => Promise<PeerClientView>;
+	deletePeer: (id: string) => Promise<void>;
+	verifyPeer: (id: string) => Promise<{ status: string; latencyMs?: number; message?: string }>;
+	reorderPeers: (orderedIds: string[]) => Promise<void>;
+}
+
+// module-level cache: 全コンポーネントで共有
+let cachedPeers: PeerClientView[] | null = null;
+const listeners = new Set<(peers: PeerClientView[]) => void>();
+
+function broadcast(peers: PeerClientView[]) {
+	cachedPeers = peers;
+	for (const l of listeners) l(peers);
+}
+
+async function fetchPeers(): Promise<PeerClientView[]> {
+	const res = await authFetch(`${API_BASE}/api/peers`);
+	if (!res.ok) throw new Error(`Failed to load peers: HTTP ${res.status}`);
+	const data = (await res.json()) as { peers: PeerClientView[] };
+	return data.peers;
+}
+
+export function usePeers(): UsePeersReturn {
+	const [peers, setPeers] = useState<PeerClientView[]>(() => cachedPeers ?? []);
+	const [isLoading, setIsLoading] = useState(() => cachedPeers === null);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const listener = (next: PeerClientView[]) => setPeers(next);
+		listeners.add(listener);
+		return () => {
+			listeners.delete(listener);
+		};
+	}, []);
+
+	const refresh = useCallback(async () => {
+		try {
+			const next = await fetchPeers();
+			broadcast(next);
+			setError(null);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to load peers");
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	// 初回ロード
+	useEffect(() => {
+		if (cachedPeers === null) {
+			void refresh();
+		} else {
+			setIsLoading(false);
+		}
+	}, [refresh]);
+
+	const addPeer = useCallback(async (input: PeerCreateInput): Promise<PeerClientView> => {
+		const res = await authFetch(`${API_BASE}/api/peers`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(input),
+		});
+		if (!res.ok) {
+			const err = (await res.json().catch(() => ({}))) as { error?: string };
+			throw new Error(err.error ?? `HTTP ${res.status}`);
+		}
+		const data = (await res.json()) as { peer: PeerClientView };
+		await refresh();
+		return data.peer;
+	}, [refresh]);
+
+	const updatePeerFn = useCallback(async (id: string, input: PeerUpdateInput): Promise<PeerClientView> => {
+		const res = await authFetch(`${API_BASE}/api/peers/${id}`, {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(input),
+		});
+		if (!res.ok) {
+			const err = (await res.json().catch(() => ({}))) as { error?: string };
+			throw new Error(err.error ?? `HTTP ${res.status}`);
+		}
+		const data = (await res.json()) as { peer: PeerClientView };
+		await refresh();
+		return data.peer;
+	}, [refresh]);
+
+	const deletePeerFn = useCallback(async (id: string): Promise<void> => {
+		const res = await authFetch(`${API_BASE}/api/peers/${id}`, { method: "DELETE" });
+		if (!res.ok) {
+			const err = (await res.json().catch(() => ({}))) as { error?: string };
+			throw new Error(err.error ?? `HTTP ${res.status}`);
+		}
+		await refresh();
+	}, [refresh]);
+
+	const verifyPeerFn = useCallback(async (id: string) => {
+		const res = await authFetch(`${API_BASE}/api/peers/${id}/verify`, { method: "POST" });
+		if (!res.ok) {
+			const err = (await res.json().catch(() => ({}))) as { error?: string };
+			throw new Error(err.error ?? `HTTP ${res.status}`);
+		}
+		const result = (await res.json()) as { status: string; latencyMs?: number; message?: string };
+		// verify は registry を更新するので peers も再取得
+		await refresh();
+		return result;
+	}, [refresh]);
+
+	const reorderPeers = useCallback(async (orderedIds: string[]): Promise<void> => {
+		const res = await authFetch(`${API_BASE}/api/peers/order`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ order: orderedIds }),
+		});
+		if (!res.ok) {
+			const err = (await res.json().catch(() => ({}))) as { error?: string };
+			throw new Error(err.error ?? `HTTP ${res.status}`);
+		}
+		await refresh();
+	}, [refresh]);
+
+	return {
+		peers,
+		isLoading,
+		error,
+		refresh,
+		addPeer,
+		updatePeer: updatePeerFn,
+		deletePeer: deletePeerFn,
+		verifyPeer: verifyPeerFn,
+		reorderPeers,
+	};
+}

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -4,6 +4,9 @@ import {
 	DEFAULT_AGENT_PROVIDER,
 	type ExtendedSessionResponse,
 	type IndicatorState,
+	LOCAL_PEER_ID,
+	type PeerSession,
+	type PeerSessionsResponse,
 	type SessionResponse,
 	type SessionTheme,
 } from "../../../shared/types";
@@ -13,6 +16,10 @@ const API_BASE = import.meta.env.VITE_API_URL || "";
 
 // Module-level cache (shared across all useSessions instances, updated by WS push)
 let cachedSessions: ExtendedSessionResponse[] | null = null;
+// Remote peer sessions (excluding local). Updated by polling /api/peers/sessions.
+let cachedRemotePeerSessions: PeerSession[] = [];
+
+const PEER_POLL_INTERVAL = 5000;
 
 /** hookイベントでcachedSessionsのindicatorStateを即座に更新する */
 export function updateCachedSessionsByHookEvent(
@@ -69,21 +76,51 @@ interface UseSessionsReturn {
 	) => Promise<boolean>;
 }
 
+function mergedSessions(): ExtendedSessionResponse[] {
+	const local = (cachedSessions ?? []).map((s) =>
+		// 既存の WS push 由来セッションには peerId が付かないので、local として注釈
+		s.peerId ? s : { ...s, peerId: LOCAL_PEER_ID },
+	);
+	return [...local, ...cachedRemotePeerSessions];
+}
+
 function updateSessions(
 	setSessions: React.Dispatch<React.SetStateAction<ExtendedSessionResponse[]>>,
-	newSessions: ExtendedSessionResponse[],
+	newLocalSessions: ExtendedSessionResponse[],
 ) {
-	cachedSessions = newSessions;
+	cachedSessions = newLocalSessions;
+	const merged = mergedSessions();
 	setSessions((prev) => {
-		const newJson = JSON.stringify(newSessions);
+		const newJson = JSON.stringify(merged);
 		const prevJson = JSON.stringify(prev);
-		return newJson === prevJson ? prev : newSessions;
+		return newJson === prevJson ? prev : merged;
 	});
+}
+
+async function pollRemotePeerSessions(
+	setSessions: React.Dispatch<React.SetStateAction<ExtendedSessionResponse[]>>,
+): Promise<boolean> {
+	try {
+		const res = await authFetch(`${API_BASE}/api/peers/sessions`);
+		if (!res.ok) return false;
+		const data = (await res.json()) as PeerSessionsResponse;
+		if (!Array.isArray(data.sessions)) return false;
+		const remote = data.sessions.filter((s) => s.peerId !== LOCAL_PEER_ID);
+		const stableJson = JSON.stringify(remote);
+		const prevJson = JSON.stringify(cachedRemotePeerSessions);
+		if (stableJson === prevJson) return true;
+		cachedRemotePeerSessions = remote;
+		const merged = mergedSessions();
+		setSessions(merged);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export function useSessions(): UseSessionsReturn {
 	const [sessions, setSessions] = useState<ExtendedSessionResponse[]>(
-		() => cachedSessions || [],
+		() => mergedSessions(),
 	);
 	const [isLoading, setIsLoading] = useState(() => !cachedSessions);
 	const [error, setError] = useState<string | null>(null);
@@ -91,7 +128,7 @@ export function useSessions(): UseSessionsReturn {
 	// Listen for WS push and hook events
 	useEffect(() => {
 		const hookHandler = () => {
-			if (cachedSessions) setSessions(cachedSessions);
+			if (cachedSessions) setSessions(mergedSessions());
 		};
 
 		const pushHandler = (e: Event) => {
@@ -107,6 +144,24 @@ export function useSessions(): UseSessionsReturn {
 		return () => {
 			window.removeEventListener("cchub-hook-event", hookHandler);
 			window.removeEventListener("cchub-sessions-push", pushHandler);
+		};
+	}, []);
+
+	// Poll remote peer sessions (only fires while non-local peers exist)
+	useEffect(() => {
+		let cancelled = false;
+		let timer: ReturnType<typeof setInterval> | null = null;
+
+		void pollRemotePeerSessions(setSessions);
+
+		timer = setInterval(() => {
+			if (cancelled) return;
+			void pollRemotePeerSessions(setSessions);
+		}, PEER_POLL_INTERVAL);
+
+		return () => {
+			cancelled = true;
+			if (timer) clearInterval(timer);
 		};
 	}, []);
 

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -11,6 +11,8 @@ import {
 	type SessionTheme,
 } from "../../../shared/types";
 import { authFetch, isTransientNetworkError } from "../services/api";
+import { sessionFetch } from "../services/peer-fetch";
+import { usePeers } from "./usePeers";
 
 const API_BASE = import.meta.env.VITE_API_URL || "";
 
@@ -119,6 +121,7 @@ async function pollRemotePeerSessions(
 }
 
 export function useSessions(): UseSessionsReturn {
+	const { peers } = usePeers();
 	const [sessions, setSessions] = useState<ExtendedSessionResponse[]>(
 		() => mergedSessions(),
 	);
@@ -195,7 +198,8 @@ export function useSessions(): UseSessionsReturn {
 	const deleteSession = useCallback(async (id: string): Promise<boolean> => {
 		setError(null);
 		try {
-			const response = await authFetch(`${API_BASE}/api/sessions/${id}`, {
+			const session = sessions.find((s) => s.id === id);
+			const response = await sessionFetch(session, peers, `/api/sessions/${id}`, {
 				method: "DELETE",
 			});
 
@@ -209,14 +213,17 @@ export function useSessions(): UseSessionsReturn {
 			}
 			return false;
 		}
-	}, []);
+	}, [sessions, peers]);
 
 	const updateSessionTheme = useCallback(
 		async (id: string, theme: SessionTheme | null): Promise<boolean> => {
 			setError(null);
 			try {
-				const response = await authFetch(
-					`${API_BASE}/api/sessions/${id}/theme`,
+				const session = sessions.find((s) => s.id === id);
+				const response = await sessionFetch(
+					session,
+					peers,
+					`/api/sessions/${id}/theme`,
 					{
 						method: "PUT",
 						headers: { "Content-Type": "application/json" },
@@ -239,7 +246,7 @@ export function useSessions(): UseSessionsReturn {
 				return false;
 			}
 		},
-		[],
+		[sessions, peers],
 	);
 
 	return {

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -19,6 +19,9 @@ import {
 	type TerminalRef,
 } from "../components/Terminal";
 import { useMultiplexedTerminal } from "../hooks/useMultiplexedTerminal";
+import { usePeerConnection } from "../hooks/usePeerConnection";
+import { usePeers } from "../hooks/usePeers";
+import { useSessions } from "../hooks/useSessions";
 import { fireHookNotification } from "../utils/hookNotification";
 import { makePseudoViewport } from "../utils/viewport-pseudo";
 
@@ -101,9 +104,15 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 		// Tracks whether initial zoom has been done (for multi-pane sessions)
 		const initialZoomDoneRef = useRef(false);
 
+		// Multi-server: sessionId が remote peer のものなら、その peer の WS に接続する
+		const { peers } = usePeers();
+		const { sessions: apiSessions } = useSessions();
+		const peerConn = usePeerConnection(sessionId, apiSessions, peers);
+
 		const controlTerminal = useMultiplexedTerminal({
 			sessionId,
-			token,
+			token: peerConn.token ?? token,
+			peerWsBase: peerConn.wsBase,
 			onPaneViewport: (paneId, viewport) => {
 				lastViewportRef.current.set(paneId, viewport);
 				let perPane = paneViewportCacheRef.current.get(paneId);

--- a/frontend/src/services/peer-fetch.ts
+++ b/frontend/src/services/peer-fetch.ts
@@ -1,0 +1,50 @@
+/**
+ * Multi-server: session の peerId に応じて peer 側 API を直接叩くヘルパー。
+ *
+ * Hub の REST API (/api/sessions/:id/theme 等) は local session 用なので、
+ * peer のセッションには peer 自身の URL + 取得済みトークンで fetch する。
+ */
+import { LOCAL_PEER_ID, type PeerClientView } from "../../../shared/types";
+import { authFetch, fetchWithTimeout } from "./api";
+
+interface SessionWithPeer {
+	peerId?: string;
+}
+
+export function resolveSessionApi(
+	session: SessionWithPeer | undefined,
+	peers: PeerClientView[],
+): { apiBase: string; token: string | null; isRemote: boolean } {
+	const peerId = session?.peerId;
+	if (!peerId || peerId === LOCAL_PEER_ID) {
+		return { apiBase: "", token: null, isRemote: false };
+	}
+	const peer = peers.find((p) => p.id === peerId);
+	if (!peer || peer.url === "self") {
+		return { apiBase: "", token: null, isRemote: false };
+	}
+	return {
+		apiBase: peer.url.replace(/\/+$/, ""),
+		token: peer.wsToken ?? null,
+		isRemote: true,
+	};
+}
+
+/**
+ * Session が remote peer に属するなら peer URL + そのトークンで fetch、
+ * それ以外なら Hub に対する authFetch にフォールバックする。
+ */
+export async function sessionFetch(
+	session: SessionWithPeer | undefined,
+	peers: PeerClientView[],
+	path: string,
+	init: RequestInit = {},
+): Promise<Response> {
+	const { apiBase, token, isRemote } = resolveSessionApi(session, peers);
+	if (!isRemote) {
+		return authFetch(`${apiBase}${path}`, init);
+	}
+	const headers = new Headers(init.headers);
+	if (token) headers.set("Authorization", `Bearer ${token}`);
+	return fetchWithTimeout(`${apiBase}${path}`, { ...init, headers });
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -210,6 +210,25 @@ export interface PeerSessionsResponse {
   errors?: { peerId: string; message: string }[];
 }
 
+export interface DiscoveredPeer {
+  /** Tailscale が報告する短いホスト名 */
+  displayName: string;
+  /** Tailscale MagicDNS 名 */
+  hostname: string;
+  /** 検出した URL (デフォルトポート) */
+  url: string;
+  /** cchub バージョン */
+  version?: string;
+  /** 既に peers.json に登録済みか */
+  alreadyRegistered: boolean;
+  /** 登録済みなら nickname */
+  registeredAs?: string;
+}
+
+export interface PeerDiscoverResponse {
+  discovered: DiscoveredPeer[];
+}
+
 export const PeerCreateSchema = z.object({
   nickname: z.string().min(1).max(64),
   url: z.url(),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -232,7 +232,9 @@ export interface PeerDiscoverResponse {
 export const PeerCreateSchema = z.object({
   nickname: z.string().min(1).max(64),
   url: z.url(),
-  password: z.string().min(1),  // peer へ代理ログインするため必須
+  // peer 側で auth が無効 (パスワード未設定) ならクライアントは password を
+  // 送らなくて良い。loginToPeer 側で 400 = "auth disabled" を空トークンで処理する
+  password: z.string().optional(),
   color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -171,6 +171,67 @@ export type CreateSessionInput = z.infer<typeof CreateSessionSchema>;
 export type ResizeTerminalInput = z.infer<typeof ResizeTerminalSchema>;
 
 // =============================================================================
+// Peer (multi-server) Types
+// =============================================================================
+
+// "self" は Hub 自身を指す疑似 URL。フロント側で window.origin に解決する
+export const SELF_PEER_URL = 'self' as const;
+export const LOCAL_PEER_ID = 'local' as const;
+
+export type PeerStatus = 'online' | 'offline' | 'unauthorized' | 'unknown';
+
+export interface Peer {
+  id: string;          // 'local' or 'p_xxxx'
+  nickname: string;    // ユーザー表示名（絵文字OK）
+  url: string;         // 'self' か 'https://host:port'
+  color: string;       // '#RRGGBB' バッジ色
+  order: number;       // 表示順
+}
+
+// クライアントに払い出すペア情報（wsToken 含む）
+export interface PeerClientView extends Peer {
+  wsToken?: string;      // peer に直接WS接続するときの Bearer トークン (selfなら不要)
+  status: PeerStatus;
+  lastSeenAt?: string;   // ISO8601
+  latencyMs?: number;    // 直近のverify時のレイテンシ
+  errorMessage?: string; // unauthorized等の理由
+}
+
+export interface PeerListResponse {
+  peers: PeerClientView[];
+}
+
+// マージされたセッション一覧の項目。peer情報は ExtendedSessionResponse に直接生やしてある
+export type PeerSession = ExtendedSessionResponse & { peerId: string };
+
+export interface PeerSessionsResponse {
+  sessions: PeerSession[];
+  // peer 毎のエラーがあれば返す（一部peerが落ちていても他は表示するため）
+  errors?: { peerId: string; message: string }[];
+}
+
+export const PeerCreateSchema = z.object({
+  nickname: z.string().min(1).max(64),
+  url: z.url(),
+  password: z.string().min(1),  // peer へ代理ログインするため必須
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+});
+
+export const PeerUpdateSchema = z.object({
+  nickname: z.string().min(1).max(64).optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+  password: z.string().min(1).optional(),  // 再認証用
+});
+
+export const PeerOrderSchema = z.object({
+  order: z.array(z.string()),  // peer id の配列
+});
+
+export type PeerCreateInput = z.infer<typeof PeerCreateSchema>;
+export type PeerUpdateInput = z.infer<typeof PeerUpdateSchema>;
+export type PeerOrderInput = z.infer<typeof PeerOrderSchema>;
+
+// =============================================================================
 // File Viewer Types
 // =============================================================================
 
@@ -394,6 +455,11 @@ export interface ExtendedSessionResponse extends SessionResponse {
   durationMinutes?: number;
   firstMessageId?: string;
   metrics?: SessionMetrics;
+  // Multi-server: 所属 peer の情報。`/api/peers/sessions` から返るときに付く。
+  // 単一 peer (= local only) の通常運用では unset。
+  peerId?: string;
+  peerNickname?: string;
+  peerColor?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Hub holds a peer registry (`~/.cc-hub/peers.json`, mode 0600) and serves merged session list to clients — no per-device setup
- Active session's terminal WebSocket switches to the owning peer directly (Hub stays out of the I/O path)
- Tailscale tailnet auto-discovery (`tailscale status` + `:5923/health` probe) with one-click add and confirm prompt
- Per-session REST ops (theme, title, delete) route to the owning peer

## What's in
- **Phase 1**: peer registry CRUD, Servers tab UI (desktop + mobile), session list merge with nickname badge / color border / color picker
- **Phase 2**: `useMultiplexedTerminal` accepts `peerWsBase`; mobile (TerminalPage) and desktop (DesktopLayout) both wired
- **Discovery**: `GET /api/peers/discover` returns reachable cchub instances on the tailnet; UI shows a confirm dialog before scanning so it's never automatic / opt-in only
- **No-password peers**: `/api/auth/required` pre-check, empty password OK for open peers
- **Per-session REST routing**: `sessionFetch(session, peers, path, init)` helper picks peer URL + token

## Bug fixes uncovered along the way
- `fetchAndOpenSession` was re-running every render (unstable `createInitialSession` in useEffect deps) and overwriting `activeSessionId` from localStorage — that was the root cause of peer terminals \"opening then snapping back\"
- Peer's `sessions-updated` push was overwriting the Hub's merged view, flipping `peerId` back to `local` and bouncing the WebSocket between Hub and peer
- Mobile TerminalPage wasn't passing `peerWsBase` to `useMultiplexedTerminal`

## Known limitations (future work)
- File viewer, conversation viewer, session resume, session order — still Hub-only
- Same-machine self-peering (test setup) produces duplicate session IDs; production peers on distinct machines are fine

## Test plan
- [x] Add peer with password (Tailscale URL): registered, sessions appear with badge
- [x] Add peer without password: clear error if peer in fact requires one
- [x] Discover button shows confirm prompt, then finds cchub on tailnet
- [x] Mobile (Android Chrome): tap MacBook session → terminal opens, stays connected
- [x] Theme change on a peer session — verified PUTs the peer's URL
- [x] Existing single-server (no peers added) usage unchanged
- [ ] PR reviewer: try on your own MacBook/Linux pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)