### PR TITLE
Release v0.1.156

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.156] - 2026-05-23
+
+### Fixed
+- **tmux viewport の cursor 補正を session metadata ベースに整理**: これまで `pane-viewport.ts` に散っていた cursor 補正を `viewport-cursor-policy.ts` に切り出し、`agent=currentCommand` が `codex` のときだけ footer 専用の cursor policy を使うように変更した。shell 系は従来の padFill ベースの補正を維持しつつ、最後の表示行を超えないように軽くクランプして `haskel` などの空行ズレを抑えた (`backend/src/services/pane-viewport.ts`, `backend/src/services/viewport-cursor-policy.ts`, `backend/src/routes/terminal-mux.ts`, `backend/src/routes/sessions.ts`)
+
 ## [0.1.155] - 2026-05-23
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.155",
+  "version": "0.1.156",
   "generated": "2026-05-23",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.155",
+  "version": "0.1.156",
   "generated": "2026-05-23",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -15,6 +15,7 @@ import { computeSessionMetrics } from '../services/session-metrics';
 import { getIndicatorOverride } from './notify';
 import { pushSessionsNow } from './terminal-mux';
 import { captureViewport, detectPaneState, stripAnsi, type DetectedPaneState } from '../services/pane-viewport';
+import { resolveViewportCursorPolicy } from '../services/viewport-cursor-policy';
 import type { TmuxControlSession } from '../services/tmux-control';
 
 const tmuxService = new TmuxService();
@@ -62,6 +63,7 @@ async function captureViewportSnapshot(
   cs: TmuxControlSession,
   paneId: string,
   lines: number,
+  cursorPolicy: ReturnType<typeof resolveViewportCursorPolicy> = 'default',
 ): Promise<{
   paneId: string;
   cols: number;
@@ -72,7 +74,7 @@ async function captureViewportSnapshot(
   cursor: { x: number; y: number; visible: boolean };
   detectedState: DetectedPaneState;
 } | null> {
-  const vp = await captureViewport(cs, paneId, 0);
+  const vp = await captureViewport(cs, paneId, 0, cursorPolicy);
   if (!vp) return null;
   const slice = lines > 0 ? vp.lines.slice(-lines) : vp.lines;
   const stripped = slice.map(stripAnsi);
@@ -86,6 +88,12 @@ async function captureViewportSnapshot(
     cursor: vp.cursor,
     detectedState: detectPaneState(vp.lines),
   };
+}
+
+async function resolveSessionCursorPolicy(sessionId: string): Promise<ReturnType<typeof resolveViewportCursorPolicy>> {
+  const sessions = await tmuxService.listSessions();
+  const session = sessions.find(s => s.id === sessionId);
+  return resolveViewportCursorPolicy(session?.agent ?? session?.currentCommand);
 }
 
 export const sessions = new Hono();
@@ -1066,7 +1074,8 @@ sessions.post('/:id/panes/input', async (c) => {
     if (parsed.data.waitMs > 0) {
       await new Promise(resolve => setTimeout(resolve, parsed.data.waitMs));
     }
-    const viewport = await captureViewportSnapshot(controlSession, parsed.data.paneId, parsed.data.lines);
+    const cursorPolicy = await resolveSessionCursorPolicy(id);
+    const viewport = await captureViewportSnapshot(controlSession, parsed.data.paneId, parsed.data.lines, cursorPolicy);
     return c.json({
       success: true,
       paneId: parsed.data.paneId,
@@ -1100,7 +1109,8 @@ sessions.get('/:id/panes/:paneId/viewport', async (c) => {
     if (!panes.find(p => p.paneId === paneId)) {
       return c.json({ error: 'Pane not found' }, 404);
     }
-    const viewport = await captureViewportSnapshot(controlSession, paneId, lines);
+    const cursorPolicy = await resolveSessionCursorPolicy(id);
+    const viewport = await captureViewportSnapshot(controlSession, paneId, lines, cursorPolicy);
     if (!viewport) {
       return c.json({ error: 'Failed to capture viewport' }, 500);
     }

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -9,6 +9,7 @@ import type {
   ConversationMessage,
 } from '../../../shared/types';
 import { buildSessionsList } from './sessions';
+import { resolveViewportCursorPolicy, type ViewportCursorPolicy } from '../services/viewport-cursor-policy';
 
 // Output → push debounce. Wait this long after the last %output for a pane
 // before recapturing. Shorter = lower latency; longer = fewer captures.
@@ -43,6 +44,7 @@ interface MuxSubscription {
   // Pane IDs the subscription has ever touched (request-viewport, push).
   // Used by resize to re-push known panes after tmux reflows.
   knownPanes: Set<string>;
+  cursorPolicy: ViewportCursorPolicy;
 }
 
 export interface MuxData {
@@ -242,6 +244,8 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
     controlSession.addClient();
 
     const cleanupFns: Array<() => void> = [];
+    const sessions = await tmuxService.listSessions();
+    const session = sessions.find(s => s.id === sessionId);
     const sub: MuxSubscription = {
       controlSession,
       cleanupFns,
@@ -250,6 +254,7 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
       pushTimers: new Map(),
       lastPushAt: new Map(),
       knownPanes: new Set(),
+      cursorPolicy: resolveViewportCursorPolicy(session?.agent ?? session?.currentCommand),
     };
 
     // %output → schedule a push for any pane this subscription is viewing
@@ -383,7 +388,7 @@ async function pushViewport(
   if (sub.controlSession.isDestroyed) return;
   let viewport: Awaited<ReturnType<typeof captureViewport>> = null;
   try {
-    viewport = await captureViewport(sub.controlSession, paneId, offset);
+    viewport = await captureViewport(sub.controlSession, paneId, offset, sub.cursorPolicy);
   } catch (err) {
     console.warn(`[mux] captureViewport failed for ${paneId}:`, err);
     return;

--- a/backend/src/services/__tests__/viewport-cursor-policy.test.ts
+++ b/backend/src/services/__tests__/viewport-cursor-policy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  computeCursorPadShift,
+  resolveViewportCursor,
+  resolveViewportCursorPolicy,
+} from '../viewport-cursor-policy';
+
+describe('viewport cursor policy', () => {
+  test('maps codex sessions to the codex policy', () => {
+    expect(resolveViewportCursorPolicy('codex')).toBe('codex-footer');
+    expect(resolveViewportCursorPolicy('claude')).toBe('default');
+    expect(resolveViewportCursorPolicy()).toBe('default');
+  });
+
+  test('computes cursor pad shift per policy', () => {
+    expect(computeCursorPadShift('default', 5)).toBe(3);
+    expect(computeCursorPadShift('codex-footer', 5)).toBe(0);
+  });
+
+  test('resolves a default live cursor with pad shift', () => {
+    const cursor = resolveViewportCursor('default', {
+      cols: 80,
+      rows: 24,
+      cursorX: 3,
+      cursorY: 10,
+      cursorVisible: true,
+      cursorPadShift: 2,
+      renderedLines: ['', '', '', '', '', '', '', '', '', '', '', '', 'line', ''],
+      atTail: true,
+    });
+
+    expect(cursor).toEqual({ x: 3, y: 12, visible: true });
+  });
+
+  test('clamps default cursor to the last visible content row', () => {
+    const cursor = resolveViewportCursor('default', {
+      cols: 80,
+      rows: 24,
+      cursorX: 3,
+      cursorY: 23,
+      cursorVisible: true,
+      cursorPadShift: 0,
+      renderedLines: ['prompt line', ''],
+      atTail: true,
+    });
+
+    expect(cursor).toEqual({ x: 3, y: 0, visible: true });
+  });
+
+  test('resolves Codex cursor above the footer', () => {
+    const cursor = resolveViewportCursor('codex-footer', {
+      cols: 80,
+      rows: 24,
+      cursorX: 3,
+      cursorY: 22,
+      cursorVisible: true,
+      cursorPadShift: 0,
+      renderedLines: [
+        '› h',
+        '',
+        'tab to queue message',
+      ],
+      atTail: true,
+    });
+
+    expect(cursor).toEqual({ x: 3, y: 1, visible: true });
+  });
+
+  test('hides cursor when not at tail', () => {
+    const cursor = resolveViewportCursor('default', {
+      cols: 80,
+      rows: 24,
+      cursorX: 3,
+      cursorY: 10,
+      cursorVisible: true,
+      cursorPadShift: 2,
+      renderedLines: ['line'],
+      atTail: false,
+    });
+
+    expect(cursor).toEqual({ x: 3, y: 0, visible: false });
+  });
+});

--- a/backend/src/services/pane-viewport.ts
+++ b/backend/src/services/pane-viewport.ts
@@ -20,6 +20,11 @@
 
 import type { PaneViewport, PaneCursor, PaneModes } from '../../../shared/types';
 import type { TmuxControlSession } from './tmux-control';
+import {
+  computeCursorPadShift,
+  resolveViewportCursor,
+  type ViewportCursorPolicy,
+} from './viewport-cursor-policy';
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes by design.
 const ANSI_RE = /\x1b\[[\d;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
@@ -139,25 +144,23 @@ export async function captureViewport(
   cs: TmuxControlSession,
   paneId: string,
   offset: number,
+  cursorPolicy: ViewportCursorPolicy = 'default',
 ): Promise<PaneViewport | null> {
   let metaRaw: string;
   try {
     metaRaw = await cs.sendCommand(
-      `display-message -t ${paneId} -p '#{pane_width},#{pane_height},#{cursor_x},#{cursor_y},#{cursor_flag},#{alternate_on},#{history_size}'`,
+      `display-message -t ${paneId} -p '#{pane_width},#{pane_height},#{alternate_on},#{history_size}'`,
     );
   } catch {
     return null;
   }
 
   const parts = metaRaw.trim().split(',');
-  if (parts.length < 7) return null;
+  if (parts.length < 4) return null;
   const cols = Number.parseInt(parts[0], 10);
   const rows = Number.parseInt(parts[1], 10);
-  const cx = Number.parseInt(parts[2], 10);
-  const cy = Number.parseInt(parts[3], 10);
-  const cursorVisible = parts[4] === '1';
-  const altScreen = parts[5] === '1';
-  const historySize = Number.parseInt(parts[6], 10) || 0;
+  const altScreen = parts[2] === '1';
+  const historySize = Number.parseInt(parts[3], 10) || 0;
 
   if (!Number.isFinite(cols) || !Number.isFinite(rows) || cols <= 0 || rows <= 0) {
     return null;
@@ -181,6 +184,29 @@ export async function captureViewport(
     linesRaw = await cs.sendCommand(`capture-pane -e -p -t ${paneId} -S ${start} -E ${end}`);
   } catch {
     return null;
+  }
+
+  let cx = 0;
+  let cy = 0;
+  let cursorVisible = false;
+  if (clampedOffset === 0) {
+    // Fetch cursor metadata after capture so the rendered cursor is based on
+    // the freshest possible position. This reduces visible drift on panes
+    // that redraw quickly (Codex tends to do this more than the shell UI).
+    try {
+      const cursorRaw = await cs.sendCommand(
+        `display-message -t ${paneId} -p '#{cursor_x},#{cursor_y},#{cursor_flag}'`,
+      );
+      const cursorParts = cursorRaw.trim().split(',');
+      if (cursorParts.length >= 3) {
+        cx = Number.parseInt(cursorParts[0], 10);
+        cy = Number.parseInt(cursorParts[1], 10);
+        cursorVisible = cursorParts[2] === '1';
+      }
+    } catch {
+      // Fall back to a hidden cursor if tmux is busy or the pane vanished
+      // between the viewport capture and the cursor query.
+    }
   }
 
   // tmux always returns exactly `end - start + 1` rows when both bounds are
@@ -232,7 +258,7 @@ export async function captureViewport(
         if (fetched.length > 0) {
           const prepend = fetched.slice(-padNeeded);
           lines = [...prepend, ...lines];
-          cursorPadShift = prepend.length;
+          cursorPadShift = computeCursorPadShift(cursorPolicy, prepend.length);
         }
       } else if (padStart >= -historySize) {
         try {
@@ -261,13 +287,16 @@ export async function captureViewport(
   }
 
   const atTail = clampedOffset === 0;
-  const cursor: PaneCursor = atTail
-    ? {
-        x: Math.max(0, Math.min(cols - 1, cx)),
-        y: Math.max(0, Math.min(rows - 1, cy + cursorPadShift)),
-        visible: cursorVisible,
-      }
-    : { x: 0, y: 0, visible: false };
+  const cursor: PaneCursor = resolveViewportCursor(cursorPolicy, {
+    cols,
+    rows,
+    cursorX: cx,
+    cursorY: cy,
+    cursorVisible,
+    cursorPadShift,
+    renderedLines: lines,
+    atTail,
+  });
   const modes: PaneModes = { altScreen };
 
   return {

--- a/backend/src/services/viewport-cursor-policy.ts
+++ b/backend/src/services/viewport-cursor-policy.ts
@@ -1,0 +1,63 @@
+import type { PaneCursor } from '../../../shared/types';
+
+export type ViewportCursorPolicy = 'default' | 'codex-footer';
+
+export interface ViewportCursorInput {
+  cols: number;
+  rows: number;
+  cursorX: number;
+  cursorY: number;
+  cursorVisible: boolean;
+  cursorPadShift: number;
+  renderedLines: string[];
+  atTail: boolean;
+}
+
+export function resolveViewportCursorPolicy(agent?: string): ViewportCursorPolicy {
+  return agent === 'codex' ? 'codex-footer' : 'default';
+}
+
+export function computeCursorPadShift(policy: ViewportCursorPolicy, prependCount: number): number {
+  if (policy === 'codex-footer') return 0;
+  return Math.max(0, prependCount - 2);
+}
+
+export function resolveViewportCursor(policy: ViewportCursorPolicy, input: ViewportCursorInput): PaneCursor {
+  const x = Math.max(0, Math.min(input.cols - 1, input.cursorX));
+  if (!input.atTail) {
+    return { x, y: 0, visible: false };
+  }
+
+  if (policy === 'codex-footer') {
+    const lastNonBlankRow = (() => {
+      for (let i = input.renderedLines.length - 1; i >= 0; i--) {
+        if (input.renderedLines[i]?.trim()) return i;
+      }
+      return -1;
+    })();
+    return {
+      x,
+      y: Math.max(0, Math.min(input.rows - 1, lastNonBlankRow - 1)),
+      visible: input.cursorVisible,
+    };
+  }
+
+  const lastNonBlankRow = (() => {
+    for (let i = input.renderedLines.length - 1; i >= 0; i--) {
+      if (input.renderedLines[i]?.trim()) return i;
+    }
+    return -1;
+  })();
+  const resolvedY = input.cursorY + input.cursorPadShift;
+  return {
+    x,
+    y: Math.max(
+      0,
+      Math.min(
+        input.rows - 1,
+        lastNonBlankRow >= 0 ? Math.min(resolvedY, lastNonBlankRow) : resolvedY,
+      ),
+    ),
+    visible: input.cursorVisible,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.155",
+  "version": "0.1.156",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: cursor policy を session metadata ベースに整理して Codex 用の footer 補正を分離
- fix: shell 側の cursor を最後の表示行にクランプして `haskel` の空行ズレを抑制
- chore: v0.1.156 へ patch bump

## Notes
- `bun run --filter backend typecheck`
- `bun run --filter backend test`