### PR TITLE
Release v0.1.142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.142] - 2026-05-22
+
+### Added
+- **peer 横断のセッション並び替え**: Hub 側に `${peerId}:${sessionId}` 形式の merged order を保存する `/api/peers/session-order` (GET/PUT) を新設し、ドラッグ&ドロップで Hub と remote peer のセッションを混在して並び替え可能にした。並び順は端末間で共有される (`backend/src/services/peer-registry.ts`, `backend/src/routes/peers.ts`, `frontend/src/hooks/useSessions.ts`, `frontend/src/components/SessionList.tsx`)
+
+### Fixed
+- 並び替え時に `useSortable` / `SortableContext` の id が `session.id` のみだったため、Hub と peer で同名 tmux セッション (e.g. `cchub-work-1`) があると衝突して並び替えが破綻していた問題を修正。composite key (`${peerId}:${sessionId}`) で一意化
+
 ## [0.1.141] - 2026-05-22
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -4,6 +4,7 @@ import {
   PeerCreateSchema,
   PeerUpdateSchema,
   PeerOrderSchema,
+  CrossPeerSessionOrderSchema,
   LOCAL_PEER_ID,
   SELF_PEER_URL,
   type PeerClientView,
@@ -21,6 +22,8 @@ import {
   updatePeer,
   deletePeer,
   setPeerOrder,
+  getCrossPeerSessionOrder,
+  setCrossPeerSessionOrder,
   type StoredPeer,
 } from '../services/peer-registry';
 import { loginToPeer, verifyPeer, peerFetch, PeerAuthError } from '../services/peer-auth';
@@ -128,6 +131,19 @@ peers.delete('/:id', async (c) => {
 peers.put('/order', zValidator('json', PeerOrderSchema), async (c) => {
   const { order } = c.req.valid('json');
   await setPeerOrder(order);
+  return c.json({ success: true });
+});
+
+// GET /api/peers/session-order - peer 横断のセッション並び順を取得
+peers.get('/session-order', async (c) => {
+  const order = await getCrossPeerSessionOrder();
+  return c.json({ order });
+});
+
+// PUT /api/peers/session-order - peer 横断のセッション並び順を保存
+peers.put('/session-order', zValidator('json', CrossPeerSessionOrderSchema), async (c) => {
+  const { order } = c.req.valid('json');
+  await setCrossPeerSessionOrder(order);
   return c.json({ success: true });
 });
 

--- a/backend/src/services/peer-registry.ts
+++ b/backend/src/services/peer-registry.ts
@@ -36,6 +36,9 @@ interface StoredPeer extends Peer {
 
 interface PeersStore {
   peers: StoredPeer[];
+  // Cross-peer session display order. Entries are `${peerId}:${sessionId}`
+  // composite keys so identical session names on different peers don't collide.
+  sessionOrder?: string[];
 }
 
 async function getFilePath(): Promise<string> {
@@ -215,6 +218,21 @@ export async function recordPeerFailure(id: string, message: string): Promise<vo
   if (!peer) return;
   peer.lastErrorAt = new Date().toISOString();
   peer.lastErrorMessage = message;
+  await save(store);
+}
+
+/**
+ * Cross-peer session order persisted on the Hub. Each entry is a
+ * `${peerId}:${sessionId}` composite key.
+ */
+export async function getCrossPeerSessionOrder(): Promise<string[]> {
+  const store = await load();
+  return store.sessionOrder ?? [];
+}
+
+export async function setCrossPeerSessionOrder(order: string[]): Promise<void> {
+  const store = await load();
+  store.sessionOrder = order;
   await save(store);
 }
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -35,7 +35,10 @@ import {
 	type SessionTheme,
 } from "../../../shared/types";
 import { usePeers } from "../hooks/usePeers";
-import { useSessions } from "../hooks/useSessions";
+import {
+	applyLocalSessionOrder,
+	useSessions,
+} from "../hooks/useSessions";
 import { sessionFetch } from "../services/peer-fetch";
 import { formatRelativeTime } from "../utils/format";
 import { toHomeShortPath } from "../utils/path";
@@ -637,13 +640,17 @@ function CreateSessionModal({
 }
 
 // Sortable wrapper for SessionItem (drag-to-reorder)
+function sessionCompositeKey(session: ExtendedSessionResponse): string {
+	return `${session.peerId ?? "local"}:${session.id}`;
+}
+
 function SortableSessionItem({
 	session,
 	index,
 	isDraggable,
 	...sessionItemProps
 }: {
-	session: SessionResponse;
+	session: ExtendedSessionResponse;
 	index: number;
 	isDraggable: boolean;
 } & Omit<Parameters<typeof SessionItem>[0], "session">) {
@@ -654,7 +661,10 @@ function SortableSessionItem({
 		transform,
 		transition,
 		isDragging,
-	} = useSortable({ id: session.id, disabled: !isDraggable });
+	} = useSortable({
+		id: sessionCompositeKey(session),
+		disabled: !isDraggable,
+	});
 
 	const style = {
 		transform: CSS.Transform.toString(transform),
@@ -1465,27 +1475,37 @@ export function SessionList({
 		[],
 	);
 
-	// Drag-to-reorder handler
+	// Drag-to-reorder handler. Session order is a cross-peer merged list stored
+	// on the Hub (`/api/peers/session-order`) so the same ordering applies to
+	// every peer's sessions, including drags across peer boundaries. Each entry
+	// in the saved order is a `${peerId}:${sessionId}` composite key.
 	const handleDragEnd = useCallback(
 		async (event: DragEndEvent) => {
 			const { active, over } = event;
 			if (!over || active.id === over.id) return;
 
-			const oldIndex = sessions.findIndex((s) => s.id === active.id);
-			const newIndex = sessions.findIndex((s) => s.id === over.id);
+			const oldIndex = sessions.findIndex(
+				(s) => sessionCompositeKey(s) === active.id,
+			);
+			const newIndex = sessions.findIndex(
+				(s) => sessionCompositeKey(s) === over.id,
+			);
 			if (oldIndex === -1 || newIndex === -1) return;
 
-			// Compute new order
-			const newOrder = sessions.map((s) => s.id);
-			const [moved] = newOrder.splice(oldIndex, 1);
-			newOrder.splice(newIndex, 0, moved);
+			const reordered = [...sessions];
+			const [moved] = reordered.splice(oldIndex, 1);
+			reordered.splice(newIndex, 0, moved);
 
-			// Save to backend
+			const compositeOrder = reordered.map(sessionCompositeKey);
+
+			// Optimistic local update so the UI reorders before the round-trip.
+			applyLocalSessionOrder(compositeOrder);
+
 			try {
-				await authFetch(`${API_BASE}/api/sessions/order`, {
+				await authFetch(`${API_BASE}/api/peers/session-order`, {
 					method: "PUT",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ order: newOrder }),
+					body: JSON.stringify({ order: compositeOrder }),
 				});
 			} catch (err) {
 				console.error("Failed to save session order:", err);
@@ -1799,14 +1819,14 @@ export function SessionList({
 											onDragEnd={handleDragEnd}
 										>
 											<SortableContext
-												items={filteredSessions.map((s) => s.id)}
+												items={filteredSessions.map(sessionCompositeKey)}
 												strategy={verticalListSortingStrategy}
 												disabled={!isDraggable}
 											>
 												<div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
 													{filteredSessions.map((session, index) => (
 														<SortableSessionItem
-															key={session.id}
+															key={sessionCompositeKey(session)}
 															session={session}
 															index={index}
 															isDraggable={isDraggable}

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -8,7 +8,7 @@ import {
 	type SessionResponse,
 	type SessionTheme,
 } from "../../../shared/types";
-import { isTransientNetworkError } from "../services/api";
+import { authFetch, isTransientNetworkError } from "../services/api";
 import { sessionFetch } from "../services/peer-fetch";
 import {
 	applyHookIndicatorUpdate,
@@ -16,10 +16,61 @@ import {
 } from "./usePeerSessionsWatcher";
 import { usePeers } from "./usePeers";
 
+const API_BASE = import.meta.env.VITE_API_URL || "";
+
 // Module-level merged cache produced by the peer sessions watcher.
 // Every peer — including the local Hub — pushes `sessions-updated` over its
 // own WS, so this is the single source of truth.
 let cachedSessions: ExtendedSessionResponse[] = [];
+
+// Cross-peer session order persisted on the Hub. Each entry is the composite
+// key `${peerId}:${sessionId}`. `null` = not yet fetched.
+let cachedMergedOrder: string[] | null = null;
+let mergedOrderFetched = false;
+
+function compositeKey(s: ExtendedSessionResponse): string {
+	return `${s.peerId ?? "local"}:${s.id}`;
+}
+
+function sortByMergedOrder(
+	list: ExtendedSessionResponse[],
+): ExtendedSessionResponse[] {
+	if (!cachedMergedOrder || cachedMergedOrder.length === 0) return list;
+	const orderMap = new Map(cachedMergedOrder.map((key, i) => [key, i]));
+	return [...list].sort((a, b) => {
+		const ai = orderMap.get(compositeKey(a)) ?? Number.MAX_SAFE_INTEGER;
+		const bi = orderMap.get(compositeKey(b)) ?? Number.MAX_SAFE_INTEGER;
+		return ai - bi;
+	});
+}
+
+/**
+ * Apply a new cross-peer order locally and re-sort the cached sessions.
+ * Used by the drag-end handler for optimistic update — the same value is
+ * also PUT to the Hub so reload / other clients pick it up.
+ */
+export function applyLocalSessionOrder(order: string[]) {
+	cachedMergedOrder = order;
+	cachedSessions = sortByMergedOrder(cachedSessions);
+	window.dispatchEvent(new CustomEvent("cchub-sessions-reorder"));
+}
+
+async function fetchMergedOrderOnce(): Promise<void> {
+	if (mergedOrderFetched) return;
+	mergedOrderFetched = true;
+	try {
+		const res = await authFetch(`${API_BASE}/api/peers/session-order`);
+		if (!res.ok) return;
+		const data = (await res.json()) as { order?: string[] };
+		if (Array.isArray(data.order)) {
+			cachedMergedOrder = data.order;
+			cachedSessions = sortByMergedOrder(cachedSessions);
+			window.dispatchEvent(new CustomEvent("cchub-sessions-reorder"));
+		}
+	} catch {
+		mergedOrderFetched = false;
+	}
+}
 
 /** hookイベントで Hub local セッションの indicatorState を即座に更新する */
 export function updateCachedSessionsByHookEvent(
@@ -85,18 +136,23 @@ export function useSessions(): UseSessionsReturn {
 	const [isLoading, setIsLoading] = useState(() => cachedSessions.length === 0);
 	const [error, setError] = useState<string | null>(null);
 
-	// Listen for WS push and hook events
 	useEffect(() => {
 		const hookHandler = () => setSessions(cachedSessions);
+		const reorderHandler = () => setSessions(cachedSessions);
 		window.addEventListener("cchub-hook-event", hookHandler);
-		return () => window.removeEventListener("cchub-hook-event", hookHandler);
+		window.addEventListener("cchub-sessions-reorder", reorderHandler);
+		void fetchMergedOrderOnce();
+		return () => {
+			window.removeEventListener("cchub-hook-event", hookHandler);
+			window.removeEventListener("cchub-sessions-reorder", reorderHandler);
+		};
 	}, []);
 
 	// Per-peer WS watcher already dedups by payload before notifying, so a
 	// listener firing here implies the data actually changed for some peer.
 	const handlePeerSessions = useCallback(
 		(sessionsByPeer: ReadonlyMap<string, PeerSession[]>) => {
-			cachedSessions = flattenPeerSessions(sessionsByPeer);
+			cachedSessions = sortByMergedOrder(flattenPeerSessions(sessionsByPeer));
 			setSessions(cachedSessions);
 			setIsLoading(false);
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "private": true,
   "workspaces": [
     "backend",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -248,9 +248,15 @@ export const PeerOrderSchema = z.object({
   order: z.array(z.string()),  // peer id の配列
 });
 
+// Cross-peer session display order. Each entry is `${peerId}:${sessionId}`.
+export const CrossPeerSessionOrderSchema = z.object({
+  order: z.array(z.string()),
+});
+
 export type PeerCreateInput = z.infer<typeof PeerCreateSchema>;
 export type PeerUpdateInput = z.infer<typeof PeerUpdateSchema>;
 export type PeerOrderInput = z.infer<typeof PeerOrderSchema>;
+export type CrossPeerSessionOrderInput = z.infer<typeof CrossPeerSessionOrderSchema>;
 
 // =============================================================================
 // File Viewer Types


### PR DESCRIPTION
## Changes
- feat: peer 横断のセッション並び替えに対応。Hub と remote peer のセッションを混ぜてドラッグ可能。並び順は `${peerId}:${sessionId}` 形式で Hub に保存され、端末間で共有
- fix: 並び替えの useSortable id を composite key 化。Hub と peer で同名 tmux セッションがあると衝突して並び替えが壊れる問題を解消
- backend: `/api/peers/session-order` (GET/PUT) を新設

## Notes
- frontend + backend (Hub) の修正。Mac peer 側バイナリ更新は不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)