### PR TITLE
fix: remove parent-dir traversal in getSessionForPath

### DIFF
--- a/.claude/skills/cchub-send/SKILL.md
+++ b/.claude/skills/cchub-send/SKILL.md
@@ -32,6 +32,9 @@ cchub send local:my-session:%5 "hello"
 # Enter (CR) を末尾に付ける — シェルや TUI でコマンドを実行させたいときに必須
 cchub send local:my-session:%5 "ls -la" --newline
 
+# Claude Code TUI に送って submit させる (paste mode を抜けるため CR を2回付与)
+cchub send local:my-session:%5 "プロンプト本文" --submit
+
 # stdin から payload を流し込む
 echo "echo from stdin" | cchub send local:my-session:%5 --stdin --newline
 cat script.sh | cchub send local:my-session:%5 --stdin
@@ -43,6 +46,102 @@ cchub send p_a1b2c3d4:my-session:%5 "echo ping" --newline
 # バイナリ/制御文字を送る場合は base64
 printf '\x03' | base64 | cchub send local:my-session:%5 --stdin --base64   # Ctrl+C
 ```
+
+## フラグ
+
+| フラグ | 末尾に追加 | 用途 |
+|--------|-----------|------|
+| (なし) | -- | 純粋にバイト列だけ送る (画面に表示するだけ等) |
+| `--newline` | `\r` 1回 | シェル/通常 TUI で Enter 相当 |
+| `--submit` | `\r\r` 2回 | **Claude Code TUI 専用** — paste mode を抜けて submit |
+| `--stdin` | -- | 引数の代わりに stdin から payload を読む |
+| `--base64` | -- | payload は base64 文字列扱い (制御文字/バイナリを送る用) |
+
+## 双方向で対話する (peer から返事させる)
+
+「こちらから送る」だけでなく、相手側の Claude Code に **`cchub send` で返事させる** ことで両端 Claude Code 同士の対話が成立する。
+
+### セットアップ
+
+1. **両方の peers.json にお互いを登録**:
+   ```bash
+   # A 側で B を登録 (UI からでも CLI からでも)
+   curl -sk -X POST https://<B-host>:5923/api/peers \
+     -H 'Content-Type: application/json' \
+     -d '{"nickname":"🅱 B","url":"https://<A から見た B の URL>"}'
+
+   # B 側で A を登録 (B から見える A の Tailscale ホスト名を使う)
+   curl -sk -X POST https://<A-host>:5923/api/peers \
+     -H 'Content-Type: application/json' \
+     -d '{"nickname":"🅰 A","url":"https://<B から見た A の URL>"}'
+   ```
+   peer のパスワードが無ければ token は空のまま登録できる。
+
+2. **返信側で `cchub send` の Bash permission を事前許可** ⚠️ **これを忘れると返事できない**:
+   返信側 Claude Code が `cchub send` を実行する瞬間 Bash permission prompt で停止する。`/api/sessions` の indicatorState は遅延更新なので「動いてる」ように見えてしまい、ハマる。事前に許可しておく:
+   - 返信側セッションの `.claude/settings.local.json` に `"permissions": { "allow": ["Bash(cchub send:*)"] }` を追加
+   - もしくは返信側 Claude Code を `--dangerously-skip-permissions` で起動
+   - もしくは初回のみ手動で承認: 相手側 UI を開き、permission prompt で「**Yes, and don't ask again for: cchub send**」を選ぶ。これで以降は止まらない
+
+3. **自分の pane を特定**:
+   ```bash
+   tmux display-message -p '#{session_name}:#{pane_id}'   # 例: cchub-work-1:%1
+   ```
+
+4. **送信時に返信先と返し方を明記**:
+   ```bash
+   cchub send mac:cc-hub:%6 "ステータス報告をお願いします。返信は cchub send '🅰 A:cchub-work-1:%1' '<本文>' --submit で戻してください。完了後 [reply-done] を別送" --submit
+   ```
+
+### コツ
+
+- 返信先の peer 指定は **A 側に登録した nickname / id** を使う (B 側の peers.json での名前)。両端で名前が違っていてOK
+- 返信は `--submit` を使うよう明示。`--newline` 1回だと長文では submit されない
+- 返事が複数ターン続く場合に備えて、終了マーカー (`[reply-done]` 等) を最後に別送するよう指示すると追跡しやすい (※実際には相手の Claude Code が本文末尾に連結して1回の send で済ませてくることが多いので、マーカーは本文末尾でも追跡可能な文字列にしておく)
+- 受信側 (= こちらの pane) に返事が届くと、それは「ユーザーからの新しい入力」として Claude Code TUI に流し込まれる。すなわち相手の応答が次のターンのプロンプトになる
+- **届いた返事が submit されないまま入力欄に溜まることがある** (相手側で `--submit` が抜けた / paste mode が抜けてない)。手動で進める場合は `tmux send-keys -t <自分のpane> Enter` で確定できる
+
+### デバッグ: 「届いてるのか?」を確かめる
+
+`/api/sessions` の `indicatorState` / `waitingToolName` は hook 駆動で**反応が遅れる/止まることがある**。送ったテキストが相手に届いたか、submit されたか、permission で止まってないかを正しく判断するには:
+
+- **peer の UI を実際に開いて目視確認** — これが一番確実
+- `indicatorState=completed` + `waitingToolName=UserInput` を「idle」と判断するのは危険。permission prompt 中も同じ表示になる可能性あり
+- 返信側に「処理開始 / 終了マーカー」を別送させる ⇒ 相手側 Claude Code が動いてる証拠になる
+
+### peer の hook 設定を診断する
+
+`/api/sessions` の `indicatorState` が常に `completed/UserInput` で動かない場合、相手側で **hook が `cchub notify` を呼んでいない** 可能性が高い。次のエンドポイントで peer 側の hook 登録状態を取得できる:
+
+```bash
+curl -sk https://<peer-host>:5923/api/notify/hook-status | python3 -m json.tool
+```
+
+レスポンスの `missing` 配列に欠けてる hook event が並ぶ:
+- `stop` — 応答完了が検知できない (常に processing のまま)
+- `preToolUse` — **ツール実行中の processing 状態にならない** (今回ハマったやつ)
+- `userPromptSubmit` — プロンプト送信が検知できない
+- `askUserQuestion` — AskUserQuestion 待ちが検知できない
+
+`missing` を埋めるには相手の `~/.claude/settings.json` に該当 hook を追加する:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
+    "Stop":       [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
+    "PostToolUse": [{ "matcher": "AskUserQuestion", "hooks": [{ "type": "command", "command": "cchub notify" }] }]
+  }
+}
+```
+
+> 💡 受信側 (Mac の `/api/notify`) の動作確認は、適当な session_id を投げて直接叩けば一発:
+> ```bash
+> curl -sk -X POST https://<peer-host>:5923/api/notify -H "Content-Type: application/json" \
+>   -d '{"session_id":"<ccSessionId>","hook_event_name":"PreToolUse","tool_name":"Bash"}'
+> ```
+> indicator が変化すれば受信側 OK、変化しなければ Claude Code 側 (= hook 設定) が問題
 
 ## 送信先の paneId を調べる
 
@@ -60,6 +159,7 @@ curl -sk -H "Authorization: Bearer $TOKEN" https://<peer-host>:5923/api/sessions
 
 - `cchub send` はデフォルトで `-p 5923` (本番ポート) を見にいく。dev サーバ (3456) に送りたいときは `-p 3456` を付ける
 - `--newline` を忘れるとシェルに入力されてもコマンドが実行されない (画面に文字列だけが残る)
+- **Claude Code TUI に送るときは `--submit`** を使う。paste mode を抜けるために `\r\r` (CR 2回) が必要。`--newline` (CR 1回) では multi-line として扱われ submit されないことがある
 - peer の paneId はその peer の tmux サーバから見た id なので、ローカルで `tmux list-panes` しても出てこない。peer の `/api/sessions` を叩いて確認すること
 - `peers.json` は `~/.cc-hub/peers.json` (`CC_HUB_DATA_DIR` で上書き可)。CLI は peer-registry 経由で読むので環境変数があれば自動で従う
 
@@ -73,6 +173,11 @@ curl -sk -H "Authorization: Bearer $TOKEN" https://<peer-host>:5923/api/sessions
 | `HTTP 404 Session not found` | tmux に session 自体が無い | `tmux ls` または UI で確認 |
 | `HTTP 401` | peer の token 期限切れ/不正 | UI で peer を作り直して再ログイン |
 | `peer に接続できません` | peer の URL/port 違い、サーバ停止 | URL と起動状態を確認 |
+| 文字列は届くが Claude Code が応答しない | paste mode で submit されていない | `--submit` を付ける (末尾に `\r\r` を付与) |
+| `--newline` だと長文で submit されない | CR 1回だと paste mode の改行扱い | `--newline` を `--submit` に置き換える |
+| 相手から返事が来ない | 相手側 peers.json にこちらが未登録 / 名前ミス | 相手側 `POST /api/peers` で登録、返信指示文に正確な nickname/id を書く |
+| **相手の Claude Code が `cchub send` を実行しない** | Bash permission prompt で停止 | 返信側に `Bash(cchub send:*)` を事前許可 (settings.local.json or `--dangerously-skip-permissions`) |
+| `indicatorState` 上は idle なのに submit が効いてない | hook 状態の遅延 / permission prompt 中も idle 表示 | UI を目視確認、または相手に「開始マーカーを別送」させる |
 
 ## 実装
 

--- a/backend/src/services/claude-code.ts
+++ b/backend/src/services/claude-code.ts
@@ -681,96 +681,71 @@ export class ClaudeCodeService {
 
   private async getSessionForPathUncached(workingDir: string): Promise<ClaudeCodeSession | null> {
     try {
-      // Try exact path first, then parent directories
-      let currentPath = workingDir;
+      // Exact path only. Parent-directory traversal would mis-attribute an
+      // ancestor project's latest jsonl (e.g. /Users/m0a) to a deeper tmux
+      // pane whose project dir happens to be empty — causing all panes to
+      // share the same wrong ccSessionId / recap.
+      const projectName = this.pathToProjectName(workingDir);
+      const projectDir = join(this.claudeDir, projectName);
+      const indexPath = join(projectDir, 'sessions-index.json');
 
-      while (currentPath && currentPath !== '/') {
-        const projectName = this.pathToProjectName(currentPath);
-        const projectDir = join(this.claudeDir, projectName);
-        const indexPath = join(projectDir, 'sessions-index.json');
+      try {
+        // First, find the most recently modified .jsonl file
+        const files = await readdir(projectDir);
+        const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
 
-        try {
-          // First, find the most recently modified .jsonl file
-          const files = await readdir(projectDir);
-          const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
-
-          // Get stats for all files in parallel
-          const fileStats = await Promise.all(
-            jsonlFiles.map(async (file) => {
-              try {
-                const fileStat = await stat(join(projectDir, file));
-                return { name: file, mtime: fileStat.mtimeMs };
-              } catch {
-                return null;
-              }
-            })
-          );
-
-          // Find the most recent file
-          const validStats = fileStats.filter((s): s is { name: string; mtime: number } => s !== null);
-          const latestFile = validStats.reduce<{ name: string; mtime: number } | null>(
-            (latest, current) => (!latest || current.mtime > latest.mtime) ? current : latest,
-            null
-          );
-
-          // Read the index to get cached info
-          let index: SessionsIndex | null = null;
-          try {
-            const content = await readFile(indexPath, 'utf-8');
-            index = JSON.parse(content);
-          } catch {
-            // Index doesn't exist or is invalid
-          }
-
-          // Check if the latest file is newer than what's in the index
-          if (latestFile) {
-            const sessionId = latestFile.name.replace('.jsonl', '');
-            const indexEntry = index?.entries?.find(e => e.sessionId === sessionId);
-
-            // If this file is in the index and not much newer, use cached data
-            // But always check waiting state for accuracy
-            if (indexEntry && (latestFile.mtime - (indexEntry.fileMtime || 0)) < 60000) {
-              const filePath = join(projectDir, latestFile.name);
-              const [waitingToolName, lastUserMessage, firstMessageId, lastRecap] = await Promise.all([
-                this.checkWaitingState(filePath),
-                this.readLastUserMessage(filePath),
-                this.readFirstMessageId(filePath),
-                this.readLastRecap(filePath),
-              ]);
-
-              return {
-                sessionId: indexEntry.sessionId,
-                summary: lastUserMessage || indexEntry.summary,
-                firstPrompt: indexEntry.firstPrompt,
-                messageCount: indexEntry.messageCount,
-                modified: indexEntry.modified,
-                gitBranch: indexEntry.gitBranch,
-                projectPath: indexEntry.projectPath,
-
-                waitingToolName: waitingToolName || undefined,
-                firstMessageId: firstMessageId || undefined,
-                lastRecap: lastRecap || undefined,
-              };
+        // Get stats for all files in parallel
+        const fileStats = await Promise.all(
+          jsonlFiles.map(async (file) => {
+            try {
+              const fileStat = await stat(join(projectDir, file));
+              return { name: file, mtime: fileStat.mtimeMs };
+            } catch {
+              return null;
             }
+          })
+        );
 
-            // For active sessions (not in index or much newer), read directly
+        // Find the most recent file
+        const validStats = fileStats.filter((s): s is { name: string; mtime: number } => s !== null);
+        const latestFile = validStats.reduce<{ name: string; mtime: number } | null>(
+          (latest, current) => (!latest || current.mtime > latest.mtime) ? current : latest,
+          null
+        );
+
+        // Read the index to get cached info
+        let index: SessionsIndex | null = null;
+        try {
+          const content = await readFile(indexPath, 'utf-8');
+          index = JSON.parse(content);
+        } catch {
+          // Index doesn't exist or is invalid
+        }
+
+        // Check if the latest file is newer than what's in the index
+        if (latestFile) {
+          const sessionId = latestFile.name.replace('.jsonl', '');
+          const indexEntry = index?.entries?.find(e => e.sessionId === sessionId);
+
+          // If this file is in the index and not much newer, use cached data
+          // But always check waiting state for accuracy
+          if (indexEntry && (latestFile.mtime - (indexEntry.fileMtime || 0)) < 60000) {
             const filePath = join(projectDir, latestFile.name);
-            const [firstPrompt, lastUserMessage, waitingToolName, firstMessageId, lastRecap] = await Promise.all([
-              this.readFirstPromptFromFile(filePath),
-              this.readLastUserMessage(filePath),
+            const [waitingToolName, lastUserMessage, firstMessageId, lastRecap] = await Promise.all([
               this.checkWaitingState(filePath),
+              this.readLastUserMessage(filePath),
               this.readFirstMessageId(filePath),
               this.readLastRecap(filePath),
             ]);
 
             return {
-              sessionId,
-              summary: lastUserMessage || indexEntry?.summary,
-              firstPrompt: firstPrompt || indexEntry?.firstPrompt,
-              messageCount: indexEntry?.messageCount,
-              modified: new Date(latestFile.mtime).toISOString(),
-              gitBranch: indexEntry?.gitBranch,
-              projectPath: indexEntry?.projectPath,
+              sessionId: indexEntry.sessionId,
+              summary: lastUserMessage || indexEntry.summary,
+              firstPrompt: indexEntry.firstPrompt,
+              messageCount: indexEntry.messageCount,
+              modified: indexEntry.modified,
+              gitBranch: indexEntry.gitBranch,
+              projectPath: indexEntry.projectPath,
 
               waitingToolName: waitingToolName || undefined,
               firstMessageId: firstMessageId || undefined,
@@ -778,33 +753,52 @@ export class ClaudeCodeService {
             };
           }
 
-          // Fallback to index-only data
-          if (index?.entries && index.entries.length > 0) {
-            const sortedEntries = [...index.entries].sort((a, b) => {
-              const aTime = a.fileMtime || 0;
-              const bTime = b.fileMtime || 0;
-              return bTime - aTime;
-            });
+          // For active sessions (not in index or much newer), read directly
+          const filePath = join(projectDir, latestFile.name);
+          const [firstPrompt, lastUserMessage, waitingToolName, firstMessageId, lastRecap] = await Promise.all([
+            this.readFirstPromptFromFile(filePath),
+            this.readLastUserMessage(filePath),
+            this.checkWaitingState(filePath),
+            this.readFirstMessageId(filePath),
+            this.readLastRecap(filePath),
+          ]);
 
-            const latest = sortedEntries[0];
-            return {
-              sessionId: latest.sessionId,
-              summary: latest.summary,
-              firstPrompt: latest.firstPrompt,
-              messageCount: latest.messageCount,
-              modified: latest.modified,
-              gitBranch: latest.gitBranch,
-              projectPath: latest.projectPath,
-            };
-          }
-        } catch {
-          // Index doesn't exist for this path, try parent
+          return {
+            sessionId,
+            summary: lastUserMessage || indexEntry?.summary,
+            firstPrompt: firstPrompt || indexEntry?.firstPrompt,
+            messageCount: indexEntry?.messageCount,
+            modified: new Date(latestFile.mtime).toISOString(),
+            gitBranch: indexEntry?.gitBranch,
+            projectPath: indexEntry?.projectPath,
+
+            waitingToolName: waitingToolName || undefined,
+            firstMessageId: firstMessageId || undefined,
+            lastRecap: lastRecap || undefined,
+          };
         }
 
-        // Move to parent directory
-        const parentPath = currentPath.substring(0, currentPath.lastIndexOf('/'));
-        if (parentPath === currentPath) break;
-        currentPath = parentPath || '/';
+        // Fallback to index-only data
+        if (index?.entries && index.entries.length > 0) {
+          const sortedEntries = [...index.entries].sort((a, b) => {
+            const aTime = a.fileMtime || 0;
+            const bTime = b.fileMtime || 0;
+            return bTime - aTime;
+          });
+
+          const latest = sortedEntries[0];
+          return {
+            sessionId: latest.sessionId,
+            summary: latest.summary,
+            firstPrompt: latest.firstPrompt,
+            messageCount: latest.messageCount,
+            modified: latest.modified,
+            gitBranch: latest.gitBranch,
+            projectPath: latest.projectPath,
+          };
+        }
+      } catch {
+        // Project dir does not exist for this workingDir — return null.
       }
 
       return null;
@@ -849,76 +843,66 @@ export class ClaudeCodeService {
     const sessions: ClaudeCodeSession[] = [];
 
     try {
-      let currentPath = workingDir;
+      // Exact path only — same reason as getSessionForPathUncached: parent
+      // traversal contaminates deeper panes with ancestor project sessions.
+      const projectName = this.pathToProjectName(workingDir);
+      const projectDir = join(this.claudeDir, projectName);
 
-      while (currentPath && currentPath !== '/') {
-        const projectName = this.pathToProjectName(currentPath);
-        const projectDir = join(this.claudeDir, projectName);
+      try {
+        const files = await readdir(projectDir);
+        const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
 
-        try {
-          const files = await readdir(projectDir);
-          const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
+        // Get stats for all files
+        const fileStats = await Promise.all(
+          jsonlFiles.map(async (file) => {
+            try {
+              const fileStat = await stat(join(projectDir, file));
+              return { name: file, mtime: fileStat.mtimeMs };
+            } catch {
+              return null;
+            }
+          })
+        );
 
-          // Get stats for all files
-          const fileStats = await Promise.all(
-            jsonlFiles.map(async (file) => {
-              try {
-                const fileStat = await stat(join(projectDir, file));
-                return { name: file, mtime: fileStat.mtimeMs };
-              } catch {
-                return null;
-              }
-            })
-          );
+        // Sort by mtime descending and take top N
+        const validStats = fileStats
+          .filter((s): s is { name: string; mtime: number } => s !== null)
+          .sort((a, b) => b.mtime - a.mtime)
+          .slice(0, count);
 
-          // Sort by mtime descending and take top N
-          const validStats = fileStats
-            .filter((s): s is { name: string; mtime: number } => s !== null)
-            .sort((a, b) => b.mtime - a.mtime)
-            .slice(0, count);
+        // Read session info for each file (in parallel)
+        const sessionResults = await Promise.all(
+          validStats.map(async (fileStat) => {
+            const sessionId = fileStat.name.replace('.jsonl', '');
+            const filePath = join(projectDir, fileStat.name);
 
-          // Read session info for each file (in parallel)
-          const sessionResults = await Promise.all(
-            validStats.map(async (fileStat) => {
-              const sessionId = fileStat.name.replace('.jsonl', '');
-              const filePath = join(projectDir, fileStat.name);
+            const [firstPrompt, lastUserMessage, waitingToolName, firstMessageId, lastRecap] = await Promise.all([
+              this.readFirstPromptFromFile(filePath),
+              this.readLastUserMessage(filePath),
+              this.checkWaitingState(filePath),
+              this.readFirstMessageId(filePath),
+              this.readLastRecap(filePath),
+            ]);
 
-              const [firstPrompt, lastUserMessage, waitingToolName, firstMessageId, lastRecap] = await Promise.all([
-                this.readFirstPromptFromFile(filePath),
-                this.readLastUserMessage(filePath),
-                this.checkWaitingState(filePath),
-                this.readFirstMessageId(filePath),
-                this.readLastRecap(filePath),
-              ]);
+            return {
+              sessionId,
+              summary: lastUserMessage || undefined,
+              firstPrompt: firstPrompt || undefined,
+              modified: new Date(fileStat.mtime).toISOString(),
+              projectPath: workingDir,
 
-              return {
-                sessionId,
-                summary: lastUserMessage || undefined,
-                firstPrompt: firstPrompt || undefined,
-                modified: new Date(fileStat.mtime).toISOString(),
-                projectPath: currentPath,
-
-                waitingToolName: waitingToolName || undefined,
-                firstMessageId: firstMessageId || undefined,
-                lastRecap: lastRecap || undefined,
-              };
-            })
-          );
-          sessions.push(...sessionResults);
-
-          if (sessions.length >= count) {
-            return sessions.slice(0, count);
-          }
-        } catch {
-          // Try parent directory
-        }
-
-        const parentPath = currentPath.substring(0, currentPath.lastIndexOf('/'));
-        if (parentPath === currentPath) break;
-        currentPath = parentPath || '/';
+              waitingToolName: waitingToolName || undefined,
+              firstMessageId: firstMessageId || undefined,
+              lastRecap: lastRecap || undefined,
+            };
+          })
+        );
+        sessions.push(...sessionResults);
+      } catch {
+        // Project dir does not exist for this workingDir.
       }
 
-      return sessions;
+      return sessions.slice(0, count);
     } catch {
       return sessions;
     }


### PR DESCRIPTION
## Summary

- `getSessionForPath` / `getRecentSessionsForPath` の親ディレクトリ遡上を削除
- 自身の project dir に jsonl が無い場合に祖先 (e.g. `/Users/m0a`) の最新 session が漏洩していた
- 結果として複数の tmux pane が同じ `ccSessionId` / `ccRecap` / `ccFirstPrompt` を共有してしまうバグの修正
- 親遡上が無くなっても、legitimate なケース (launchd / TZ skew) は `ptySessionId` / `tty-start-time` の経路でカバー済み
- cchub-send Skill にも diagnostic 手順を追記 (`/api/notify/hook-status` 経由で peer の hook 設定確認)

## Test plan

- [x] Linux dev backend (port 3456): 全 session が個別の ccSessionId を返す (修正前と同じ正しい挙動)
- [x] Mac dev backend (port 3457 / fix/session-recap-mismatch checkout): 漏洩なし、m0a のみ正しい session、他は null
- [ ] release → Mac で cchub update → production で再現確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)