### PR TITLE
Release v0.1.151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.151] - 2026-05-22
+
+### Fixed
+- **画像添付がリモート peer のセッションで動かなかった問題を修正**: 画像 upload は常に Hub の `/tmp/cchub-images/` に保存して、その path を tmux pane に送る作りだった。pane が remote peer 上の Claude Code につながっていると、peer 側からは Hub のディスクが見えないので「ファイルが見つかりません」になっていた。新規 `POST /api/peers/:peerId/upload/image` を追加してアクティブな pane が属する peer に multipart を proxy 転送し、peer 側の `/tmp/cchub-images/` に保存して peer-local な path を返すよう変更。フォーカス中の pane の peerId を `useSessions` → `OpenSession` → `Terminal` → `InputBar` の経路で伝搬し、`DesktopLayout` の paste / file pick、および mobile path (`TerminalPage`) の Terminal にも peerId を渡すよう揃えた (`backend/src/routes/peers.ts`, `backend/src/routes/upload.ts`, `frontend/src/utils/upload-image.ts`, `frontend/src/components/InputBar.tsx`, `frontend/src/components/Terminal.tsx`, `frontend/src/components/DesktopLayout.tsx`, `frontend/src/pages/TerminalPage.tsx`)
+
 ## [0.1.150] - 2026-05-22
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.150",
+  "version": "0.1.151",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.150",
+  "version": "0.1.151",
   "generated": "2026-05-22",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.150",
+  "version": "0.1.151",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(upload): route image attachments to the peer that owns the active session — fixes "file not found" when uploading from a remote-peer session

## Notes
- Adds `POST /api/peers/:peerId/upload/image` proxy and threads `peerId` from sessions through `Terminal` / `InputBar` and the mobile `TerminalPage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)