### PR TITLE
fix(panes): route REST fallbacks through peer/auth-aware helpers

### DIFF
--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -504,6 +504,7 @@ export function DesktopLayout({
 	const controlTerminal = useMultiplexedTerminal({
 		sessionId: controlSessionId || "",
 		peerWsBase: peerConn.wsBase,
+		peerApiBase: peerConn.apiBase,
 		token: peerConn.token,
 		onPaneViewport: (paneId, viewport) => {
 			lastViewportRef.current.set(paneId, viewport);

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -1455,12 +1455,17 @@ export function SessionList({
 			direction?: "h" | "v",
 		) => {
 			try {
-				const endpoint =
+				// Peer sessions are merged into the same list (flattenPeerSessions),
+				// so the action could target a remote peer's session. Route through
+				// sessionFetch so the request reaches the owning Hub/peer with the
+				// right token, not always the local Hub origin. #258
+				const session = sessions.find((s) => s.id === sessionId);
+				const path =
 					action === "split"
-						? `${API_BASE}/api/sessions/${sessionId}/panes/split`
-						: `${API_BASE}/api/sessions/${sessionId}/panes/${action}`;
+						? `/api/sessions/${sessionId}/panes/split`
+						: `/api/sessions/${sessionId}/panes/${action}`;
 				const body = action === "split" ? { paneId, direction } : { paneId };
-				const response = await authFetch(endpoint, {
+				const response = await sessionFetch(session, peers, path, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify(body),
@@ -1472,7 +1477,7 @@ export function SessionList({
 				console.error(`Pane ${action} failed:`, err);
 			}
 		},
-		[],
+		[sessions, peers],
 	);
 
 	// Drag-to-reorder handler. Session order is a cross-peer merged list stored
@@ -1910,8 +1915,17 @@ export function SessionList({
 								type="button"
 								onClick={async () => {
 									try {
-										await authFetch(
-											`${API_BASE}/api/sessions/${encodeURIComponent(paneToClose.sessionId)}/panes/close`,
+										// Route to the owning Hub/peer instead of always the
+										// local Hub — otherwise closing a pane on a remote
+										// peer's session silently fails (or, on id collision,
+										// closes the wrong pane). #258
+										const session = sessions.find(
+											(s) => s.id === paneToClose.sessionId,
+										);
+										await sessionFetch(
+											session,
+											peers,
+											`/api/sessions/${encodeURIComponent(paneToClose.sessionId)}/panes/close`,
 											{
 												method: "POST",
 												headers: { "Content-Type": "application/json" },

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PaneViewport, TmuxLayoutNode } from "../../../shared/types";
+import { authFetch, fetchWithTimeout } from "../services/api";
 import { reportWsLatency } from "../services/latency-store";
 import { appendWsToken } from "../services/peer-ws";
 import { getDeviceId } from "../utils/device-id";
@@ -10,6 +11,10 @@ interface UseMultiplexedTerminalOptions {
 	// Multi-server: アクティブな peer の WS base URL ("wss://host:port") を指定。
 	// 省略時は Hub (window.location.host) を使う。
 	peerWsBase?: string | null;
+	// REST API base URL for the peer that owns this session ("" for Hub, e.g.
+	// "https://peer:port" for a remote peer). Used by REST fallbacks when the
+	// mux WebSocket is closed. #256
+	peerApiBase?: string | null;
 	onPaneViewport?: (paneId: string, viewport: PaneViewport) => void;
 	onLayoutChange?: (layout: TmuxLayoutNode) => void;
 	onNewSession?: (sessionId: string, sessionName: string) => void;
@@ -535,7 +540,7 @@ export function dispatchInputEcho(
 export function useMultiplexedTerminal(
 	options: UseMultiplexedTerminalOptions,
 ): UseMultiplexedTerminalReturn {
-	const { sessionId, token, peerWsBase } = options;
+	const { sessionId, token, peerWsBase, peerApiBase } = options;
 	const [isConnected, setIsConnected] = useState(false);
 	const [deadPanes, setDeadPanes] = useState<Set<string>>(new Set());
 
@@ -666,25 +671,34 @@ export function useMultiplexedTerminal(
 			});
 			if (sharedWs?.readyState === WebSocket.OPEN) {
 				sendSessionMessage({ type: "respawn-pane", paneId });
-			} else {
-				const apiBase = import.meta.env.VITE_API_URL || "";
-				fetch(
-					`${apiBase}/api/sessions/${encodeURIComponent(sessionId)}/panes/respawn`,
-					{
-						method: "POST",
-						headers: { "Content-Type": "application/json" },
-						body: JSON.stringify({ paneId }),
-					},
-				)
-					.then(() => {
-						setTimeout(() => ensureConnection(), 500);
-					})
-					.catch(() => {
-						setTimeout(() => ensureConnection(), 500);
-					});
+				return;
 			}
+			// WS is down — fall back to REST. The old fallback used plain fetch()
+			// against the Hub origin: it 401'd under password auth (no Bearer
+			// header) and POSTed to the wrong server for peer sessions. Route
+			// through authFetch for local and the peer base+token for remote. #256
+			const path = `/api/sessions/${encodeURIComponent(sessionId)}/panes/respawn`;
+			const body = JSON.stringify({ paneId });
+			const headers: HeadersInit = { "Content-Type": "application/json" };
+			const isRemotePeer = peerApiBase && peerApiBase.length > 0;
+			const request = isRemotePeer
+				? (() => {
+						const peerHeaders = new Headers(headers);
+						if (token) peerHeaders.set("Authorization", `Bearer ${token}`);
+						return fetchWithTimeout(`${peerApiBase}${path}`, {
+							method: "POST",
+							headers: peerHeaders,
+							body,
+						});
+					})()
+				: authFetch(
+						`${import.meta.env.VITE_API_URL || ""}${path}`,
+						{ method: "POST", headers, body },
+					);
+			const reconnect = () => setTimeout(() => ensureConnection(), 500);
+			request.then(reconnect).catch(reconnect);
 		},
-		[sessionId],
+		[sessionId, token, peerApiBase],
 	);
 
 	return {

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -115,6 +115,7 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 			sessionId,
 			token: peerConn.token ?? token,
 			peerWsBase: peerConn.wsBase,
+			peerApiBase: peerConn.apiBase,
 			onPaneViewport: (paneId, viewport) => {
 				lastViewportRef.current.set(paneId, viewport);
 				let perPane = paneViewportCacheRef.current.get(paneId);


### PR DESCRIPTION
## Summary

Three pane-related REST calls bypassed peer routing / Bearer auth and silently failed under password auth or for remote-peer sessions:

- \`useMultiplexedTerminal.respawnPane\` (#256) — fallback POST when the mux WebSocket is closed used plain \`fetch()\` (no Bearer, Hub origin only).
- \`SessionList.handlePaneAction\` (#258) — focus/close/split used \`authFetch\` against the Hub even for peer sessions.
- \`SessionList\` pane-close confirmation dialog (#258) — same shape, same bug.

This PR adds \`peerApiBase\` to \`useMultiplexedTerminal\` options and routes the respawn fallback through \`authFetch\` (local) / peer URL + token (remote). \`SessionList\` looks up the owning session and routes pane actions / close confirm via \`sessionFetch\` — local behavior is unchanged because \`sessionFetch\` delegates to \`authFetch\` when \`isRemote\` is false.

## Test plan
- [x] Lint / typecheck pass
- Manual: local-session pane close/split/focus still hits the Hub (unchanged URL via authFetch); remote-peer pane actions now reach the right server.

Closes #256
Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)