### PR TITLE
fix(sessions): resume sessionId を制約+quoteしてshellインジェクション阻止 (#234)

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { homedir } from 'node:os';
-import { AGENT_PROVIDERS, AGENT_PROVIDER_IDS, CreateSessionSchema, DEFAULT_AGENT_PROVIDER, PaneIdSchema, agentResumeCommand, agentSupportsConversationMetadata, type AgentProvider, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
+import { AGENT_PROVIDERS, AGENT_PROVIDER_IDS, CreateSessionSchema, DEFAULT_AGENT_PROVIDER, PaneIdSchema, SessionIdSchema, agentResumeCommand, agentSupportsConversationMetadata, type AgentProvider, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
 import { TmuxService } from '../services/tmux';
 import { controlSessions, getOrCreateControlSession } from '../services/tmux-control';
 import { ClaudeCodeService } from '../services/claude-code';
@@ -382,8 +382,8 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
 
 
 const ResumeSessionSchema = z.object({
-  ccSessionId: z.string().optional(),
-  sessionId: z.string().optional(),
+  ccSessionId: SessionIdSchema.optional(),
+  sessionId: SessionIdSchema.optional(),
   agent: z.enum(AGENT_PROVIDER_IDS).optional(),
 });
 
@@ -634,7 +634,7 @@ sessions.get('/prompts/search', async (c) => {
 // POST /sessions/history/resume - Resume a session from history (creates new tmux session)
 // NOTE: Must be defined BEFORE /:id routes
 const ResumeHistorySchema = z.object({
-  sessionId: z.string(),
+  sessionId: SessionIdSchema,
   projectPath: z.string(),
   agent: z.enum(AGENT_PROVIDER_IDS).optional(),
 });

--- a/backend/tests/unit/agent-providers.test.ts
+++ b/backend/tests/unit/agent-providers.test.ts
@@ -88,8 +88,9 @@ describe('Agent provider registry', () => {
 
   test('builds resume commands per agent', () => {
     expect(agentResumeCommand('claude')).toBe('claude -r');
-    expect(agentResumeCommand('claude', 'abc-123')).toBe('claude -r abc-123');
+    // session id is single-quoted (typed into an interactive shell) — #234
+    expect(agentResumeCommand('claude', 'abc-123')).toBe("claude -r 'abc-123'");
     expect(agentResumeCommand('codex')).toBe('codex resume');
-    expect(agentResumeCommand('codex', 'thread-xyz')).toBe('codex resume thread-xyz');
+    expect(agentResumeCommand('codex', 'thread-xyz')).toBe("codex resume 'thread-xyz'");
   });
 });

--- a/backend/tests/unit/resume-sessionid.test.ts
+++ b/backend/tests/unit/resume-sessionid.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { SessionIdSchema, agentResumeCommand } from '../../../shared/types';
+
+// Regression for #234: resume sessionId is typed into an interactive shell via
+// `claude -r <id>` / `codex resume <id>`. An unconstrained id like
+// "x; rm -rf ~ #" executed arbitrary commands on the host.
+
+describe('SessionIdSchema', () => {
+  test('accepts UUID-like ids', () => {
+    expect(SessionIdSchema.safeParse('038c282f-3b3f-43c4-9f60-0c3a9e503b7d').success).toBe(true);
+    expect(SessionIdSchema.safeParse('thread_abc.123-XYZ').success).toBe(true);
+  });
+
+  test('rejects shell-injection / whitespace / quote payloads', () => {
+    for (const bad of ['x; rm -rf ~ #', 'a b', 'a\nkill', "a'b", 'a$(id)', 'a|b', '../etc', '', 'a/b']) {
+      expect(SessionIdSchema.safeParse(bad).success).toBe(false);
+    }
+  });
+});
+
+describe('agentResumeCommand quoting (defense-in-depth)', () => {
+  test('single-quotes the session id', () => {
+    expect(agentResumeCommand('claude', 'abc-123')).toBe("claude -r 'abc-123'");
+    expect(agentResumeCommand('codex', 'thread-xyz')).toBe("codex resume 'thread-xyz'");
+  });
+
+  test('escapes embedded single quotes so a value cannot break out', () => {
+    // Even if validation were bypassed, the value stays inside the quoted arg.
+    expect(agentResumeCommand('claude', "a'b")).toBe("claude -r 'a'\\''b'");
+  });
+
+  test('no id yields the bare resume command', () => {
+    expect(agentResumeCommand('claude')).toBe('claude -r');
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -90,7 +90,12 @@ export function agentSupportsConversationMetadata(agent: string | undefined): bo
 
 export function agentResumeCommand(agent: AgentProvider, sessionId?: string): string {
   const base = AGENT_PROVIDERS[agent].resumeCommand;
-  return sessionId ? `${base} ${sessionId}` : base;
+  if (!sessionId) return base;
+  // The command is typed into an interactive shell via tmux send-keys, so the
+  // session id is single-quoted to guarantee it cannot break out of the
+  // argument — defense-in-depth on top of SessionIdSchema at the routes. #234
+  const quoted = `'${sessionId.replace(/'/g, `'\\''`)}'`;
+  return `${base} ${quoted}`;
 }
 
 export interface SessionResponse {
@@ -126,6 +131,11 @@ export const LoginSchema = z.object({
 
 // Pane ID validation (e.g., "%0", "%1")
 export const PaneIdSchema = z.string().regex(/^%\d+$/, 'Invalid pane ID');
+
+// Agent session id validation. Claude/Codex session ids are UUID-like; this
+// also bounds them to shell-safe characters because the id is typed into an
+// interactive shell via `claude -r <id>` / `codex resume <id>` (#234).
+export const SessionIdSchema = z.string().regex(/^[A-Za-z0-9._-]+$/, 'Invalid session id');
 
 export interface PaneInfo {
   paneId: string;          // "%0", "%1"


### PR DESCRIPTION
## 概要
resume ルートの `sessionId` が bare `z.string()` で、`agentResumeCommand` → `claude -r <id>` / `codex resume <id>` として send-keys でペインの対話シェルに入力されていた（#234, High）。`x; rm -rf ~ #` のような値でホスト上の任意コマンドが実行でき、peer proxy 経由で他ホストにも到達した。

## 変更
- `SessionIdSchema`(`^[A-Za-z0-9._-]+$`) を追加し、`ResumeSessionSchema`・`ResumeHistorySchema` の sessionId に適用（shell メタ文字を拒否）。
- `agentResumeCommand` が sessionId を single-quote（多重防御。将来検証が緩んでも引数を抜け出せない）。

## 検証
- backend 全 207 テスト pass（新規 `resume-sessionid.test.ts` + `agent-providers.test.ts` 更新）、lint / typecheck pass
- **dev 実機（/history/resume）**:
  - セキュリティ: `x; touch ... #`・`a\nkill`・`a$(id)`・`a|b`・`../../etc` すべて **400**、マーカー未作成、rogue tmux セッション未作成
  - 回帰: 正規 `valid-id-123` は schema 通過し success（quote 済みコマンドを生成）

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)