### PR TITLE
Release v0.1.140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.140] - 2026-05-22
+
+### Changed
+- **peer セッション取得を polling → WS push に統一**: 5秒間隔の `GET /api/peers/sessions` を撤廃し、各 remote peer の `/ws/mux` に常時接続して `sessions-updated` push を直接購読するよう変更。PWA を peer セッションのまま再オープンした場合に Hub の sessions-updated が一度も届かず Linux 側のセッションが画面から消える問題も同時に解消する。WS 接続は peer 単位で永続化されるので peer 切替で leak しない (`frontend/src/hooks/usePeerSessionsWatcher.ts` 新規, `frontend/src/hooks/useSessions.ts`)
+- **peer WS URL ヘルパー共通化**: `peerHttpUrlToWsUrl` / `appendWsToken` を `frontend/src/services/peer-ws.ts` に切り出し、`useMultiplexedTerminal` / `usePeerConnection` / `usePeerSessionsWatcher` の3箇所のインライン正規表現を統一 (`frontend/src/services/peer-ws.ts` 新規)
+- watcher の再接続を exponential backoff (5s→60s cap) に変更。永続的にオフラインな peer への connect loop を抑制
+
 ## [0.1.139] - 2026-05-22
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PaneViewport, TmuxLayoutNode } from "../../../shared/types";
 import { reportWsLatency } from "../services/latency-store";
+import { appendWsToken } from "../services/peer-ws";
 
 interface UseMultiplexedTerminalOptions {
 	sessionId: string;
@@ -206,10 +207,7 @@ function ensureConnection(token?: string | null, wsBase?: string | null) {
 		sharedConnectWatchdog = null;
 	}
 
-	let wsUrl = `${desiredBase}/ws/mux`;
-	if (desiredToken) {
-		wsUrl += `?token=${encodeURIComponent(desiredToken)}`;
-	}
+	const wsUrl = appendWsToken(`${desiredBase}/ws/mux`, desiredToken);
 
 	const ws = new WebSocket(wsUrl);
 	sharedWs = ws;

--- a/frontend/src/hooks/usePeerConnection.ts
+++ b/frontend/src/hooks/usePeerConnection.ts
@@ -4,6 +4,7 @@ import {
 	LOCAL_PEER_ID,
 	type PeerClientView,
 } from "../../../shared/types";
+import { peerHttpUrlToWsUrl } from "../services/peer-ws";
 
 export interface PeerConnectionInfo {
 	peerId: string;
@@ -39,10 +40,9 @@ export function usePeerConnection(
 		const peer = peers.find((p) => p.id === peerId);
 		if (!peer || peer.url === "self") return hubInfo;
 
-		const wsBase = peer.url.replace(/^http(s?):/, (_match, s) => `ws${s}:`).replace(/\/+$/, "");
 		return {
 			peerId,
-			wsBase,
+			wsBase: peerHttpUrlToWsUrl(peer.url),
 			token: peer.wsToken ?? null,
 			apiBase: peer.url.replace(/\/+$/, ""),
 		};

--- a/frontend/src/hooks/usePeerSessionsWatcher.ts
+++ b/frontend/src/hooks/usePeerSessionsWatcher.ts
@@ -1,0 +1,214 @@
+/**
+ * Each remote peer gets a persistent WebSocket to its `/ws/mux` so
+ * `sessions-updated` push lands in the client without polling. The terminal
+ * sharedWs only follows the currently-active session, so leaving this watcher
+ * separate lets every peer's session list stay live in the background.
+ */
+import { useEffect, useMemo } from "react";
+import {
+	LOCAL_PEER_ID,
+	type MuxServerMessage,
+	type PeerClientView,
+	type PeerSession,
+	type SessionResponse,
+} from "../../../shared/types";
+import { appendWsToken, peerHttpUrlToWsUrl } from "../services/peer-ws";
+
+type PeerSessionsListener = (
+	sessionsByPeer: ReadonlyMap<string, PeerSession[]>,
+) => void;
+
+interface PeerWatcher {
+	ws: WebSocket | null;
+	retryTimer: number | null;
+	retryAttempt: number;
+	lastSessionsJson: string;
+	closed: boolean;
+}
+
+const RETRY_INITIAL_MS = 5_000;
+const RETRY_MAX_MS = 60_000;
+
+const watchers = new Map<string, PeerWatcher>();
+const peerInfoById = new Map<string, PeerClientView>();
+const sessionsByPeer = new Map<string, PeerSession[]>();
+const listeners = new Set<PeerSessionsListener>();
+
+function notifyListeners() {
+	for (const listener of listeners) listener(sessionsByPeer);
+}
+
+function peerWsUrl(peer: PeerClientView): string {
+	const base = peerHttpUrlToWsUrl(peer.url);
+	return appendWsToken(`${base}/ws/mux`, peer.wsToken ?? null);
+}
+
+function enrichPeerSessions(
+	peer: PeerClientView,
+	sessions: SessionResponse[],
+): PeerSession[] {
+	return sessions.map((s) => ({
+		...s,
+		peerId: peer.id,
+		peerNickname: peer.nickname,
+		peerColor: peer.color,
+	}));
+}
+
+function scheduleRetry(peerId: string) {
+	const watcher = watchers.get(peerId);
+	if (!watcher || watcher.closed) return;
+	if (watcher.retryTimer !== null) return;
+	const delay = Math.min(
+		RETRY_INITIAL_MS * 2 ** watcher.retryAttempt,
+		RETRY_MAX_MS,
+	);
+	watcher.retryAttempt++;
+	watcher.retryTimer = window.setTimeout(() => {
+		watcher.retryTimer = null;
+		const peer = peerInfoById.get(peerId);
+		if (peer && !watcher.closed) openWatcher(peer);
+	}, delay);
+}
+
+function openWatcher(peer: PeerClientView) {
+	let watcher = watchers.get(peer.id);
+	if (!watcher) {
+		watcher = {
+			ws: null,
+			retryTimer: null,
+			retryAttempt: 0,
+			lastSessionsJson: "",
+			closed: false,
+		};
+		watchers.set(peer.id, watcher);
+	}
+	if (
+		watcher.ws &&
+		(watcher.ws.readyState === WebSocket.OPEN ||
+			watcher.ws.readyState === WebSocket.CONNECTING)
+	) {
+		return;
+	}
+
+	try {
+		const ws = new WebSocket(peerWsUrl(peer));
+		watcher.ws = ws;
+
+		ws.onopen = () => {
+			if (watcher) watcher.retryAttempt = 0;
+		};
+
+		ws.onmessage = (event) => {
+			if (typeof event.data !== "string") return;
+			let msg: MuxServerMessage;
+			try {
+				msg = JSON.parse(event.data) as MuxServerMessage;
+			} catch {
+				return;
+			}
+			if (msg.type !== "sessions-updated") return;
+
+			// Per-peer dedup: backend already filters identical payloads, but a
+			// second listener registering would otherwise re-stringify the same
+			// data downstream. Hash once here.
+			const json = JSON.stringify(msg.sessions);
+			if (json === watcher.lastSessionsJson) return;
+			watcher.lastSessionsJson = json;
+
+			sessionsByPeer.set(peer.id, enrichPeerSessions(peer, msg.sessions));
+			notifyListeners();
+		};
+
+		ws.onclose = () => {
+			if (watcher) watcher.ws = null;
+			// Keep last-known sessions until reconnect succeeds; clearing here would
+			// flash the UI empty on transient drops.
+			if (watcher && !watcher.closed) scheduleRetry(peer.id);
+		};
+	} catch {
+		scheduleRetry(peer.id);
+	}
+}
+
+function closeWatcher(peerId: string) {
+	const watcher = watchers.get(peerId);
+	if (!watcher) return;
+	watcher.closed = true;
+	if (watcher.retryTimer !== null) {
+		window.clearTimeout(watcher.retryTimer);
+		watcher.retryTimer = null;
+	}
+	if (watcher.ws) {
+		try {
+			watcher.ws.close();
+		} catch {
+			// ignore
+		}
+		watcher.ws = null;
+	}
+	watchers.delete(peerId);
+	if (sessionsByPeer.delete(peerId)) notifyListeners();
+}
+
+function reconcile(peers: PeerClientView[]) {
+	const want = new Map<string, PeerClientView>();
+	for (const peer of peers) {
+		if (peer.id === LOCAL_PEER_ID) continue;
+		if (peer.url === "self") continue;
+		want.set(peer.id, peer);
+	}
+
+	for (const id of Array.from(watchers.keys())) {
+		const next = want.get(id);
+		if (!next) {
+			closeWatcher(id);
+			continue;
+		}
+		const prev = peerInfoById.get(id);
+		if (prev && (prev.url !== next.url || prev.wsToken !== next.wsToken)) {
+			closeWatcher(id);
+		}
+	}
+
+	for (const peer of want.values()) {
+		peerInfoById.set(peer.id, peer);
+		openWatcher(peer);
+	}
+
+	for (const id of Array.from(peerInfoById.keys())) {
+		if (!want.has(id)) peerInfoById.delete(id);
+	}
+}
+
+/**
+ * Stabilize the dependency for reconcile. `usePeers()` returns a new array
+ * reference on every poll, but only `id|url|wsToken` actually affect the
+ * watcher; rerun reconcile only when one of those changes.
+ */
+function peersWatcherKey(peers: PeerClientView[]): string {
+	return peers
+		.map((p) => `${p.id}|${p.url}|${p.wsToken ?? ""}`)
+		.sort()
+		.join(";");
+}
+
+export function usePeerSessionsWatcher(
+	peers: PeerClientView[],
+	onChange: PeerSessionsListener,
+) {
+	const key = useMemo(() => peersWatcherKey(peers), [peers]);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: `key` already encodes the parts of `peers` that matter; including the raw array would re-run on every poll.
+	useEffect(() => {
+		reconcile(peers);
+	}, [key]);
+
+	useEffect(() => {
+		listeners.add(onChange);
+		onChange(sessionsByPeer);
+		return () => {
+			listeners.delete(onChange);
+		};
+	}, [onChange]);
+}

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -6,22 +6,20 @@ import {
 	type IndicatorState,
 	LOCAL_PEER_ID,
 	type PeerSession,
-	type PeerSessionsResponse,
 	type SessionResponse,
 	type SessionTheme,
 } from "../../../shared/types";
-import { authFetch, isTransientNetworkError } from "../services/api";
+import { isTransientNetworkError } from "../services/api";
 import { sessionFetch } from "../services/peer-fetch";
+import { usePeerSessionsWatcher } from "./usePeerSessionsWatcher";
 import { usePeers } from "./usePeers";
 
-const API_BASE = import.meta.env.VITE_API_URL || "";
-
-// Module-level cache (shared across all useSessions instances, updated by WS push)
+// Module-level cache (shared across all useSessions instances).
+// `cachedSessions`: Hub-local sessions, fed by the multiplexed terminal WS push.
+// `cachedRemotePeerSessions`: flat list of remote peer sessions, fed by the
+// per-peer WS watcher (usePeerSessionsWatcher).
 let cachedSessions: ExtendedSessionResponse[] | null = null;
-// Remote peer sessions (excluding local). Updated by polling /api/peers/sessions.
 let cachedRemotePeerSessions: PeerSession[] = [];
-
-const PEER_POLL_INTERVAL = 5000;
 
 /** hookイベントでcachedSessionsのindicatorStateを即座に更新する */
 export function updateCachedSessionsByHookEvent(
@@ -102,25 +100,14 @@ function updateSessions(
 	});
 }
 
-async function pollRemotePeerSessions(
-	setSessions: React.Dispatch<React.SetStateAction<ExtendedSessionResponse[]>>,
-): Promise<boolean> {
-	try {
-		const res = await authFetch(`${API_BASE}/api/peers/sessions`);
-		if (!res.ok) return false;
-		const data = (await res.json()) as PeerSessionsResponse;
-		if (!Array.isArray(data.sessions)) return false;
-		const remote = data.sessions.filter((s) => s.peerId !== LOCAL_PEER_ID);
-		const stableJson = JSON.stringify(remote);
-		const prevJson = JSON.stringify(cachedRemotePeerSessions);
-		if (stableJson === prevJson) return true;
-		cachedRemotePeerSessions = remote;
-		const merged = mergedSessions();
-		setSessions(merged);
-		return true;
-	} catch {
-		return false;
+function flattenPeerSessions(
+	sessionsByPeer: ReadonlyMap<string, PeerSession[]>,
+): PeerSession[] {
+	const out: PeerSession[] = [];
+	for (const sessions of sessionsByPeer.values()) {
+		out.push(...sessions);
 	}
+	return out;
 }
 
 export function useSessions(): UseSessionsReturn {
@@ -153,23 +140,16 @@ export function useSessions(): UseSessionsReturn {
 		};
 	}, []);
 
-	// Poll remote peer sessions (only fires while non-local peers exist)
-	useEffect(() => {
-		let cancelled = false;
-		let timer: ReturnType<typeof setInterval> | null = null;
-
-		void pollRemotePeerSessions(setSessions);
-
-		timer = setInterval(() => {
-			if (cancelled) return;
-			void pollRemotePeerSessions(setSessions);
-		}, PEER_POLL_INTERVAL);
-
-		return () => {
-			cancelled = true;
-			if (timer) clearInterval(timer);
-		};
-	}, []);
+	// Per-peer WS watcher already dedups by payload before notifying, so a
+	// listener firing here implies the data actually changed for some peer.
+	const handlePeerSessions = useCallback(
+		(sessionsByPeer: ReadonlyMap<string, PeerSession[]>) => {
+			cachedRemotePeerSessions = flattenPeerSessions(sessionsByPeer);
+			setSessions(mergedSessions());
+		},
+		[],
+	);
+	usePeerSessionsWatcher(peers, handlePeerSessions);
 
 	const createSession = useCallback(
 		async (

--- a/frontend/src/services/peer-ws.ts
+++ b/frontend/src/services/peer-ws.ts
@@ -1,0 +1,16 @@
+/**
+ * Peer WebSocket URL helpers — shared by `useMultiplexedTerminal`,
+ * `usePeerConnection`, and `usePeerSessionsWatcher`.
+ */
+
+export function peerHttpUrlToWsUrl(httpUrl: string): string {
+	return httpUrl
+		.replace(/^http(s?):/, (_match, s) => `ws${s}:`)
+		.replace(/\/+$/, "");
+}
+
+export function appendWsToken(wsUrl: string, token: string | null): string {
+	if (!token) return wsUrl;
+	const sep = wsUrl.includes("?") ? "&" : "?";
+	return `${wsUrl}${sep}token=${encodeURIComponent(token)}`;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- change: `/api/peers/sessions` polling 撲滅 → 各 remote peer の `/ws/mux` に常時接続して `sessions-updated` push を購読する設計に統一 (`frontend/src/hooks/usePeerSessionsWatcher.ts` 新規)
- change: PWA を peer セッションのまま再オープンした際、Hub の sessions-updated が一度も届かず Linux 側のセッションが消える問題を同時解消
- chore: peer WS URL ヘルパー (`peerHttpUrlToWsUrl` / `appendWsToken`) を `services/peer-ws.ts` に共通化。`useMultiplexedTerminal` / `usePeerConnection` / `usePeerSessionsWatcher` の3箇所を統一
- chore: watcher の再接続を exponential backoff (5s→60s cap) に変更

## Notes
- frontend のみ。backend 変更なし
- Mac 側 cchub バイナリの更新不要 (既存 WS endpoint をそのまま使用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)