### PR TITLE
fix(auth): ハードコードJWT秘密鍵を廃止しランダム生成+永続化 (#230)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,7 +12,7 @@ import { notify } from './routes/notify';
 import { peers } from './routes/peers';
 import { muxOpen, muxMessage, muxClose, type MuxData } from './routes/terminal-mux';
 import { parseArgs, runCli, VERSION } from './cli';
-import { conditionalAuthMiddleware, isAuthRequired, getJwtSecret } from './middleware/auth';
+import { conditionalAuthMiddleware, isAuthRequired, getJwtSecret, initJwtSecret } from './middleware/auth';
 import { AuthService } from './services/auth';
 import { getDataDir } from './utils/storage';
 import { t } from './i18n';
@@ -311,6 +311,11 @@ if (resolvedPassword) {
 } else {
   console.log(`⚠️  ${t('server.passwordNotSet')}`);
 }
+
+// Resolve the JWT signing secret (generates + persists a random one on first
+// run). Must run before any request is served so no token is ever signed with
+// a guessable default.
+await initJwtSecret();
 
 // Start server
 const port = args.port;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,3 +1,6 @@
+import { randomBytes } from 'node:crypto';
+import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
+import { join } from 'node:path';
 import { createMiddleware } from 'hono/factory';
 import type { Context, Next } from 'hono';
 import { AuthService, type JwtPayload } from '../services/auth';
@@ -10,7 +13,34 @@ declare module 'hono' {
   }
 }
 
-const jwtSecret = process.env.JWT_SECRET || 'development-secret-change-in-production';
+// The JWT signing secret. Resolved at startup by initJwtSecret(): an explicit
+// JWT_SECRET env var wins, otherwise a random 32-byte secret is generated once
+// and persisted (0600) in the data dir. There is intentionally NO usable
+// default — a hardcoded fallback would let anyone with the source forge tokens
+// and bypass password auth entirely.
+let jwtSecret: string | null = process.env.JWT_SECRET || null;
+
+// Resolve (and if necessary generate + persist) the JWT signing secret.
+// Must be awaited once at server startup before any request is served.
+export async function initJwtSecret(): Promise<void> {
+  if (jwtSecret) return;
+  const dataDir = getDataDir();
+  const secretPath = join(dataDir, 'jwt-secret');
+  try {
+    const existing = (await readFile(secretPath, 'utf-8')).trim();
+    if (existing) {
+      jwtSecret = existing;
+      return;
+    }
+  } catch {
+    // Not yet persisted — fall through to generate.
+  }
+  const generated = randomBytes(32).toString('hex');
+  await mkdir(dataDir, { recursive: true });
+  await writeFile(secretPath, generated, { mode: 0o600 });
+  await chmod(secretPath, 0o600);
+  jwtSecret = generated;
+}
 
 // Check if password auth is enabled
 export function isAuthRequired(): boolean {
@@ -38,7 +68,7 @@ export const conditionalAuthMiddleware = createMiddleware(async (c: Context, nex
   }
 
   const token = authHeader.slice(7);
-  const authService = new AuthService(getDataDir(), jwtSecret);
+  const authService = new AuthService(getDataDir(), getJwtSecret());
 
   try {
     const payload = await authService.verifyToken(token);
@@ -58,7 +88,7 @@ export const authMiddleware = createMiddleware(async (c: Context, next: Next) =>
   }
 
   const token = authHeader.slice(7);
-  const authService = new AuthService(getDataDir(), jwtSecret);
+  const authService = new AuthService(getDataDir(), getJwtSecret());
 
   try {
     const payload = await authService.verifyToken(token);
@@ -70,5 +100,8 @@ export const authMiddleware = createMiddleware(async (c: Context, next: Next) =>
 });
 
 export function getJwtSecret(): string {
+  if (!jwtSecret) {
+    throw new Error('JWT secret not initialized — call initJwtSecret() at startup');
+  }
   return jwtSecret;
 }

--- a/backend/tests/unit/jwt-secret.test.ts
+++ b/backend/tests/unit/jwt-secret.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { AuthService } from '../../src/services/auth';
+
+// Regression for #230: the JWT signing secret must never fall back to a
+// guessable hardcoded default. initJwtSecret() generates and persists a random
+// secret (0600) when neither JWT_SECRET env nor a persisted secret exists.
+
+const TEST_DATA_DIR = join(import.meta.dir, '.test-data-jwt');
+const OLD_HARDCODED_DEFAULT = 'development-secret-change-in-production';
+
+let initJwtSecret: () => Promise<void>;
+let getJwtSecret: () => string;
+
+beforeAll(async () => {
+  delete process.env.JWT_SECRET;
+  process.env.CC_HUB_DATA_DIR = TEST_DATA_DIR;
+  await rm(TEST_DATA_DIR, { recursive: true, force: true });
+  // Import after env setup so the module's secret starts uninitialized.
+  ({ initJwtSecret, getJwtSecret } = await import('../../src/middleware/auth'));
+});
+
+afterAll(async () => {
+  await rm(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+describe('jwt secret (initJwtSecret / getJwtSecret)', () => {
+  test('getJwtSecret throws before initialization', () => {
+    expect(() => getJwtSecret()).toThrow();
+  });
+
+  test('initJwtSecret generates a 64-hex secret persisted with mode 0600', async () => {
+    await initJwtSecret();
+    const secret = getJwtSecret();
+    expect(secret).toMatch(/^[0-9a-f]{64}$/);
+
+    const st = await stat(join(TEST_DATA_DIR, 'jwt-secret'));
+    expect(st.mode & 0o777).toBe(0o600);
+  });
+
+  test('a second initJwtSecret call returns the same persisted secret', async () => {
+    const first = getJwtSecret();
+    await initJwtSecret();
+    expect(getJwtSecret()).toBe(first);
+  });
+
+  test('no usable default: a token signed with the old hardcoded secret is rejected', async () => {
+    const secret = getJwtSecret();
+    const attacker = new AuthService(TEST_DATA_DIR, OLD_HARDCODED_DEFAULT);
+    const forged = await attacker.generateTokenForUser('attacker');
+
+    await expect(new AuthService(TEST_DATA_DIR, secret).verifyToken(forged)).rejects.toThrow();
+  });
+
+  test('a token signed with the resolved secret verifies', async () => {
+    const secret = getJwtSecret();
+    const svc = new AuthService(TEST_DATA_DIR, secret);
+    const token = await svc.generateTokenForUser('alice');
+    const payload = await svc.verifyToken(token);
+    expect(payload.username).toBe('alice');
+  });
+});


### PR DESCRIPTION
## 概要
`backend/src/middleware/auth.ts:13` の JWT 署名鍵が公開定数 `development-secret-change-in-production` にフォールバックしていた問題を修正（#230, Critical）。`JWT_SECRET` はどのデプロイ経路でも設定されないため、OSS のソースを知る誰もが有効トークンを偽造し `CCHUB_PASSWORD` を完全に回避できた。

## 変更
- `initJwtSecret()` を追加。起動時に秘密鍵を解決する:
  - `JWT_SECRET` env があればそれを使用
  - 無ければ `<dataDir>/jwt-secret` を読込、存在しなければ `randomBytes(32)` を生成し 0600 で永続化
- `getJwtSecret()` は未初期化なら throw（使える既定値を排除）
- middleware は `getJwtSecret()` を参照
- `index.ts` 起動シーケンス（パスワード解決後）で `await initJwtSecret()`

## 影響
旧デフォルト鍵で署名された既存トークンは無効化され、ユーザーは一度だけ再ログインが必要。

## 検証
- backend 全 187 テスト pass、新規回帰テスト `jwt-secret.test.ts`(5件) 追加
- lint / typecheck pass
- 実地確認: 一時 data dir で 64-hex 鍵生成・mode 0600・永続化一致・旧デフォルト鍵トークンが拒否・正規トークンが検証成功

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)