### PR TITLE
fix(session-history): projectDirName/sessionId のパストラバーサルを拒否 (#233)

### DIFF
--- a/backend/src/services/session-history.ts
+++ b/backend/src/services/session-history.ts
@@ -7,6 +7,24 @@ import type { HistorySession } from '../../../shared/types';
 
 export type { HistorySession };
 
+/**
+ * A Claude/Codex project dir name and session id are always single flat path
+ * segments (no separators). Client-supplied values are joined under
+ * ~/.claude/projects, so anything containing a separator or `..` could escape
+ * that base and enumerate/read arbitrary host files. Reject those. (#233)
+ */
+export function isFlatSegment(value: string): boolean {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value !== '.' &&
+    value !== '..' &&
+    !value.includes('/') &&
+    !value.includes('\\') &&
+    !value.includes('\0')
+  );
+}
+
 interface SessionMetadata {
   startTime?: string;
   endTime?: string;
@@ -330,6 +348,7 @@ export class SessionHistoryService {
    */
   async getProjectSessions(projectDirName: string): Promise<HistorySession[]> {
     const sessions: HistorySession[] = [];
+    if (!isFlatSegment(projectDirName)) return sessions;
     const projectDir = join(this.projectsDir, projectDirName);
 
     try {
@@ -427,9 +446,12 @@ export class SessionHistoryService {
   }
 
   async getConversation(sessionId: string, projectDirName?: string): Promise<ConversationMessage[]> {
+    // sessionId is interpolated into `${sessionId}.jsonl` under projectsDir;
+    // reject anything that isn't a flat segment so it can't traverse. (#233)
+    if (!isFlatSegment(sessionId)) return [];
     try {
       // If projectDirName is provided, look directly in that directory
-      if (projectDirName) {
+      if (projectDirName && isFlatSegment(projectDirName)) {
         const projectDir = join(this.projectsDir, projectDirName);
         const directPath = join(projectDir, `${sessionId}.jsonl`);
         const messages = await this.parseJsonlFile(directPath);
@@ -492,6 +514,9 @@ export class SessionHistoryService {
       const projectDirs = await readdir(this.projectsDir);
 
       for (const sessionId of sessionIds) {
+        // sessionId is interpolated into `${sessionId}.jsonl`; skip any that
+        // isn't a flat segment so it can't traverse out of projectsDir. (#233)
+        if (!isFlatSegment(sessionId)) continue;
         // Find the session file
         for (const dir of projectDirs) {
           const indexPath = join(this.projectsDir, dir, 'sessions-index.json');

--- a/backend/tests/unit/session-history-traversal.test.ts
+++ b/backend/tests/unit/session-history-traversal.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { isFlatSegment, SessionHistoryService } from '../../src/services/session-history';
+
+// Regression for #233: client-supplied projectDirName / sessionId are joined
+// under ~/.claude/projects. Path-separator or `..` values must be rejected so
+// they can't traverse out and enumerate/read arbitrary host files.
+
+describe('isFlatSegment', () => {
+  test('accepts real project dir names and session ids', () => {
+    expect(isFlatSegment('-home-m0a-cchub-work-1')).toBe(true);
+    expect(isFlatSegment('54e8db01-6213-4169-8de9-1d2be2ac3513')).toBe(true);
+  });
+
+  test('rejects traversal / separator / empty values', () => {
+    for (const v of ['../../../etc', '..', '.', '', 'a/b', 'a\\b', '/etc', 'x\0y', '../../home/m0a/.ssh']) {
+      expect(isFlatSegment(v)).toBe(false);
+    }
+  });
+});
+
+describe('SessionHistoryService traversal inputs', () => {
+  const svc = new SessionHistoryService();
+
+  test('getProjectSessions rejects traversal dir name (returns [])', async () => {
+    expect(await svc.getProjectSessions('../../../etc')).toEqual([]);
+    expect(await svc.getProjectSessions('../..')).toEqual([]);
+  });
+
+  test('getConversation rejects traversal sessionId/projectDirName (returns [])', async () => {
+    expect(await svc.getConversation('../../../../etc/passwd')).toEqual([]);
+    expect(await svc.getConversation('passwd', '../../../../etc')).toEqual([]);
+  });
+
+  test('getSessionsMetadata skips traversal session ids', async () => {
+    const r = await svc.getSessionsMetadata(['../../../etc/passwd', 'a/b']);
+    expect(Object.keys(r)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要
`getProjectSessions` / `getConversation` / `getSessionsMetadata` が client 供給の `projectDirName`・`sessionId` を無検証で `~/.claude/projects` 配下に `join` していた問題を修正（#233, High）。`../../../etc` のような値（Hono の単一セグメントルータを percent-encode で回避可能）で base を脱出し、任意ディレクトリの列挙とホスト上の任意 `*.jsonl` 読取ができた（パスワード未設定なら無認証、peer proxy 経由でも到達）。

## 変更
- `isFlatSegment()` を追加。パス区切り・NUL・`.`/`..`/空を含む値を拒否（実際の project dir 名 / session id は常に単一フラットセグメント）。
- `getProjectSessions`: 不正な `projectDirName` は空を返す
- `getConversation`: `sessionId` を先頭で検証、`projectDirName` ブランチは flat segment 時のみ使用（不正時は通常検索にフォールバック）
- `getSessionsMetadata`: 不正な `sessionId` をスキップ

## 検証
- backend 全 202 テスト pass（新規 `session-history-traversal.test.ts` 5件）、lint / typecheck pass
- **dev 実機**:
  - 回帰: 正規 `projects/-home-m0a` → 11 セッション、実セッションの会話 → 36 メッセージ
  - セキュリティ: `projectDirName=../../../../tmp/cchub233` で probe jsonl を**読まない**（`PROBE_233_SECRET` 漏洩なし）、`projects/..%2F..%2F..%2Fetc` → 0 件、`/tmp` probe 列挙 → 0 件

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)