### PR TITLE
fix(keyboard): soft-keyboard Shift+Tab sends VT back-tab

### DIFF
--- a/frontend/src/components/Keyboard.tsx
+++ b/frontend/src/components/Keyboard.tsx
@@ -212,6 +212,17 @@ export function Keyboard({
 				return;
 			}
 
+			// Handle Shift+Tab as VT back-tab (CSI Z). Claude Code uses this
+			// to cycle auto-mode / plan-mode / accept-edits (the "shift+tab to
+			// cycle" hint in its status line). The fallthrough below would
+			// otherwise resolve to "\t".toUpperCase() === "\t" and lose the
+			// Shift entirely.
+			if (shiftPressed && keyDef.key === "\t") {
+				onSend("\x1b[Z");
+				setShiftPressed(false);
+				return;
+			}
+
 			// Determine the character to send
 			let char = shiftPressed
 				? keyDef.shiftKey || keyDef.key.toUpperCase()


### PR DESCRIPTION
## Summary

ソフトウェアキーボードで Shift+Tab を押しても Claude Code の auto/plan/accept-edits の cycle が動かない問題を修正。

`Keyboard.tsx` の `sendKeyPress` には Shift+Tab の専用処理が無く、フォールバックで `"\t".toUpperCase()` = `"\t"` になっていたため、Shift が落ちて素の Tab が送られていた。既存の Shift+Enter 分岐と同じ要領で `\x1b[Z` (CSI Z = VT back-tab、xterm が Shift+Tab で送るシーケンス) を返すよう追加。

`FloatingKeyboard` は内部で `Keyboard` を使っているので 1 箇所修正で両モード対応。

## Test plan

- [x] `bun run lint` — clean
- [x] dev サーバ起動 — フロント / バックともコンパイルエラーなし
- [ ] 実機で TAB ボタンを単独タップ → Tab (`\t`) が届く
- [ ] ⇧ → TAB の順で押す → Claude Code の status line で auto / plan / accept-edits が cycle する

🤖 Generated with [Claude Code](https://claude.com/claude-code)