### PR TITLE
fix(peers): peer file proxy で Range/条件付きヘッダを転送 (#237)

### DIFF
--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -570,6 +570,13 @@ async function proxyPeerFiles(c: Context): Promise<Response> {
   if (peer.wsToken) headers.set('Authorization', `Bearer ${peer.wsToken}`);
   const ct = c.req.header('Content-Type');
   if (ct) headers.set('Content-Type', ct);
+  // Forward range/conditional headers so peer-hosted media (video/audio) can be
+  // seeked and large files stream as ranged 206s instead of full-body 200s —
+  // the peer's /files/raw supports Range only when the header reaches it. #237
+  for (const h of ['Range', 'If-Range', 'If-None-Match', 'If-Modified-Since']) {
+    const v = c.req.header(h);
+    if (v) headers.set(h, v);
+  }
 
   const init: RequestInit = { method: c.req.method, headers };
   if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {


### PR DESCRIPTION
## 概要
`proxyPeerFiles` が `Authorization`+`Content-Type` のみの新規 Headers を作り、client の `Range`/`If-Range`/`If-None-Match`/`If-Modified-Since` を転送していなかった（#237, High）。peer 側 `/files/raw` は Range が届いた時だけ 206 を返すため、peer ホストの `<video>`/`<audio>` がシークできず、大ファイルも全転送されていた。

## 変更
- 上記 4 ヘッダを上流 fetch へ転送。上流の status/ヘッダ pass-through により 206 + `Content-Range`/`Accept-Ranges` がそのまま返る。

## 検証
- backend 全 211 テスト pass、lint / typecheck pass
- **dev 実機（2 インスタンス: hub:3456 / peer:3457 を Tailscale ホスト名で登録）**:
  - proxy 経由 `/files/raw` に `Range: bytes=0-3` → **206 Partial Content + `Content-Range: bytes 0-3/1000`**（= Range が転送され peer が partial を返す。修正前は転送されず 200）
  - Range なし → 200

## 既知の別 finding（本 PR 対象外）
peer を直接叩いても 206 の body が full（1000B）で返る不整合を確認。これは peer 側 `/files/raw` の Range 未クランプ（Content-Length/body 不整合）という**別の medium finding**（`files.ts:419-475`）であり、proxy 転送とは独立。peer メディアの完全なシークにはこちらの修正も別途必要。

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)