### PR TITLE
Release v0.1.141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.141] - 2026-05-22
+
+### Fixed
+- **Hub local セッションが peer 接続中に消える問題を完全解消**: v0.1.140 で peer のセッション一覧を WS push に統一したが、Hub local 自身は引き続き `useMultiplexedTerminal` の sharedWs (アクティブセッションの peer に追従する) 経由でしか受信できておらず、Mac peer のセッションを開いた状態のままだと Hub の sessions-updated が来ず Linux 側の一覧が空になっていた。`usePeerSessionsWatcher` を Hub local も対象にして全 peer (local 含む) に独立 WS を張る設計に変更。`useMultiplexedTerminal` 側の sessions-updated dispatch は重複防止で撤去 (`frontend/src/hooks/usePeerSessionsWatcher.ts`, `frontend/src/hooks/useSessions.ts`, `frontend/src/hooks/useMultiplexedTerminal.ts`)
+- 副次: `cachedSessions` / `cachedRemotePeerSessions` の二系統 cache を watcher の sessionsByPeer 一系統に統合し、`mergedSessions` / `updateSessions` を撤去して useSessions のコードを簡素化
+
 ## [0.1.140] - 2026-05-22
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -303,21 +303,11 @@ function ensureConnection(token?: string | null, wsBase?: string | null) {
 			}
 			case "unsubscribed":
 				break;
-			case "sessions-updated": {
-				// Multi-server: peer 接続中の sessions-updated はその peer 単独の
-				// セッション一覧で、Hub が返すマージ済みリストと整合しない。
-				// Hub に向いている時 (or 初期接続) のみ受け取る。
-				const isHubConnection =
-					currentWsBase === null || currentWsBase === getWsBase();
-				if (isHubConnection) {
-					window.dispatchEvent(
-						new CustomEvent("cchub-sessions-push", {
-							detail: msg.sessions,
-						}),
-					);
-				}
+			case "sessions-updated":
+				// Sessions are sourced from `usePeerSessionsWatcher` (one dedicated WS
+				// per peer including the Hub itself), so the terminal sharedWs ignores
+				// these pushes to avoid double-updating the cache.
 				break;
-			}
 			case "viewport": {
 				if (msgSessionId !== currentSession) return;
 				const viewport = msg.viewport as PaneViewport;

--- a/frontend/src/hooks/usePeerSessionsWatcher.ts
+++ b/frontend/src/hooks/usePeerSessionsWatcher.ts
@@ -6,6 +6,7 @@
  */
 import { useEffect, useMemo } from "react";
 import {
+	type IndicatorState,
 	LOCAL_PEER_ID,
 	type MuxServerMessage,
 	type PeerClientView,
@@ -38,7 +39,17 @@ function notifyListeners() {
 	for (const listener of listeners) listener(sessionsByPeer);
 }
 
+function isLocalPeer(peer: PeerClientView): boolean {
+	return peer.id === LOCAL_PEER_ID || peer.url === "self";
+}
+
 function peerWsUrl(peer: PeerClientView): string {
+	if (isLocalPeer(peer)) {
+		const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+		const base = `${protocol}//${window.location.host}`;
+		const token = localStorage.getItem("cc-hub-token");
+		return appendWsToken(`${base}/ws/mux`, token);
+	}
 	const base = peerHttpUrlToWsUrl(peer.url);
 	return appendWsToken(`${base}/ws/mux`, peer.wsToken ?? null);
 }
@@ -152,10 +163,12 @@ function closeWatcher(peerId: string) {
 }
 
 function reconcile(peers: PeerClientView[]) {
+	// Watch every peer including the local Hub. Without a dedicated WS for
+	// the Hub, the multiplexed terminal sharedWs is the only source of
+	// `sessions-updated`, and that WS follows the active session's peer —
+	// when it's pointing at a remote peer the Hub's session list goes stale.
 	const want = new Map<string, PeerClientView>();
 	for (const peer of peers) {
-		if (peer.id === LOCAL_PEER_ID) continue;
-		if (peer.url === "self") continue;
 		want.set(peer.id, peer);
 	}
 
@@ -191,6 +204,33 @@ function peersWatcherKey(peers: PeerClientView[]): string {
 		.map((p) => `${p.id}|${p.url}|${p.wsToken ?? ""}`)
 		.sort()
 		.join(";");
+}
+
+/**
+ * Push an immediate indicatorState change for the local-Hub sessions whose
+ * Claude Code session matches `ccSessionId`. Called from hook event handlers
+ * so the spinner reacts before the next `sessions-updated` push arrives.
+ */
+export function applyHookIndicatorUpdate(
+	ccSessionId: string,
+	indicatorState: IndicatorState,
+): boolean {
+	const local = sessionsByPeer.get(LOCAL_PEER_ID);
+	if (!local) return false;
+	let changed = false;
+	const next = local.map((session) => {
+		if (session.ccSessionId !== ccSessionId) return session;
+		if (!session.panes) return session;
+		changed = true;
+		return {
+			...session,
+			panes: session.panes.map((pane) => ({ ...pane, indicatorState })),
+		};
+	});
+	if (!changed) return false;
+	sessionsByPeer.set(LOCAL_PEER_ID, next);
+	notifyListeners();
+	return true;
 }
 
 export function usePeerSessionsWatcher(

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -4,44 +4,33 @@ import {
 	DEFAULT_AGENT_PROVIDER,
 	type ExtendedSessionResponse,
 	type IndicatorState,
-	LOCAL_PEER_ID,
 	type PeerSession,
 	type SessionResponse,
 	type SessionTheme,
 } from "../../../shared/types";
 import { isTransientNetworkError } from "../services/api";
 import { sessionFetch } from "../services/peer-fetch";
-import { usePeerSessionsWatcher } from "./usePeerSessionsWatcher";
+import {
+	applyHookIndicatorUpdate,
+	usePeerSessionsWatcher,
+} from "./usePeerSessionsWatcher";
 import { usePeers } from "./usePeers";
 
-// Module-level cache (shared across all useSessions instances).
-// `cachedSessions`: Hub-local sessions, fed by the multiplexed terminal WS push.
-// `cachedRemotePeerSessions`: flat list of remote peer sessions, fed by the
-// per-peer WS watcher (usePeerSessionsWatcher).
-let cachedSessions: ExtendedSessionResponse[] | null = null;
-let cachedRemotePeerSessions: PeerSession[] = [];
+// Module-level merged cache produced by the peer sessions watcher.
+// Every peer — including the local Hub — pushes `sessions-updated` over its
+// own WS, so this is the single source of truth.
+let cachedSessions: ExtendedSessionResponse[] = [];
 
-/** hookイベントでcachedSessionsのindicatorStateを即座に更新する */
+/** hookイベントで Hub local セッションの indicatorState を即座に更新する */
 export function updateCachedSessionsByHookEvent(
 	event: string,
 	ccSessionId?: string,
 ) {
 	const newState = hookEventToIndicatorState(event);
-	if (!newState || !ccSessionId || !cachedSessions) return;
-
-	cachedSessions = cachedSessions.map((session) => {
-		if (session.ccSessionId !== ccSessionId) return session;
-		if (!session.panes) return session;
-		return {
-			...session,
-			panes: session.panes.map((pane) => ({
-				...pane,
-				indicatorState: newState,
-			})),
-		};
-	});
-
-	window.dispatchEvent(new CustomEvent("cchub-hook-event"));
+	if (!newState || !ccSessionId) return;
+	if (applyHookIndicatorUpdate(ccSessionId, newState)) {
+		window.dispatchEvent(new CustomEvent("cchub-hook-event"));
+	}
 }
 
 function hookEventToIndicatorState(event: string): IndicatorState | null {
@@ -79,31 +68,10 @@ interface UseSessionsReturn {
 	) => Promise<boolean>;
 }
 
-function mergedSessions(): ExtendedSessionResponse[] {
-	const local = (cachedSessions ?? []).map((s) =>
-		// 既存の WS push 由来セッションには peerId が付かないので、local として注釈
-		s.peerId ? s : { ...s, peerId: LOCAL_PEER_ID },
-	);
-	return [...local, ...cachedRemotePeerSessions];
-}
-
-function updateSessions(
-	setSessions: React.Dispatch<React.SetStateAction<ExtendedSessionResponse[]>>,
-	newLocalSessions: ExtendedSessionResponse[],
-) {
-	cachedSessions = newLocalSessions;
-	const merged = mergedSessions();
-	setSessions((prev) => {
-		const newJson = JSON.stringify(merged);
-		const prevJson = JSON.stringify(prev);
-		return newJson === prevJson ? prev : merged;
-	});
-}
-
 function flattenPeerSessions(
 	sessionsByPeer: ReadonlyMap<string, PeerSession[]>,
-): PeerSession[] {
-	const out: PeerSession[] = [];
+): ExtendedSessionResponse[] {
+	const out: ExtendedSessionResponse[] = [];
 	for (const sessions of sessionsByPeer.values()) {
 		out.push(...sessions);
 	}
@@ -112,40 +80,25 @@ function flattenPeerSessions(
 
 export function useSessions(): UseSessionsReturn {
 	const { peers } = usePeers();
-	const [sessions, setSessions] = useState<ExtendedSessionResponse[]>(
-		() => mergedSessions(),
-	);
-	const [isLoading, setIsLoading] = useState(() => !cachedSessions);
+	const [sessions, setSessions] =
+		useState<ExtendedSessionResponse[]>(cachedSessions);
+	const [isLoading, setIsLoading] = useState(() => cachedSessions.length === 0);
 	const [error, setError] = useState<string | null>(null);
 
 	// Listen for WS push and hook events
 	useEffect(() => {
-		const hookHandler = () => {
-			if (cachedSessions) setSessions(mergedSessions());
-		};
-
-		const pushHandler = (e: Event) => {
-			const pushed = (e as CustomEvent).detail as ExtendedSessionResponse[];
-			if (pushed) {
-				updateSessions(setSessions, pushed);
-				setIsLoading(false);
-			}
-		};
-
+		const hookHandler = () => setSessions(cachedSessions);
 		window.addEventListener("cchub-hook-event", hookHandler);
-		window.addEventListener("cchub-sessions-push", pushHandler);
-		return () => {
-			window.removeEventListener("cchub-hook-event", hookHandler);
-			window.removeEventListener("cchub-sessions-push", pushHandler);
-		};
+		return () => window.removeEventListener("cchub-hook-event", hookHandler);
 	}, []);
 
 	// Per-peer WS watcher already dedups by payload before notifying, so a
 	// listener firing here implies the data actually changed for some peer.
 	const handlePeerSessions = useCallback(
 		(sessionsByPeer: ReadonlyMap<string, PeerSession[]>) => {
-			cachedRemotePeerSessions = flattenPeerSessions(sessionsByPeer);
-			setSessions(mergedSessions());
+			cachedSessions = flattenPeerSessions(sessionsByPeer);
+			setSessions(cachedSessions);
+			setIsLoading(false);
 		},
 		[],
 	);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: Hub local セッションが peer 接続中に消える問題を完全解消。v0.1.140 で remote peer の WS 化までは入れたが、Hub local は依然として terminal sharedWs 経由だったため peer 接続中は来なかった。watcher で Hub も独立 WS を張る設計に変更
- chore: `cachedSessions` / `cachedRemotePeerSessions` の二系統 cache を撤廃、watcher の `sessionsByPeer` 一系統に統合

## Notes
- frontend のみ。backend 変更なし
- Mac 側バイナリ更新不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)