### PR TITLE
Release v0.1.145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.145] - 2026-05-22
+
+### Changed
+- **「キャッシュクリア」を完全リセット仕様に強化**: 従来は Service Worker unregister と Cache API 削除のみで、IndexedDB / localStorage / sessionStorage が残り、`location.reload()` も memory cache を許容していたため、PWA がスタックしたバージョンに留まることがあった。`frontend/src/utils/nuke-cache.ts` (新規) に統一処理を切り出し、SW + Cache API + IndexedDB + localStorage + sessionStorage をすべて削除した上で `?_nocache=<timestamp>` 付きの cache-busted hard reload (`location.replace`) を行う。Dashboard の「キャッシュクリア」ボタンと `Ctrl/Cmd+Shift+F5` ショートカット両方で同じ処理を実行 (`frontend/src/components/dashboard/Dashboard.tsx`, `frontend/src/components/DesktopLayout.tsx`)
+- 副作用: localStorage を消すため認証トークンも消える → 再ログインが必要になる
+
 ## [0.1.144] - 2026-05-22
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.144",
+  "version": "0.1.145",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.144",
+  "version": "0.1.145",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -18,6 +18,7 @@ import type {
 } from "../../../shared/types";
 import { useMultiplexedTerminal } from "../hooks/useMultiplexedTerminal";
 import { usePeerConnection } from "../hooks/usePeerConnection";
+import { nukeClientCache } from "../utils/nuke-cache";
 import { usePeers } from "../hooks/usePeers";
 import {
 	updateCachedSessionsByHookEvent,
@@ -1101,16 +1102,7 @@ export function DesktopLayout({
 			// Ctrl/Cmd + Shift + F5: Cache clear & reload
 			if (e.shiftKey && e.key === "F5") {
 				e.preventDefault();
-				Promise.all(
-					[
-						navigator.serviceWorker
-							?.getRegistrations()
-							.then((regs) => Promise.all(regs.map((r) => r.unregister()))),
-						caches
-							?.keys()
-							.then((keys) => Promise.all(keys.map((k) => caches.delete(k)))),
-					].filter(Boolean),
-				).then(() => location.reload());
+				void nukeClientCache();
 				return;
 			}
 

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useDashboard } from "../../hooks/useDashboard";
 import { useTheme } from "../../hooks/useTheme";
 import { useUiScale } from "../../hooks/useUiScale";
+import { nukeClientCache } from "../../utils/nuke-cache";
 import { DailyUsageChart } from "./DailyUsageChart";
 import { HourlyHeatmap } from "./HourlyHeatmap";
 import { ModelUsageChart } from "./ModelUsageChart";
@@ -55,15 +56,7 @@ export function Dashboard({ className = "", compact = false }: DashboardProps) {
 	const handleClearCache = useCallback(async () => {
 		setCacheClearing(true);
 		try {
-			if ("serviceWorker" in navigator) {
-				const regs = await navigator.serviceWorker.getRegistrations();
-				await Promise.all(regs.map((r) => r.unregister()));
-			}
-			if (typeof caches !== "undefined") {
-				const keys = await caches.keys();
-				await Promise.all(keys.map((k) => caches.delete(k)));
-			}
-			setTimeout(() => location.reload(), 500);
+			await nukeClientCache();
 		} catch (e) {
 			console.error("Cache clear failed:", e);
 			setCacheClearing(false);

--- a/frontend/src/utils/nuke-cache.ts
+++ b/frontend/src/utils/nuke-cache.ts
@@ -1,0 +1,65 @@
+/**
+ * Wipe every client-side cache and persistent storage CC Hub touches, then
+ * hard-reload with a cache-busting query string. Used by the dashboard
+ * "Clear cache" button and the Ctrl/Cmd+Shift+F5 keybinding when a PWA gets
+ * stuck on an outdated bundle.
+ *
+ * Side effect: localStorage is cleared, so the user has to log in again.
+ */
+export async function nukeClientCache(): Promise<void> {
+	// 1. Stop and unregister all Service Workers
+	if ("serviceWorker" in navigator) {
+		try {
+			const regs = await navigator.serviceWorker.getRegistrations();
+			await Promise.all(regs.map((r) => r.unregister()));
+		} catch {
+			/* permissions may deny */
+		}
+	}
+	// 2. Drop every Cache API entry (precache, runtime, api-cache, ...)
+	if (typeof caches !== "undefined") {
+		try {
+			const keys = await caches.keys();
+			await Promise.all(keys.map((k) => caches.delete(k)));
+		} catch {
+			/* ignore */
+		}
+	}
+	// 3. Wipe IndexedDB (PWA frameworks and some libs persist state here)
+	if ("indexedDB" in window && typeof indexedDB.databases === "function") {
+		try {
+			const dbs = await indexedDB.databases();
+			await Promise.all(
+				dbs.map(
+					(db) =>
+						new Promise<void>((resolve) => {
+							if (!db.name) return resolve();
+							const req = indexedDB.deleteDatabase(db.name);
+							const done = () => resolve();
+							req.onsuccess = done;
+							req.onerror = done;
+							req.onblocked = done;
+						}),
+				),
+			);
+		} catch {
+			/* ignore */
+		}
+	}
+	// 4. Clear localStorage / sessionStorage (auth token included)
+	try {
+		localStorage.clear();
+	} catch {
+		/* private mode */
+	}
+	try {
+		sessionStorage.clear();
+	} catch {
+		/* private mode */
+	}
+	// 5. Cache-busted hard reload — `?_nocache=…` prevents the browser from
+	// satisfying the request from the memory/HTTP cache
+	const url = new URL(`${location.origin}/`);
+	url.searchParams.set("_nocache", Date.now().toString(36));
+	location.replace(url.toString());
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.144",
+  "version": "0.1.145",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- change: 「キャッシュクリア」を完全リセット仕様に強化。Service Worker / Cache API / IndexedDB / localStorage / sessionStorage を全削除し、`?_nocache=<ts>` 付きの hard reload で memory/HTTP cache も bypass する
- chore: 共通処理を `frontend/src/utils/nuke-cache.ts` に集約。Dashboard ボタンと Ctrl/Cmd+Shift+F5 ショートカット両方で同じ処理

## Notes
- localStorage を消すので再ログインが必要
- frontend のみ。backend 変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)