### PR TITLE
Release v0.1.150

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.150] - 2026-05-22
+
+### Added
+- **ダッシュボードのマルチサーバー対応**: 登録された peer ごとに `ServerInfo` カードを並べて、各 peer の CPU / Memory / Disk / Swap / Load を独立にポーリング表示する。新規 hook `usePeerServerMetrics` が `/api/peers/:peerId/dashboard` を 30 秒間隔で叩く。Throughput はブラウザの WS バイト数を見ているので Local カードのみで表示し、remote カードでは抑制する (`frontend/src/components/dashboard/PeerServerCard.tsx`, `frontend/src/hooks/usePeerServerMetrics.ts`, `backend/src/routes/peers.ts`, `backend/src/routes/dashboard.ts`)
+
+### Changed
+- **接続端末数をユニーク化**: `connectedClients` バッジが従来は WebSocket 接続数 (= 同じブラウザの複数タブ・再接続も別カウント) を返していた。フロントが `localStorage` に永続 UUID を保存して mux WS の URL に `?deviceId=...` で送信し、backend は deviceId 単位でユニーク化した数を返すよう変更。1 端末から複数タブを開いても 1 カウント、別端末/別ブラウザは別カウントになる (`frontend/src/utils/device-id.ts`, `frontend/src/hooks/useMultiplexedTerminal.ts`, `backend/src/index.ts`, `backend/src/routes/terminal-mux.ts`)
+
 ## [0.1.149] - 2026-05-22
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.149",
+  "version": "0.1.150",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.149",
+  "version": "0.1.150",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.149",
+  "version": "0.1.150",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- feat(dashboard): per-peer ServerInfo cards — 各 peer の CPU / Memory / Disk / Swap / Load を独立にポーリング表示
- chore(mux): connected-clients を端末単位（localStorage UUID + deviceId）でユニーク化

## Notes
- 同じブラウザの複数タブ・再接続は 1 端末としてカウント
- Throughput はブラウザ局所値のため Local カードのみで表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)