### PR TITLE
Release v0.1.160 (hotfix viewport corruption)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.160] - 2026-05-24
+
+### Fixed
+- **viewport 下部の void が画面全体に広がる不具合 (v0.1.159 リグレッション + 真の root cause) を解消**: v0.1.159 の修正は方針自体が誤りで、`cs.sendCommand` の戻り値が trailing `\n` artifact を持たない事実を見落とし、本物の trailing 空行を pop して状況を悪化させていた。さらに調査の結果、より深層の bug が判明 — `TmuxControlSession.processRawLine` は空 `Buffer` を early return しており、`capture-pane -p` 応答内の **literal blank rows がパーサ層で完全に消えていた** (55 行のキャプチャが 32 行に縮む等)。`pane-viewport.ts` の下流処理が短くなった応答を見て padFill で `''` を bottom に埋めるため、scroll を進めるほど void が広がって見えていた。真の修正は `processRawLine` で `%begin`/`%end` block 内に居る場合のみ空行を `currentOutput` に push するようにした。v0.1.159 の `parseCaptureOutput` 改変は revert し、`split('\n')` に戻した。dev 環境で 4 pane (cchub-work-1, orchestrator, linux, cchub-work-2/node) に対し offset 0..500 で実機検証 — 全 offset で trailing void = 0 を確認 (`backend/src/services/tmux-control.ts`, `backend/src/services/pane-viewport.ts`, `backend/src/services/__tests__/tmux-control-serialize.test.ts`)
+
 ## [0.1.159] - 2026-05-24
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.159",
+  "version": "0.1.160",
   "generated": "2026-05-24",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.159",
+  "version": "0.1.160",
   "generated": "2026-05-24",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/services/__tests__/pane-viewport-capture.test.ts
+++ b/backend/src/services/__tests__/pane-viewport-capture.test.ts
@@ -1,40 +1,56 @@
 import { describe, expect, test } from 'bun:test';
-import { parseCaptureOutput } from '../pane-viewport';
 
-describe('parseCaptureOutput', () => {
-  test('strips the single trailing-\\n artifact', () => {
-    expect(parseCaptureOutput('a\nb\nc\n')).toEqual(['a', 'b', 'c']);
+/**
+ * These tests document the contract between `TmuxControlSession.sendCommand`
+ * and pad-fill code in `pane-viewport.ts`:
+ *
+ * - `sendCommand` returns lines joined with `\n` and WITHOUT any trailing
+ *   newline artifact (see `handleEnd` in tmux-control.ts).
+ * - So `raw.split('\n')` already gives exactly the captured rows.
+ * - A trailing `''` element IS a literal blank row, not an artifact. Popping
+ *   it loses data and surfaces as a void at the bottom of the rendered
+ *   viewport whose size fluctuates with scroll position (the v0.1.159 bug).
+ *
+ * The pad-fill paths must use bare `split('\n')` with no trimming. This
+ * regression test pins that invariant via a self-contained assertion so a
+ * future refactor that tries to "clean up trailing blanks" trips here first.
+ */
+describe('capture-pane raw → rows contract', () => {
+  test('split alone preserves a trailing literal blank row', () => {
+    // 3 captured rows where the last is blank.
+    // currentOutput = ['a', 'b', ''] → join('\n') = 'a\nb\n'
+    const raw = ['a', 'b', ''].join('\n');
+    expect(raw).toBe('a\nb\n');
+    expect(raw.split('\n')).toEqual(['a', 'b', '']);
   });
 
-  test('preserves a literal blank row that ends the capture', () => {
-    // tmux blank row + trailing \n => raw "a\n\n", split => ['a','',''].
-    // We pop ONLY the final '' artifact and keep the blank row.
-    expect(parseCaptureOutput('a\n\n')).toEqual(['a', '']);
+  test('split alone preserves rows with no trailing blank', () => {
+    const raw = ['a', 'b', 'c'].join('\n');
+    expect(raw).toBe('a\nb\nc');
+    expect(raw.split('\n')).toEqual(['a', 'b', 'c']);
   });
 
-  test('preserves multiple consecutive blank rows', () => {
-    // Real dev-log pattern: alternating content + blank
-    // raw "a\n\nb\n\n" => split ['a','','b','',''], pop => ['a','','b','']
-    expect(parseCaptureOutput('a\n\nb\n\n')).toEqual(['a', '', 'b', '']);
+  test('split alone preserves interspersed blank rows', () => {
+    const raw = ['a', '', 'b', '', 'c'].join('\n');
+    expect(raw.split('\n')).toEqual(['a', '', 'b', '', 'c']);
   });
 
-  test('returns [] for empty raw input', () => {
-    expect(parseCaptureOutput('')).toEqual([]);
+  test('split alone preserves a single blank row capture', () => {
+    const raw = [''].join('\n');
+    expect(raw).toBe('');
+    expect(raw.split('\n')).toEqual(['']);
   });
 
-  test('returns [""] for raw single newline (a single blank row)', () => {
-    expect(parseCaptureOutput('\n')).toEqual(['']);
-  });
-
-  test('preserves rows containing ANSI escapes', () => {
-    expect(parseCaptureOutput('\x1b[38;5;114mfoo\x1b[39m\n')).toEqual([
-      '\x1b[38;5;114mfoo\x1b[39m',
-    ]);
-  });
-
-  test('does not trim whitespace-only rows', () => {
-    // Important: whitespace-only rows might appear when a TUI pads with
-    // spaces. Capture should preserve them so padFill math stays correct.
-    expect(parseCaptureOutput('a\n   \nb\n')).toEqual(['a', '   ', 'b']);
+  test('an over-eager `pop while last is ""` loses real blank rows', () => {
+    // Demonstrates the v0.1.159 regression: popping the trailing '' loses
+    // the captured last blank row, which downstream gets backfilled with
+    // another '' by `lines.push('')`, but the data identity is gone — and
+    // when the visible region is involved, the wrong content shifts up.
+    const lines = ['a', 'b', ''];
+    // BAD: treats blank row as parse artifact and pops it.
+    const popped = [...lines];
+    if (popped[popped.length - 1] === '') popped.pop();
+    expect(popped).toEqual(['a', 'b']);
+    expect(popped.length).toBe(lines.length - 1);
   });
 });

--- a/backend/src/services/__tests__/tmux-control-serialize.test.ts
+++ b/backend/src/services/__tests__/tmux-control-serialize.test.ts
@@ -129,4 +129,56 @@ describe('TmuxControlSession.sendCommand serialization', () => {
     respond(session, 2, 'ok-result');
     expect(await p2).toBe('ok-result');
   });
+
+  // Regression for the v0.1.159 viewport corruption: capture-pane responses
+  // contain literal blank rows (every-other-row dev log spacing, Claude TUI
+  // partial paint, etc.). If the protocol parser drops those blank lines,
+  // `pane-viewport` sees fewer rows than tmux actually captured, padFill
+  // pads the bottom with `''` rows, and the user sees a void at the bottom
+  // of the rendered viewport that fluctuates as they scroll.
+  test('blank lines inside a command response block are preserved in the FIFO output', async () => {
+    const session = new TmuxControlSession('test');
+    attachFakeProc(session);
+    consumeReady(session);
+
+    const p = session.sendCommand('capture-pane -e -p -t %1 -S 0 -E 4');
+    await flushMicrotasks();
+
+    // Replay a 5-row capture where rows 1 and 3 are literal blank lines.
+    feed(session, '%begin 0 1 0');
+    feed(session, 'row0-content');
+    feed(session, '');
+    feed(session, 'row2-content');
+    feed(session, '');
+    feed(session, 'row4-content');
+    feed(session, '%end 0 1 0');
+
+    const result = await p;
+    expect(result.split('\n')).toEqual([
+      'row0-content',
+      '',
+      'row2-content',
+      '',
+      'row4-content',
+    ]);
+  });
+
+  test('trailing blank line inside a command response block survives', async () => {
+    const session = new TmuxControlSession('test');
+    attachFakeProc(session);
+    consumeReady(session);
+
+    const p = session.sendCommand('capture-pane -e -p -t %1 -S 0 -E 2');
+    await flushMicrotasks();
+
+    // Last captured row is a literal blank — must NOT be silently dropped.
+    feed(session, '%begin 0 1 0');
+    feed(session, 'row0');
+    feed(session, 'row1');
+    feed(session, '');
+    feed(session, '%end 0 1 0');
+
+    const result = await p;
+    expect(result.split('\n')).toEqual(['row0', 'row1', '']);
+  });
 });

--- a/backend/src/services/pane-viewport.ts
+++ b/backend/src/services/pane-viewport.ts
@@ -112,35 +112,18 @@ function isVisuallyBlank(s: string): boolean {
 }
 
 /**
- * Parse a `tmux capture-pane -e -p` raw result into row strings.
- *
- * tmux always emits a trailing `\n` so `split('\n')` produces one extra
- * empty string at the end which is a parse artifact, not a real row.
- * We pop exactly that artifact and preserve every other element — including
- * `''` rows that correspond to actually-blank lines in the captured range.
- *
- * Critical: do NOT loop-pop visually-blank trailing rows. Blank rows in
- * tmux scrollback represent real content (e.g. dev-log spacers) and
- * dropping them shortens prepend slices used by padFill, surfacing as a
- * void whose size fluctuates with scroll position.
- */
-export function parseCaptureOutput(raw: string): string[] {
-  const lines = raw.split('\n');
-  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
-  return lines;
-}
-
-/**
  * Fetch up to `wanted` rows of scrollback ending just above the visible
  * region (`-S -wanted -E -1`). Returns the literal rows or [] on failure.
  *
- * We only strip the trailing-`\n` artifact from `split('\n')`. We must NOT
- * trim further visually-blank rows: those represent actual blank lines in
- * the scrollback at that position. Dropping them produces fewer than `wanted`
- * rows, which downstream gets padded with `''` at the BOTTOM of the rendered
- * viewport — surfacing as a void whose size fluctuates with scroll position
- * (any pane whose scrollback interleaves content and blanks, e.g. dev logs,
- * exhibits a moving void as the user scrolls).
+ * IMPORTANT: do NOT trim trailing blank rows here. `cs.sendCommand` already
+ * returns the lines joined with `\n` and WITHOUT any trailing newline
+ * artifact (see `TmuxControlSession.handleEnd` → `currentOutput.join('\n')`).
+ * So `split('\n')` gives exactly the captured rows. A trailing `''` element
+ * means the last captured row is a literal blank line in the scrollback —
+ * popping it loses that real row and surfaces as a void at the BOTTOM of
+ * the rendered viewport whose size fluctuates with scroll position (any
+ * pane whose scrollback interleaves content and blanks, e.g. dev-server
+ * logs, exhibits the bug clearly).
  */
 async function captureScrollback(
   cs: TmuxControlSession,
@@ -152,7 +135,7 @@ async function captureScrollback(
     const raw = await cs.sendCommand(
       `capture-pane -e -p -t ${paneId} -S -${wanted} -E -1`,
     );
-    return parseCaptureOutput(raw);
+    return raw.split('\n');
   } catch {
     return [];
   }
@@ -244,7 +227,7 @@ export async function captureViewport(
   // tmux always returns exactly `end - start + 1` rows when both bounds are
   // in-range; pad with blanks defensively in case it returned fewer (e.g.
   // racing with a resize).
-  let lines = parseCaptureOutput(linesRaw);
+  let lines = linesRaw.split('\n');
   if (lines.length > rows) {
     lines = lines.slice(0, rows);
   }
@@ -297,7 +280,12 @@ export async function captureViewport(
           const padRaw = await cs.sendCommand(
             `capture-pane -e -p -t ${paneId} -S ${padStart} -E ${padEnd}`,
           );
-          const padLines = parseCaptureOutput(padRaw);
+          // Plain split. Do NOT trim trailing rows: see the comment on
+          // `captureScrollback` for why. A trailing `''` here means the
+          // row immediately above the visible window is a literal blank
+          // in the scrollback; popping it shortens the prepend and
+          // surfaces as a void at the bottom of the rendered viewport.
+          const padLines = padRaw.split('\n');
           if (padLines.length > 0) {
             const prepend = padLines.slice(-padNeeded);
             lines = [...prepend, ...lines];

--- a/backend/src/services/tmux-control.ts
+++ b/backend/src/services/tmux-control.ts
@@ -262,7 +262,18 @@ export class TmuxControlSession {
    * as UTF-8 string since they contain only ASCII or complete UTF-8.
    */
   private processRawLine(rawLine: Buffer): void {
-    if (rawLine.length === 0) return;
+    if (rawLine.length === 0) {
+      // Blank line. Inside a command response block this is a literal blank
+      // row in the response data (e.g. blank scrollback rows in
+      // `capture-pane -p` output). Dropping it shortens the response and
+      // surfaces downstream as missing rows / shifted viewports / void at
+      // the bottom of rendered panes. Outside a block, blank lines are
+      // protocol whitespace we can safely ignore.
+      if (this.currentBeginNum !== null) {
+        this.currentOutput.push('');
+      }
+      return;
+    }
 
     try {
       // Fast check: %output lines are the most frequent and must be

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.159",
+  "version": "0.1.160",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary

**Hotfix for the v0.1.159 viewport corruption** that the user reported as "void state is taking over the entire screen, and gets progressively worse as you scroll".

## Root cause

Two-layer bug:

1. **The real bug (long-standing)**: \`TmuxControlSession.processRawLine\` had \`if (rawLine.length === 0) return;\` BEFORE checking whether we were inside a \`%begin\`/\`%end\` response block. tmux's \`capture-pane -p\` faithfully emits literal blank rows (every-other-row dev-log spacing, Claude TUI partial paint, etc.), and the tokenizer dropped every one of them. A 55-row capture surfaced as a 32-row response in dev probing.
2. **v0.1.159's "fix" made it worse**: \`parseCaptureOutput\` popped a trailing \`''\` thinking it was a parse artifact, but \`cs.sendCommand\` returns lines joined WITHOUT a trailing-\\n artifact — so the pop actually destroyed the last literal blank row of every capture.

Combined, the user saw the void grow as they scrolled and, at large offsets, eat most of the screen.

## Fix

- \`processRawLine\`: push \`''\` to \`currentOutput\` when a blank line arrives inside a response block. Continue ignoring blank lines outside blocks (protocol whitespace).
- \`pane-viewport.ts\`: revert the \`parseCaptureOutput\` helper. Visible capture and pad captures use plain \`split('\n')\` again.
- Tests: 2 new regression tests in \`tmux-control-serialize.test.ts\` (interspersed blanks survive; trailing blank survives). Rewrote \`pane-viewport-capture.test.ts\` to document the \`sendCommand → split\` contract.

## Test plan

- [x] 182 backend tests pass (incl. 2 new + rewritten capture-contract tests)
- [x] biome lint pass
- [x] Live dev backend probed via /ws/mux:
  - 4 panes (cchub-work-1, orchestrator, linux, cchub-work-2/node)
  - offsets 0, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 50, 100, 200, 500
  - **All offsets: trailing void = 0** (was 11-14 with v0.1.159, 0-1 with v0.1.158)