### PR TITLE
feat(upload): route image uploads to the peer that owns the active session

### DIFF
--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -30,6 +30,7 @@ import { loginToPeer, verifyPeer, peerFetch, PeerAuthError } from '../services/p
 import { discoverPeers } from '../services/peer-discovery';
 import { buildSessionsList, sessionHistoryService, codexHistoryService } from './sessions';
 import { buildDashboard } from './dashboard';
+import { saveUploadedImage } from './upload';
 import type { DashboardResponse } from '../../../shared/types';
 
 export const peers = new Hono();
@@ -395,6 +396,66 @@ peers.post('/:peerId/files/mkdir', async (c) => {
   const data = await res.json().catch(() => ({}));
   if (res.ok) return c.json(data as Record<string, unknown>);
   return c.json(data as Record<string, unknown>, (res.status >= 400 && res.status < 600 ? res.status : 502) as 400 | 404 | 500 | 502);
+});
+
+// POST /api/peers/:peerId/upload/image
+// 画像アップロードを peer 側に転送し、peer のローカル絶対パスを返す。
+// peer 上で動いている Claude Code が、そのパスを直接読めるようにするため必須。
+peers.post('/:peerId/upload/image', async (c) => {
+  const peerId = c.req.param('peerId');
+  const peer = (await listPeers()).find(p => p.id === peerId);
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+
+  // ── local: ハブ自身に保存
+  if (peer.url === SELF_PEER_URL) {
+    try {
+      const formData = await c.req.formData();
+      const file = formData.get('image');
+      if (!file || !(file instanceof File)) {
+        return c.json({ error: 'No image file provided' }, 400);
+      }
+      const result = await saveUploadedImage(file);
+      return c.json({ success: true, ...result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to upload image';
+      const status = /Invalid file type|too large/.test(message) ? 400 : 500;
+      if (status === 500) console.error('Upload error (self):', err);
+      return c.json({ error: message }, status);
+    }
+  }
+
+  // ── remote: peer の /api/upload/image に multipart を中継
+  let incoming: FormData;
+  try {
+    incoming = await c.req.formData();
+  } catch {
+    return c.json({ error: 'Invalid multipart body' }, 400);
+  }
+  const file = incoming.get('image');
+  if (!file || !(file instanceof File)) {
+    return c.json({ error: 'No image file provided' }, 400);
+  }
+
+  // 新しい FormData に詰め直して peer に転送 (元の FormData をそのまま fetch
+  // body に渡すと boundary 制御が安定しないことがあるため)
+  const outgoing = new FormData();
+  outgoing.append('image', file, file.name);
+
+  try {
+    const res = await peerFetch(peer.id, peer.url, peer.wsToken, '/api/upload/image', {
+      method: 'POST',
+      body: outgoing,
+    });
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!res.ok) {
+      const status = (res.status >= 400 && res.status < 600 ? res.status : 502) as 400 | 401 | 404 | 500 | 502;
+      return c.json(data, status);
+    }
+    return c.json(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Upload to peer failed';
+    return c.json({ error: message }, 502);
+  }
 });
 
 // GET /api/peers/:peerId/dashboard - peer (or self) の dashboard を返す

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -5,19 +5,17 @@ import { join } from 'node:path';
 
 const upload = new Hono();
 
-// Directory for uploaded images (accessible from terminal sessions)
+// Directory for uploaded images (accessible from terminal sessions on this host)
 const UPLOAD_DIR = '/tmp/cchub-images';
 
-// Ensure upload directory exists
 async function ensureUploadDir() {
   try {
     await mkdir(UPLOAD_DIR, { recursive: true });
   } catch {
-    // Directory might already exist
+    // already exists
   }
 }
 
-// Generate unique filename
 function generateFilename(originalName: string): string {
   const ext = originalName.split('.').pop()?.toLowerCase() || 'png';
   const id = randomBytes(8).toString('hex');
@@ -25,11 +23,39 @@ function generateFilename(originalName: string): string {
   return `${timestamp}-${id}.${ext}`;
 }
 
-// Upload image
+const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+const MAX_SIZE = 10 * 1024 * 1024;
+
+export interface UploadedImage {
+  path: string;
+  filename: string;
+}
+
+/**
+ * Persist an uploaded image file to this host's UPLOAD_DIR.
+ * Returns a host-local absolute path that the local agent (Claude Code etc.)
+ * can read directly.
+ */
+export async function saveUploadedImage(file: File): Promise<UploadedImage> {
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    throw new Error('Invalid file type. Allowed: PNG, JPEG, GIF, WebP');
+  }
+  if (file.size > MAX_SIZE) {
+    throw new Error('File too large. Max 10MB');
+  }
+
+  await ensureUploadDir();
+
+  const filename = generateFilename(file.name);
+  const filepath = join(UPLOAD_DIR, filename);
+  const buffer = await file.arrayBuffer();
+  await writeFile(filepath, Buffer.from(buffer));
+
+  return { path: filepath, filename };
+}
+
 upload.post('/image', async (c) => {
   try {
-    await ensureUploadDir();
-
     const formData = await c.req.formData();
     const file = formData.get('image');
 
@@ -37,33 +63,13 @@ upload.post('/image', async (c) => {
       return c.json({ error: 'No image file provided' }, 400);
     }
 
-    // Validate file type
-    const allowedTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
-    if (!allowedTypes.includes(file.type)) {
-      return c.json({ error: 'Invalid file type. Allowed: PNG, JPEG, GIF, WebP' }, 400);
-    }
-
-    // Validate file size (max 10MB)
-    const maxSize = 10 * 1024 * 1024;
-    if (file.size > maxSize) {
-      return c.json({ error: 'File too large. Max 10MB' }, 400);
-    }
-
-    // Generate filename and save
-    const filename = generateFilename(file.name);
-    const filepath = join(UPLOAD_DIR, filename);
-
-    const buffer = await file.arrayBuffer();
-    await writeFile(filepath, Buffer.from(buffer));
-
-    return c.json({
-      success: true,
-      path: filepath,
-      filename,
-    });
+    const result = await saveUploadedImage(file);
+    return c.json({ success: true, ...result });
   } catch (err) {
-    console.error('Upload error:', err);
-    return c.json({ error: 'Failed to upload image' }, 500);
+    const message = err instanceof Error ? err.message : 'Failed to upload image';
+    const status = /Invalid file type|too large/.test(message) ? 400 : 500;
+    if (status === 500) console.error('Upload error:', err);
+    return c.json({ error: message }, status);
   }
 });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -102,6 +102,8 @@ interface OpenSession {
 	theme?: SessionTheme;
 	panes?: PaneInfo[];
 	indicatorState?: IndicatorState;
+	// Multi-server: the peer this session lives on. Unset = local Hub.
+	peerId?: string;
 }
 
 function apiToOpenSession(s: ExtendedSessionResponse): OpenSession {
@@ -117,6 +119,7 @@ function apiToOpenSession(s: ExtendedSessionResponse): OpenSession {
 		theme: s.theme,
 		panes: s.panes,
 		indicatorState: s.indicatorState,
+		peerId: s.peerId,
 	};
 }
 

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -26,6 +26,7 @@ import {
 } from "../hooks/useSessions";
 import { authFetch } from "../services/api";
 import { fireHookNotification } from "../utils/hookNotification";
+import { uploadImage } from "../utils/upload-image";
 import { makePseudoViewport } from "../utils/viewport-pseudo";
 import { DashboardPanel } from "./DashboardPanel";
 import { FloatingKeyboard, type FloatingKeyboardRef } from "./FloatingKeyboard";
@@ -48,6 +49,8 @@ interface OpenSession {
 	currentPath?: string;
 	ccSessionId?: string;
 	theme?: SessionTheme;
+	// Multi-server: peer this session belongs to. Unset = local Hub.
+	peerId?: string;
 }
 
 interface DesktopState {
@@ -468,6 +471,20 @@ export function DesktopLayout({
 
 	const desktopStateRef = useRef(desktopState);
 	desktopStateRef.current = desktopState;
+	const sessionsRef = useRef(sessions);
+	sessionsRef.current = sessions;
+
+	// Resolve the peer that owns the currently-active pane's session, so
+	// image uploads land on the host whose Claude Code will read them.
+	const getActivePeerId = useCallback((): string | undefined => {
+		const pane = findPaneById(
+			desktopStateRef.current.root,
+			activePaneRef.current,
+		);
+		const sid = pane?.type === "terminal" ? pane.sessionId : null;
+		if (!sid) return undefined;
+		return sessionsRef.current.find((s) => s.id === sid)?.peerId;
+	}, []);
 
 	// Timer for applying exact tmux pane sizes after layout-change
 	const layoutSizeTimerRef = useRef<number | null>(null);
@@ -890,16 +907,12 @@ export function DesktopLayout({
 				const imageType = item.types.find((t) => t.startsWith("image/"));
 				if (imageType) {
 					const blob = await item.getType(imageType);
-					const formData = new FormData();
-					formData.append("image", blob, "clipboard-image.png");
-
-					const response = await authFetch(`${API_BASE}/api/upload/image`, {
-						method: "POST",
-						body: formData,
-					});
-
-					const result = await response.json();
-					if (response.ok && result.path) {
+					const result = await uploadImage(
+						blob,
+						getActivePeerId(),
+						"clipboard-image.png",
+					);
+					if (result.ok && result.path) {
 						const ref = terminalRefs.current?.get(activePaneRef.current);
 						ref?.sendInput(result.path);
 					} else {
@@ -1166,29 +1179,18 @@ export function DesktopLayout({
 			setIsUploading(true);
 
 			try {
-				const formData = new FormData();
-				formData.append("image", file);
-
-				const response = await authFetch(`${API_BASE}/api/upload/image`, {
-					method: "POST",
-					body: formData,
-				});
-
-				const result = await response.json();
-
-				if (response.ok && result.path) {
+				const result = await uploadImage(file, getActivePeerId());
+				if (result.ok && result.path) {
 					const ref = terminalRefs.current?.get(activePaneRef.current);
 					ref?.sendInput(result.path);
 				} else {
 					console.error("Upload failed:", result.error);
 				}
-			} catch (err) {
-				console.error("Upload error:", err);
 			} finally {
 				setIsUploading(false);
 			}
 		},
-		[],
+		[getActivePeerId],
 	);
 
 	const handleUrlExtract = useCallback(() => {

--- a/frontend/src/components/InputBar.tsx
+++ b/frontend/src/components/InputBar.tsx
@@ -15,7 +15,7 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { authFetch } from "../services/api";
+import { uploadImage } from "../utils/upload-image";
 import { Keyboard } from "./Keyboard";
 
 export type InputMode = "hidden" | "shortcuts" | "input";
@@ -34,6 +34,8 @@ interface InputBarProps {
 	onOverlayTap?: () => void;
 	showOverlay?: boolean;
 	hideKeyboard?: boolean;
+	/** Peer this terminal targets; used to route image uploads. Unset = local. */
+	peerId?: string;
 }
 
 export const InputBar = memo(
@@ -48,6 +50,7 @@ export const InputBar = memo(
 			onOverlayTap,
 			showOverlay = true,
 			hideKeyboard,
+			peerId,
 		},
 		ref,
 	) {
@@ -94,8 +97,6 @@ export const InputBar = memo(
 		const inputBarSwipeRef = useRef<{ startX: number; startY: number } | null>(
 			null,
 		);
-
-		const API_BASE = import.meta.env.VITE_API_URL || "";
 
 		// Auto-hide position toggle
 		const resetPositionToggleTimer = useCallback(() => {
@@ -170,14 +171,8 @@ export const InputBar = memo(
 			e.target.value = "";
 			setIsUploading(true);
 			try {
-				const formData = new FormData();
-				formData.append("image", file);
-				const response = await authFetch(`${API_BASE}/api/upload/image`, {
-					method: "POST",
-					body: formData,
-				});
-				const result = await response.json();
-				if (response.ok && result.path) {
+				const result = await uploadImage(file, peerId);
+				if (result.ok && result.path) {
 					sendRef.current(result.path);
 				} else {
 					console.error("Upload failed:", result.error);
@@ -185,9 +180,6 @@ export const InputBar = memo(
 						`\r\n[Upload error: ${result.error || "Unknown error"}]\r\n`,
 					);
 				}
-			} catch (err) {
-				console.error("Upload error:", err);
-				sendRef.current("\r\n[Upload error: Network error]\r\n");
 			} finally {
 				setIsUploading(false);
 			}

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -40,6 +40,8 @@ interface ExtendedSession {
 	currentCommand?: string;
 	theme?: SessionTheme;
 	panes?: PaneInfo[];
+	// Multi-server: peer this session lives on. Unset = local Hub.
+	peerId?: string;
 }
 
 // Control mode context passed through the pane tree
@@ -656,6 +658,7 @@ function TerminalPane({
 							key={`${sessionId}-${reloadKey}-${globalReloadKey}`}
 							ref={terminalRef}
 							sessionId={sessionId}
+							peerId={session?.peerId}
 							hideKeyboard={true}
 							onConnect={handleConnect}
 							onDisconnect={handleDisconnect}

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -76,6 +76,9 @@ export interface ControlModeConfig {
 
 interface TerminalProps {
 	sessionId: string;
+	/** Peer this session belongs to. Routes image uploads to the right host
+	 *  so the Claude Code instance can actually read the file. */
+	peerId?: string;
 	onConnect?: () => void;
 	onDisconnect?: () => void;
 	onError?: (error: string) => void;
@@ -116,6 +119,7 @@ export const TerminalComponent = memo(
 	forwardRef<TerminalRef, TerminalProps>(function TerminalComponent(
 		{
 			sessionId,
+			peerId,
 			onConnect,
 			onDisconnect,
 			onError,
@@ -1428,6 +1432,7 @@ export const TerminalComponent = memo(
 					onOverlayTap={onOverlayTap}
 					showOverlay={showOverlay}
 					hideKeyboard={hideKeyboard}
+					peerId={peerId}
 				/>
 
 				{/* Bottom overlay when keyboard is hidden (mobile only) */}

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -108,6 +108,8 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 		const { peers } = usePeers();
 		const { sessions: apiSessions } = useSessions();
 		const peerConn = usePeerConnection(sessionId, apiSessions, peers);
+		// peerId of the session we're rendering; used to route image uploads.
+		const sessionPeerId = apiSessions.find((s) => s.id === sessionId)?.peerId;
 
 		const controlTerminal = useMultiplexedTerminal({
 			sessionId,
@@ -390,6 +392,7 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 					<TerminalComponent
 						ref={ref}
 						sessionId={sessionId}
+						peerId={sessionPeerId}
 						onError={(err) => setError(err)}
 						overlayContent={overlayContent}
 						onOverlayTap={onOverlayTap}

--- a/frontend/src/utils/upload-image.ts
+++ b/frontend/src/utils/upload-image.ts
@@ -1,0 +1,55 @@
+import { LOCAL_PEER_ID } from "../../../shared/types";
+import { authFetch } from "../services/api";
+
+const API_BASE = import.meta.env.VITE_API_URL || "";
+
+export interface UploadImageResult {
+	ok: boolean;
+	/** Path on the host that owns the destination Claude Code session.
+	 *  This is what we send into the tmux pane. */
+	path?: string;
+	filename?: string;
+	error?: string;
+}
+
+/**
+ * Upload an image and get back a path that the agent on the **same host as
+ * the active session** can read. When `peerId` is local (or unset) the Hub
+ * stores it locally; for remote peers the upload is proxied to that peer so
+ * the file lands on the peer's disk.
+ */
+export async function uploadImage(
+	file: File | Blob,
+	peerId?: string,
+	filenameHint = "image.png",
+): Promise<UploadImageResult> {
+	const formData = new FormData();
+	if (file instanceof File) {
+		formData.append("image", file);
+	} else {
+		formData.append("image", file, filenameHint);
+	}
+
+	const isRemote = peerId && peerId !== LOCAL_PEER_ID;
+	const url = isRemote
+		? `${API_BASE}/api/peers/${encodeURIComponent(peerId)}/upload/image`
+		: `${API_BASE}/api/upload/image`;
+
+	try {
+		const response = await authFetch(url, { method: "POST", body: formData });
+		const json = (await response.json().catch(() => ({}))) as {
+			path?: string;
+			filename?: string;
+			error?: string;
+		};
+		if (!response.ok || !json.path) {
+			return { ok: false, error: json.error ?? `HTTP ${response.status}` };
+		}
+		return { ok: true, path: json.path, filename: json.filename };
+	} catch (err) {
+		return {
+			ok: false,
+			error: err instanceof Error ? err.message : "Network error",
+		};
+	}
+}


### PR DESCRIPTION
## Summary
- Image uploads used to always save to the Hub's `/tmp/cchub-images/`, then send that Hub-local path into the focused tmux pane. For panes running on a **remote peer**, the peer's Claude Code can't read a Hub path, so the upload was effectively broken in multi-server setups.
- New backend route `POST /api/peers/:peerId/upload/image` proxies multipart uploads to the peer's own `/api/upload/image`, so the file lands on the peer's disk and the returned path is valid on that host.
- Frontend `utils/upload-image.ts` helper picks the right URL based on the active pane's session peerId. `OpenSession` / `ExtendedSession` / `Terminal` / `InputBar` carry `peerId` so the focused pane drives the upload target. `DesktopLayout` uses a small ref-backed `getActivePeerId()` for paste-image and file-pick.
- `backend/src/routes/upload.ts` extracted `saveUploadedImage()` for re-use by the peer proxy.

## Test plan
- [x] `bun run lint` clean
- [x] `POST /api/peers/local/upload/image` saves file to local `/tmp/cchub-images/` (verified by `ls`)
- [x] `POST /api/peers/p_<mac>/upload/image` returns success with a peer-local path; multipart proxied through `peerFetch` over Tailscale
- [ ] Manual UI: drop/paste image into a local pane → goes to Hub; into a mac peer pane → goes to mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)