### PR TITLE
fix(chat,keyboard): don't clear the input when the send didn't land

### DIFF
--- a/frontend/src/components/FloatingKeyboard.tsx
+++ b/frontend/src/components/FloatingKeyboard.tsx
@@ -285,15 +285,19 @@ export const FloatingKeyboard = forwardRef<
 
 	// Send text to terminal
 	const sendText = (text: string) => {
+		// onSend can return false when the terminal is mid-reconnect or there is
+		// no active pane. Treat undefined as success (legacy callers). If the
+		// send didn't land, keep inputValue and skip addToHistory / clear so the
+		// user can retry instead of silently losing the message. #264
 		if (text) {
+			const textRes = text.includes("\n")
+				? onSend(`\x1b[200~${text}\x1b[201~`)
+				: onSend(text);
+			if (textRes === false) return;
 			addToHistory(text);
-			if (text.includes("\n")) {
-				onSend(`\x1b[200~${text}\x1b[201~`);
-			} else {
-				onSend(text);
-			}
 		}
-		onSend("\r");
+		const enterRes = onSend("\r");
+		if (enterRes === false) return;
 		setInputValue("");
 		historyIndexRef.current = -1;
 		savedInputRef.current = "";

--- a/frontend/src/components/chat/ChatComposer.tsx
+++ b/frontend/src/components/chat/ChatComposer.tsx
@@ -29,13 +29,15 @@ export function ChatComposer({
 	const send = useCallback(() => {
 		const text = value;
 		if (!text.trim() || !paneId) return;
-		if (text.includes("\n")) {
-			sendTerminalInput(sessionId, paneId, `\x1b[200~${text}\x1b[201~`);
-		} else {
-			sendTerminalInput(sessionId, paneId, text);
-		}
-		sendTerminalInput(sessionId, paneId, "\r");
-		setValue("");
+		// During reconnect / disconnect sendTerminalInput returns false without
+		// throwing. Clearing the textarea regardless would silently drop the
+		// user's message. Only clear when both the text and the trailing \r
+		// landed on the WS. #263
+		const textOk = text.includes("\n")
+			? sendTerminalInput(sessionId, paneId, `\x1b[200~${text}\x1b[201~`)
+			: sendTerminalInput(sessionId, paneId, text);
+		const enterOk = textOk && sendTerminalInput(sessionId, paneId, "\r");
+		if (textOk && enterOk) setValue("");
 	}, [sessionId, paneId, value]);
 
 	const onKeyDown = useCallback(


### PR DESCRIPTION
## Summary

\`sendTerminalInput\` (chat) and \`onSend\` (floating keyboard) return \`false\` without throwing when the WebSocket is closed / there is no active pane. Two composers were ignoring the return value:

- \`ChatComposer.send\` (#263) cleared the textarea unconditionally → message dropped silently during a reconnect window. Also exposed a partial-send race (text lands but trailing \`\\r\` doesn't).
- \`FloatingKeyboard.sendText\` (#264) cleared + \`addToHistory\` unconditionally → tablet users' typed message went to history but never to the pane.

This PR captures the return values; the textarea is only cleared (and \`addToHistory\` only fired) when the sends actually landed. \`undefined\` from legacy callers is treated as success.

## Test plan
- [x] Lint / typecheck pass
- Manual: when the mux WS is connected, send works as before; when the WS is disconnected, the textarea / floating-keyboard input keeps its content so the user can retry.

Closes #263
Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)