### PR TITLE
feat(peers): cchub send CLI for cross-server pane input

### DIFF
--- a/.claude/skills/cchub-send/SKILL.md
+++ b/.claude/skills/cchub-send/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: cchub-send
+description: CC Hub の `cchub send` で、ローカル or peer サーバの tmux パネルにテキスト/コマンドを送信する。「/cchub-send」「ペインに送って」「セッションに入力」「peerに送信」「リモートセッションに送って」などで起動する。
+---
+
+# cchub-send
+
+別の CC Hub サーバ (peer) や自分自身のセッションのパネルに、CLI からテキストを送り込むためのスキル。
+
+`POST /api/sessions/:id/panes/input` を叩く `cchub send` サブコマンドを使う。
+
+## 前提
+
+- 送信先サーバ (local もしくは peer) で `cchub` が動いている (デフォルト 5923)
+- peer に送る場合は `peers.json` に peer が登録済み (UI で追加するか peer-registry が生成済み)
+- peer 認証がある場合は登録時に bearer token が `peers.json` に保存されている
+
+## ターゲット指定
+
+`<peer>:<session>:<paneId>` の3パート構成。
+
+- `<peer>`: `local` / `self` / peer id (`p_xxxx`) / peer の nickname
+- `<session>`: tmux セッション名 (= cchub の session id)
+- `<paneId>`: tmux pane id (例: `%7`)
+
+## 基本コマンド
+
+```bash
+# 引数で text を渡す（純粋に bytes だけ送る）
+cchub send local:my-session:%5 "hello"
+
+# Enter (CR) を末尾に付ける — シェルや TUI でコマンドを実行させたいときに必須
+cchub send local:my-session:%5 "ls -la" --newline
+
+# stdin から payload を流し込む
+echo "echo from stdin" | cchub send local:my-session:%5 --stdin --newline
+cat script.sh | cchub send local:my-session:%5 --stdin
+
+# peer (nickname or id) に送る
+cchub send 🏠Studio:cc-hub:%2 "echo ping" --newline
+cchub send p_a1b2c3d4:my-session:%5 "echo ping" --newline
+
+# バイナリ/制御文字を送る場合は base64
+printf '\x03' | base64 | cchub send local:my-session:%5 --stdin --base64   # Ctrl+C
+```
+
+## 送信先の paneId を調べる
+
+```bash
+# ローカル
+curl -sk https://localhost:5923/api/sessions \
+  | python3 -c "import json,sys; [print(f\"{s['name']}: {[p['paneId'] for p in s.get('panes',[])]}\") for s in json.load(sys.stdin)['sessions']]"
+
+# 認証付きの場合 (token は peers.json から取得)
+TOKEN=$(python3 -c "import json; print(json.load(open('$HOME/.cc-hub/peers.json'))['peers'][0].get('wsToken',''))")
+curl -sk -H "Authorization: Bearer $TOKEN" https://<peer-host>:5923/api/sessions
+```
+
+## 注意
+
+- `cchub send` はデフォルトで `-p 5923` (本番ポート) を見にいく。dev サーバ (3456) に送りたいときは `-p 3456` を付ける
+- `--newline` を忘れるとシェルに入力されてもコマンドが実行されない (画面に文字列だけが残る)
+- peer の paneId はその peer の tmux サーバから見た id なので、ローカルで `tmux list-panes` しても出てこない。peer の `/api/sessions` を叩いて確認すること
+- `peers.json` は `~/.cc-hub/peers.json` (`CC_HUB_DATA_DIR` で上書き可)。CLI は peer-registry 経由で読むので環境変数があれば自動で従う
+
+## トラブルシュート
+
+| 症状 | 原因 | 対処 |
+|------|------|------|
+| `target は <peer>:<session>:<paneId> 形式で指定してください` | コロン区切りが3つ揃っていない | `<peer>:<session>:<paneId>` に直す |
+| `peer "<name>" が見つかりません` | nickname/id 不一致 | UI の Settings → Peers で確認 |
+| `HTTP 404 Pane not found` | paneId がそのセッションに存在しない | `GET /api/sessions` で再確認 |
+| `HTTP 404 Session not found` | tmux に session 自体が無い | `tmux ls` または UI で確認 |
+| `HTTP 401` | peer の token 期限切れ/不正 | UI で peer を作り直して再ログイン |
+| `peer に接続できません` | peer の URL/port 違い、サーバ停止 | URL と起動状態を確認 |
+
+## 実装
+
+- CLI: `backend/src/commands/send.ts` (`runSend`)
+- HTTP: `backend/src/routes/sessions.ts` の `POST /:id/panes/input`
+- スキーマ: `PaneInputSchema` (`paneId`, `data`, `encoding: 'utf-8' | 'base64'`)
+- 内部的には `TmuxControlSession.sendInput(paneId, Buffer)` を呼ぶ (xterm からのキー入力と同じ経路)

--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -9,7 +9,7 @@ const isDev = process.argv.some(arg => arg.includes('--watch'));
 const DEFAULT_PORT = isDev ? 3456 : 5923;
 
 interface CliOptions {
-  command: 'serve' | 'setup' | 'uninstall' | 'update' | 'status' | 'notify' | 'help' | 'version' | 'debug';
+  command: 'serve' | 'setup' | 'uninstall' | 'update' | 'status' | 'notify' | 'help' | 'version' | 'debug' | 'send';
   port: number;
   host: string;
   password?: string;
@@ -18,6 +18,11 @@ interface CliOptions {
   debugSubcommand?: 'enable' | 'disable' | 'profile' | 'status';
   debugPort?: number;
   debugSeconds?: number;
+  sendTarget?: string;
+  sendText?: string;
+  sendStdin?: boolean;
+  sendNewline?: boolean;
+  sendBase64?: boolean;
 }
 
 function printHelp(): void {
@@ -31,6 +36,9 @@ ${t('cli.usage')}
   cchub update [options]    Check and apply updates
   cchub status              Show service status
   cchub notify              Send hook event (reads JSON from stdin)
+  cchub send <target> [text]  Send input to a pane on a peer or local server
+                              target: <peer>:<session>:<paneId>
+                              (peer can be 'local', a peer id, or a nickname)
   cchub debug <sub>         Toggle Bun inspector mode on the running service
                             sub: enable | disable | profile | status
 
@@ -46,6 +54,11 @@ update options:
 debug options:
   --port <port>          Inspector port (default 9229)
   --seconds <n>          For 'profile' sub: enable for N seconds then auto-disable
+
+send options:
+  --stdin                Read payload from stdin instead of arg
+  --newline              Append \\r to payload (acts like pressing Enter)
+  --base64               Treat payload as base64 (binary-safe)
 
 ${t('cli.examples')}
   ${t('cli.exampleStart')}
@@ -85,6 +98,29 @@ export function parseArgs(args: string[]): CliOptions {
         break;
       case 'notify':
         options.command = 'notify';
+        break;
+      case 'send': {
+        options.command = 'send';
+        const next = args[i + 1];
+        if (next && !next.startsWith('-')) {
+          options.sendTarget = next;
+          i++;
+          const maybeText = args[i + 1];
+          if (maybeText !== undefined && !maybeText.startsWith('-')) {
+            options.sendText = maybeText;
+            i++;
+          }
+        }
+        break;
+      }
+      case '--stdin':
+        options.sendStdin = true;
+        break;
+      case '--newline':
+        options.sendNewline = true;
+        break;
+      case '--base64':
+        options.sendBase64 = true;
         break;
       case 'debug': {
         options.command = 'debug';
@@ -190,6 +226,10 @@ export async function runCli(options: CliOptions): Promise<'serve' | 'exit'> {
       await runNotify(options);
       return 'exit';
 
+    case 'send':
+      await runSend(options);
+      return 'exit';
+
     case 'debug':
       await runDebug(options);
       return 'exit';
@@ -217,6 +257,27 @@ async function runUpdate(options: CliOptions): Promise<void> {
 async function runNotify(options: CliOptions): Promise<void> {
   const { sendNotify } = await import('./commands/notify');
   await sendNotify(options.port);
+}
+
+async function runSend(options: CliOptions): Promise<void> {
+  if (!options.sendTarget) {
+    console.error('❌ target is required: cchub send <peer>:<session>:<paneId> [text]');
+    process.exit(1);
+  }
+  const { runSend: runSendImpl } = await import('./commands/send');
+  try {
+    await runSendImpl({
+      target: options.sendTarget,
+      text: options.sendText,
+      stdin: options.sendStdin ?? false,
+      newline: options.sendNewline ?? false,
+      base64: options.sendBase64 ?? false,
+      localPort: options.port,
+    });
+  } catch (err) {
+    console.error(`❌ ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
 }
 
 async function runStatus(): Promise<void> {

--- a/backend/src/commands/send.ts
+++ b/backend/src/commands/send.ts
@@ -1,0 +1,113 @@
+/**
+ * cchub send - send raw input to a specific pane on a peer or local cchub server.
+ *
+ * Usage:
+ *   cchub send <peer>:<session>:<paneId> "text"
+ *   echo "text" | cchub send <peer>:<session>:<paneId> --stdin
+ *   cchub send <peer>:<session>:<paneId> "ls -la" --newline
+ *
+ * <peer> can be a peer nickname, peer id, or "local" for self.
+ */
+
+import { listPeers, type StoredPeer } from '../services/peer-registry';
+
+export interface SendOptions {
+  target: string;
+  text?: string;
+  stdin: boolean;
+  newline: boolean;
+  base64: boolean;
+  localPort: number;
+}
+
+interface ParsedTarget {
+  peer: string;
+  sessionId: string;
+  paneId: string;
+}
+
+function parseTarget(target: string): ParsedTarget {
+  const parts = target.split(':');
+  if (parts.length !== 3 || parts.some(p => !p)) {
+    throw new Error(`target は <peer>:<session>:<paneId> 形式で指定してください (got: ${target})`);
+  }
+  return { peer: parts[0], sessionId: parts[1], paneId: parts[2] };
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of Bun.stdin.stream()) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+async function resolvePeer(name: string, localPort: number): Promise<{ url: string; token?: string }> {
+  if (name === 'local' || name === 'self') {
+    // cchub serves HTTPS on localhost (Tailscale cert). notify.ts uses the same pattern.
+    return { url: `https://localhost:${localPort}` };
+  }
+  const peers = await listPeers();
+  const match = peers.find(
+    (p): p is StoredPeer => p.id === name || p.nickname === name,
+  );
+  if (!match) {
+    const known = peers.map(p => `${p.id} (${p.nickname})`).join(', ');
+    throw new Error(`peer "${name}" が見つかりません。登録済み peer: ${known || '(none)'}`);
+  }
+  if (match.url === 'self') {
+    return { url: `http://localhost:${localPort}`, token: undefined };
+  }
+  return { url: match.url.replace(/\/+$/, ''), token: match.wsToken };
+}
+
+export async function runSend(options: SendOptions): Promise<void> {
+  const target = parseTarget(options.target);
+
+  let payload: string;
+  if (options.stdin) {
+    payload = await readStdin();
+  } else if (options.text !== undefined) {
+    payload = options.text;
+  } else {
+    throw new Error('text 引数か --stdin のいずれかを指定してください');
+  }
+
+  if (options.newline) {
+    payload = `${payload}\r`;
+  }
+
+  const peer = await resolvePeer(target.peer, options.localPort);
+
+  // base64 指定時は payload は既に base64 文字列のはず。utf-8 のときはそのまま渡す
+  const body = {
+    paneId: target.paneId,
+    data: payload,
+    encoding: options.base64 ? 'base64' : 'utf-8',
+  };
+
+  // Tailscale 証明書は localhost 名と一致しないので TLS 検証を切る (notify.ts と同じ運用)
+  if (peer.url.startsWith('https://')) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  }
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (peer.token) {
+    headers.Authorization = `Bearer ${peer.token}`;
+  }
+
+  const url = `${peer.url}/api/sessions/${encodeURIComponent(target.sessionId)}/panes/input`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '');
+    throw new Error(`send 失敗: HTTP ${res.status} ${errText}`);
+  }
+
+  const json = (await res.json().catch(() => ({}))) as { bytes?: number };
+  console.log(`✅ sent ${json.bytes ?? payload.length} bytes to ${target.peer}:${target.sessionId}:${target.paneId}`);
+}

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -820,6 +820,12 @@ const PaneRespawnSchema = z.object({
   paneId: PaneIdSchema,
 });
 
+const PaneInputSchema = z.object({
+  paneId: PaneIdSchema,
+  data: z.string(),
+  encoding: z.enum(['utf-8', 'base64']).optional().default('utf-8'),
+});
+
 // POST /sessions/:id/panes/focus - Focus a specific pane
 sessions.post('/:id/panes/focus', async (c) => {
   const id = c.req.param('id');
@@ -965,6 +971,40 @@ sessions.post('/:id/panes/respawn', async (c) => {
     return c.json({ success: true });
   } catch (_error) {
     return c.json({ error: 'Failed to respawn pane' }, 500);
+  }
+});
+
+// POST /sessions/:id/panes/input - Send raw input bytes to a specific pane
+sessions.post('/:id/panes/input', async (c) => {
+  const id = c.req.param('id');
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = PaneInputSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid request', issues: parsed.error.issues }, 400);
+  }
+
+  const exists = await tmuxService.sessionExists(id);
+  if (!exists) {
+    return c.json({ error: 'Session not found' }, 404);
+  }
+
+  try {
+    const controlSession = controlSessions.get(id) || await getOrCreateControlSession(id);
+    const panes = await controlSession.listPanes();
+    const targetPane = panes.find(p => p.paneId === parsed.data.paneId);
+    if (!targetPane) {
+      return c.json({ error: 'Pane not found' }, 404);
+    }
+
+    const buffer = parsed.data.encoding === 'base64'
+      ? Buffer.from(parsed.data.data, 'base64')
+      : Buffer.from(parsed.data.data, 'utf-8');
+    await controlSession.sendInput(parsed.data.paneId, buffer);
+
+    return c.json({ success: true, paneId: parsed.data.paneId, bytes: buffer.length });
+  } catch (_error) {
+    return c.json({ error: 'Failed to send input' }, 500);
   }
 });
 


### PR DESCRIPTION
## Summary
- Add `POST /api/sessions/:id/panes/input` to send raw bytes to a specific tmux pane (utf-8 or base64 payload)
- Add `cchub send <peer>:<session>:<paneId> [text]` CLI subcommand that POSTs to that endpoint on local or peer servers, using the bearer token from `peers.json`
- Supports `--stdin`, `--newline` (append CR), `--base64`
- Add `cchub-send` skill documenting target syntax, flag usage, paneId discovery, and troubleshooting

## Test plan
- [x] `cchub send local:<session>:<paneId> "echo hello" --newline` runs the command in the target pane
- [x] `echo "..." | cchub send ... --stdin` reads payload from stdin
- [x] Invalid paneId → HTTP 404 `Pane not found`
- [x] Unknown peer → CLI error listing known peers
- [x] Bad target format → CLI error explaining the expected shape
- [x] Verified end-to-end: dev server → tmux pane → browser shows output in real time (via agent-browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)