### PR TITLE
fix(terminal): cancel rAF loops and WebGL reload timer on teardown

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -336,6 +336,10 @@ export const TerminalComponent = memo(
 			const container = containerRef.current;
 			const initialFontSize = loadFontSize(sessionId);
 			const themeColors = getTerminalThemes()[sessionTheme || "default"];
+			// Captured in the effect closure so the cleanup can clear the WebGL
+			// context-loss reload timer if the effect tears down before it fires.
+			// #262
+			let webglReloadTimer: number | null = null;
 			const term = new Terminal({
 				fontSize: initialFontSize,
 				fontFamily:
@@ -420,7 +424,8 @@ export const TerminalComponent = memo(
 						"[Terminal] WebGL context lost, disposing and reloading",
 					);
 					webglAddon.dispose();
-					setTimeout(() => {
+					webglReloadTimer = window.setTimeout(() => {
+						webglReloadTimer = null;
 						try {
 							const newWebgl = new WebglAddon();
 							newWebgl.onContextLoss(() => {
@@ -1059,6 +1064,14 @@ export const TerminalComponent = memo(
 			return () => {
 				if (longPressTimer) clearTimeout(longPressTimer);
 				if (mouseLongPressTimer) clearTimeout(mouseLongPressTimer);
+				// Cancel rAF loops and the WebGL reload timer so they don't keep
+				// running against the disposed terminal — momentum scroll, touch
+				// coalesce, wheel flush, and the queued WebGL re-init all post
+				// scrollBy / setState back into the now-stale closure. #262
+				if (scrollRafId !== null) cancelAnimationFrame(scrollRafId);
+				if (momentumRafId !== null) cancelAnimationFrame(momentumRafId);
+				if (pendingScrollRafId !== null) cancelAnimationFrame(pendingScrollRafId);
+				if (webglReloadTimer !== null) clearTimeout(webglReloadTimer);
 				if (container) {
 					container.removeEventListener("touchstart", handleTouchStart);
 					container.removeEventListener("touchmove", handleTouchMove);


### PR DESCRIPTION
## Summary

The main terminal-creation effect (deps \`[sessionId, connect, sessionTheme]\`) starts several requestAnimationFrame loops and a setTimeout that the cleanup never cancelled:

- momentumRafId — fling-scroll friction loop
- scrollRafId — touch scroll coalesce frame
- pendingScrollRafId — wheel/scroll flush frame
- WebGL context-loss reload setTimeout

When the effect re-ran (sessionTheme change, sessionId switch, unmount) the old closure's animate kept calling rAF and pushed scrollBy / setState into the freshly recreated (or disposed) terminal — stale scroll-position badges, unwanted viewport mutations, wasted frames until friction decayed. The WebGL timer could also call \`term.loadAddon\` on an already-disposed terminal.

This PR captures the WebGL timer id in the effect closure and cancels all four rAF/timer ids in cleanup.

## Test plan
- [x] Lint / typecheck pass
- Manual: fling-scroll the terminal then trigger a teardown (sessionTheme change or session switch) — no stale scroll-indicator updates / no scrollBy on the new terminal.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)