### PR TITLE
fix(terminal-mux): ping を sessionId gate より前で応答し再接続ストーム解消 (#236)

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -195,6 +195,16 @@ export async function muxMessage(ws: ServerWebSocket<MuxData>, message: string |
     return;
   }
 
+  // Keepalive. Handle before the sessionId/subscription gate below: the client
+  // pings with sessionId="" whenever no terminal is selected (dashboard, file
+  // viewer, history). If those pings were dropped, the client never gets a
+  // pong, force-closes after the timeout, and reconnect-storms. #236
+  if (msg.type === 'ping') {
+    ws.data.lastPingAt = Date.now();
+    ws.send(JSON.stringify({ type: 'pong', timestamp: msg.timestamp }));
+    return;
+  }
+
   const sessionId = (msg as { sessionId?: string }).sessionId;
   if (!sessionId) return;
 
@@ -612,11 +622,6 @@ async function handleControlMessage(
       case 'request-viewport': {
         sub.liveOffset.set(msg.paneId, Math.max(0, msg.offset | 0));
         await pushViewport(ws, sessionId, sub, msg.paneId, msg.offset);
-        break;
-      }
-      case 'ping': {
-        ws.data.lastPingAt = Date.now();
-        ws.send(JSON.stringify({ type: 'pong', timestamp: msg.timestamp }));
         break;
       }
       case 'client-info': {


### PR DESCRIPTION
## 概要
`ping` が `handleControlMessage` 内（`if (!sessionId) return` + `if (!sub) return` gate の後ろ）でのみ処理されていた（#236, High）。client はターミナル未選択時（ダッシュボード/ファイルビューア/履歴）に `sessionId=""` で ping するため、これが無言で drop され pong が返らず、25s タイムアウトで force-close → ~25s ごとの再接続ストームになっていた（sessions-updated / conversation プッシュを中断）。

## 変更
- `muxMessage` のトップレベル（gate の前）で `ping` を処理（`lastPingAt` 更新 + `pong` 返信）。
- `handleControlMessage` の dead な ping case を削除。

## 検証
- backend 全 211 テスト pass、lint / typecheck pass
- **dev 実機（WS）**: subscribe せず `sessionId=''` の ping → **pong 受信**、未 subscribe の sessionId の ping → **pong 受信**（修正前は両方 drop）

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)