### PR TITLE
fix(files): sessionWorkingDirをライブセッションと照合しbase信頼を廃止 (#232)

### DIFF
--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -4,10 +4,44 @@ import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { FileService } from '../services/file-service';
 import { FileChangeTracker } from '../services/file-change-tracker';
+import { TmuxService } from '../services/tmux';
 import type { FileListResponse, FileReadResponse, FileChangesResponse, FileInfo, GitChangesResponse, GitDiffResponse, GitFileChange, GitChangeStatus } from '../../../shared/types';
 
 const fileService = new FileService();
 const changeTracker = new FileChangeTracker();
+const tmuxService = new TmuxService();
+
+/**
+ * The client supplies `sessionWorkingDir` as the base for file access. It MUST
+ * be the working directory of an actual live session/pane (or a directory
+ * below one); otherwise a client could set base=/etc (or ~/.ssh, /) and the
+ * only confinement check (requested path startsWith base) would happily read
+ * or write arbitrary host files. We resolve the candidate against the
+ * authoritative live-session list and compare realpaths so a symlinked base
+ * can't smuggle an off-tree path. (#232)
+ */
+async function isAllowedSessionDir(sessionWorkingDir: string): Promise<boolean> {
+  let target: string;
+  try {
+    target = await realpath(sessionWorkingDir);
+  } catch {
+    return false;
+  }
+  const sessions = await tmuxService.listSessions();
+  for (const s of sessions) {
+    for (const cand of [s.currentPath, ...(s.panes ?? []).map((p) => p.path)]) {
+      if (!cand) continue;
+      let base: string;
+      try {
+        base = await realpath(cand);
+      } catch {
+        continue;
+      }
+      if (target === base || target.startsWith(`${base}/`)) return true;
+    }
+  }
+  return false;
+}
 
 export const files = new Hono();
 
@@ -23,6 +57,10 @@ files.get('/list', async (c) => {
 
   if (!path || !sessionWorkingDir) {
     return c.json({ error: 'Missing path or sessionWorkingDir parameter' }, 400);
+  }
+
+  if (!(await isAllowedSessionDir(sessionWorkingDir))) {
+    return c.json({ error: 'Access denied' }, 403);
   }
 
   try {
@@ -59,6 +97,10 @@ files.get('/read', async (c) => {
 
   if (!path || !sessionWorkingDir) {
     return c.json({ error: 'Missing path or sessionWorkingDir parameter' }, 400);
+  }
+
+  if (!(await isAllowedSessionDir(sessionWorkingDir))) {
+    return c.json({ error: 'Access denied' }, 403);
   }
 
   try {
@@ -424,6 +466,10 @@ files.get('/raw', async (c) => {
     return c.json({ error: 'Missing path or sessionWorkingDir parameter' }, 400);
   }
 
+  if (!(await isAllowedSessionDir(sessionWorkingDir))) {
+    return c.json({ error: 'Access denied' }, 403);
+  }
+
   try {
     const validPath = await fileService.validatePath(path, sessionWorkingDir);
     if (!validPath) {
@@ -490,6 +536,10 @@ files.get('/download', async (c) => {
     return c.json({ error: 'Missing path or sessionWorkingDir parameter' }, 400);
   }
 
+  if (!(await isAllowedSessionDir(sessionWorkingDir))) {
+    return c.json({ error: 'Access denied' }, 403);
+  }
+
   try {
     const validPath = await fileService.validatePath(path, sessionWorkingDir);
     if (!validPath) {
@@ -539,6 +589,10 @@ files.post('/upload', async (c) => {
 
     if (typeof destPath !== 'string' || typeof sessionWorkingDir !== 'string') {
       return c.json({ error: 'Missing path or sessionWorkingDir' }, 400);
+    }
+
+    if (!(await isAllowedSessionDir(sessionWorkingDir))) {
+      return c.json({ error: 'Access denied' }, 403);
     }
 
     const validDir = await fileService.validatePath(destPath, sessionWorkingDir);


### PR DESCRIPTION
## 概要
file ルート（/list, /read, /raw, /download, /upload）が client 供給の `sessionWorkingDir` をそのまま FileService の信頼 base に渡していた問題を修正（#232, Critical）。唯一の確認が `requested.startsWith(base)` のため、client が base と path を同一の任意ツリーに設定（例 base=/etc, path=/etc/passwd、~/.ssh、/upload で任意書込）するとセッションサンドボックスを越えて任意ホストファイルを read/write できた。

## 変更
- `isAllowedSessionDir()` を追加。client の `sessionWorkingDir` を**権威あるライブセッション一覧**（各セッションの currentPath + 各ペインの path）と照合し、実セッションの作業ディレクトリ（またはその配下）でなければ 403。
- realpath 同士で比較し、symlink base による抜け道を防止。
- /list, /read, /raw, /download, /upload の入口に gate を追加。

## 検証
- backend 全 197 テスト pass、lint / typecheck pass
- **dev 実機**（隔離セッション `cchub232test` を `/tmp/cchub232dir` で起動）:
  - 回帰: 正規 base での `/list` 200、`/read hello.txt` 200 + 内容取得
  - セキュリティ: `base=/etc & path=/etc/passwd` → 403、`base=/ & path=/` → 403、`/raw /etc/passwd` → 403、`download ~/.ssh/id_rsa` → 403、正規 base を騙った `path=/etc/passwd` トラバーサル → 403

注: `/git-changes`・`/git-diff`・`/changes` の client 作業ディレクトリ受理は別 finding（medium・未検証）で、本 PR の範囲外。

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)