### PR TITLE
fix(html-preview): drop allow-same-origin to prevent token exfiltration

### DIFF
--- a/frontend/src/components/files/HtmlViewer.tsx
+++ b/frontend/src/components/files/HtmlViewer.tsx
@@ -29,10 +29,14 @@ export function HtmlViewer({ content, fileName }: HtmlViewerProps) {
 
 			{/* Content */}
 			<div className="flex-1 bg-white">
+				{/* sandbox="allow-scripts" without allow-same-origin gives the
+				    frame a unique opaque origin, so a malicious preview HTML cannot
+				    reach window.parent.localStorage (auth token) or hit the cchub
+				    API as the logged-in user. #261 */}
 				<iframe
 					src={blobUrl}
 					className="w-full h-full border-0"
-					sandbox="allow-scripts allow-same-origin"
+					sandbox="allow-scripts"
 					title={fileName}
 				/>
 			</div>


### PR DESCRIPTION
## Summary

HTML preview iframe (`HtmlViewer.tsx`) was sandboxed as `allow-scripts allow-same-origin` — the combination MDN explicitly warns against. Because the blob URL inherits the cchub origin, scripts inside a previewed HTML file can run `window.parent.localStorage.getItem('cc-hub-token')` to steal the JWT or issue authenticated fetches to the cchub API.

Dropping \`allow-same-origin\` forces the frame to a **unique opaque origin** while still letting the HTML render and execute its own scripts. No code in this repo accesses the iframe's \`contentDocument\` / \`contentWindow\` so there is no consumer that relied on same-origin (grep verified).

## Test plan
- [x] Lint / typecheck pass
- [x] Dev server starts cleanly, HTML preview component unchanged otherwise
- Browser-side: opening an .html file in the preview still renders correctly; scripts inside it now see a unique origin and cannot access \`parent.localStorage\`

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)