### PR TITLE
Release v0.1.149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.149] - 2026-05-22
+
+### Fixed
+- **v0.1.148 で全 tmux session の indicator が常に `completed` のまま動かなくなった退化を修正**: 親遡上削除により `ccSessionId` が null になり、hook event の `session_id` と紐付けできなくなっていた。親遡上は復活させて hook 紐付け用の `ccSessionId` は取得し、漏洩防止のために recap 系 (`ccRecap` / `ccFirstPrompt` / `ccSummary`) は `ccSession.projectPath === currentPath` のときだけ表示するよう分離 (`backend/src/services/claude-code.ts`, `backend/src/routes/sessions.ts`)
+- **`pathToProjectName` が `.` を `-` に置換していなかった問題を修正**: Claude Code 側は `/Users/m0a/repo/github.com/m0a/cc-hub` → `-Users-m0a-repo-github-com-m0a-cc-hub` のように `.` も `-` に変換するが、cchub の `pathToProjectName` は `/` のみ置換していたため、`.` を含む path (`github.com` 等) の project dir を見つけられず親遡上で祖先 (= `/Users/m0a`) のセッションを全 pane に共有してしまっていた。`/` と `.` の両方を置換するよう修正 (`backend/src/services/claude-code.ts`)
+
+### Changed
+- `cchub-send` Skill に複数行 paste の submit 挙動 (`--submit` フラグの末尾 CR2回でも paste mode を抜けないことがある) と、対処手順 (別 send で `\r` を追い打ち / 受信側 pane で `tmux send-keys Enter`) を追記 (`.claude/skills/cchub-send/SKILL.md`)
+
 ## [0.1.148] - 2026-05-22
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.148",
+  "version": "0.1.149",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.148",
+  "version": "0.1.149",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.148",
+  "version": "0.1.149",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: v0.1.148 で動かなくなった indicator 連携を復活 + recap 漏洩は引き続き防止 (#211)
- fix: pathToProjectName が `.` を `-` に置換していなかった問題を修正 (Claude Code 命名規則に合わせる) (#211)

## Notes
- v0.1.148 の親遡上削除で `ccSessionId` が null になり hook event とマッチしなくなった退化を解消
- recap は exact path match の時のみ表示 (`ccSession.projectPath === currentPath`) で漏洩防止を維持
- pathToProjectName 修正により `.` を含む path (`github.com` 等) でも exact match が成功し、sibling pane indicator 同期の副作用も消失
- Mac dev (port 3457) で各 session が個別 ccSessionId / 個別 recap / sibling 漏れなしを確認済
- Linux dev (port 3456) で回帰なしを確認済