### PR TITLE
Release v0.1.143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.143] - 2026-05-22
+
+### Fixed
+- **peer sessions watcher の WS が backend zombie 検知で 60 秒ごとに切断され、retry ループに陥っていた問題を修正**: v0.1.140 で導入した watcher が ping を送っていなかったため、Hub の `terminal-mux` (`PING_TIMEOUT_MS=60s`) で zombie 判定され `close → 5s 後 retry → close` のサイクルに入っていた。Linux Hub 側に対しても Mac peer 側に対しても同様に発生し、その副作用で peer のターミナル表示が停止する症状が出ていた。watcher に 25 秒間隔の ping を追加 (`frontend/src/hooks/usePeerSessionsWatcher.ts`)
+
 ## [0.1.142] - 2026-05-22
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/hooks/usePeerSessionsWatcher.ts
+++ b/frontend/src/hooks/usePeerSessionsWatcher.ts
@@ -22,6 +22,7 @@ type PeerSessionsListener = (
 interface PeerWatcher {
 	ws: WebSocket | null;
 	retryTimer: number | null;
+	pingTimer: number | null;
 	retryAttempt: number;
 	lastSessionsJson: string;
 	closed: boolean;
@@ -29,6 +30,8 @@ interface PeerWatcher {
 
 const RETRY_INITIAL_MS = 5_000;
 const RETRY_MAX_MS = 60_000;
+// Backend zombie cutoff is 60s; ping every 25s with margin.
+const PING_INTERVAL_MS = 25_000;
 
 const watchers = new Map<string, PeerWatcher>();
 const peerInfoById = new Map<string, PeerClientView>();
@@ -88,6 +91,7 @@ function openWatcher(peer: PeerClientView) {
 		watcher = {
 			ws: null,
 			retryTimer: null,
+			pingTimer: null,
 			retryAttempt: 0,
 			lastSessionsJson: "",
 			closed: false,
@@ -107,7 +111,15 @@ function openWatcher(peer: PeerClientView) {
 		watcher.ws = ws;
 
 		ws.onopen = () => {
-			if (watcher) watcher.retryAttempt = 0;
+			if (!watcher) return;
+			watcher.retryAttempt = 0;
+			// Backend disconnects WS that hasn't sent a `ping` for 60s, so keep it
+			// alive while the watcher's only job is to listen for pushes.
+			watcher.pingTimer = window.setInterval(() => {
+				if (ws.readyState === WebSocket.OPEN) {
+					ws.send(JSON.stringify({ type: "ping", timestamp: Date.now() }));
+				}
+			}, PING_INTERVAL_MS);
 		};
 
 		ws.onmessage = (event) => {
@@ -132,10 +144,15 @@ function openWatcher(peer: PeerClientView) {
 		};
 
 		ws.onclose = () => {
-			if (watcher) watcher.ws = null;
+			if (!watcher) return;
+			watcher.ws = null;
+			if (watcher.pingTimer !== null) {
+				window.clearInterval(watcher.pingTimer);
+				watcher.pingTimer = null;
+			}
 			// Keep last-known sessions until reconnect succeeds; clearing here would
 			// flash the UI empty on transient drops.
-			if (watcher && !watcher.closed) scheduleRetry(peer.id);
+			if (!watcher.closed) scheduleRetry(peer.id);
 		};
 	} catch {
 		scheduleRetry(peer.id);
@@ -149,6 +166,10 @@ function closeWatcher(peerId: string) {
 	if (watcher.retryTimer !== null) {
 		window.clearTimeout(watcher.retryTimer);
 		watcher.retryTimer = null;
+	}
+	if (watcher.pingTimer !== null) {
+		window.clearInterval(watcher.pingTimer);
+		watcher.pingTimer = null;
 	}
 	if (watcher.ws) {
 		try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: peer sessions watcher の WS が ping を送らず Hub の zombie 検知 (60s) で切断 → 5s retry のループに陥っていた問題を修正。25秒間隔の ping 送信を追加。これに伴う副作用で peer terminal 表示が止まる現象も解消

## Notes
- frontend のみ。backend 変更なし
- Mac 側バイナリ更新不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)