### PR TITLE
Release v0.1.155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.155] - 2026-05-23
+
+### Fixed
+- **ソフトウェアキーボードの Shift+Tab が効かなかった問題を修正**: `Keyboard.tsx` の `sendKeyPress` に Shift+Tab の専用処理がなく、フォールバックで `"\t".toUpperCase()` = `"\t"` となって Shift が落ちて素の Tab が送られていた。既存の Shift+Enter 分岐と同じパターンで `\x1b[Z` (CSI Z = VT back-tab、xterm が Shift+Tab で送るシーケンス) を返すよう追加。Claude Code の `shift+tab to cycle` (auto-mode / plan-mode / accept-edits の切り替え) がモバイル/タブレットの仮想キーボードからも使えるようになる (`frontend/src/components/Keyboard.tsx`)
+
 ## [0.1.154] - 2026-05-23
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "generated": "2026-05-23",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "generated": "2026-05-23",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(keyboard): ソフトウェアキーボードで Shift+Tab が `\x1b[Z` (VT back-tab) を送るよう修正
  - これまで Shift が落ちて素の Tab しか飛ばず、Claude Code の `shift+tab to cycle` (auto / plan / accept-edits) がモバイル/タブレットの仮想キーボードから動かなかった
  - 既存の Shift+Enter 分岐と同じパターンで明示的に `\x1b[Z` を送る

## Notes
詳細は #222。