### PR TITLE
fix(codex): use per-effect cancellation flag in conversation poll

### DIFF
--- a/frontend/src/hooks/useCodexConversation.ts
+++ b/frontend/src/hooks/useCodexConversation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { ConversationMessage } from "../../../shared/types";
 import { authFetch } from "../services/api";
 
@@ -29,10 +29,12 @@ export function useCodexConversation({
 }: UseCodexConversationOptions): UseCodexConversationResult {
 	const [messages, setMessages] = useState<ConversationMessage[]>([]);
 	const [isReady, setIsReady] = useState(false);
-	const cancelledRef = useRef(false);
 
 	useEffect(() => {
-		cancelledRef.current = false;
+		// Per-effect cancellation flag. A shared ref would be reset when the
+		// next effect run sets it back to false, letting a late response from
+		// the previous threadId overwrite the new thread's messages. #257
+		let cancelled = false;
 		setMessages([]);
 		setIsReady(false);
 
@@ -46,13 +48,13 @@ export function useCodexConversation({
 				const response = await authFetch(url, { cache: "no-store" });
 				if (!response.ok) throw new Error(`status ${response.status}`);
 				const data = await response.json();
-				if (cancelledRef.current) return;
+				if (cancelled) return;
 				setMessages(data.messages ?? []);
 			} catch (err) {
-				if (!cancelledRef.current)
+				if (!cancelled)
 					console.error("Failed to fetch codex conversation:", err);
 			} finally {
-				if (!cancelledRef.current) setIsReady(true);
+				if (!cancelled) setIsReady(true);
 			}
 		};
 
@@ -60,7 +62,7 @@ export function useCodexConversation({
 		const id = window.setInterval(fetchOnce, pollIntervalMs);
 
 		return () => {
-			cancelledRef.current = true;
+			cancelled = true;
 			window.clearInterval(id);
 		};
 	}, [threadId, enabled, pollIntervalMs]);


### PR DESCRIPTION
## Summary

\`useCodexConversation\` shared a single \`cancelledRef\` across every effect run. When \`threadId\` switched A→B, A's cleanup set \`cancelledRef.current = true\`, but the new effect for B immediately reset it to false (line 35). A late response from A's in-flight fetch then saw \`cancelled === false\` and overwrote B's messages — the user could end up viewing the wrong Codex conversation.

Replace the shared ref with a \`let cancelled = false\` captured in the effect closure. Each effect run gets its own flag; thread A's in-flight requests stay cancelled regardless of what thread B does after.

## Test plan
- [x] Lint / typecheck pass
- Manual: switching between Codex threads in rapid succession no longer surfaces the previous thread's messages.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)