### PR TITLE
fix(glasses): clear subscribedSession on WS close so re-subscribe fires

### DIFF
--- a/glasses/src/ws-client.ts
+++ b/glasses/src/ws-client.ts
@@ -80,6 +80,10 @@ export class CcHubWsClient {
 
     this.ws.onclose = () => {
       console.log('[ws] closed')
+      // The reconnected socket is a brand-new server session with no
+      // subscriptions. Reset our local view so onReady's subscribe() sends
+      // a fresh 'subscribe' instead of the early-return dedup. #265
+      this.subscribedSession = null
       this.scheduleReconnect()
     }
 


### PR DESCRIPTION
## Summary

CcHubWsClient kept \`subscribedSession\` across the \`onclose → scheduleReconnect\` cycle. The reconnected socket is a brand-new server session with no subscriptions, but \`subscribe(sessionId)\` early-returns when \`this.subscribedSession === sessionId\` — so onReady's post-reconnect call never re-sent the \`subscribe\` message. Viewports stopped arriving after any network blip until the user manually switched sessions.

This PR resets \`this.subscribedSession = null\` in \`onclose\` so the next \`subscribe()\` actually goes out on the wire. \`terminalBuffers\` is intentionally kept so the UI doesn't flash blank during reconnect.

## Test plan
- [x] Glasses lint + typecheck pass
- Manual: trigger a WS drop / server restart with the glasses paired; conversation/choice extraction resumes without manually switching sessions.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)