### PR TITLE
Release v0.1.144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.144] - 2026-05-22
+
+### Fixed
+- **他 peer の indicator state / OS 通知が動かない問題を修正**: 従来は peer の `hook-event` (Stop / PreToolUse / UserPromptSubmit / PostToolUse) が「ターミナルでアクティブに表示している peer」の sharedWs 経由でしか届かず、他 peer は通知も indicator 即時更新も受け取れなかった。`usePeerSessionsWatcher` が各 peer 用 WS で hook-event を受け、`applyHookIndicatorUpdate` (全 peer 横断検索) で indicator を即時反映 + `fireHookNotification` で OS 通知を発火するように変更 (`frontend/src/hooks/usePeerSessionsWatcher.ts`)
+- 副次: `applyHookIndicatorUpdate` を Hub local 限定から全 peer 横断検索 (ccSessionId UUID) に変更
+
 ## [0.1.143] - 2026-05-22
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/hooks/usePeerSessionsWatcher.ts
+++ b/frontend/src/hooks/usePeerSessionsWatcher.ts
@@ -14,6 +14,7 @@ import {
 	type SessionResponse,
 } from "../../../shared/types";
 import { appendWsToken, peerHttpUrlToWsUrl } from "../services/peer-ws";
+import { fireHookNotification } from "../utils/hookNotification";
 
 type PeerSessionsListener = (
 	sessionsByPeer: ReadonlyMap<string, PeerSession[]>,
@@ -130,6 +131,28 @@ function openWatcher(peer: PeerClientView) {
 			} catch {
 				return;
 			}
+
+			if (msg.type === "hook-event") {
+				// Indicator state should react before the next 5s sessions-updated push.
+				// `ccSessionId` is a UUID so it is safe to look up across all peers.
+				const ccSessionId = msg.sessionId;
+				const newState = hookEventToIndicatorState(msg.event);
+				if (ccSessionId && newState) {
+					applyHookIndicatorUpdate(ccSessionId, newState);
+				}
+				// Forward to OS notification path so non-active peers can notify too.
+				// The terminal sharedWs only ever subscribes to one peer, so without
+				// this the user never gets notified from any other peer.
+				fireHookNotification(
+					msg.event,
+					msg.cwd,
+					ccSessionId,
+					msg.data,
+					msg.message,
+				);
+				return;
+			}
+
 			if (msg.type !== "sessions-updated") return;
 
 			// Per-peer dedup: backend already filters identical payloads, but a
@@ -228,30 +251,51 @@ function peersWatcherKey(peers: PeerClientView[]): string {
 }
 
 /**
- * Push an immediate indicatorState change for the local-Hub sessions whose
+ * Push an immediate indicatorState change for any peer's sessions whose
  * Claude Code session matches `ccSessionId`. Called from hook event handlers
  * so the spinner reacts before the next `sessions-updated` push arrives.
+ * Covers Hub-local sessions as well as remote peers — `ccSessionId` is a
+ * Claude-generated UUID so collisions across peers are negligible.
  */
 export function applyHookIndicatorUpdate(
 	ccSessionId: string,
 	indicatorState: IndicatorState,
 ): boolean {
-	const local = sessionsByPeer.get(LOCAL_PEER_ID);
-	if (!local) return false;
 	let changed = false;
-	const next = local.map((session) => {
-		if (session.ccSessionId !== ccSessionId) return session;
-		if (!session.panes) return session;
-		changed = true;
-		return {
-			...session,
-			panes: session.panes.map((pane) => ({ ...pane, indicatorState })),
-		};
-	});
-	if (!changed) return false;
-	sessionsByPeer.set(LOCAL_PEER_ID, next);
-	notifyListeners();
-	return true;
+	for (const [peerId, sessions] of sessionsByPeer) {
+		let peerChanged = false;
+		const next = sessions.map((session) => {
+			if (session.ccSessionId !== ccSessionId) return session;
+			if (!session.panes) return session;
+			peerChanged = true;
+			return {
+				...session,
+				panes: session.panes.map((pane) => ({ ...pane, indicatorState })),
+			};
+		});
+		if (peerChanged) {
+			sessionsByPeer.set(peerId, next);
+			changed = true;
+		}
+	}
+	if (changed) notifyListeners();
+	return changed;
+}
+
+function hookEventToIndicatorState(event: string): IndicatorState | null {
+	switch (event) {
+		case "Stop":
+		case "Notification":
+		case "SubagentStop":
+			return "completed";
+		case "PostToolUse":
+			return "waiting_input";
+		case "PreToolUse":
+		case "UserPromptSubmit":
+			return "processing";
+		default:
+			return null;
+	}
 }
 
 export function usePeerSessionsWatcher(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: 他 peer の indicator state / OS 通知が動かない問題を修正。peer hook event は従来 active な terminal sharedWs 経由でしか来なかったため、別 peer の通知や spinner 反映が落ちていた。watcher で hook-event も受信し、indicator 即時更新 + OS 通知発火を peer 横断で動かす
- chore: `applyHookIndicatorUpdate` を全 peer 横断検索に変更 (ccSessionId は UUID なので衝突懸念なし)

## Notes
- frontend のみ。backend 変更なし
- Mac 側バイナリ更新不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)