### PR TITLE
fix(claude-code): bound the long-lived service caches with TTL + size cap

### DIFF
--- a/backend/src/services/__tests__/claude-code-cache.test.ts
+++ b/backend/src/services/__tests__/claude-code-cache.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'bun:test';
+import { ClaudeCodeService } from '../claude-code';
+
+// Verify the cache eviction policy directly via the static helper that
+// ClaudeCodeService uses to bound its long-lived per-instance Maps.
+//
+// We reach the private static through a typed alias purely for testability;
+// the runtime contract (TTL sweep + size cap) is the public guarantee. #249
+const evictAndCap = (
+  ClaudeCodeService as unknown as {
+    evictAndCap: <V extends { timestamp: number }>(cache: Map<string, V>, ttlMs: number) => void;
+  }
+).evictAndCap;
+const CAP = (ClaudeCodeService as unknown as { CACHE_MAX_ENTRIES: number }).CACHE_MAX_ENTRIES;
+
+describe('ClaudeCodeService.evictAndCap', () => {
+  test('TTL sweep removes expired entries', () => {
+    const m = new Map<string, { timestamp: number }>();
+    const now = Date.now();
+    m.set('old', { timestamp: now - 60_000 });
+    m.set('fresh', { timestamp: now - 1_000 });
+    evictAndCap(m, 5_000);
+    expect(m.has('old')).toBe(false);
+    expect(m.has('fresh')).toBe(true);
+  });
+
+  test('does not evict any fresh entries when none are expired', () => {
+    const m = new Map<string, { timestamp: number }>();
+    const now = Date.now();
+    for (let i = 0; i < 50; i++) m.set(`k${i}`, { timestamp: now });
+    evictAndCap(m, 60_000);
+    expect(m.size).toBe(50);
+  });
+
+  test('hard cap evicts oldest (Map insertion order) when over capacity', () => {
+    const m = new Map<string, { timestamp: number }>();
+    const now = Date.now();
+    for (let i = 0; i < CAP + 25; i++) m.set(`k${i}`, { timestamp: now });
+    evictAndCap(m, 60_000);
+    expect(m.size).toBeLessThanOrEqual(CAP);
+    // First 25 entries should be evicted (FIFO).
+    for (let i = 0; i < 25; i++) expect(m.has(`k${i}`)).toBe(false);
+    expect(m.has(`k${CAP + 24}`)).toBe(true);
+  });
+
+  test('combines TTL sweep then hard-cap eviction', () => {
+    const m = new Map<string, { timestamp: number }>();
+    const now = Date.now();
+    // 100 expired, then CAP fresh
+    for (let i = 0; i < 100; i++) m.set(`old${i}`, { timestamp: now - 60_000 });
+    for (let i = 0; i < CAP; i++) m.set(`new${i}`, { timestamp: now });
+    evictAndCap(m, 5_000);
+    expect(m.size).toBe(CAP);
+    expect(m.has('old0')).toBe(false);
+    expect(m.has('new0')).toBe(true);
+  });
+
+  test('empty cache is a no-op', () => {
+    const m = new Map<string, { timestamp: number }>();
+    evictAndCap(m, 1_000);
+    expect(m.size).toBe(0);
+  });
+});

--- a/backend/src/services/claude-code.ts
+++ b/backend/src/services/claude-code.ts
@@ -98,6 +98,28 @@ export class ClaudeCodeService {
   private pathResultCache = new Map<string, { data: unknown; timestamp: number }>();
   private static readonly PATH_RESULT_CACHE_TTL = 3_000; // 3 seconds
 
+  // Hard cap on each cache: long-lived ClaudeCodeService singletons used to leak
+  // an entry per ever-seen JSONL/path/tty — every distinct session a self-hosted
+  // server ever saw would stay resident forever. Evict on insert by sweeping
+  // expired entries first, then dropping the oldest (Map insertion order) until
+  // size <= cap. #249
+  private static readonly CACHE_MAX_ENTRIES = 1000;
+
+  private static evictAndCap<V extends { timestamp: number }>(
+    cache: Map<string, V>,
+    ttlMs: number,
+  ): void {
+    const now = Date.now();
+    for (const [key, value] of cache) {
+      if (now - value.timestamp >= ttlMs) cache.delete(key);
+    }
+    while (cache.size > ClaudeCodeService.CACHE_MAX_ENTRIES) {
+      const oldest = cache.keys().next().value;
+      if (oldest === undefined) break;
+      cache.delete(oldest);
+    }
+  }
+
   constructor() {
     this.claudeDir = join(homedir(), '.claude', 'projects');
   }
@@ -133,11 +155,13 @@ export class ClaudeCodeService {
     for (const line of args) {
       const match = line.match(/claude\s+-r\s+([a-f0-9-]{36})/i);
       if (match) {
+        ClaudeCodeService.evictAndCap(this.ttySessionCache, ClaudeCodeService.TTY_SESSION_CACHE_TTL);
         this.ttySessionCache.set(ttyName, { sessionId: match[1], timestamp: Date.now() });
         return match[1];
       }
     }
 
+    ClaudeCodeService.evictAndCap(this.ttySessionCache, ClaudeCodeService.TTY_SESSION_CACHE_TTL);
     this.ttySessionCache.set(ttyName, { sessionId: null, timestamp: Date.now() });
     return null;
   }
@@ -612,6 +636,7 @@ export class ClaudeCodeService {
         lastRecap: lastRecap || undefined,
       };
 
+      ClaudeCodeService.evictAndCap(this.sessionDataCache, ClaudeCodeService.SESSION_DATA_CACHE_TTL);
       this.sessionDataCache.set(filePath, {
         data,
         fileMtime: fileStat.mtimeMs,
@@ -666,6 +691,7 @@ export class ClaudeCodeService {
   }
 
   private setPathCached(key: string, data: unknown): void {
+    ClaudeCodeService.evictAndCap(this.pathResultCache, ClaudeCodeService.PATH_RESULT_CACHE_TTL);
     this.pathResultCache.set(key, { data, timestamp: Date.now() });
   }
 


### PR DESCRIPTION
## Summary

\`ClaudeCodeService\` is a module-level singleton. Its three internal Maps (\`sessionDataCache\`, \`pathResultCache\`, \`ttySessionCache\`) only ever grew — the TTL constants were used to decide whether to *reuse* an entry, never to evict one. Every distinct JSONL / path / tty the running server ever saw stayed resident, so a self-hosted server bled memory over weeks of use.

Adds a static \`evictAndCap\` helper that:
- sweeps entries older than the per-cache TTL on every insert
- trims to a 1000-entry hard cap (FIFO via Map insertion order)

Wired into every \`cache.set\` call site so all three caches stay bounded.

## Test plan
- [x] \`bun test src/services/__tests__/claude-code-cache.test.ts\` — 5 pass (TTL sweep, FIFO cap, combined, empty)
- [x] Backend lint / typecheck pass

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)