### PR TITLE
Release v0.1.153

### DIFF
--- a/.claude/skills/cchub-send/SKILL.md
+++ b/.claude/skills/cchub-send/SKILL.md
@@ -56,6 +56,34 @@ printf '\x03' | base64 | cchub send local:my-session:%5 --stdin --base64   # Ctr
 | `--submit` | `\r\r` 2回 | **Claude Code TUI 専用** — paste mode を抜けて submit |
 | `--stdin` | -- | 引数の代わりに stdin から payload を読む |
 | `--base64` | -- | payload は base64 文字列扱い (制御文字/バイナリを送る用) |
+| `--wait` | -- | 送信後に peer の pane viewport を取得して stdout に出す (色付き)。`detectedState` も併記される |
+| `--wait-ms <N>` | -- | `--wait` のスナップショット待ち時間 (ms, default 800)。Claude TUI の再描画完了を待つ |
+| `--lines <N>` | -- | viewport で返す末尾行数 (default 20) |
+
+## 状態を見る — `cchub peek` と `cchub send --wait`
+
+「送ったけど相手どうなってる？」を **UI を開かずに** 確認するための仕組み。`/api/sessions/:id/panes/:paneId/viewport` を叩いて pane の最新画面を取得し、内蔵ヒューリスティクスで状態を判定する。
+
+```bash
+# 送信せず現状だけ覗く
+cchub peek 🏠Studio:cc-hub:%6 --lines 15
+
+# 送って返事を待たずに、その直後の peer 画面を見る
+cchub send 🏠Studio:cc-hub:%6 "ステータス報告" --submit --wait
+cchub send 🏠Studio:cc-hub:%6 "巨大プロンプト" --submit --wait --wait-ms 1500 --lines 30
+```
+
+返値の `detectedState` は次のいずれか:
+
+| state | 意味 | 対処 |
+|-------|------|------|
+| `idle` | プロンプト待機中 (`✻/✳` マーカー or 空入力箱) | 送信OK |
+| `processing` | ツール実行中 (`(esc to interrupt)` / `· Verb… (… tokens …)` スピナー) | 完了を待つ |
+| `permission_prompt` | 権限ダイアログ表示中 (`Do you want to ...?`, `Yes, and don't ask again`) | **追加で `cchub send` しても飲まれない**。peer 側で承認するか、`Bash(cchub send:*)` 等を事前許可しておくこと |
+| `ask_user_question` | `AskUserQuestion` の番号選択待ち | 番号 (`1`/`2`/...) を `--newline` で送る |
+| `unknown` | 上記いずれも当てはまらず | 念のため `cchub peek --lines 30` で生画面を確認 |
+
+⚠️ 判定はあくまで viewport 文字列パターンマッチ。Claude Code TUI の表記が変わると外れる可能性あり (`backend/src/services/pane-viewport.ts` の `detectPaneState`)。判定が `unknown` でも実際の画面 (`text` フィールド or 色付き出力) は信頼できる。
 
 ## 双方向で対話する (peer から返事させる)
 
@@ -106,7 +134,8 @@ printf '\x03' | base64 | cchub send local:my-session:%5 --stdin --base64   # Ctr
 
 `/api/sessions` の `indicatorState` / `waitingToolName` は hook 駆動で**反応が遅れる/止まることがある**。送ったテキストが相手に届いたか、submit されたか、permission で止まってないかを正しく判断するには:
 
-- **peer の UI を実際に開いて目視確認** — これが一番確実
+- **`cchub send --wait` / `cchub peek` を使う** — viewport 取得 + 状態判定が一発で返るので、UI を開かなくても「届いてる/止まってる」が分かる (推奨)
+- それでも判定が怪しいときは **peer の UI を実際に開いて目視確認**
 - `indicatorState=completed` + `waitingToolName=UserInput` を「idle」と判断するのは危険。permission prompt 中も同じ表示になる可能性あり
 - 返信側に「処理開始 / 終了マーカー」を別送させる ⇒ 相手側 Claude Code が動いてる証拠になる
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.153] - 2026-05-23
+
+### Added
+- **`cchub peek` / `cchub send --wait` で peer pane の状態を覗けるように**: peer に送ったあと「届いてるのか？permission prompt で止まってないか？」を UI を開かずに確認するための仕組み。pane viewport を取得して `idle / processing / permission_prompt / ask_user_question / unknown` のいずれかにヒューリスティック判定する。`POST /api/sessions/:id/panes/input` に `{wait, waitMs, lines}` を追加 (送信後に viewport を返す)、新規 `GET /api/sessions/:id/panes/:paneId/viewport` を peek のバックエンドとして追加。CLI 側は `cchub send --wait/--wait-ms/--lines` と新規 `cchub peek <peer>:<session>:<paneId>`。判定ロジックは `backend/src/services/pane-viewport.ts` の `detectPaneState()` (`(esc to interrupt)` / `tokens)` スピナーで processing、`Do you want to ...?` / `Yes, and don't ask again` で permission_prompt、`✻/✳/✶` マーカー or 空入力箱で idle 等を検知)。cchub-send スキルのドキュメントも更新済み (`backend/src/cli.ts`, `backend/src/commands/send.ts`, `backend/src/routes/sessions.ts`, `backend/src/services/pane-viewport.ts`, `.claude/skills/cchub-send/SKILL.md`)
+
 ## [0.1.152] - 2026-05-22
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,8 +113,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.152",
-  "generated": "2026-05-22",
+  "version": "0.1.153",
+  "generated": "2026-05-23",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.152",
-  "generated": "2026-05-22",
+  "version": "0.1.153",
+  "generated": "2026-05-23",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -9,7 +9,7 @@ const isDev = process.argv.some(arg => arg.includes('--watch'));
 const DEFAULT_PORT = isDev ? 3456 : 5923;
 
 interface CliOptions {
-  command: 'serve' | 'setup' | 'uninstall' | 'update' | 'status' | 'notify' | 'help' | 'version' | 'debug' | 'send';
+  command: 'serve' | 'setup' | 'uninstall' | 'update' | 'status' | 'notify' | 'help' | 'version' | 'debug' | 'send' | 'peek';
   port: number;
   host: string;
   password?: string;
@@ -24,6 +24,10 @@ interface CliOptions {
   sendNewline?: boolean;
   sendSubmit?: boolean;
   sendBase64?: boolean;
+  sendWait?: boolean;
+  sendWaitMs?: number;
+  sendLines?: number;
+  peekTarget?: string;
 }
 
 function printHelp(): void {
@@ -40,6 +44,9 @@ ${t('cli.usage')}
   cchub send <target> [text]  Send input to a pane on a peer or local server
                               target: <peer>:<session>:<paneId>
                               (peer can be 'local', a peer id, or a nickname)
+  cchub peek <target>       Snapshot a pane's current viewport (last 20 rows
+                            by default) — useful for checking peer state
+                            without opening the peer UI.
   cchub debug <sub>         Toggle Bun inspector mode on the running service
                             sub: enable | disable | profile | status
 
@@ -62,6 +69,14 @@ send options:
   --submit               Append \\r\\r — Claude Code TUI needs two CRs to exit
                          paste mode and actually send the message
   --base64               Treat payload as base64 (binary-safe)
+  --wait                 After sending, snapshot the peer pane viewport and
+                         print it (with detected state: idle / processing /
+                         permission_prompt / ask_user_question / unknown).
+  --wait-ms <n>          Delay before snapshot when --wait is set (default 800)
+  --lines <n>            Trailing rows to include in viewport (default 20)
+
+peek options:
+  --lines <n>            Trailing rows to include in viewport (default 20)
 
 ${t('cli.examples')}
   ${t('cli.exampleStart')}
@@ -116,6 +131,15 @@ export function parseArgs(args: string[]): CliOptions {
         }
         break;
       }
+      case 'peek': {
+        options.command = 'peek';
+        const next = args[i + 1];
+        if (next && !next.startsWith('-')) {
+          options.peekTarget = next;
+          i++;
+        }
+        break;
+      }
       case '--stdin':
         options.sendStdin = true;
         break;
@@ -127,6 +151,25 @@ export function parseArgs(args: string[]): CliOptions {
         break;
       case '--base64':
         options.sendBase64 = true;
+        break;
+      case '--wait':
+        options.sendWait = true;
+        break;
+      case '--wait-ms':
+        i++;
+        options.sendWaitMs = parseInt(args[i], 10);
+        if (Number.isNaN(options.sendWaitMs) || options.sendWaitMs < 0) {
+          console.error('❌ --wait-ms must be a non-negative integer');
+          process.exit(1);
+        }
+        break;
+      case '--lines':
+        i++;
+        options.sendLines = parseInt(args[i], 10);
+        if (Number.isNaN(options.sendLines) || options.sendLines < 0) {
+          console.error('❌ --lines must be a non-negative integer');
+          process.exit(1);
+        }
         break;
       case 'debug': {
         options.command = 'debug';
@@ -236,6 +279,10 @@ export async function runCli(options: CliOptions): Promise<'serve' | 'exit'> {
       await runSend(options);
       return 'exit';
 
+    case 'peek':
+      await runPeek(options);
+      return 'exit';
+
     case 'debug':
       await runDebug(options);
       return 'exit';
@@ -279,6 +326,27 @@ async function runSend(options: CliOptions): Promise<void> {
       newline: options.sendNewline ?? false,
       submit: options.sendSubmit ?? false,
       base64: options.sendBase64 ?? false,
+      localPort: options.port,
+      wait: options.sendWait ?? false,
+      waitMs: options.sendWaitMs ?? 800,
+      lines: options.sendLines ?? 20,
+    });
+  } catch (err) {
+    console.error(`❌ ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+async function runPeek(options: CliOptions): Promise<void> {
+  if (!options.peekTarget) {
+    console.error('❌ target is required: cchub peek <peer>:<session>:<paneId>');
+    process.exit(1);
+  }
+  const { runPeek: runPeekImpl } = await import('./commands/send');
+  try {
+    await runPeekImpl({
+      target: options.peekTarget,
+      lines: options.sendLines ?? 20,
       localPort: options.port,
     });
   } catch (err) {

--- a/backend/src/commands/send.ts
+++ b/backend/src/commands/send.ts
@@ -22,6 +22,38 @@ export interface SendOptions {
   submit: boolean;
   base64: boolean;
   localPort: number;
+  // --wait: after sending, snapshot the pane viewport and print it. Useful so
+  // the sender can see what landed on the peer's screen (and whether the peer
+  // is mid-permission-prompt) without opening the peer UI.
+  wait: boolean;
+  waitMs: number;   // delay before snapshot
+  lines: number;    // trailing rows to print (0 = whole viewport)
+}
+
+interface ViewportResponse {
+  cols: number;
+  rows: number;
+  totalLines: number;
+  lines: string[];      // ANSI preserved
+  text: string;          // ANSI stripped
+  cursor: { x: number; y: number; visible: boolean };
+  detectedState: 'permission_prompt' | 'ask_user_question' | 'processing' | 'idle' | 'unknown';
+}
+
+function printViewport(target: ParsedTarget, vp: ViewportResponse): void {
+  const stateLabel: Record<ViewportResponse['detectedState'], string> = {
+    permission_prompt: '⚠️  permission_prompt (peer is waiting for Yes/No)',
+    ask_user_question: '❓ ask_user_question (peer is waiting for a numbered choice)',
+    processing: '⏳ processing (peer is running a tool)',
+    idle: '✳  idle (peer is at the prompt)',
+    unknown: '?  unknown',
+  };
+  console.error(`\n── ${target.peer}:${target.sessionId}:${target.paneId} (${vp.cols}x${vp.rows}) — ${stateLabel[vp.detectedState]}`);
+  // Print viewport WITH ANSI escapes preserved so colors come through.
+  for (const line of vp.lines) {
+    console.log(line);
+  }
+  console.error(`── end ─ cursor (${vp.cursor.x},${vp.cursor.y})`);
 }
 
 interface ParsedTarget {
@@ -87,11 +119,16 @@ export async function runSend(options: SendOptions): Promise<void> {
   const peer = await resolvePeer(target.peer, options.localPort);
 
   // base64 指定時は payload は既に base64 文字列のはず。utf-8 のときはそのまま渡す
-  const body = {
+  const body: Record<string, unknown> = {
     paneId: target.paneId,
     data: payload,
     encoding: options.base64 ? 'base64' : 'utf-8',
   };
+  if (options.wait) {
+    body.wait = true;
+    body.waitMs = options.waitMs;
+    body.lines = options.lines;
+  }
 
   // Tailscale 証明書は localhost 名と一致しないので TLS 検証を切る (notify.ts と同じ運用)
   if (peer.url.startsWith('https://')) {
@@ -115,6 +152,40 @@ export async function runSend(options: SendOptions): Promise<void> {
     throw new Error(`send 失敗: HTTP ${res.status} ${errText}`);
   }
 
-  const json = (await res.json().catch(() => ({}))) as { bytes?: number };
-  console.log(`✅ sent ${json.bytes ?? payload.length} bytes to ${target.peer}:${target.sessionId}:${target.paneId}`);
+  const json = (await res.json().catch(() => ({}))) as { bytes?: number; viewport?: ViewportResponse };
+  console.error(`✅ sent ${json.bytes ?? payload.length} bytes to ${target.peer}:${target.sessionId}:${target.paneId}`);
+  if (json.viewport) {
+    printViewport(target, json.viewport);
+  }
+}
+
+export interface PeekOptions {
+  target: string;
+  lines: number;
+  localPort: number;
+}
+
+export async function runPeek(options: PeekOptions): Promise<void> {
+  const target = parseTarget(options.target);
+  const peer = await resolvePeer(target.peer, options.localPort);
+
+  if (peer.url.startsWith('https://')) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  }
+
+  const headers: Record<string, string> = {};
+  if (peer.token) {
+    headers.Authorization = `Bearer ${peer.token}`;
+  }
+
+  const url = `${peer.url}/api/sessions/${encodeURIComponent(target.sessionId)}/panes/${encodeURIComponent(target.paneId)}/viewport?lines=${options.lines}`;
+  const res = await fetch(url, { headers });
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '');
+    throw new Error(`peek 失敗: HTTP ${res.status} ${errText}`);
+  }
+
+  const vp = (await res.json()) as ViewportResponse;
+  printViewport(target, vp);
 }

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -14,6 +14,8 @@ import { getAllSessionMetadata, setSessionTheme, setSessionTitle, getSessionOrde
 import { computeSessionMetrics } from '../services/session-metrics';
 import { getIndicatorOverride } from './notify';
 import { pushSessionsNow } from './terminal-mux';
+import { captureViewport, detectPaneState, stripAnsi, type DetectedPaneState } from '../services/pane-viewport';
+import type { TmuxControlSession } from '../services/tmux-control';
 
 const tmuxService = new TmuxService();
 const claudeCodeService = new ClaudeCodeService();
@@ -49,6 +51,41 @@ export function findDuplicateAgentWorkingDirSession<T extends { agent?: string; 
 /** Notify mux clients of session changes after mutations */
 function notifySessionChange(): void {
   pushSessionsNow();
+}
+
+/**
+ * Capture a pane viewport for peer-dialog tooling (cchub send --wait, peek).
+ * Returns the trailing `lines` rows (0 = all), with both ANSI-preserved and
+ * stripped variants plus a heuristic `detectedState`.
+ */
+async function captureViewportSnapshot(
+  cs: TmuxControlSession,
+  paneId: string,
+  lines: number,
+): Promise<{
+  paneId: string;
+  cols: number;
+  rows: number;
+  totalLines: number;
+  lines: string[];
+  text: string;
+  cursor: { x: number; y: number; visible: boolean };
+  detectedState: DetectedPaneState;
+} | null> {
+  const vp = await captureViewport(cs, paneId, 0);
+  if (!vp) return null;
+  const slice = lines > 0 ? vp.lines.slice(-lines) : vp.lines;
+  const stripped = slice.map(stripAnsi);
+  return {
+    paneId: vp.paneId,
+    cols: vp.cols,
+    rows: vp.rows,
+    totalLines: vp.lines.length,
+    lines: slice,
+    text: stripped.join('\n'),
+    cursor: vp.cursor,
+    detectedState: detectPaneState(vp.lines),
+  };
 }
 
 export const sessions = new Hono();
@@ -837,6 +874,12 @@ const PaneInputSchema = z.object({
   paneId: PaneIdSchema,
   data: z.string(),
   encoding: z.enum(['utf-8', 'base64']).optional().default('utf-8'),
+  // peer-dialog helpers: if `wait` is true the response includes a viewport
+  // snapshot captured `waitMs` after the input is delivered. `lines` is how
+  // many trailing rows to return (0 = all). Defaults match the CLI defaults.
+  wait: z.boolean().optional().default(false),
+  waitMs: z.number().int().min(0).max(10000).optional().default(800),
+  lines: z.number().int().min(0).max(500).optional().default(20),
 });
 
 // POST /sessions/:id/panes/focus - Focus a specific pane
@@ -1015,9 +1058,55 @@ sessions.post('/:id/panes/input', async (c) => {
       : Buffer.from(parsed.data.data, 'utf-8');
     await controlSession.sendInput(parsed.data.paneId, buffer);
 
-    return c.json({ success: true, paneId: parsed.data.paneId, bytes: buffer.length });
+    if (!parsed.data.wait) {
+      return c.json({ success: true, paneId: parsed.data.paneId, bytes: buffer.length });
+    }
+
+    // Give the TUI time to render before snapshotting.
+    if (parsed.data.waitMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, parsed.data.waitMs));
+    }
+    const viewport = await captureViewportSnapshot(controlSession, parsed.data.paneId, parsed.data.lines);
+    return c.json({
+      success: true,
+      paneId: parsed.data.paneId,
+      bytes: buffer.length,
+      viewport,
+    });
   } catch (_error) {
     return c.json({ error: 'Failed to send input' }, 500);
+  }
+});
+
+// GET /sessions/:id/panes/:paneId/viewport - Snapshot a pane's current viewport
+sessions.get('/:id/panes/:paneId/viewport', async (c) => {
+  const id = c.req.param('id');
+  const paneId = c.req.param('paneId');
+  const linesParam = c.req.query('lines');
+  const lines = linesParam ? Math.max(0, Math.min(500, Number.parseInt(linesParam, 10) || 0)) : 20;
+
+  if (!paneId.startsWith('%')) {
+    return c.json({ error: 'paneId must start with %' }, 400);
+  }
+
+  const exists = await tmuxService.sessionExists(id);
+  if (!exists) {
+    return c.json({ error: 'Session not found' }, 404);
+  }
+
+  try {
+    const controlSession = controlSessions.get(id) || await getOrCreateControlSession(id);
+    const panes = await controlSession.listPanes();
+    if (!panes.find(p => p.paneId === paneId)) {
+      return c.json({ error: 'Pane not found' }, 404);
+    }
+    const viewport = await captureViewportSnapshot(controlSession, paneId, lines);
+    if (!viewport) {
+      return c.json({ error: 'Failed to capture viewport' }, 500);
+    }
+    return c.json(viewport);
+  } catch (_error) {
+    return c.json({ error: 'Failed to capture viewport' }, 500);
   }
 });
 

--- a/backend/src/services/pane-viewport.ts
+++ b/backend/src/services/pane-viewport.ts
@@ -27,6 +27,74 @@ export function stripAnsi(s: string): string {
   return s.replace(ANSI_RE, '');
 }
 
+export type DetectedPaneState =
+  | 'permission_prompt'   // Claude Code permission dialog visible
+  | 'ask_user_question'   // AskUserQuestion (numbered choice) dialog visible
+  | 'processing'          // Claude Code "Esc to interrupt" / spinner visible
+  | 'idle'                // Claude Code prompt visible, idle ✳ marker
+  | 'unknown';            // nothing decisive found in viewport
+
+/**
+ * Best-effort detection of what state the pane is currently in, based purely
+ * on the rendered viewport. Used by peer-dialog tools (`cchub send --wait`,
+ * `cchub peek`) so the sender can disambiguate idle vs. permission-prompt vs.
+ * mid-processing — `indicatorState` from hooks is too coarse for this.
+ *
+ * Heuristics are based on patterns Claude Code prints. They will need updating
+ * if Claude Code's TUI changes. Detection is intentionally non-authoritative;
+ * 'unknown' is fine.
+ */
+export function detectPaneState(lines: string[]): DetectedPaneState {
+  // Walk the last ~25 visible rows (where prompts always live).
+  const tail = lines.slice(-25).map(stripAnsi);
+  const joined = tail.join('\n');
+
+  // Permission prompt — Claude Code's confirm dialog.
+  // Examples: "Do you want to proceed?", "1. Yes", "Yes, and don't ask again"
+  if (
+    /Do you want to (proceed|make this edit|create)/i.test(joined) ||
+    /Yes, and don'?t ask again/i.test(joined) ||
+    /^\s*❯?\s*[12]\.\s+(Yes|No)\b/m.test(joined)
+  ) {
+    return 'permission_prompt';
+  }
+
+  // AskUserQuestion — numbered choice list, distinguishable from permission
+  // by lacking the Yes/No structure and usually having ≥3 options.
+  if (/^\s*❯?\s*[1-9][.)]\s+\S/m.test(joined) && /\?\s*$/m.test(joined)) {
+    return 'ask_user_question';
+  }
+
+  // Processing — Claude Code spinner has these signatures, in priority order:
+  //  - explicit "(esc to interrupt)" hint
+  //  - the "· <Verb>… (<time> · ↓/↑ <n> tokens · ...)" spinner line. The
+  //    spinner verb changes per release (Kneading, Brewing, Pondering, …),
+  //    so we anchor on the stable "tokens" keyword followed by ")" on the
+  //    same line — this is uniquely emitted by the spinner.
+  if (
+    /\(esc to interrupt\)/i.test(joined) ||
+    /tokens(?:\s*·[^)]*)?\)\s*$/m.test(joined)
+  ) {
+    return 'processing';
+  }
+
+  // Idle — Claude prints "✻/✳/✶ <verb>"-prefixed status line above the input
+  // box (✻ = completed task, ✳ = idle waiting), or the input box is visible
+  // and empty ("│ > " or "❯ " alone on a line). If the spinner check above
+  // didn't match and we still see Claude's mode-hint footer, we treat it as
+  // idle by default.
+  if (
+    /^\s*[✳✻✶✴]\s/m.test(joined) ||
+    /^\s*│\s+>\s*$/m.test(joined) ||
+    /^\s*❯\s*$/m.test(joined) ||
+    /⏵⏵\s+(auto mode|accept edits|plan mode)/.test(joined)
+  ) {
+    return 'idle';
+  }
+
+  return 'unknown';
+}
+
 function isVisuallyBlank(s: string): boolean {
   return stripAnsi(s).trim() === '';
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.152",
+  "version": "0.1.153",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
peer pane との対話で「相手が今どうなってる？」をUIを開かずに把握できる仕組みを追加。

- 新規CLI: `cchub peek <peer>:<session>:<paneId>` — 送信せず peer pane の現状を覗く
- 既存CLI拡張: `cchub send --wait [--wait-ms N] [--lines N]` — 送信後に peer pane viewport を取得して色付きで出力
- 新規API: `GET /api/sessions/:id/panes/:paneId/viewport`
- 既存API拡張: `POST /api/sessions/:id/panes/input` が `{wait, waitMs, lines}` を受けて viewport を返すように
- `detectPaneState()` — viewport から `idle / processing / permission_prompt / ask_user_question / unknown` を判定
- `cchub-send` skill ドキュメント (home + project copy) を更新

## Test plan
- [x] dev環境で 4セッションに対して GET /viewport を叩き、processing / idle が正しく検知された
- [x] CLI (`cchub peek`, `cchub send --wait`) が viewport を色付きで出力するのを確認
- [x] backend typecheck / lint 通過
- [ ] リリース後、実 peer 間で `cchub send --wait` の対話フロー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)