### PR TITLE
feat(dashboard): per-peer ServerInfo cards + unique-device count

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -348,10 +348,12 @@ export default {
         }
       }
 
+      const deviceId = url.searchParams.get('deviceId') || undefined;
       const upgraded = server.upgrade(req, {
         data: {
           mux: true,
           visitorId: crypto.randomUUID(),
+          deviceId,
           subscriptions: new Map(),
           conversationWatchers: new Map(),
           lastPingAt: Date.now(),

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -32,10 +32,7 @@ async function getDiskUsage(): Promise<{ total: number; used: number; available:
   }
 }
 
-export const dashboard = new Hono();
-
-// GET /dashboard - Get dashboard data
-dashboard.get('/', async (c) => {
+export async function buildDashboard(): Promise<DashboardResponse> {
   const [usageLimits, codexUsageLimits, dailyActivity, modelUsage, hourlyActivity, usageHistory, systemMetrics, diskUsage] = await Promise.all([
     anthropicUsageService.getUsageLimits(),
     codexUsageService.getUsageLimits(),
@@ -55,12 +52,12 @@ dashboard.get('/', async (c) => {
     );
   }
 
-  const response: DashboardResponse = {
+  return {
     limits: null, // Deprecated
     usageLimits,
     usageLimitsStatus: anthropicUsageService.getStatus(),
     codexUsageLimits,
-    usageHistory: usageHistory,
+    usageHistory,
     dailyActivity,
     modelUsage,
     costEstimates: [],
@@ -70,6 +67,12 @@ dashboard.get('/', async (c) => {
     diskUsage: diskUsage || undefined,
     connectedClients: getConnectedClientCount(),
   };
+}
 
+export const dashboard = new Hono();
+
+// GET /dashboard - Get dashboard data
+dashboard.get('/', async (c) => {
+  const response = await buildDashboard();
   return c.json(response);
 });

--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -29,6 +29,8 @@ import {
 import { loginToPeer, verifyPeer, peerFetch, PeerAuthError } from '../services/peer-auth';
 import { discoverPeers } from '../services/peer-discovery';
 import { buildSessionsList, sessionHistoryService, codexHistoryService } from './sessions';
+import { buildDashboard } from './dashboard';
+import type { DashboardResponse } from '../../../shared/types';
 
 export const peers = new Hono();
 
@@ -393,6 +395,30 @@ peers.post('/:peerId/files/mkdir', async (c) => {
   const data = await res.json().catch(() => ({}));
   if (res.ok) return c.json(data as Record<string, unknown>);
   return c.json(data as Record<string, unknown>, (res.status >= 400 && res.status < 600 ? res.status : 502) as 400 | 404 | 500 | 502);
+});
+
+// GET /api/peers/:peerId/dashboard - peer (or self) の dashboard を返す
+peers.get('/:peerId/dashboard', async (c) => {
+  const peerId = c.req.param('peerId');
+  const peer = (await listPeers()).find(p => p.id === peerId);
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+
+  if (peer.url === SELF_PEER_URL) {
+    const data = await buildDashboard();
+    return c.json(data);
+  }
+
+  try {
+    const res = await peerFetch(peer.id, peer.url, peer.wsToken, '/api/dashboard');
+    if (!res.ok) {
+      return c.json({ error: `HTTP ${res.status}` }, 502);
+    }
+    const data = (await res.json()) as DashboardResponse;
+    return c.json(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Fetch failed';
+    return c.json({ error: message }, 502);
+  }
 });
 
 // GET /api/peers/sessions - 全 peer のセッション一覧をマージして返す

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -48,6 +48,9 @@ interface MuxSubscription {
 export interface MuxData {
   mux: true;
   visitorId: string;
+  /** Stable per-device identifier sent by the client (localStorage UUID).
+   *  Used to count unique devices, falling back to visitorId if absent. */
+  deviceId?: string;
   subscriptions: Map<string, MuxSubscription>;
   conversationWatchers: Map<string, ConversationWatcher>;
   lastPingAt: number;
@@ -122,7 +125,14 @@ export function pushSessionsNow() {
 }
 
 export function getConnectedClientCount(): number {
-  return activeMuxConnections.size;
+  // Count unique devices, not raw WebSocket connections.
+  // A client without a deviceId (very old client / direct WS test) falls back
+  // to its per-connection visitorId so it still counts as one.
+  const devices = new Set<string>();
+  for (const ws of activeMuxConnections) {
+    devices.add(ws.data.deviceId ?? ws.data.visitorId);
+  }
+  return devices.size;
 }
 
 export function broadcastToMuxClients(msg: Record<string, unknown>) {

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,7 +1,8 @@
 import { Globe, Moon, Sun } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDashboard } from "../../hooks/useDashboard";
+import { usePeers } from "../../hooks/usePeers";
 import { useTheme } from "../../hooks/useTheme";
 import { useUiScale } from "../../hooks/useUiScale";
 import { nukeClientCache } from "../../utils/nuke-cache";
@@ -9,7 +10,7 @@ import { DailyUsageChart } from "./DailyUsageChart";
 import { HourlyHeatmap } from "./HourlyHeatmap";
 import { ModelUsageChart } from "./ModelUsageChart";
 import { NetworkLatency } from "./NetworkLatency";
-import { ServerInfo } from "./ServerInfo";
+import { PeerServerCard } from "./PeerServerCard";
 import { UsageLimits } from "./UsageLimits";
 
 // Onboarding localStorage keys
@@ -25,6 +26,11 @@ type AgentTab = "claude" | "codex";
 
 export function Dashboard({ className = "", compact = false }: DashboardProps) {
 	const { t, i18n } = useTranslation();
+	const { peers } = usePeers();
+	const sortedPeers = useMemo(
+		() => [...peers].sort((a, b) => a.order - b.order),
+		[peers],
+	);
 	const { data, isLoading, error } = useDashboard(30000);
 	const { theme, toggleTheme } = useTheme();
 	const {
@@ -157,13 +163,9 @@ export function Dashboard({ className = "", compact = false }: DashboardProps) {
 					<div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
 						<NetworkLatency />
 					</div>
-					<div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
-						<ServerInfo
-							systemMetrics={data?.systemMetrics}
-							diskUsage={data?.diskUsage}
-							connectedClients={data?.connectedClients}
-						/>
-					</div>
+					{sortedPeers.map((peer) => (
+						<PeerServerCard key={peer.id} peer={peer} />
+					))}
 					<div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
 						<UsageLimits
 							data={data?.usageLimits || null}

--- a/frontend/src/components/dashboard/PeerServerCard.tsx
+++ b/frontend/src/components/dashboard/PeerServerCard.tsx
@@ -1,0 +1,49 @@
+import type { PeerClientView } from "../../../../shared/types";
+import { LOCAL_PEER_ID } from "../../../../shared/types";
+import { usePeerServerMetrics } from "../../hooks/usePeerServerMetrics";
+import { ServerInfo } from "./ServerInfo";
+
+interface PeerServerCardProps {
+	peer: PeerClientView;
+}
+
+/**
+ * Wraps ServerInfo so each peer's CPU / memory / disk panel is driven by its
+ * own polling hook. Throughput is local-only (it tracks this browser's WS
+ * bytes), so it's only shown on the local peer card.
+ */
+export function PeerServerCard({ peer }: PeerServerCardProps) {
+	const isLocal = peer.id === LOCAL_PEER_ID;
+	const { systemMetrics, diskUsage, connectedClients, error } =
+		usePeerServerMetrics(peer.id);
+
+	return (
+		<div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06]">
+			<div className="flex items-center gap-1.5 mb-2">
+				<span
+					aria-hidden="true"
+					className="w-2 h-2 rounded-full shrink-0"
+					style={{ backgroundColor: peer.color }}
+				/>
+				<span className="text-[11px] text-th-text-muted truncate">
+					{peer.nickname}
+				</span>
+				{error && (
+					<span
+						className="text-[10px] text-amber-400 ml-auto truncate"
+						title={error}
+					>
+						offline
+					</span>
+				)}
+			</div>
+			<ServerInfo
+				systemMetrics={systemMetrics}
+				diskUsage={diskUsage}
+				connectedClients={connectedClients}
+				label={peer.nickname}
+				hideThroughput={!isLocal}
+			/>
+		</div>
+	);
+}

--- a/frontend/src/components/dashboard/ServerInfo.tsx
+++ b/frontend/src/components/dashboard/ServerInfo.tsx
@@ -207,6 +207,10 @@ interface ServerInfoProps {
 		mountpoint: string;
 	};
 	connectedClients?: number;
+	/** Label for the panel header; defaults to "Server". */
+	label?: string;
+	/** Hide the throughput chart (it tracks this browser's WS bytes, not the peer's). */
+	hideThroughput?: boolean;
 }
 
 // Throughput history (kept in module scope so it persists across re-renders)
@@ -238,12 +242,15 @@ export function ServerInfo({
 	systemMetrics,
 	diskUsage,
 	connectedClients,
+	label,
+	hideThroughput = false,
 }: ServerInfoProps) {
 	const isLight = useIsLightMode();
 
 	const [throughput, setThroughput] = useState(0);
 	const [, forceUpdate] = useState(0);
 	useEffect(() => {
+		if (hideThroughput) return;
 		const interval = setInterval(() => {
 			const val = window.__cchub_ws_bytes_per_sec || 0;
 			setThroughput(val);
@@ -257,7 +264,7 @@ export function ServerInfo({
 			forceUpdate((n) => n + 1);
 		}, 1000);
 		return () => clearInterval(interval);
-	}, []);
+	}, [hideThroughput]);
 
 	const getCpu = useMemo(() => (s: SystemMetricsSnapshot) => s.cpuPercent, []);
 	const getMem = useMemo(
@@ -276,7 +283,9 @@ export function ServerInfo({
 	return (
 		<div className="space-y-3">
 			<div className="flex items-center justify-between">
-				<h3 className="text-[13px] font-semibold text-zinc-300">Server</h3>
+				<h3 className="text-[13px] font-semibold text-zinc-300 truncate">
+					{label ?? "Server"}
+				</h3>
 				<div className="flex items-center gap-1.5">
 					<Users className="w-3 h-3 text-teal-400" />
 					<span className="text-[12px] text-teal-400 font-mono tabular-nums">
@@ -323,7 +332,8 @@ export function ServerInfo({
 						/>
 					</div>
 
-					{/* Throughput */}
+					{/* Throughput (local-only — tracks this browser's WS bytes) */}
+					{!hideThroughput && (
 					<div>
 						<div className="flex items-baseline justify-between mb-0.5">
 							<span className="text-[11px] text-zinc-500">Throughput</span>
@@ -391,6 +401,7 @@ export function ServerInfo({
 							</div>
 						)}
 					</div>
+					)}
 				</div>
 			)}
 

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -33,7 +33,6 @@ export function useDashboard(
 			if (!isTransientNetworkError(err)) {
 				setError(err instanceof Error ? err.message : "Unknown error");
 			}
-			// Keep previous data on error (don't setData(null))
 		} finally {
 			setIsLoading(false);
 		}
@@ -42,7 +41,6 @@ export function useDashboard(
 	useEffect(() => {
 		fetchDashboard();
 
-		// Auto-refresh at interval
 		const interval = setInterval(fetchDashboard, refreshInterval);
 		return () => clearInterval(interval);
 	}, [fetchDashboard, refreshInterval]);

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { PaneViewport, TmuxLayoutNode } from "../../../shared/types";
 import { reportWsLatency } from "../services/latency-store";
 import { appendWsToken } from "../services/peer-ws";
+import { getDeviceId } from "../utils/device-id";
 
 interface UseMultiplexedTerminalOptions {
 	sessionId: string;
@@ -207,7 +208,9 @@ function ensureConnection(token?: string | null, wsBase?: string | null) {
 		sharedConnectWatchdog = null;
 	}
 
-	const wsUrl = appendWsToken(`${desiredBase}/ws/mux`, desiredToken);
+	const baseWsUrl = appendWsToken(`${desiredBase}/ws/mux`, desiredToken);
+	const sep = baseWsUrl.includes("?") ? "&" : "?";
+	const wsUrl = `${baseWsUrl}${sep}deviceId=${encodeURIComponent(getDeviceId())}`;
 
 	const ws = new WebSocket(wsUrl);
 	sharedWs = ws;

--- a/frontend/src/hooks/usePeerServerMetrics.ts
+++ b/frontend/src/hooks/usePeerServerMetrics.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react";
+import type { DashboardResponse } from "../../../shared/types";
+import { authFetch, isTransientNetworkError } from "../services/api";
+
+const API_BASE = import.meta.env.VITE_API_URL || "";
+
+export interface PeerServerMetrics {
+	systemMetrics?: DashboardResponse["systemMetrics"];
+	diskUsage?: DashboardResponse["diskUsage"];
+	connectedClients?: number;
+}
+
+interface UsePeerServerMetricsReturn extends PeerServerMetrics {
+	isLoading: boolean;
+	error: string | null;
+	refetch: () => Promise<void>;
+}
+
+/**
+ * Fetch the server-info slice of a peer's dashboard payload
+ * (systemMetrics / diskUsage / connectedClients) on a polling interval.
+ * Other dashboard fields (usage limits, daily activity, etc.) are intentionally
+ * ignored — those live in the local-only top-level dashboard.
+ */
+export function usePeerServerMetrics(
+	peerId: string,
+	refreshInterval: number = 30000,
+): UsePeerServerMetricsReturn {
+	const [metrics, setMetrics] = useState<PeerServerMetrics>({});
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const fetchMetrics = useCallback(async () => {
+		try {
+			const url = `${API_BASE}/api/peers/${encodeURIComponent(peerId)}/dashboard`;
+			const response = await authFetch(url);
+			if (!response.ok) {
+				throw new Error(`HTTP ${response.status}`);
+			}
+			const data = (await response.json()) as DashboardResponse;
+			setMetrics({
+				systemMetrics: data.systemMetrics,
+				diskUsage: data.diskUsage,
+				connectedClients: data.connectedClients,
+			});
+			setError(null);
+		} catch (err) {
+			if (!isTransientNetworkError(err)) {
+				setError(err instanceof Error ? err.message : "Unknown error");
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	}, [peerId]);
+
+	useEffect(() => {
+		setIsLoading(true);
+		fetchMetrics();
+		const interval = setInterval(fetchMetrics, refreshInterval);
+		return () => clearInterval(interval);
+	}, [fetchMetrics, refreshInterval]);
+
+	return {
+		...metrics,
+		isLoading,
+		error,
+		refetch: fetchMetrics,
+	};
+}

--- a/frontend/src/utils/device-id.ts
+++ b/frontend/src/utils/device-id.ts
@@ -1,0 +1,31 @@
+/**
+ * Stable per-device identifier.
+ *
+ * Generated once on first load and persisted in `localStorage`. Used by the
+ * mux WebSocket to let the server count unique devices instead of raw socket
+ * connections (so multiple tabs on the same browser count as one).
+ */
+
+const STORAGE_KEY = "cchub-device-id";
+
+export function getDeviceId(): string {
+	try {
+		const existing = localStorage.getItem(STORAGE_KEY);
+		if (existing) return existing;
+	} catch {
+		// localStorage unavailable (private mode, etc.) — fall through to a
+		// session-scoped fallback so the connection still has a deviceId.
+	}
+
+	const fresh =
+		typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+			? crypto.randomUUID()
+			: `d_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+
+	try {
+		localStorage.setItem(STORAGE_KEY, fresh);
+	} catch {
+		// non-persistent — still return the value for this session
+	}
+	return fresh;
+}


### PR DESCRIPTION
## Summary
- Each registered peer (Local + remote) now gets its own ServerInfo card on the dashboard, polling `/api/peers/:peerId/dashboard` so CPU / memory / disk reflect the peer machine.
- Throughput tracks this browser's WS bytes, so it's shown only on the local card; remote cards hide it.
- Connected-client badge counts **unique devices** instead of raw WebSocket connections — the frontend persists a UUID in `localStorage` and sends it on the mux WS as `?deviceId=...`; backend dedupes by deviceId.

## Test plan
- [x] Verified two distinct ServerInfo cards (Local + mac peer) populate independently via Tailscale-connected mac
- [x] Multi-tab in same browser → counts as 1 device
- [x] Distinct deviceIds via test WS clients → count increments per unique deviceId, returns to baseline on disconnect
- [x] `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)