### PR TITLE
Release v0.1.147

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.147] - 2026-05-22
+
+### Fixed
+- **新規 `claude` セッション (= `-r` フラグ無し) で `ccSessionId` が取れず indicator state の即時更新と通知が動かない問題を修正**: `buildSessionsList` の最終 path fallback (`ccSessionsByPath.get(currentPath)`) が `ptySessionId` 必須になっていたため、`claude -r <uuid>` ではない新規起動セッションでは hook event の `session_id` と紐付けるべき `ccSessionId` が常に `undefined` になり、`applyHookIndicatorUpdate` が peer 横断検索しても何にもヒットしないという経路ができていた。条件から `ptySessionId` 要件を外し、`getSessionByTtyStartTime` (TZ skew で失敗することがある) が null を返したら無条件で cwd 配下の最新 `.jsonl` にフォールバックするよう変更 (`backend/src/routes/sessions.ts`)
+
+### Added
+- **`cchub send --submit` フラグ**: 末尾に `\r\r` を追加して送信する。Claude Code の TUI は paste mode に入った入力を `\r` 1回では submit せず、明示的に2回の Enter を要求するため、`cchub send` から Claude Code に対話させるときは `--newline` ではなく `--submit` を使うのが確実 (`backend/src/commands/send.ts`, `backend/src/cli.ts`)
+
 ## [0.1.146] - 2026-05-22
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.146",
+  "version": "0.1.147",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.146",
+  "version": "0.1.147",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -22,6 +22,7 @@ interface CliOptions {
   sendText?: string;
   sendStdin?: boolean;
   sendNewline?: boolean;
+  sendSubmit?: boolean;
   sendBase64?: boolean;
 }
 
@@ -57,7 +58,9 @@ debug options:
 
 send options:
   --stdin                Read payload from stdin instead of arg
-  --newline              Append \\r to payload (acts like pressing Enter)
+  --newline              Append \\r to payload (acts like pressing Enter once)
+  --submit               Append \\r\\r — Claude Code TUI needs two CRs to exit
+                         paste mode and actually send the message
   --base64               Treat payload as base64 (binary-safe)
 
 ${t('cli.examples')}
@@ -118,6 +121,9 @@ export function parseArgs(args: string[]): CliOptions {
         break;
       case '--newline':
         options.sendNewline = true;
+        break;
+      case '--submit':
+        options.sendSubmit = true;
         break;
       case '--base64':
         options.sendBase64 = true;
@@ -271,6 +277,7 @@ async function runSend(options: CliOptions): Promise<void> {
       text: options.sendText,
       stdin: options.sendStdin ?? false,
       newline: options.sendNewline ?? false,
+      submit: options.sendSubmit ?? false,
       base64: options.sendBase64 ?? false,
       localPort: options.port,
     });

--- a/backend/src/commands/send.ts
+++ b/backend/src/commands/send.ts
@@ -16,6 +16,10 @@ export interface SendOptions {
   text?: string;
   stdin: boolean;
   newline: boolean;
+  // Append `\r\r` so Claude Code's TUI exits paste mode and submits the input.
+  // Plain `--newline` is `\r` only, which Claude Code treats as a newline
+  // inside multi-line paste and never submits.
+  submit: boolean;
   base64: boolean;
   localPort: number;
 }
@@ -75,6 +79,9 @@ export async function runSend(options: SendOptions): Promise<void> {
 
   if (options.newline) {
     payload = `${payload}\r`;
+  }
+  if (options.submit) {
+    payload = `${payload}\r\r`;
   }
 
   const peer = await resolvePeer(target.peer, options.localPort);

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -121,7 +121,13 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         ccSession = await claudeCodeService.getSessionByTtyStartTime(s.paneTty, s.currentPath);
       }
 
-      if (!ccSession && ptySessionId) {
+      // Final fallback: pick the most recent `.jsonl` for the working dir. Earlier
+      // this branch required `ptySessionId` (i.e. only ran for `claude -r <uuid>`),
+      // which meant a freshly-started `claude` (no `-r`) whose tty-start-time
+      // detection failed (TZ skew on macOS launchd, etc.) ended up with no
+      // ccSession at all — and therefore no `ccSessionId` for hook events to
+      // match against, so the indicator never reacted.
+      if (!ccSession) {
         const pathSession = ccSessionsByPath.get(s.currentPath);
         if (pathSession) {
           ccSession = pathSession;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.146",
+  "version": "0.1.147",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: 新規 `claude` セッション (`-r` 無し) で `ccSessionId` 取得が失敗し、indicator 即時更新も通知も動かない問題を修正。path fallback の `ptySessionId` 要件を撤去
- feat: `cchub send --submit` 追加。Claude Code に対して確実に submit させたい時に `\r\r` を末尾追加

## Notes
- backend のみ。**Mac peer 側も `cchub update` で v0.1.147 必須** (Mac peer 側の buildSessionsList が ccSessionId を sessions-updated に乗せる主体なので)

🤖 Generated with [Claude Code](https://claude.com/claude-code)