### PR TITLE
Release v0.1.159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.159] - 2026-05-24
+
+### Fixed
+- **スクロール時に viewport 下部の void エリアが offset に応じて変動する不具合を解消**: `pane-viewport.ts` の padFill ロジック (`captureScrollback` と scrolled-mode の pad capture 両方) が pad capture の trailing visually-blank rows を多段 `pop` で削っており、scrollback に空行を含む pane (e.g., dev server logs は 1 行おきに空行) で `prepend` が `padNeeded` に届かず、後段の `lines.push('')` が rendered viewport の **bottom** に void を埋めていた。scroll offset によって content/blank の parity が変わるので void サイズが 0〜数行で変動して見えた。修正は tmux capture-pane が必ず付ける trailing `\n` artifact のみを 1 回 pop するシンプルな `parseCaptureOutput()` helper に置き換え、scrollback 内の本物の空行を保持するようにした。実機 sim では修正前 odd offset で 1 行 void → 修正後全 offset で void = 0 (`backend/src/services/pane-viewport.ts`, `backend/src/services/__tests__/pane-viewport-capture.test.ts`)
+
 ## [0.1.158] - 2026-05-24
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.158",
+  "version": "0.1.159",
   "generated": "2026-05-24",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.158",
+  "version": "0.1.159",
   "generated": "2026-05-24",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/services/__tests__/pane-viewport-capture.test.ts
+++ b/backend/src/services/__tests__/pane-viewport-capture.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { parseCaptureOutput } from '../pane-viewport';
+
+describe('parseCaptureOutput', () => {
+  test('strips the single trailing-\\n artifact', () => {
+    expect(parseCaptureOutput('a\nb\nc\n')).toEqual(['a', 'b', 'c']);
+  });
+
+  test('preserves a literal blank row that ends the capture', () => {
+    // tmux blank row + trailing \n => raw "a\n\n", split => ['a','',''].
+    // We pop ONLY the final '' artifact and keep the blank row.
+    expect(parseCaptureOutput('a\n\n')).toEqual(['a', '']);
+  });
+
+  test('preserves multiple consecutive blank rows', () => {
+    // Real dev-log pattern: alternating content + blank
+    // raw "a\n\nb\n\n" => split ['a','','b','',''], pop => ['a','','b','']
+    expect(parseCaptureOutput('a\n\nb\n\n')).toEqual(['a', '', 'b', '']);
+  });
+
+  test('returns [] for empty raw input', () => {
+    expect(parseCaptureOutput('')).toEqual([]);
+  });
+
+  test('returns [""] for raw single newline (a single blank row)', () => {
+    expect(parseCaptureOutput('\n')).toEqual(['']);
+  });
+
+  test('preserves rows containing ANSI escapes', () => {
+    expect(parseCaptureOutput('\x1b[38;5;114mfoo\x1b[39m\n')).toEqual([
+      '\x1b[38;5;114mfoo\x1b[39m',
+    ]);
+  });
+
+  test('does not trim whitespace-only rows', () => {
+    // Important: whitespace-only rows might appear when a TUI pads with
+    // spaces. Capture should preserve them so padFill math stays correct.
+    expect(parseCaptureOutput('a\n   \nb\n')).toEqual(['a', '   ', 'b']);
+  });
+});

--- a/backend/src/services/pane-viewport.ts
+++ b/backend/src/services/pane-viewport.ts
@@ -112,8 +112,35 @@ function isVisuallyBlank(s: string): boolean {
 }
 
 /**
+ * Parse a `tmux capture-pane -e -p` raw result into row strings.
+ *
+ * tmux always emits a trailing `\n` so `split('\n')` produces one extra
+ * empty string at the end which is a parse artifact, not a real row.
+ * We pop exactly that artifact and preserve every other element — including
+ * `''` rows that correspond to actually-blank lines in the captured range.
+ *
+ * Critical: do NOT loop-pop visually-blank trailing rows. Blank rows in
+ * tmux scrollback represent real content (e.g. dev-log spacers) and
+ * dropping them shortens prepend slices used by padFill, surfacing as a
+ * void whose size fluctuates with scroll position.
+ */
+export function parseCaptureOutput(raw: string): string[] {
+  const lines = raw.split('\n');
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+/**
  * Fetch up to `wanted` rows of scrollback ending just above the visible
- * region (`-S -wanted -E -1`). Returns trimmed rows or [] on failure.
+ * region (`-S -wanted -E -1`). Returns the literal rows or [] on failure.
+ *
+ * We only strip the trailing-`\n` artifact from `split('\n')`. We must NOT
+ * trim further visually-blank rows: those represent actual blank lines in
+ * the scrollback at that position. Dropping them produces fewer than `wanted`
+ * rows, which downstream gets padded with `''` at the BOTTOM of the rendered
+ * viewport — surfacing as a void whose size fluctuates with scroll position
+ * (any pane whose scrollback interleaves content and blanks, e.g. dev logs,
+ * exhibits a moving void as the user scrolls).
  */
 async function captureScrollback(
   cs: TmuxControlSession,
@@ -125,9 +152,7 @@ async function captureScrollback(
     const raw = await cs.sendCommand(
       `capture-pane -e -p -t ${paneId} -S -${wanted} -E -1`,
     );
-    const sb = raw.split('\n');
-    while (sb.length > 0 && isVisuallyBlank(sb[sb.length - 1])) sb.pop();
-    return sb;
+    return parseCaptureOutput(raw);
   } catch {
     return [];
   }
@@ -219,7 +244,7 @@ export async function captureViewport(
   // tmux always returns exactly `end - start + 1` rows when both bounds are
   // in-range; pad with blanks defensively in case it returned fewer (e.g.
   // racing with a resize).
-  let lines = linesRaw.split('\n');
+  let lines = parseCaptureOutput(linesRaw);
   if (lines.length > rows) {
     lines = lines.slice(0, rows);
   }
@@ -272,10 +297,7 @@ export async function captureViewport(
           const padRaw = await cs.sendCommand(
             `capture-pane -e -p -t ${paneId} -S ${padStart} -E ${padEnd}`,
           );
-          const padLines = padRaw.split('\n');
-          while (padLines.length > 0 && isVisuallyBlank(padLines[padLines.length - 1])) {
-            padLines.pop();
-          }
+          const padLines = parseCaptureOutput(padRaw);
           if (padLines.length > 0) {
             const prepend = padLines.slice(-padNeeded);
             lines = [...prepend, ...lines];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.158",
+  "version": "0.1.159",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary

スクロール時に viewport 下部の void エリアが offset によって変動する不具合の修正。

## Root cause

`pane-viewport.ts` の padFill (`captureScrollback` と scrolled-mode pad block 両方) が pad capture の trailing visually-blank rows を多段 \`pop\` で削っていた。
これで \`prepend\` の長さが \`padNeeded\` に届かなくなり、後段の \`while (lines.length < rows) lines.push('')\` が rendered viewport の **bottom** に \`''\` を埋め、void として表面化していた。
scroll offset によって content/blank の parity が変わるので void サイズが offset ごとに変動して見えた。

## Fix

tmux capture-pane は常に trailing \`\n\` を付ける → \`split('\n')\` で末尾に \`''\` artifact が 1 つできる。**この artifact のみを pop** すれば十分。
共通処理を \`parseCaptureOutput()\` helper に切り出して使い回し。scrollback 内の本物の空行は保持される。

## Test plan

- [x] Unit tests (\`pane-viewport-capture.test.ts\`): trailing artifact / 末尾 blank row / 連続 blank / ANSI 保持 / whitespace-only など 7 ケース
- [x] backend 全 test pass (182 pass / 0 fail, 175→182 で 7 new)
- [x] Live tmux に対する Python sim: 修正前 %117 (node dev pane) odd offset で 1 行 void → 修正後全 offset で 0
- [x] lint pass