### PR TITLE
Release v0.1.154

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.154] - 2026-05-23
+
+### Fixed
+- **macOS で tmux ペインが突然 1〜2 行の CSV だけになる / 文章の途中に空白が抜ける問題を修正**: `TmuxControlSession.sendCommand` の `pendingQueue` を同じセッションを共有する複数の呼び出し (ライブ WebSocket viewport + `cchub peek` / `cchub send --wait`) が共有していたため、10s タイムアウト時の `pendingQueue.splice` で FIFO がズレ、`display-message` メタデータの応答 (例: `277,74,2,70,0,0,8452` = `cols,rows,cx,cy,cflag,alt,hist`) が後続の `capture-pane` 応答に化けてペインの内容として描画されていた。`commandTail` プロミスチェーンによる直列化で stdin への書き込みを前コマンドの settle 後に限定し、タイムアウト時 (30s に延長) は単体 pending の splice ではなくセッション全体を `destroy()` するよう変更。遅延応答による silent corruption を根絶 (`backend/src/services/tmux-control.ts`, `backend/src/services/__tests__/tmux-control-serialize.test.ts`)
+
 ## [0.1.153] - 2026-05-23
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.153",
+  "version": "0.1.154",
   "generated": "2026-05-23",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.153",
+  "version": "0.1.154",
   "generated": "2026-05-23",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.153",
+  "version": "0.1.154",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(tmux-control): macOS で tmux ペインが突然 1〜2 行の CSV だけになる / 文章の途中に空白が抜ける問題を修正
  - 同じ `TmuxControlSession` を共有する WS viewport + `cchub peek` / `cchub send --wait` の応答 FIFO がタイムアウト時の splice でズレ、`display-message` のメタデータ (`cols,rows,cx,cy,...`) が `capture-pane` 応答に化けてペインに描画されていた
  - `sendCommand` を `commandTail` プロミスチェーンで直列化、タイムアウト時はセッション全体を destroy する設計に変更
  - ユニットテスト 3 件追加

## Notes
詳細は #220 (fix(tmux-control): serialize sendCommand to prevent FIFO drift) を参照。