### PR TITLE
fix(update): verify SHA-256 / magic / length before replacing the binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,17 @@ jobs:
           name: cchub-macos-arm64
           path: dist
 
+      # Publish per-asset SHA-256 hashes so `cchub update` can verify the
+      # downloaded binary's integrity before replacing the running service. #255
+      - name: Generate SHA256SUMS
+        working-directory: dist
+        run: sha256sum cchub-linux-x64 cchub-macos-arm64 > SHA256SUMS
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/cchub-linux-x64
             dist/cchub-macos-arm64
+            dist/SHA256SUMS
           generate_release_notes: true

--- a/backend/src/commands/__tests__/update-integrity.test.ts
+++ b/backend/src/commands/__tests__/update-integrity.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from 'bun:test';
+import { isExecutableMagic, parseSha256Sums } from '../update';
+
+const ELF = new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00]);
+const MACHO_64_LE = new Uint8Array([0xcf, 0xfa, 0xed, 0xfe, 0x07, 0x00, 0x00, 0x01]);
+const MACHO_FAT_BE = new Uint8Array([0xca, 0xfe, 0xba, 0xbe, 0x00, 0x00, 0x00, 0x02]);
+const NOT_EXEC = new Uint8Array([0x3c, 0x21, 0x44, 0x4f, 0x43, 0x54, 0x59]); // '<!DOCTY'
+
+describe('isExecutableMagic', () => {
+  test('accepts ELF for linux binary', () => {
+    expect(isExecutableMagic(ELF, 'cchub-linux-x64')).toBe(true);
+  });
+
+  test('rejects non-ELF for linux binary', () => {
+    expect(isExecutableMagic(MACHO_64_LE, 'cchub-linux-x64')).toBe(false);
+    expect(isExecutableMagic(NOT_EXEC, 'cchub-linux-x64')).toBe(false);
+  });
+
+  test('accepts Mach-O thin and fat for macos binary', () => {
+    expect(isExecutableMagic(MACHO_64_LE, 'cchub-macos-arm64')).toBe(true);
+    expect(isExecutableMagic(MACHO_FAT_BE, 'cchub-macos-arm64')).toBe(true);
+  });
+
+  test('rejects ELF for macos binary', () => {
+    expect(isExecutableMagic(ELF, 'cchub-macos-arm64')).toBe(false);
+  });
+
+  test('rejects truncated input', () => {
+    expect(isExecutableMagic(new Uint8Array([0x7f, 0x45]), 'cchub-linux-x64')).toBe(false);
+    expect(isExecutableMagic(new Uint8Array(), 'cchub-linux-x64')).toBe(false);
+  });
+
+  test('unknown platform falls back to permissive', () => {
+    expect(isExecutableMagic(NOT_EXEC, 'cchub-something-else')).toBe(true);
+  });
+});
+
+describe('parseSha256Sums', () => {
+  const sample = [
+    'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789  cchub-linux-x64',
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef *cchub-macos-arm64',
+    '',
+    '# comment',
+  ].join('\n');
+
+  test('extracts hash by name (BSD or GNU format)', () => {
+    expect(parseSha256Sums(sample, 'cchub-linux-x64')).toBe(
+      'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+    );
+    expect(parseSha256Sums(sample, 'cchub-macos-arm64')).toBe(
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    );
+  });
+
+  test('returns null for unknown binary', () => {
+    expect(parseSha256Sums(sample, 'cchub-windows-x64')).toBe(null);
+  });
+
+  test('returns null for empty input', () => {
+    expect(parseSha256Sums('', 'cchub-linux-x64')).toBe(null);
+  });
+
+  test('ignores malformed lines', () => {
+    const bad = 'not-a-hash cchub-linux-x64\n  cchub-linux-x64';
+    expect(parseSha256Sums(bad, 'cchub-linux-x64')).toBe(null);
+  });
+
+  test('hex casing is normalised to lower case', () => {
+    const upper = 'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789  cchub-linux-x64';
+    expect(parseSha256Sums(upper, 'cchub-linux-x64')).toBe(
+      'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+    );
+  });
+});

--- a/backend/src/commands/update.ts
+++ b/backend/src/commands/update.ts
@@ -1,11 +1,61 @@
 // cchub update command - check and apply updates from GitHub Releases
 
-import { copyFile, rename, chmod, readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { copyFile, rename, chmod, readFile, unlink } from 'node:fs/promises';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { VERSION } from '../cli';
 import { t } from '../i18n';
+
+const SHA256SUMS_ASSET = 'SHA256SUMS';
+
+/**
+ * Verify the first bytes of the downloaded buffer look like a real executable
+ * for our target platform. Defense in depth against a tampered/corrupted
+ * download even before the SHA-256 check runs. #255
+ */
+export function isExecutableMagic(bytes: Uint8Array, binaryName: string): boolean {
+  if (bytes.length < 4) return false;
+  const b0 = bytes[0] as number;
+  const b1 = bytes[1] as number;
+  const b2 = bytes[2] as number;
+  const b3 = bytes[3] as number;
+  if (binaryName.includes('linux')) {
+    // ELF: 0x7f 'E' 'L' 'F'
+    return b0 === 0x7f && b1 === 0x45 && b2 === 0x4c && b3 === 0x46;
+  }
+  if (binaryName.includes('macos') || binaryName.includes('darwin')) {
+    // Mach-O thin (64-bit LE on disk = cf fa ed fe), 32-bit (ce fa ed fe),
+    // or Universal/fat (cafebabe / cafebabf).
+    if (b0 === 0xcf && b1 === 0xfa && b2 === 0xed && b3 === 0xfe) return true;
+    if (b0 === 0xce && b1 === 0xfa && b2 === 0xed && b3 === 0xfe) return true;
+    if (b0 === 0xca && b1 === 0xfe && b2 === 0xba && (b3 === 0xbe || b3 === 0xbf)) return true;
+    return false;
+  }
+  // Unknown platform — be permissive rather than block updates we don't
+  // recognise. The SHA-256 check still applies.
+  return true;
+}
+
+/**
+ * Parse a SHA256SUMS file (one "<hex>  <name>" per line, optional '*' before
+ * the name for binary mode) and return the lowercase hash for `binaryName`,
+ * or null if absent. #255
+ */
+export function parseSha256Sums(text: string, binaryName: string): string | null {
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const m = line.match(/^([0-9a-fA-F]{64})\s+\*?(\S.*)$/);
+    if (m && m[2] === binaryName) return m[1].toLowerCase();
+  }
+  return null;
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
 
 /** Read the binary path registered in the systemd/launchd service file */
 async function getServiceBinaryPath(): Promise<string | null> {
@@ -143,7 +193,35 @@ function isNewerVersion(latest: string, current: string): boolean {
   return false;
 }
 
-async function downloadBinary(url: string, destPath: string): Promise<boolean> {
+async function fetchExpectedSha256(
+  release: GitHubRelease,
+  binaryName: string,
+): Promise<string | null> {
+  const asset = release.assets.find((a) => a.name === SHA256SUMS_ASSET);
+  if (!asset) return null;
+  try {
+    const res = await fetch(asset.browser_download_url);
+    if (!res.ok) return null;
+    return parseSha256Sums(await res.text(), binaryName);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Download the binary into `destPath` and verify it before returning. Verifies
+ * (a) the byte count against Content-Length when the server provided one,
+ * (b) the executable magic bytes for the target platform, and
+ * (c) the SHA-256 against the value published in the release's SHA256SUMS.
+ * Any failure deletes `destPath` and returns false so the caller never renames
+ * an unverified file over the running service binary. #255
+ */
+async function downloadBinary(
+  url: string,
+  destPath: string,
+  expectedSha256: string,
+  binaryName: string,
+): Promise<boolean> {
   try {
     console.log('📥 ダウンロード中...');
     const response = await fetch(url);
@@ -153,12 +231,40 @@ async function downloadBinary(url: string, destPath: string): Promise<boolean> {
     }
 
     const buffer = await response.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+
+    const declared = response.headers.get('content-length');
+    if (declared !== null) {
+      const expected = Number.parseInt(declared, 10);
+      if (Number.isFinite(expected) && expected !== bytes.byteLength) {
+        throw new Error(
+          `Length mismatch: got ${bytes.byteLength} bytes but Content-Length was ${expected}`,
+        );
+      }
+    }
+
+    if (!isExecutableMagic(bytes, binaryName)) {
+      throw new Error('Downloaded file is not a recognised executable for this platform');
+    }
+
+    const actualSha = sha256Hex(bytes);
+    if (actualSha !== expectedSha256) {
+      throw new Error(
+        `Checksum mismatch: expected ${expectedSha256}, got ${actualSha}. Aborting to avoid running an untrusted binary.`,
+      );
+    }
+
     await Bun.write(destPath, buffer);
     await chmod(destPath, 0o755);
 
     return true;
   } catch (error) {
     console.error('❌ ダウンロードに失敗しました:', error);
+    try {
+      await unlink(destPath);
+    } catch {
+      // best-effort cleanup of the partial file
+    }
     return false;
   }
 }
@@ -217,11 +323,28 @@ export async function checkAndUpdate(checkOnly: boolean, autoMode: boolean): Pro
     console.log(`📋 サービス登録パス: ${servicePath}`);
   }
 
+  // Verify the release publishes a SHA256SUMS file and that it contains an
+  // entry for our binary BEFORE downloading. Older releases (<= v0.1.161) do
+  // not have this; users on those versions are upgrading to the first version
+  // that publishes one, so the next update naturally succeeds. #255
+  const expectedSha256 = await fetchExpectedSha256(release, binaryName);
+  if (!expectedSha256) {
+    console.error(
+      `❌ SHA256SUMS が見つかりません (${binaryName}) — 整合性検証に失敗するため更新を中止します`,
+    );
+    return;
+  }
+
   // Download to temp location
   const tempPath = `${currentPath}.new`;
   const backupPath = `${currentPath}.bak`;
 
-  const success = await downloadBinary(asset.browser_download_url, tempPath);
+  const success = await downloadBinary(
+    asset.browser_download_url,
+    tempPath,
+    expectedSha256,
+    binaryName,
+  );
   if (!success) {
     return;
   }


### PR DESCRIPTION
## Summary

\`cchub update\` used to download the release asset and rename() it over the running service binary with **no integrity check** — no checksum, no signature, no executable-magic check. Anyone who could tamper with the bytes (compromised release asset, malicious mirror, successful MITM) got arbitrary code execution as the service user, run automatically by the daily \`--auto\` timer.

This PR:
- Publishes \`SHA256SUMS\` alongside the per-platform binaries in the release workflow.
- Makes \`cchub update\` **require** \`SHA256SUMS\` and an entry for the current binary; aborts if missing.
- Verifies the downloaded binary against:
  - Content-Length (when the server sent one)
  - executable magic bytes (ELF for linux, Mach-O thin/fat for macos)
  - SHA-256 from the published \`SHA256SUMS\`
- Cleans up the temp file on any failure so the live binary is never replaced with unverified bytes.

## Backwards compat
Releases \`<= v0.1.161\` predate \`SHA256SUMS\`. Users on those versions are upgrading to the first release that publishes it, so the next \`cchub update\` (running the OLD binary, no check) naturally succeeds; once on the new binary, all subsequent updates verify.

## Test plan
- [x] \`bun test src/commands/__tests__/update-integrity.test.ts\` — 11 pass (magic-byte per platform, BSD/GNU SHA256SUMS line formats, comments, malformed lines, hex casing)
- [x] Backend lint / typecheck pass
- [x] Dev server starts cleanly
- [x] \`cchub update --check\` against \`origin/main\` ⇒ \`✅ 最新版です (v0.1.161)\` (loads the new code without error)

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)