### PR TITLE
feat(files): route FileViewer through the peer that owns the files

### DIFF
--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import {
   PeerCreateSchema,
@@ -529,3 +529,76 @@ peers.get('/sessions', async (c) => {
     : { sessions: merged };
   return c.json(response);
 });
+
+// -----------------------------------------------------------------------------
+// Generic Files API proxy
+// -----------------------------------------------------------------------------
+// FileViewer (list / read / raw / changes / git-changes / git-diff / language /
+// download / upload) needs to target the peer that owns the files on disk.
+// The individual /browse and /mkdir proxies above stay as-is — they were added
+// first and have specific shapes. Everything else is forwarded via this
+// catch-all so we don't have to hand-write a route per endpoint.
+//
+// We bypass peerFetch (5s timeout) so that streamed responses such as
+// /files/raw on a large image or video don't get cut off mid-flight.
+
+function normalizePeerBaseUrl(u: string): string {
+  return u.replace(/\/+$/, '');
+}
+
+async function proxyPeerFiles(c: Context): Promise<Response> {
+  const peerId = c.req.param('peerId');
+  const peer = (await listPeers()).find(p => p.id === peerId);
+  if (!peer) return c.json({ error: 'Peer not found' }, 404);
+  if (peer.url === SELF_PEER_URL) {
+    return c.json({ error: 'Use /api/files/* for local peer' }, 400);
+  }
+
+  // /api/peers/:peerId/files/<rest>?<query>  →  peer's /api/files/<rest>?<query>
+  const incoming = new URL(c.req.url);
+  const prefix = `/api/peers/${peerId}/files`;
+  const subpath = incoming.pathname.startsWith(prefix)
+    ? incoming.pathname.slice(prefix.length)
+    : '';
+  const targetPath = `/api/files${subpath}${incoming.search}`;
+
+  const headers = new Headers();
+  if (peer.wsToken) headers.set('Authorization', `Bearer ${peer.wsToken}`);
+  const ct = c.req.header('Content-Type');
+  if (ct) headers.set('Content-Type', ct);
+
+  const init: RequestInit = { method: c.req.method, headers };
+  if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+    init.body = c.req.raw.body;
+    // Bun requires duplex: 'half' when streaming a request body.
+    (init as RequestInit & { duplex?: string }).duplex = 'half';
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${normalizePeerBaseUrl(peer.url)}${targetPath}`, init);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Peer unreachable';
+    return c.json({ error: message }, 502);
+  }
+
+  // Strip hop-by-hop headers but keep Content-Type / Content-Length etc.
+  const respHeaders = new Headers();
+  for (const [k, v] of upstream.headers) {
+    const lk = k.toLowerCase();
+    if (lk === 'connection' || lk === 'transfer-encoding' || lk === 'keep-alive') continue;
+    respHeaders.set(k, v);
+  }
+  return new Response(upstream.body, { status: upstream.status, headers: respHeaders });
+}
+
+peers.all('/:peerId/files/list', proxyPeerFiles);
+peers.all('/:peerId/files/read', proxyPeerFiles);
+peers.all('/:peerId/files/raw', proxyPeerFiles);
+peers.all('/:peerId/files/download', proxyPeerFiles);
+peers.all('/:peerId/files/upload', proxyPeerFiles);
+peers.all('/:peerId/files/language', proxyPeerFiles);
+peers.all('/:peerId/files/changes/:dir', proxyPeerFiles);
+peers.all('/:peerId/files/git-changes/:dir', proxyPeerFiles);
+peers.all('/:peerId/files/git-diff/:dir', proxyPeerFiles);
+peers.all('/:peerId/files/images/:filename', proxyPeerFiles);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -272,8 +272,12 @@ export function App() {
 		null,
 	);
 	const [showOverlay, setShowOverlay] = useState(true);
-	// FileViewer state: per-session instances kept mounted for state preservation
-	const [fileViewerDirs, setFileViewerDirs] = useState<string[]>([]);
+	// FileViewer state: per-session instances kept mounted for state preservation.
+	// `peerId` rides along so the FileViewer hits the host that actually owns the
+	// files (otherwise remote-peer paths return "Access denied" from the Hub).
+	const [fileViewerDirs, setFileViewerDirs] = useState<
+		{ dir: string; peerId?: string }[]
+	>([]);
 	const [activeFileViewerDir, setActiveFileViewerDir] = useState<string | null>(
 		null,
 	);
@@ -281,8 +285,10 @@ export function App() {
 	const [fileViewerOpenDirs, setFileViewerOpenDirs] = useState<Set<string>>(
 		new Set(),
 	);
-	const openFileViewer = useCallback((dir: string) => {
-		setFileViewerDirs((prev) => (prev.includes(dir) ? prev : [...prev, dir]));
+	const openFileViewer = useCallback((dir: string, peerId?: string) => {
+		setFileViewerDirs((prev) =>
+			prev.some((d) => d.dir === dir) ? prev : [...prev, { dir, peerId }],
+		);
 		setActiveFileViewerDir(dir);
 		setFileViewerOpenDirs((prev) => {
 			const next = new Set(prev);
@@ -1002,7 +1008,15 @@ export function App() {
 					))}
 				<button
 					type="button"
-					onClick={() => openFileViewer(activeSession?.currentPath || "/")}
+					onClick={() => {
+						// Resolve peerId from apiSessions as well — when reload restores
+						// activeSessionId for a remote-peer session, openSessions can
+						// momentarily lack the entry while apiSessions already has it.
+						const peerId =
+							activeSession?.peerId ??
+							apiSessions.find((s) => s.id === activeSessionId)?.peerId;
+						openFileViewer(activeSession?.currentPath || "/", peerId);
+					}}
 					className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
 					title="ファイルブラウザ"
 					data-onboarding="file-browser"
@@ -1286,10 +1300,11 @@ export function App() {
 			)}
 
 			{/* File Viewer Modal - per-session instances kept mounted */}
-			{fileViewerDirs.map((dir) => (
+			{fileViewerDirs.map(({ dir, peerId }) => (
 				<FileViewer
 					key={dir}
 					sessionWorkingDir={dir}
+					peerId={peerId}
 					onClose={() => closeFileViewer(dir)}
 					hidden={
 						!fileViewerOpenDirs.has(dir) ||

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -270,7 +270,9 @@ export function DesktopLayout({
 	const { sessions: apiSessions } = useSessions();
 
 	// Merge prop sessions with API sessions to get latest theme info
-	// propSessionsにないセッションもapiSessionsから追加する（分割ペイン用）
+	// propSessionsにないセッションもapiSessionsから追加する（分割ペイン用）。
+	// `peerId` は session が属する host を表す不変属性なので、apiSessions 側を
+	// 真の値として常に採用する (propSession 側は古いキャッシュ/未設定のことがある)。
 	const sessions =
 		apiSessions.length > 0
 			? apiSessions.map((apiSession) => {
@@ -284,6 +286,7 @@ export function DesktopLayout({
 								agent: apiSession.agent,
 								agentSessionId: apiSession.agentSessionId,
 								panes: apiSession.panes,
+								peerId: apiSession.peerId ?? propSession.peerId,
 							}
 						: {
 								id: apiSession.id,
@@ -296,6 +299,7 @@ export function DesktopLayout({
 								currentCommand: apiSession.currentCommand,
 								theme: apiSession.theme,
 								panes: apiSession.panes,
+								peerId: apiSession.peerId,
 							};
 				})
 			: propSessions;

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -299,15 +299,19 @@ export function DesktopLayout({
 							};
 				})
 			: propSessions;
-	const [fileViewerDirs, setFileViewerDirs] = useState<string[]>([]);
+	const [fileViewerDirs, setFileViewerDirs] = useState<
+		{ dir: string; peerId?: string }[]
+	>([]);
 	const [activeFileViewerDir, setActiveFileViewerDir] = useState<string | null>(
 		null,
 	);
 	const [fileViewerOpenDirs, setFileViewerOpenDirs] = useState<Set<string>>(
 		new Set(),
 	);
-	const openFileViewer = useCallback((dir: string) => {
-		setFileViewerDirs((prev) => (prev.includes(dir) ? prev : [...prev, dir]));
+	const openFileViewer = useCallback((dir: string, peerId?: string) => {
+		setFileViewerDirs((prev) =>
+			prev.some((d) => d.dir === dir) ? prev : [...prev, { dir, peerId }],
+		);
 		setActiveFileViewerDir(dir);
 		setFileViewerOpenDirs((prev) => {
 			const next = new Set(prev);
@@ -1397,7 +1401,7 @@ export function DesktopLayout({
 									type="button"
 									onClick={() => {
 										const dir = activeSession?.currentPath;
-										if (dir) openFileViewer(dir);
+										if (dir) openFileViewer(dir, activeSession?.peerId);
 									}}
 									className="p-2 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
 									title="ファイル"
@@ -1506,10 +1510,11 @@ export function DesktopLayout({
 			/>
 
 			{/* File Viewer Modal - per-session instances kept mounted */}
-			{fileViewerDirs.map((dir) => (
+			{fileViewerDirs.map(({ dir, peerId }) => (
 				<FileViewer
 					key={dir}
 					sessionWorkingDir={dir}
+					peerId={peerId}
 					onClose={() => closeFileViewer(dir)}
 					hidden={
 						!fileViewerOpenDirs.has(dir) ||

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -56,7 +56,7 @@ export interface ControlModeContext {
 	onCopyPrompt?: (text: string) => void;
 	setKeyboardVisible?: (visible: boolean) => void;
 	onShowSessions?: () => void;
-	onOpenFileViewer?: (dir: string) => void;
+	onOpenFileViewer?: (dir: string, peerId?: string) => void;
 }
 
 interface PaneContainerProps {
@@ -226,7 +226,7 @@ function TerminalPane({
 		(e: React.MouseEvent) => {
 			e.stopPropagation();
 			const s = sessionId ? sessions.find((s) => s.id === sessionId) : null;
-			controlModeContext.onOpenFileViewer?.(s?.currentPath || "/");
+			controlModeContext.onOpenFileViewer?.(s?.currentPath || "/", s?.peerId);
 			controlModeContext.setKeyboardVisible?.(false);
 		},
 		[controlModeContext, sessionId, sessions],

--- a/frontend/src/components/files/FileViewer.tsx
+++ b/frontend/src/components/files/FileViewer.tsx
@@ -54,6 +54,8 @@ function getStoredChangesDisplay(): ChangesDisplay {
 
 interface FileViewerProps {
 	sessionWorkingDir: string;
+	/** Peer that owns the files on disk. Unset / "local" → the Hub. */
+	peerId?: string;
 	onClose: () => void;
 	initialPath?: string;
 	onCopyPrompt?: (text: string) => void;
@@ -137,6 +139,7 @@ function getFileName(path: string): string {
 
 export function FileViewer({
 	sessionWorkingDir,
+	peerId,
 	onClose,
 	initialPath,
 	onCopyPrompt,
@@ -162,7 +165,13 @@ export function FileViewer({
 		getChanges,
 		getGitChanges,
 		getGitDiff,
-	} = useFileViewer(sessionWorkingDir);
+	} = useFileViewer(sessionWorkingDir, peerId);
+
+	// Files API prefix that matches the peer (`/api/files` for local, the
+	// `/api/peers/<id>/files` proxy for remote). Used for upload/download/raw
+	// URLs that don't go through useFileViewer.
+	const filesApiBase =
+		peerId && peerId !== "local" ? `/api/peers/${peerId}/files` : "/api/files";
 
 	const [viewMode, setViewMode] = useState<ViewMode>("browser");
 	const [listMode, setListMode] = useState<ListMode>("browser");
@@ -221,7 +230,7 @@ export function FileViewer({
 					);
 				}
 				console.log("[upload] sending POST /api/files/upload");
-				const res = await fetch("/api/files/upload", {
+				const res = await fetch(`${filesApiBase}/upload`, {
 					method: "POST",
 					body: formData,
 				});
@@ -257,7 +266,7 @@ export function FileViewer({
 
 	const handleDownloadFile = useCallback(() => {
 		if (!selectedFile) return;
-		const url = `/api/files/download?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`;
+		const url = `${filesApiBase}/download?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`;
 		// Use a temporary anchor to trigger download with proper filename from Content-Disposition
 		const a = document.createElement("a");
 		a.href = url;
@@ -778,7 +787,7 @@ export function FileViewer({
 													mimeType={selectedFile.mimeType}
 													fileName={getFileName(selectedFile.path)}
 													size={selectedFile.size}
-													srcUrl={`/api/files/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
+													srcUrl={`${filesApiBase}/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
 												/>
 											) : isMediaFile(selectedFile.path) ? (
 												<div className="flex flex-col h-full bg-th-bg">
@@ -790,7 +799,7 @@ export function FileViewer({
 																playsInline
 																preload="metadata"
 																className="w-full h-full object-contain rounded"
-																src={`/api/files/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
+																src={`${filesApiBase}/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
 															/>
 														) : (
 															// biome-ignore lint/a11y/useMediaCaption: arbitrary user files; no caption track available
@@ -798,7 +807,7 @@ export function FileViewer({
 																controls
 																preload="metadata"
 																className="w-full max-w-md"
-																src={`/api/files/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
+																src={`${filesApiBase}/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
 															/>
 														)}
 													</div>
@@ -924,7 +933,7 @@ export function FileViewer({
 								mimeType={selectedFile.mimeType}
 								fileName={getFileName(selectedFile.path)}
 								size={selectedFile.size}
-								srcUrl={`/api/files/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
+								srcUrl={`${filesApiBase}/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
 							/>
 						) : isMediaFile(selectedFile.path) ? (
 							<div className="flex flex-col items-center justify-center h-full p-4 bg-th-bg">
@@ -933,14 +942,14 @@ export function FileViewer({
 									<video
 										controls
 										className="max-w-full max-h-full rounded"
-										src={`/api/files/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
+										src={`${filesApiBase}/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
 									/>
 								) : (
 									// biome-ignore lint/a11y/useMediaCaption: arbitrary user files; no caption track available
 									<audio
 										controls
 										className="w-full max-w-md"
-										src={`/api/files/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
+										src={`${filesApiBase}/raw?path=${encodeURIComponent(selectedFile.path)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`}
 									/>
 								)}
 								<div className="mt-2 text-xs text-th-text-muted">

--- a/frontend/src/hooks/useFileViewer.ts
+++ b/frontend/src/hooks/useFileViewer.ts
@@ -1,9 +1,10 @@
-import { useCallback, useState } from "react";
-import type {
-	FileChange,
-	FileContent,
-	FileInfo,
-	GitFileChange,
+import { useCallback, useMemo, useState } from "react";
+import {
+	LOCAL_PEER_ID,
+	type FileChange,
+	type FileContent,
+	type FileInfo,
+	type GitFileChange,
 } from "../../../shared/types";
 import { authFetch, isTransientNetworkError } from "../services/api";
 
@@ -32,7 +33,14 @@ interface UseFileViewerReturn {
 	) => Promise<{ language: string; isImage: boolean; isText: boolean }>;
 }
 
-export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
+/**
+ * `peerId` (optional) routes every files API call to the peer that owns the
+ * file system on disk. Unset / `local` → the Hub.
+ */
+export function useFileViewer(
+	sessionWorkingDir: string,
+	peerId?: string,
+): UseFileViewerReturn {
 	const [currentPath, setCurrentPath] = useState(sessionWorkingDir);
 	const [files, setFiles] = useState<FileInfo[]>([]);
 	const [parentPath, setParentPath] = useState<string | null>(null);
@@ -42,6 +50,13 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 	const [gitBranch, setGitBranch] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+
+	const filesApiBase = useMemo(() => {
+		const isRemote = peerId && peerId !== LOCAL_PEER_ID;
+		return isRemote
+			? `${API_BASE}/api/peers/${encodeURIComponent(peerId)}/files`
+			: `${API_BASE}/api/files`;
+	}, [peerId]);
 
 	const listDirectory = useCallback(
 		async (path: string) => {
@@ -53,9 +68,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 					path,
 					sessionWorkingDir,
 				});
-				const response = await authFetch(
-					`${API_BASE}/api/files/list?${params}`,
-				);
+				const response = await authFetch(`${filesApiBase}/list?${params}`);
 
 				if (!response.ok) {
 					const data = await response
@@ -76,7 +89,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 				setIsLoading(false);
 			}
 		},
-		[sessionWorkingDir],
+		[sessionWorkingDir, filesApiBase],
 	);
 
 	const readFile = useCallback(
@@ -93,9 +106,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 					params.set("maxSize", maxSize.toString());
 				}
 
-				const response = await authFetch(
-					`${API_BASE}/api/files/read?${params}`,
-				);
+				const response = await authFetch(`${filesApiBase}/read?${params}`);
 
 				if (!response.ok) {
 					const data = await response
@@ -114,7 +125,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 				setIsLoading(false);
 			}
 		},
-		[sessionWorkingDir],
+		[sessionWorkingDir, filesApiBase],
 	);
 
 	const getChanges = useCallback(async () => {
@@ -123,7 +134,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 
 		try {
 			const response = await authFetch(
-				`${API_BASE}/api/files/changes/${encodeURIComponent(sessionWorkingDir)}`,
+				`${filesApiBase}/changes/${encodeURIComponent(sessionWorkingDir)}`,
 			);
 
 			if (!response.ok) {
@@ -142,7 +153,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 		} finally {
 			setIsLoading(false);
 		}
-	}, [sessionWorkingDir]);
+	}, [sessionWorkingDir, filesApiBase]);
 
 	const getGitChanges = useCallback(async () => {
 		setIsLoading(true);
@@ -150,7 +161,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 
 		try {
 			const response = await authFetch(
-				`${API_BASE}/api/files/git-changes/${encodeURIComponent(sessionWorkingDir)}`,
+				`${filesApiBase}/git-changes/${encodeURIComponent(sessionWorkingDir)}`,
 			);
 
 			if (!response.ok) {
@@ -170,7 +181,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 		} finally {
 			setIsLoading(false);
 		}
-	}, [sessionWorkingDir]);
+	}, [sessionWorkingDir, filesApiBase]);
 
 	const getGitDiff = useCallback(
 		async (filePath: string, staged?: boolean): Promise<string> => {
@@ -179,7 +190,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 				if (staged) params.set("staged", "true");
 
 				const response = await authFetch(
-					`${API_BASE}/api/files/git-diff/${encodeURIComponent(sessionWorkingDir)}?${params}`,
+					`${filesApiBase}/git-diff/${encodeURIComponent(sessionWorkingDir)}?${params}`,
 				);
 
 				if (!response.ok) {
@@ -192,7 +203,7 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 				return "";
 			}
 		},
-		[sessionWorkingDir],
+		[sessionWorkingDir, filesApiBase],
 	);
 
 	const navigateTo = useCallback(
@@ -212,18 +223,19 @@ export function useFileViewer(sessionWorkingDir: string): UseFileViewerReturn {
 		setSelectedFile(null);
 	}, []);
 
-	const getLanguage = useCallback(async (path: string) => {
-		const params = new URLSearchParams({ path });
-		const response = await authFetch(
-			`${API_BASE}/api/files/language?${params}`,
-		);
+	const getLanguage = useCallback(
+		async (path: string) => {
+			const params = new URLSearchParams({ path });
+			const response = await authFetch(`${filesApiBase}/language?${params}`);
 
-		if (!response.ok) {
-			return { language: "plaintext", isImage: false, isText: true };
-		}
+			if (!response.ok) {
+				return { language: "plaintext", isImage: false, isText: true };
+			}
 
-		return response.json();
-	}, []);
+			return response.json();
+		},
+		[filesApiBase],
+	);
 
 	return {
 		currentPath,


### PR DESCRIPTION
## Summary
- Opening the file browser against a remote-peer session returned **Access denied** because the FileViewer always hit the Hub's `/api/files/*` even when the active session lived on a different host.
- Backend: new generic `/api/peers/:peerId/files/*` catch-all proxy that forwards `list / read / raw / changes / git-changes / git-diff / language / download / upload / images` to the peer's own `/api/files` endpoints. Uses a direct `fetch` (not `peerFetch`) so binary streams from `/raw` aren't aborted by the 5s peer-fetch timeout. Existing `/browse` and `/mkdir` individual proxies are untouched.
- Frontend: `useFileViewer` takes an optional `peerId` and rewrites every files API URL accordingly. `FileViewer` threads the same prefix into `upload`/`download`/`raw` URLs. `DesktopLayout` stores `{ dir, peerId }` pairs for open viewers; `PaneContainer.onOpenFileViewer` now passes the session's `peerId` through.

## Test plan
- [x] `bun run lint` clean
- [x] `GET /api/peers/p_<mac>/files/list?path=...&sessionWorkingDir=...` returns the mac repo listing (3045 bytes verified via Tailscale)
- [ ] Manual UI: open file browser from a mac-peer session; previously "Access denied", expect file tree to appear; open a file → content/raw also serves from mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)