### PR TITLE
feat: aggregate session history across peers

### DIFF
--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -11,6 +11,9 @@ import {
   type PeerSession,
   type PeerSessionsResponse,
   type ExtendedSessionResponse,
+  type PeerHistoryProject,
+  type PeerHistoryProjectsResponse,
+  type HistorySession,
 } from '../../../shared/types';
 import {
   listPeers,
@@ -22,7 +25,7 @@ import {
 } from '../services/peer-registry';
 import { loginToPeer, verifyPeer, peerFetch, PeerAuthError } from '../services/peer-auth';
 import { discoverPeers } from '../services/peer-discovery';
-import { buildSessionsList } from './sessions';
+import { buildSessionsList, sessionHistoryService, codexHistoryService } from './sessions';
 
 export const peers = new Hono();
 
@@ -144,6 +147,185 @@ peers.post('/:id/verify', async (c) => {
     status: result.status === 401 ? 'unauthorized' : 'offline',
     message: result.message,
   });
+});
+
+// -----------------------------------------------------------------------------
+// History アグリゲーション
+// 各 peer の `/api/sessions/history/...` を並列 fetch して merge する。
+// dirName は peer 間で衝突しうるので、peer 情報を必ず併載してクライアントが
+// (peerId, dirName) の複合キーで識別できるようにする。
+// -----------------------------------------------------------------------------
+
+interface HistoryProjectsResp {
+  projects: Array<{
+    dirName: string;
+    projectPath: string;
+    projectName: string;
+    sessionCount: number;
+    latestModified?: string;
+  }>;
+}
+
+async function buildLocalHistoryProjects(): Promise<HistoryProjectsResp['projects']> {
+  const [claudeProjects, codexProjects] = await Promise.all([
+    sessionHistoryService.getProjects(),
+    codexHistoryService.getProjects(),
+  ]);
+  const byDir = new Map<string, HistoryProjectsResp['projects'][number]>();
+  for (const p of claudeProjects) byDir.set(p.dirName, p);
+  for (const p of codexProjects) {
+    const existing = byDir.get(p.dirName);
+    if (existing) {
+      existing.sessionCount += p.sessionCount;
+      if (!existing.latestModified || (p.latestModified && p.latestModified > existing.latestModified)) {
+        existing.latestModified = p.latestModified;
+      }
+    } else {
+      byDir.set(p.dirName, p);
+    }
+  }
+  return Array.from(byDir.values()).sort((a, b) => a.projectName.localeCompare(b.projectName));
+}
+
+// GET /api/peers/history/projects - 全 peer のプロジェクトを merge
+peers.get('/history/projects', async (c) => {
+  const allPeers = await listPeers();
+  const errors: { peerId: string; message: string }[] = [];
+
+  const results = await Promise.all(allPeers.map(async (peer): Promise<PeerHistoryProject[]> => {
+    try {
+      let projects: HistoryProjectsResp['projects'];
+      if (peer.url === SELF_PEER_URL) {
+        projects = await buildLocalHistoryProjects();
+      } else {
+        const res = await peerFetch(peer.id, peer.url, peer.wsToken, '/api/sessions/history/projects');
+        if (!res.ok) {
+          errors.push({ peerId: peer.id, message: `HTTP ${res.status}` });
+          return [];
+        }
+        const data = (await res.json()) as HistoryProjectsResp;
+        if (!Array.isArray(data.projects)) {
+          errors.push({ peerId: peer.id, message: 'Invalid response' });
+          return [];
+        }
+        projects = data.projects;
+      }
+      return projects.map(p => ({
+        ...p,
+        peerId: peer.id,
+        peerNickname: peer.nickname,
+        peerColor: peer.color,
+      }));
+    } catch (err) {
+      errors.push({ peerId: peer.id, message: err instanceof Error ? err.message : 'Fetch failed' });
+      return [];
+    }
+  }));
+
+  const merged = results.flat();
+  const response: PeerHistoryProjectsResponse = errors.length > 0
+    ? { projects: merged, errors }
+    : { projects: merged };
+  return c.json(response);
+});
+
+async function buildLocalProjectSessions(dirName: string): Promise<HistorySession[]> {
+  const [claudeSessions, codexSessions] = await Promise.all([
+    sessionHistoryService.getProjectSessions(dirName),
+    codexHistoryService.getProjectSessions(dirName),
+  ]);
+  const merged: HistorySession[] = [
+    ...claudeSessions.map(s => ({ ...s, agent: s.agent ?? 'claude' as const })),
+    ...codexSessions,
+  ].sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+  return merged;
+}
+
+// GET /api/peers/history/:peerId/projects/:dirName - 指定 peer のプロジェクト内 session 一覧
+peers.get('/history/:peerId/projects/:dirName', async (c) => {
+  const peerId = c.req.param('peerId');
+  const dirName = c.req.param('dirName');
+  const peer = (await listPeers()).find(p => p.id === peerId);
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+
+  let sessions: HistorySession[];
+  if (peer.url === SELF_PEER_URL) {
+    sessions = await buildLocalProjectSessions(dirName);
+  } else {
+    const path = `/api/sessions/history/projects/${encodeURIComponent(dirName)}`;
+    const res = await peerFetch(peer.id, peer.url, peer.wsToken, path);
+    if (!res.ok) return c.json({ error: `HTTP ${res.status}` }, 502);
+    const data = (await res.json()) as { sessions: HistorySession[] };
+    sessions = data.sessions ?? [];
+  }
+  // peer 情報を付与
+  const enriched = sessions.map(s => ({
+    ...s,
+    peerId: peer.id,
+    peerNickname: peer.nickname,
+    peerColor: peer.color,
+  }));
+  return c.json({ sessions: enriched });
+});
+
+// GET /api/peers/history/:peerId/:sessionId/conversation - 指定 peer の会話履歴
+peers.get('/history/:peerId/:sessionId/conversation', async (c) => {
+  const peerId = c.req.param('peerId');
+  const sessionId = c.req.param('sessionId');
+  const peer = (await listPeers()).find(p => p.id === peerId);
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+
+  const agent = c.req.query('agent');
+  const projectDirName = c.req.query('projectDirName');
+  const lastQuery = c.req.query('last');
+  const last = lastQuery ? parseInt(lastQuery, 10) : undefined;
+
+  if (peer.url === SELF_PEER_URL) {
+    const messages = agent === 'codex'
+      ? await codexHistoryService.getConversation(sessionId)
+      : await sessionHistoryService.getConversation(sessionId, projectDirName);
+    return c.json({ messages: last ? messages.slice(-last) : messages });
+  }
+
+  const qs = new URLSearchParams();
+  if (agent) qs.set('agent', agent);
+  if (projectDirName) qs.set('projectDirName', projectDirName);
+  if (lastQuery) qs.set('last', lastQuery);
+  const suffix = qs.toString() ? `?${qs.toString()}` : '';
+  const path = `/api/sessions/history/${encodeURIComponent(sessionId)}/conversation${suffix}`;
+  const res = await peerFetch(peer.id, peer.url, peer.wsToken, path);
+  if (!res.ok) return c.json({ error: `HTTP ${res.status}` }, 502);
+  const data = (await res.json()) as { messages: unknown[] };
+  return c.json(data);
+});
+
+// POST /api/peers/history/:peerId/resume - 指定 peer 上で session を resume
+peers.post('/history/:peerId/resume', async (c) => {
+  const peerId = c.req.param('peerId');
+  const peer = (await listPeers()).find(p => p.id === peerId);
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+
+  const body = await c.req.json().catch(() => ({}));
+
+  if (peer.url === SELF_PEER_URL) {
+    // self: Hub の resume 処理を呼ぶしかないが、 sessions.ts が export してないので
+    // peer の REST API 経由で投げる (localhost 越しではなく Hub 自身に対しては
+    // 認証無効/有効に関わらず直接 fetch では成り立たない)。
+    // → /api/peers の同期 fetch を経由しない最もシンプルな方法: 内部関数を export
+    // 今回は最小実装として「self の resume はクライアント側で Hub の /api/sessions/history/resume を直に呼ぶ」前提にし、
+    // この endpoint は remote 専用とする。
+    return c.json({ error: 'Use /api/sessions/history/resume for local sessions' }, 400);
+  }
+
+  const init: RequestInit = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+  const path = '/api/sessions/history/resume';
+  const res = await peerFetch(peer.id, peer.url, peer.wsToken, path, init);
+  const data = await res.json().catch(() => ({}));
+  return c.json(data as Record<string, unknown>, res.ok ? 200 : 502);
 });
 
 // GET /api/peers/sessions - 全 peer のセッション一覧をマージして返す

--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -324,8 +324,10 @@ peers.post('/history/:peerId/resume', async (c) => {
   };
   const path = '/api/sessions/history/resume';
   const res = await peerFetch(peer.id, peer.url, peer.wsToken, path, init);
-  const data = await res.json().catch(() => ({}));
-  return c.json(data as Record<string, unknown>, res.ok ? 200 : 502);
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  // peer 側のステータスをそのまま透過 (duplicate_working_dir などのコードもクライアントに届ける)
+  if (res.ok) return c.json(data);
+  return c.json(data, (res.status >= 400 && res.status < 600 ? res.status : 502) as 400 | 401 | 404 | 409 | 500 | 502);
 });
 
 // GET /api/peers/sessions - 全 peer のセッション一覧をマージして返す

--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -330,6 +330,55 @@ peers.post('/history/:peerId/resume', async (c) => {
   return c.json(data, (res.status >= 400 && res.status < 600 ? res.status : 502) as 400 | 401 | 404 | 409 | 500 | 502);
 });
 
+// -----------------------------------------------------------------------------
+// Files API プロキシ (peer 上のディレクトリ browse / mkdir 用)
+// 新規セッション作成ダイアログで peer 側の filesystem を参照させるため、
+// /api/files/browse と /api/files/mkdir を peer-aware にする。
+// -----------------------------------------------------------------------------
+
+// GET /api/peers/:peerId/files/browse?path=...
+peers.get('/:peerId/files/browse', async (c) => {
+  const peerId = c.req.param('peerId');
+  const peer = (await listPeers()).find(p => p.id === peerId);
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+
+  const qsPath = c.req.query('path');
+  const suffix = qsPath ? `?path=${encodeURIComponent(qsPath)}` : '';
+  const path = `/api/files/browse${suffix}`;
+
+  if (peer.url === SELF_PEER_URL) {
+    // self は Hub の /api/files/browse をそのまま使えるが、ルーター越しに呼ぶより
+    // クライアントが直接 /api/files/browse を叩いた方が良いので、ここは remote 専用と割り切る
+    return c.json({ error: 'Use /api/files/browse for local peer' }, 400);
+  }
+
+  const res = await peerFetch(peer.id, peer.url, peer.wsToken, path);
+  const data = await res.json().catch(() => ({}));
+  if (res.ok) return c.json(data as Record<string, unknown>);
+  return c.json(data as Record<string, unknown>, (res.status >= 400 && res.status < 600 ? res.status : 502) as 400 | 404 | 500 | 502);
+});
+
+// POST /api/peers/:peerId/files/mkdir
+peers.post('/:peerId/files/mkdir', async (c) => {
+  const peerId = c.req.param('peerId');
+  const peer = (await listPeers()).find(p => p.id === peerId);
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+  if (peer.url === SELF_PEER_URL) {
+    return c.json({ error: 'Use /api/files/mkdir for local peer' }, 400);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const init: RequestInit = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+  const res = await peerFetch(peer.id, peer.url, peer.wsToken, '/api/files/mkdir', init);
+  const data = await res.json().catch(() => ({}));
+  if (res.ok) return c.json(data as Record<string, unknown>);
+  return c.json(data as Record<string, unknown>, (res.status >= 400 && res.status < 600 ? res.status : 502) as 400 | 404 | 500 | 502);
+});
+
 // GET /api/peers/sessions - 全 peer のセッション一覧をマージして返す
 peers.get('/sessions', async (c) => {
   const allPeers = await listPeers();

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -19,8 +19,9 @@ const tmuxService = new TmuxService();
 const claudeCodeService = new ClaudeCodeService();
 const codexService = new CodexService();
 const codexConversationService = new CodexConversationService();
-const sessionHistoryService = new SessionHistoryService();
-const codexHistoryService = new CodexHistoryService(undefined, codexConversationService);
+// peers.ts からも参照するため export
+export const sessionHistoryService = new SessionHistoryService();
+export const codexHistoryService = new CodexHistoryService(undefined, codexConversationService);
 const promptHistoryService = new PromptHistoryService();
 
 export function shellQuote(value: string): string {

--- a/frontend/src/components/SessionHistory.tsx
+++ b/frontend/src/components/SessionHistory.tsx
@@ -17,6 +17,7 @@ import type {
 } from "../../../shared/types";
 import {
 	type ProjectInfo,
+	projectKey,
 	useSessionHistory,
 } from "../hooks/useSessionHistory";
 import { authFetch } from "../services/api";
@@ -181,12 +182,23 @@ function ProjectGroupItem({
 		}
 	};
 
+	const showPeerBadge =
+		project.peerId && project.peerId !== "local" && project.peerNickname;
+
 	return (
 		<div>
 			<button
 				type="button"
 				onClick={handleToggle}
 				className="w-full flex items-center gap-2 px-3 py-2 hover:bg-white/[0.03] rounded-md transition-colors"
+				style={
+					showPeerBadge && project.peerColor
+						? {
+								borderLeft: `3px solid ${project.peerColor}`,
+								paddingLeft: 8,
+							}
+						: undefined
+				}
 			>
 				<ChevronRight
 					className={`w-3.5 h-3.5 text-zinc-600 transition-transform duration-150 ${isExpanded ? "rotate-90" : ""}`}
@@ -195,6 +207,21 @@ function ProjectGroupItem({
 				<span className="flex-1 text-left text-[13px] text-zinc-400 truncate">
 					{project.projectName}
 				</span>
+				{showPeerBadge && (
+					<span
+						className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+						style={{
+							backgroundColor: `${project.peerColor}26`,
+							color: project.peerColor,
+						}}
+					>
+						<span
+							className="w-1 h-1 rounded-full"
+							style={{ backgroundColor: project.peerColor }}
+						/>
+						{project.peerNickname}
+					</span>
+				)}
 				<span className="text-[11px] text-zinc-600 tabular-nums">
 					{project.sessionCount}
 				</span>
@@ -309,6 +336,7 @@ export function SessionHistory({
 				session.sessionId,
 				session.projectPath,
 				session.agent,
+				session.peerId,
 			);
 
 			if (result) {
@@ -372,6 +400,7 @@ export function SessionHistory({
 				session.sessionId,
 				projectDirName,
 				session.agent,
+				session.peerId,
 			);
 			setConversation(messages);
 		} finally {
@@ -422,6 +451,7 @@ export function SessionHistory({
 				session.sessionId,
 				undefined,
 				session.agent,
+				session.peerId,
 			);
 			setConversation(messages);
 		} finally {
@@ -509,20 +539,25 @@ export function SessionHistory({
 					</div>
 				) : (
 					/* Project list */
-					projects.map((project) => (
-						<ProjectGroupItem
-							key={project.dirName}
-							project={project}
-							sessions={sessionsByProject.get(project.dirName)}
-							isLoading={loadingProjects.has(project.dirName)}
-							onExpand={() => fetchProjectSessions(project.dirName)}
-							onTap={handleTap}
-							onResume={handleResume}
-							onNavigate={handleNavigate}
-							resumingId={resumingId}
-							activeCcSessionIds={activeCcSessionIds}
-						/>
-					))
+					projects.map((project) => {
+						const key = projectKey(project.peerId, project.dirName);
+						return (
+							<ProjectGroupItem
+								key={key}
+								project={project}
+								sessions={sessionsByProject.get(key)}
+								isLoading={loadingProjects.has(key)}
+								onExpand={() =>
+									fetchProjectSessions(project.peerId, project.dirName)
+								}
+								onTap={handleTap}
+								onResume={handleResume}
+								onNavigate={handleNavigate}
+								resumingId={resumingId}
+								activeCcSessionIds={activeCcSessionIds}
+							/>
+						);
+					})
 				)}
 			</div>
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -100,12 +100,16 @@ import { SessionHistory } from "./SessionHistory";
 const API_BASE = import.meta.env.VITE_API_URL || "";
 
 // Directory browser API functions
+// peerId が指定された場合は /api/peers/:peerId/files/* に振り分け。
 async function browseDirectory(
 	path?: string,
+	peerId?: string,
 ): Promise<{ path: string; files: FileInfo[]; parentPath: string | null }> {
-	const url = path
-		? `${API_BASE}/api/files/browse?path=${encodeURIComponent(path)}`
+	const isRemote = peerId && peerId !== "local";
+	const base = isRemote
+		? `${API_BASE}/api/peers/${encodeURIComponent(peerId)}/files/browse`
 		: `${API_BASE}/api/files/browse`;
+	const url = path ? `${base}?path=${encodeURIComponent(path)}` : base;
 	const response = await authFetch(url);
 	if (!response.ok) {
 		throw new Error("Failed to browse directory");
@@ -115,8 +119,13 @@ async function browseDirectory(
 
 async function createDirectory(
 	path: string,
+	peerId?: string,
 ): Promise<{ path: string; success: boolean }> {
-	const response = await authFetch(`${API_BASE}/api/files/mkdir`, {
+	const isRemote = peerId && peerId !== "local";
+	const url = isRemote
+		? `${API_BASE}/api/peers/${encodeURIComponent(peerId)}/files/mkdir`
+		: `${API_BASE}/api/files/mkdir`;
+	const response = await authFetch(url, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ path }),
@@ -310,8 +319,6 @@ function CreateSessionModal({
 	const [selectedPeerId, setSelectedPeerId] = useState<string>(LOCAL_PEER_ID);
 	const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
 	const [currentPath, setCurrentPath] = useState<string>("");
-	// peer 選択時は Hub のディレクトリピッカーが使えないので、生 path 入力にする
-	const [remoteWorkingDir, setRemoteWorkingDir] = useState<string>("~");
 	const [directories, setDirectories] = useState<FileInfo[]>([]);
 	const [parentPath, setParentPath] = useState<string | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
@@ -329,36 +336,42 @@ function CreateSessionModal({
 	const existingNamesRef = useRef(existingNames);
 	existingNamesRef.current = existingNames;
 
-	const loadDirectory = useCallback(async (path?: string) => {
-		setIsLoading(true);
-		setError(null);
-		try {
-			const result = await browseDirectory(path);
-			setCurrentPath(result.path);
-			setDirectories(result.files);
-			setParentPath(result.parentPath);
+	const loadDirectory = useCallback(
+		async (path: string | undefined, peerId: string) => {
+			setIsLoading(true);
+			setError(null);
+			try {
+				const target = peerId === LOCAL_PEER_ID ? undefined : peerId;
+				const result = await browseDirectory(path, target);
+				setCurrentPath(result.path);
+				setDirectories(result.files);
+				setParentPath(result.parentPath);
 
-			// Auto-suggest session name from directory name (only if not manually edited)
-			if (!nameManuallyEditedRef.current) {
-				const dirName = result.path.split("/").pop() || "";
-				let suggested = dirName;
-				let counter = 1;
-				while (existingNamesRef.current.has(suggested)) {
-					suggested = `${dirName}-${counter++}`;
+				// Auto-suggest session name from directory name (only if not manually edited)
+				if (!nameManuallyEditedRef.current) {
+					const dirName = result.path.split("/").pop() || "";
+					let suggested = dirName;
+					let counter = 1;
+					while (existingNamesRef.current.has(suggested)) {
+						suggested = `${dirName}-${counter++}`;
+					}
+					setName(suggested);
 				}
-				setName(suggested);
+			} catch (err) {
+				setError(err instanceof Error ? err.message : "Failed to load directory");
+				setDirectories([]);
+				setParentPath(null);
+			} finally {
+				setIsLoading(false);
 			}
-		} catch (err) {
-			setError(err instanceof Error ? err.message : "Failed to load directory");
-		} finally {
-			setIsLoading(false);
-		}
-	}, []);
+		},
+		[],
+	);
 
-	// Load initial directory
+	// Initial load + peer 切替時のリロード
 	useEffect(() => {
-		loadDirectory();
-	}, [loadDirectory]);
+		loadDirectory(undefined, selectedPeerId);
+	}, [loadDirectory, selectedPeerId]);
 
 	// Focus new folder input when shown
 	useEffect(() => {
@@ -368,12 +381,12 @@ function CreateSessionModal({
 	}, [showNewFolderInput]);
 
 	const handleDirectoryClick = (dir: FileInfo) => {
-		loadDirectory(dir.path);
+		loadDirectory(dir.path, selectedPeerId);
 	};
 
 	const handleGoUp = () => {
 		if (parentPath) {
-			loadDirectory(parentPath);
+			loadDirectory(parentPath, selectedPeerId);
 		}
 	};
 
@@ -383,8 +396,7 @@ function CreateSessionModal({
 	};
 
 	const handleSubmit = () => {
-		const workingDir = isRemote ? remoteWorkingDir.trim() : currentPath;
-		onConfirm(name, workingDir, agent, isRemote ? selectedPeerId : undefined);
+		onConfirm(name, currentPath, agent, isRemote ? selectedPeerId : undefined);
 	};
 
 	const handleCreateFolder = async () => {
@@ -394,11 +406,12 @@ function CreateSessionModal({
 		setError(null);
 		try {
 			const newPath = `${currentPath}/${newFolderName.trim()}`;
-			await createDirectory(newPath);
+			const target = isRemote ? selectedPeerId : undefined;
+			await createDirectory(newPath, target);
 			setShowNewFolderInput(false);
 			setNewFolderName("");
 			// Navigate to the new directory
-			loadDirectory(newPath);
+			loadDirectory(newPath, selectedPeerId);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to create folder");
 		} finally {
@@ -482,27 +495,7 @@ function CreateSessionModal({
 					</div>
 				)}
 
-				{/* Remote workingDir input (peer 選択時) */}
-				{isRemote && (
-					<label className="mb-3 block">
-						<span className="text-xs text-th-text-secondary mb-1 block">
-							{t("session.workingDirectory")} (peer 上のパス)
-						</span>
-						<input
-							type="text"
-							value={remoteWorkingDir}
-							onChange={(e) => setRemoteWorkingDir(e.target.value)}
-							placeholder="~"
-							className="w-full px-3 py-2 bg-th-bg border border-th-border rounded text-th-text font-mono text-sm placeholder-th-text-muted focus:outline-none focus:border-blue-500"
-						/>
-						<p className="mt-1 text-[11px] text-th-text-muted">
-							ディレクトリ一覧は peer 側に存在する必要があります。`~` でホームディレクトリ。
-						</p>
-					</label>
-				)}
-
-				{/* Directory picker — local 選択時のみ */}
-				{!isRemote && (
+				{/* Directory picker — local / remote 共通 (remote は peer 側の filesystem を browse) */}
 				<div className="flex-1 min-h-0 flex flex-col">
 					<div className="flex items-center justify-between mb-2">
 						<span className="text-xs text-th-text-secondary">
@@ -619,7 +612,6 @@ function CreateSessionModal({
 						)}
 					</div>
 				</div>
-				)}
 
 				{/* Action buttons */}
 				<div className="flex gap-3 justify-end mt-3 pt-3 border-t border-th-border">

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -1296,6 +1296,7 @@ export function SessionList({
 		title: string;
 		subtitle: string;
 		isActive: boolean;
+		peerId?: string;
 	} | null>(null);
 	const [conversation, setConversation] = useState<ConversationMessage[]>([]);
 	const [loadingConversation, setLoadingConversation] = useState(false);
@@ -1396,17 +1397,19 @@ export function SessionList({
 			title: string,
 			subtitle: string,
 			isActive: boolean,
+			peerId?: string,
 		) => {
 			setViewingConversation({
 				sessionId: ccSessionId,
 				title,
 				subtitle,
 				isActive,
+				peerId,
 			});
 			setLoadingConversation(true);
 			setConversation([]);
 			try {
-				const messages = await fetchConversation(ccSessionId);
+				const messages = await fetchConversation(ccSessionId, undefined, undefined, peerId);
 				setConversation(messages);
 			} finally {
 				setLoadingConversation(false);
@@ -1419,7 +1422,12 @@ export function SessionList({
 	const handleRefreshConversation = useCallback(async () => {
 		if (!viewingConversation) return;
 		try {
-			const messages = await fetchConversation(viewingConversation.sessionId);
+			const messages = await fetchConversation(
+				viewingConversation.sessionId,
+				undefined,
+				undefined,
+				viewingConversation.peerId,
+			);
 			setConversation(messages);
 		} catch (err) {
 			console.error("Failed to refresh conversation:", err);

--- a/frontend/src/hooks/useSessionHistory.ts
+++ b/frontend/src/hooks/useSessionHistory.ts
@@ -2,34 +2,36 @@ import { useCallback, useEffect, useState } from "react";
 import type {
 	ConversationMessage,
 	HistorySession,
+	PeerHistoryProject,
+	PeerHistoryProjectsResponse,
 } from "../../../shared/types";
+import { LOCAL_PEER_ID } from "../../../shared/types";
 import { authFetch, isTransientNetworkError } from "../services/api";
 
 const API_BASE = import.meta.env.VITE_API_URL || "";
 
-export interface ProjectInfo {
-	dirName: string;
-	projectPath: string;
-	projectName: string;
-	sessionCount: number;
-	latestModified?: string;
+// Multi-server: 内部キーは `${peerId}::${dirName}` で識別する (peer 跨ぎで dirName が
+// 衝突しうるため)。UI 側もこのキーで expand 状態などを持つ。
+export type ProjectKey = string;
+export function projectKey(peerId: string, dirName: string): ProjectKey {
+	return `${peerId}::${dirName}`;
 }
 
+export type ProjectInfo = PeerHistoryProject;
+
 interface UseSessionHistoryResult {
-	// Project-level data (fast initial load)
 	projects: ProjectInfo[];
 	isLoadingProjects: boolean;
 
-	// Session-level data (lazy loaded per project)
-	sessionsByProject: Map<string, HistorySession[]>;
-	loadingProjects: Set<string>;
+	sessionsByProject: Map<ProjectKey, HistorySession[]>;
+	loadingProjects: Set<ProjectKey>;
 	fetchProjectSessions: (
+		peerId: string,
 		dirName: string,
 		forceRefresh?: boolean,
 	) => Promise<void>;
 	refreshAllLoadedProjects: () => Promise<void>;
 
-	// Search
 	searchResults: HistorySession[];
 	isSearching: boolean;
 	searchQuery: string;
@@ -38,17 +40,18 @@ interface UseSessionHistoryResult {
 
 	error: string | null;
 
-	// Actions
 	refresh: () => Promise<void>;
 	resumeSession: (
 		sessionId: string,
 		projectPath: string,
 		agent?: "claude" | "codex",
+		peerId?: string,
 	) => Promise<{ tmuxSessionId: string } | null>;
 	fetchConversation: (
 		sessionId: string,
 		projectDirName?: string,
 		agent?: "claude" | "codex",
+		peerId?: string,
 	) => Promise<ConversationMessage[]>;
 }
 
@@ -56,19 +59,18 @@ export function useSessionHistory(): UseSessionHistoryResult {
 	const [projects, setProjects] = useState<ProjectInfo[]>([]);
 	const [isLoadingProjects, setIsLoadingProjects] = useState(true);
 	const [sessionsByProject, setSessionsByProject] = useState<
-		Map<string, HistorySession[]>
+		Map<ProjectKey, HistorySession[]>
 	>(new Map());
-	const [loadingProjects, setLoadingProjects] = useState<Set<string>>(
+	const [loadingProjects, setLoadingProjects] = useState<Set<ProjectKey>>(
 		new Set(),
 	);
 	const [error, setError] = useState<string | null>(null);
 
-	// Search state
 	const [searchResults, setSearchResults] = useState<HistorySession[]>([]);
 	const [isSearching, setIsSearching] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
 
-	// Fetch project list (fast)
+	// 全 peer のプロジェクト一覧を取得
 	const fetchProjects = useCallback(async (silent = false) => {
 		try {
 			if (!silent) {
@@ -76,13 +78,12 @@ export function useSessionHistory(): UseSessionHistoryResult {
 				setError(null);
 			}
 			const response = await authFetch(
-				`${API_BASE}/api/sessions/history/projects`,
+				`${API_BASE}/api/peers/history/projects`,
 			);
 			if (!response.ok) {
 				throw new Error("Failed to fetch projects");
 			}
-			const data = await response.json();
-			// Only update state if data has changed to prevent unnecessary re-renders
+			const data = (await response.json()) as PeerHistoryProjectsResponse;
 			setProjects((prev) => {
 				const newJson = JSON.stringify(data.projects || []);
 				const prevJson = JSON.stringify(prev);
@@ -99,31 +100,28 @@ export function useSessionHistory(): UseSessionHistoryResult {
 		}
 	}, []);
 
-	// Fetch sessions for a specific project (lazy)
 	const fetchProjectSessions = useCallback(
-		async (dirName: string, forceRefresh = false) => {
-			// Skip if already loaded or loading (unless forceRefresh)
+		async (peerId: string, dirName: string, forceRefresh = false) => {
+			const key = projectKey(peerId, dirName);
 			if (
 				!forceRefresh &&
-				(sessionsByProject.has(dirName) || loadingProjects.has(dirName))
+				(sessionsByProject.has(key) || loadingProjects.has(key))
 			) {
 				return;
 			}
 
 			try {
-				setLoadingProjects((prev) => new Set(prev).add(dirName));
-
+				setLoadingProjects((prev) => new Set(prev).add(key));
 				const response = await authFetch(
-					`${API_BASE}/api/sessions/history/projects/${encodeURIComponent(dirName)}`,
+					`${API_BASE}/api/peers/history/${encodeURIComponent(peerId)}/projects/${encodeURIComponent(dirName)}`,
 				);
 				if (!response.ok) {
 					throw new Error("Failed to fetch project sessions");
 				}
-				const data = await response.json();
-
+				const data = (await response.json()) as { sessions?: HistorySession[] };
 				setSessionsByProject((prev) => {
 					const next = new Map(prev);
-					next.set(dirName, data.sessions || []);
+					next.set(key, data.sessions ?? []);
 					return next;
 				});
 			} catch (err) {
@@ -131,7 +129,7 @@ export function useSessionHistory(): UseSessionHistoryResult {
 			} finally {
 				setLoadingProjects((prev) => {
 					const next = new Set(prev);
-					next.delete(dirName);
+					next.delete(key);
 					return next;
 				});
 			}
@@ -139,14 +137,14 @@ export function useSessionHistory(): UseSessionHistoryResult {
 		[sessionsByProject, loadingProjects],
 	);
 
-	// Refresh all loaded projects (after resume, etc.)
 	const refreshAllLoadedProjects = useCallback(async () => {
-		const loadedDirNames = Array.from(sessionsByProject.keys());
-		// Clear cache
+		const loadedKeys = Array.from(sessionsByProject.keys());
 		setSessionsByProject(new Map());
-		// Re-fetch all
 		await Promise.all(
-			loadedDirNames.map((dirName) => fetchProjectSessions(dirName, true)),
+			loadedKeys.map((key) => {
+				const [peerId, dirName] = key.split("::");
+				return fetchProjectSessions(peerId, dirName, true);
+			}),
 		);
 	}, [sessionsByProject, fetchProjectSessions]);
 
@@ -155,16 +153,18 @@ export function useSessionHistory(): UseSessionHistoryResult {
 			sessionId: string,
 			projectPath: string,
 			agent?: "claude" | "codex",
+			peerId?: string,
 		) => {
 			try {
-				const response = await authFetch(
-					`${API_BASE}/api/sessions/history/resume`,
-					{
-						method: "POST",
-						headers: { "Content-Type": "application/json" },
-						body: JSON.stringify({ sessionId, projectPath, agent }),
-					},
-				);
+				const isRemote = peerId && peerId !== LOCAL_PEER_ID;
+				const url = isRemote
+					? `${API_BASE}/api/peers/history/${encodeURIComponent(peerId)}/resume`
+					: `${API_BASE}/api/sessions/history/resume`;
+				const response = await authFetch(url, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ sessionId, projectPath, agent }),
+				});
 				if (!response.ok) {
 					const errorData = await response.json().catch(() => ({}));
 					const err = new Error(errorData.error || "Failed to resume session");
@@ -186,21 +186,21 @@ export function useSessionHistory(): UseSessionHistoryResult {
 			sessionId: string,
 			projectDirName?: string,
 			agent?: "claude" | "codex",
+			peerId?: string,
 		): Promise<ConversationMessage[]> => {
 			try {
-				const url = new URL(
-					`${API_BASE}/api/sessions/history/${sessionId}/conversation`,
-					window.location.origin,
-				);
+				const isRemote = peerId && peerId !== LOCAL_PEER_ID;
+				const base = isRemote
+					? `${API_BASE}/api/peers/history/${encodeURIComponent(peerId)}/${encodeURIComponent(sessionId)}/conversation`
+					: `${API_BASE}/api/sessions/history/${encodeURIComponent(sessionId)}/conversation`;
+				const url = new URL(base, window.location.origin);
 				if (projectDirName) {
 					url.searchParams.set("projectDirName", projectDirName);
 				}
 				if (agent === "codex") {
 					url.searchParams.set("agent", "codex");
 				}
-				const response = await authFetch(url.toString(), {
-					cache: "no-store",
-				});
+				const response = await authFetch(url.toString(), { cache: "no-store" });
 				if (!response.ok) {
 					throw new Error("Failed to fetch conversation");
 				}
@@ -214,7 +214,7 @@ export function useSessionHistory(): UseSessionHistoryResult {
 		[],
 	);
 
-	// Search sessions with streaming (incremental results)
+	// Search は Hub の SSE をそのまま使用 (Phase: peer 横断 search は未実装)
 	const searchSessions = useCallback(async (query: string) => {
 		setSearchQuery(query);
 		if (!query.trim()) {
@@ -223,10 +223,9 @@ export function useSessionHistory(): UseSessionHistoryResult {
 		}
 
 		setIsSearching(true);
-		setSearchResults([]); // Clear previous results
+		setSearchResults([]);
 
 		try {
-			// Use EventSource for SSE streaming
 			const url = `${API_BASE}/api/sessions/history/search/stream?q=${encodeURIComponent(query)}`;
 			const eventSource = new EventSource(url);
 
@@ -235,7 +234,7 @@ export function useSessionHistory(): UseSessionHistoryResult {
 					const session = JSON.parse(event.data) as HistorySession;
 					setSearchResults((prev) => [...prev, session]);
 				} catch {
-					// Ignore parse errors
+					/* Ignore parse errors */
 				}
 			};
 
@@ -260,13 +259,11 @@ export function useSessionHistory(): UseSessionHistoryResult {
 		}
 	}, []);
 
-	// Clear search
 	const clearSearch = useCallback(() => {
 		setSearchQuery("");
 		setSearchResults([]);
 	}, []);
 
-	// Initial load: projects only
 	useEffect(() => {
 		fetchProjects();
 	}, [fetchProjects]);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -505,10 +505,31 @@ export interface HistorySession {
   // Which agent produced this history entry. Drives the resume command
   // (`claude -r <id>` vs `codex resume <id>`) and the badge in the UI.
   agent?: AgentProvider;
+  // Multi-server: 履歴が属する peer の情報
+  peerId?: string;
+  peerNickname?: string;
+  peerColor?: string;
 }
 
 export interface HistorySessionsResponse {
   sessions: HistorySession[];
+}
+
+// Multi-server: 履歴プロジェクト (~/.claude/projects/ のディレクトリ単位)
+export interface PeerHistoryProject {
+  dirName: string;
+  projectPath: string;
+  projectName: string;
+  sessionCount: number;
+  latestModified?: string;
+  peerId: string;
+  peerNickname?: string;
+  peerColor?: string;
+}
+
+export interface PeerHistoryProjectsResponse {
+  projects: PeerHistoryProject[];
+  errors?: { peerId: string; message: string }[];
 }
 
 export interface ToolUseInfo {


### PR DESCRIPTION
## Summary
- 履歴 (history) タブで全 peer のプロジェクト・セッションを合体表示
- 各 project/session に peer ニックネームバッジ + 色付き左ボーダー
- 「再開」と会話履歴表示も session の peerId に応じて該当 peer の API に振り分け

## Backend
- 集約 endpoint を peers ルーターに追加
  - \`GET /api/peers/history/projects\` (peerId 注釈つきで合体)
  - \`GET /api/peers/history/:peerId/projects/:dirName\`
  - \`GET /api/peers/history/:peerId/:sessionId/conversation\`
  - \`POST /api/peers/history/:peerId/resume\`
- self peer 分は service singleton (\`sessionHistoryService\` / \`codexHistoryService\`) を直接呼ぶことで、Tailscale-only HTTPS 環境でも自己ループ fetch 不要に

## Frontend
- \`useSessionHistory\`: cache キーを \`\${peerId}::\${dirName}\` の複合に変更。peer 跨ぎで dirName 衝突しても干渉しない
- \`resumeSession(..., peerId?)\` と \`fetchConversation(..., peerId?)\` を peer 対応
- \`SessionHistory\` の ProjectGroupItem に peer バッジ + 色ボーダー (local では非表示)
- \`SessionList.handleShowConversation\` も peerId を伝播

## 未対応 (Phase 4 候補)
- search (SSE) は当面 Hub のみ。peer 横断 search は順序とストリーミング merge をどう設計するか別途検討
- prompt 履歴検索もまだ Hub のみ

## Test plan
- [x] Hub に MacBook を peer 登録 → 履歴タブに MacBook 由来 4 project が peer バッジ付きで表示
- [x] MacBook の project を expand → そのプロジェクトの session 一覧表示 + 再開ボタン
- [x] 既存単一サーバー (peer なし) で UI 変化なし
- [ ] Reviewer: 別マシン peer で動作確認 (resume / conversation viewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)