### PR TITLE
Release v0.1.138

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.138] - 2026-05-21
+
+### Fixed
+- **Lost セッション再開時の peer ルーティング**: `SessionList.handleResume` がローカル Hub の `/api/sessions/history/resume` を `authFetch` で直接叩いており、`session.peerId` を無視していた。これにより remote peer (例: Mac) 上のロストセッションを再開しようとすると Hub (例: Linux) 側で `cd '/Users/m0a' && claude -r ...` を実行しようとして `cd: no such file or directory` で失敗していた。`sessionFetch(session, peers, …)` 経由に切り替え、所属 peer の URL に直接 POST されるよう修正。conversationId なし時の `createSession` 経路にも `session.peerId` を引き継ぐようにした。あわせてアクティブセッションの `POST /:id/resume` も peer-aware に統一 (`frontend/src/components/SessionList.tsx`)
+- `SessionListProps.onSelectSession` / `onSelectPane` の引数型を `SessionResponse` → `ExtendedSessionResponse` に拡張。resume 後のナビゲートで `peerId` を伝搬できるようにし、後続の WebSocket subscribe が正しい peer に向くようにした (`frontend/src/components/SessionList.tsx`)
+
 ## [0.1.137] - 2026-05-21
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "generated": "2026-05-21",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "generated": "2026-05-21",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -138,8 +138,8 @@ async function createDirectory(
 }
 
 interface SessionListProps {
-	onSelectSession: (session: SessionResponse) => void;
-	onSelectPane?: (session: SessionResponse, paneId: string) => void;
+	onSelectSession: (session: ExtendedSessionResponse) => void;
+	onSelectPane?: (session: ExtendedSessionResponse, paneId: string) => void;
 	onBack?: () => void;
 	onClose?: () => void; // Close button in header (used in modal)
 	inline?: boolean; // true for side panel, false for fullscreen
@@ -1318,9 +1318,13 @@ export function SessionList({
 
 				if (isLost && session?.currentPath) {
 					if (conversationId) {
-						// Lost session with a known conversation id: resume via history API
-						const response = await authFetch(
-							`${API_BASE}/api/sessions/history/resume`,
+						// Lost session with a known conversation id: resume via history API.
+						// Route to the owning peer so a remote peer's lost session is resumed
+						// on that peer's Hub, not the local one.
+						const response = await sessionFetch(
+							session,
+							peers,
+							`/api/sessions/history/resume`,
 							{
 								method: "POST",
 								headers: { "Content-Type": "application/json" },
@@ -1346,22 +1350,28 @@ export function SessionList({
 								agent: data.agent ?? session.agent,
 								theme: session.theme,
 								customTitle: session.customTitle,
+								peerId: session.peerId,
 							});
 						}
 					} else {
 						// Lost session without a conversation id: create a fresh session in the same
 						// directory using the original agent so a Codex session doesn't come back as Claude.
+						// Pass through the peerId so a remote lost session re-creates on the same peer.
 						const newSession = await createSession(
 							session.name,
 							session.currentPath,
 							session.agent,
+							session.peerId,
 						);
 						if (newSession) onSelectSession(newSession);
 					}
 				} else {
-					// Active session: resume the agent in the existing tmux session
-					const response = await authFetch(
-						`${API_BASE}/api/sessions/${sessionId}/resume`,
+					// Active session: resume the agent in the existing tmux session.
+					// Route via the owning peer for the same reason as above.
+					const response = await sessionFetch(
+						session,
+						peers,
+						`/api/sessions/${sessionId}/resume`,
 						{
 							method: "POST",
 							headers: { "Content-Type": "application/json" },
@@ -1379,7 +1389,7 @@ export function SessionList({
 				console.error("Failed to resume session:", err);
 			}
 		},
-		[sessions, onSelectSession, createSession],
+		[sessions, onSelectSession, createSession, peers],
 	);
 
 	// Show conversation for an active session

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: Lost セッション再開時の peer ルーティング ─ `SessionList.handleResume` が peerId を無視して常にローカル Hub に POST していたため、Mac peer のロストセッションを Resume すると Linux Hub 側で `cd '/Users/m0a' && claude -r ...` を実行しようとして `cd: no such file or directory` で失敗していた。`sessionFetch(session, peers, …)` 経由に切り替えて所属 peer に直接 POST するよう修正
- 関連して `SessionListProps.onSelectSession` の型を `SessionResponse` → `ExtendedSessionResponse` に拡張し、resume 後の navigation で peerId を引き継ぐようにした

## Notes
- backend 変更なし。frontend のみ
- Mac 側 cchub バイナリの更新は不要（既存の `/api/sessions/history/resume` を受けるだけ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)