### PR TITLE
fix(peers): peer URL を https+非ローカル限定にしてSSRF阻止 (#235)

### DIFF
--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -27,6 +27,7 @@ import {
   type StoredPeer,
 } from '../services/peer-registry';
 import { loginToPeer, verifyPeer, peerFetch, PeerAuthError } from '../services/peer-auth';
+import { isSafePeerUrl } from '../services/peer-url';
 import { discoverPeers } from '../services/peer-discovery';
 import { buildSessionsList, sessionHistoryService, codexHistoryService } from './sessions';
 import { buildDashboard } from './dashboard';
@@ -552,6 +553,9 @@ async function proxyPeerFiles(c: Context): Promise<Response> {
   if (!peer) return c.json({ error: 'Peer not found' }, 404);
   if (peer.url === SELF_PEER_URL) {
     return c.json({ error: 'Use /api/files/* for local peer' }, 400);
+  }
+  if (!isSafePeerUrl(peer.url)) {
+    return c.json({ error: 'Unsafe peer URL' }, 400);
   }
 
   // /api/peers/:peerId/files/<rest>?<query>  →  peer's /api/files/<rest>?<query>

--- a/backend/src/services/peer-auth.ts
+++ b/backend/src/services/peer-auth.ts
@@ -7,6 +7,7 @@
  */
 
 import { recordPeerFailure, recordPeerSuccess } from './peer-registry';
+import { isSafePeerUrl } from './peer-url';
 
 const VERIFY_TIMEOUT_MS = 5_000;
 
@@ -21,11 +22,21 @@ function normalizePeerUrl(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
+// SSRF guard: every outbound peer request goes through here. Reject non-https
+// or loopback/link-local/private targets before fetching (covers freshly
+// supplied URLs at creation and already-stored URLs). #235
+function assertSafePeerUrl(url: string): void {
+  if (!isSafePeerUrl(url)) {
+    throw new PeerAuthError(0, 'peer URL は https かつ非ローカルなホストである必要があります');
+  }
+}
+
 /**
  * peer の /api/auth/required を叩いて、認証が有効か確認する。
  * 接続失敗時は throw する (PeerAuthError)。
  */
 async function isPeerAuthRequired(url: string): Promise<boolean> {
+  assertSafePeerUrl(url);
   const base = normalizePeerUrl(url);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
@@ -60,6 +71,7 @@ async function isPeerAuthRequired(url: string): Promise<boolean> {
  *   - peer 側 auth 無効なら 400 が返るので空トークンとして扱う
  */
 export async function loginToPeer(url: string, password?: string): Promise<string> {
+  assertSafePeerUrl(url);
   const base = normalizePeerUrl(url);
 
   // password 未指定: まず peer 側の auth 設定を確認
@@ -116,6 +128,7 @@ export async function verifyPeer(
   url: string,
   token: string | undefined,
 ): Promise<{ ok: true; latencyMs: number } | { ok: false; status: number; message: string }> {
+  assertSafePeerUrl(url);
   const base = normalizePeerUrl(url);
 
   const controller = new AbortController();
@@ -161,6 +174,7 @@ export async function peerFetch(
   path: string,
   init?: RequestInit,
 ): Promise<Response> {
+  assertSafePeerUrl(url);
   const base = normalizePeerUrl(url);
 
   const headers = new Headers(init?.headers);

--- a/backend/src/services/peer-url.ts
+++ b/backend/src/services/peer-url.ts
@@ -1,0 +1,80 @@
+import { isIP } from 'node:net';
+
+/**
+ * Guards peer URLs against SSRF (#235). Peers are other CC Hub servers reached
+ * over Tailscale, so legitimate hosts are *.ts.net or the Tailscale ranges
+ * (CGNAT 100.64.0.0/10, ULA fd7a:115c:a1e0::/48) — those stay allowed. We
+ * reject non-https schemes (kills file:/gopher:/javascript:/http:) and
+ * loopback / link-local (incl. 169.254.169.254 cloud metadata) / RFC1918
+ * private hosts, which are the SSRF targets.
+ *
+ * Note: hostnames are allowed (we can't resolve DNS here); this closes the
+ * IP-literal and non-https vectors. Full resolve-time validation would be a
+ * deeper follow-up.
+ */
+export function isSafePeerUrl(rawUrl: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== 'https:') return false;
+  const host = u.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (!host) return false;
+  if (host === 'localhost' || host.endsWith('.localhost')) return false;
+  const kind = isIP(host);
+  if (kind === 4) return !isBlockedIpv4(host);
+  if (kind === 6) return !isBlockedIpv6(host);
+  // A resolvable hostname (e.g. peer.tailnet.ts.net) — allowed.
+  return true;
+}
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null;
+    const v = Number(p);
+    if (v > 255) return null;
+    n = n * 256 + v;
+  }
+  return n >>> 0;
+}
+
+function inRange(ip: number, base: string, bits: number): boolean {
+  const b = ipv4ToInt(base);
+  if (b === null) return false;
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (ip & mask) === (b & mask);
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const n = ipv4ToInt(ip);
+  if (n === null) return true;
+  if (inRange(n, '100.64.0.0', 10)) return false; // Tailscale CGNAT — allowed
+  return (
+    inRange(n, '127.0.0.0', 8) || // loopback
+    inRange(n, '10.0.0.0', 8) || // RFC1918
+    inRange(n, '172.16.0.0', 12) || // RFC1918
+    inRange(n, '192.168.0.0', 16) || // RFC1918
+    inRange(n, '169.254.0.0', 16) || // link-local + cloud metadata
+    inRange(n, '0.0.0.0', 8) // "this" network
+  );
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const h = ip.toLowerCase();
+  if (h === '::1' || h === '::') return true; // loopback / unspecified
+  // link-local fe80::/10 (fe80..febf)
+  if (/^fe[89ab]/.test(h)) return true;
+  // Tailscale ULA fd7a:115c:a1e0::/48 — allowed before the general ULA block.
+  if (h.startsWith('fd7a:115c:a1e0')) return false;
+  // other ULA fc00::/7 (fc.. / fd..)
+  if (/^f[cd]/.test(h)) return true;
+  // IPv4-mapped (::ffff:127.0.0.1 etc.)
+  const mapped = h.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isBlockedIpv4(mapped[1]);
+  return false;
+}

--- a/backend/tests/unit/peer-url.test.ts
+++ b/backend/tests/unit/peer-url.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import { isSafePeerUrl } from '../../src/services/peer-url';
+
+// Regression for #235: peer URLs are fetched server-side (with the stored
+// wsToken attached), so an attacker-chosen URL is an SSRF primitive. Only
+// https to non-local hosts (incl. Tailscale ranges) is allowed.
+
+describe('isSafePeerUrl', () => {
+  test('allows https Tailscale hosts/IPs (legitimate peers)', () => {
+    expect(isSafePeerUrl('https://beelink-arch.tail4459c9.ts.net:5923')).toBe(true);
+    expect(isSafePeerUrl('https://100.91.210.90:5923')).toBe(true); // Tailscale CGNAT 100.64/10
+    expect(isSafePeerUrl('https://example.com')).toBe(true);
+    expect(isSafePeerUrl('https://[fd7a:115c:a1e0::1]:5923')).toBe(true); // Tailscale ULA
+  });
+
+  test('rejects non-https schemes', () => {
+    for (const u of [
+      'http://100.91.210.90:5923',
+      'file:///etc/passwd',
+      'gopher://127.0.0.1:6379/_INFO',
+      'javascript:alert(1)',
+      'ftp://example.com',
+    ]) {
+      expect(isSafePeerUrl(u)).toBe(false);
+    }
+  });
+
+  test('rejects loopback / link-local / private hosts even over https', () => {
+    for (const u of [
+      'https://127.0.0.1:5923',
+      'https://localhost:5923',
+      'https://169.254.169.254/latest/meta-data/', // cloud metadata
+      'https://10.0.0.5/admin',
+      'https://172.16.0.1',
+      'https://192.168.1.1',
+      'https://[::1]:5923',
+      'https://[fe80::1]',
+      'https://0.0.0.0',
+    ]) {
+      expect(isSafePeerUrl(u)).toBe(false);
+    }
+  });
+
+  test('rejects garbage', () => {
+    expect(isSafePeerUrl('not a url')).toBe(false);
+    expect(isSafePeerUrl('')).toBe(false);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -241,7 +241,18 @@ export interface PeerDiscoverResponse {
 
 export const PeerCreateSchema = z.object({
   nickname: z.string().min(1).max(64),
-  url: z.url(),
+  // Must be https. The backend additionally rejects loopback/link-local/
+  // private hosts at fetch time to block SSRF (Tailscale ranges stay allowed). #235
+  url: z.url().refine(
+    (u) => {
+      try {
+        return new URL(u).protocol === 'https:';
+      } catch {
+        return false;
+      }
+    },
+    { message: 'peer URL は https である必要があります' },
+  ),
   // peer 側で auth が無効 (パスワード未設定) ならクライアントは password を
   // 送らなくて良い。loginToPeer 側で 400 = "auth disabled" を空トークンで処理する
   password: z.string().optional(),


### PR DESCRIPTION
## 概要
`PeerCreateSchema.url` が `z.url()` で任意 scheme/host を許可し、保存 URL は wsToken 付きでサーバ側 fetch されていた（#235, High）。client が loopback・`169.254.169.254`(クラウドメタデータ)・RFC1918 等を指す peer を登録すると、サーバが credential 付きリクエストを発行する SSRF になっていた（`file:`/`gopher:`/`javascript:` も通過）。

## 変更
- `isSafePeerUrl()`（`services/peer-url.ts`）を追加: https 必須、loopback/link-local/RFC1918 を拒否。**Tailscale 範囲（CGNAT 100.64.0.0/10, ULA fd7a:115c:a1e0::/48, `*.ts.net`）は許可**。
- 全 outbound peer fetch（`loginToPeer`/`verifyPeer`/`peerFetch` + file proxy）でガード → 新規・保存済みの両 URL を fetch 時に検証。
- `PeerCreateSchema` に https refine を追加（早期拒否）。

## 検証
- backend 全 211 テスト pass（新規 `peer-url.test.ts` 4件）、lint / typecheck pass
- **dev 実機（POST /api/peers）**:
  - `http://127.0.0.1`・`file://` → 400（schema: https 必須）
  - `https://127.0.0.1`・`https://169.254.169.254`・`https://10.0.0.5`・`https://localhost` → 400（SSRF guard メッセージ）
  - `https://<公開ホスト>` → guard を**通過**し接続失敗（別メッセージ）= Tailscale/公開 https を誤ブロックしないことを確認

注: DNS リバインディング（ホスト名が内部 IP へ解決）は resolve 時検証が要る別 follow-up。

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)