### PR TITLE
fix(peer-registry): serialize peers.json mutations and write atomically

### DIFF
--- a/backend/src/services/__tests__/peer-registry-lock.test.ts
+++ b/backend/src/services/__tests__/peer-registry-lock.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Force the data directory before the module loads so peers.json lands in our
+// scratch dir. ensureDataDir reads CC_HUB_DATA_DIR. #251
+let tempDir: string;
+let originalDataDir: string | undefined;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'cchub-peers-'));
+  originalDataDir = process.env.CC_HUB_DATA_DIR;
+  process.env.CC_HUB_DATA_DIR = tempDir;
+});
+
+afterEach(async () => {
+  if (originalDataDir === undefined) delete process.env.CC_HUB_DATA_DIR;
+  else process.env.CC_HUB_DATA_DIR = originalDataDir;
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('peer-registry mutation lock', () => {
+  test('concurrent recordPeer* calls do not overwrite each other', async () => {
+    // Re-import after we set CC_HUB_DATA_DIR so the module picks up our temp.
+    const peerRegistry = await import('../peer-registry');
+    const { createPeer, recordPeerSuccess, recordPeerFailure, getPeer } = peerRegistry;
+
+    const a = await createPeer({ nickname: 'a', url: 'https://a.example' });
+    const b = await createPeer({ nickname: 'b', url: 'https://b.example' });
+
+    // Issue interleaved success/failure updates on both peers. Without the
+    // mutation lock the load→mutate→save races would silently drop one
+    // peer's update on every overlap.
+    const ops: Array<Promise<unknown>> = [];
+    for (let i = 0; i < 20; i++) {
+      ops.push(recordPeerSuccess(a.id));
+      ops.push(recordPeerFailure(b.id, `fail ${i}`));
+    }
+    await Promise.all(ops);
+
+    const ra = await getPeer(a.id);
+    const rb = await getPeer(b.id);
+    expect(ra?.lastSeenAt).toBeDefined();
+    expect(ra?.lastErrorMessage).toBeUndefined();
+    expect(rb?.lastErrorAt).toBeDefined();
+    expect(rb?.lastErrorMessage).toBe('fail 19');
+  });
+
+  test('save is atomic via temp+rename — no truncated file under contention', async () => {
+    const { createPeer, recordPeerSuccess } = await import('../peer-registry');
+    const a = await createPeer({ nickname: 'a', url: 'https://a.example' });
+    await Promise.all(
+      Array.from({ length: 50 }, () => recordPeerSuccess(a.id)),
+    );
+    const filePath = join(tempDir, 'peers.json');
+    const text = await readFile(filePath, 'utf-8');
+    // JSON.parse rejects truncated/partial writes; the lock + atomic rename
+    // is what guarantees we never see a half-written file.
+    const parsed = JSON.parse(text);
+    expect(Array.isArray(parsed.peers)).toBe(true);
+    expect(parsed.peers.some((p: { id: string }) => p.id === a.id)).toBe(true);
+  });
+});

--- a/backend/src/services/peer-registry.ts
+++ b/backend/src/services/peer-registry.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { readFile, writeFile, chmod } from 'node:fs/promises';
+import { readFile, writeFile, chmod, rename, unlink } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import { ensureDataDir } from '../utils/storage';
 import {
@@ -9,6 +9,20 @@ import {
 } from '../../../shared/types';
 
 const PEERS_FILE = 'peers.json';
+
+// Module-level mutex serialising every load→mutate→save sequence against
+// peers.json. routes/peers.ts fans out per-peer fetches with Promise.all and
+// each completion calls recordPeerSuccess / recordPeerFailure; without this
+// chain, interleaved load/save calls clobbered each other's lastSeenAt and
+// could even reset a freshly-issued wsToken to a stale value. #251
+let mutationQueue: Promise<unknown> = Promise.resolve();
+function withMutationLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = mutationQueue.then(fn, fn);
+  // Don't propagate failures into the queue's success chain — the next caller
+  // must still get to run even if this one rejected.
+  mutationQueue = next.catch(() => undefined);
+  return next;
+}
 
 // peer 追加時にラウンドロビンで割り当てる palette。
 // ユーザーが手動で色を選ばなければ、追加順に PALETTE から拾う。
@@ -62,14 +76,27 @@ async function load(): Promise<PeersStore> {
 
 async function save(store: PeersStore): Promise<void> {
   const filePath = await getFilePath();
-  // wsToken を含むので owner read/write のみに制限。
-  // writeFile の mode は新規作成時のみ適用される ─ 既存ファイル上書き時は
-  // umask の名残で 0644 のままになりうるので、毎回 chmod で強制する。
-  await writeFile(filePath, JSON.stringify(store, null, 2), { mode: 0o600 });
+  // Write to a sibling temp file and rename atomically so a crash mid-write
+  // can't truncate peers.json (which would lose every peer's wsToken). #251
+  const tempPath = `${filePath}.tmp.${process.pid}.${randomBytes(4).toString('hex')}`;
   try {
-    await chmod(filePath, 0o600);
-  } catch {
-    /* permissions might already be correct, or fs doesn't support chmod */
+    // wsToken を含むので owner read/write のみに制限。writeFile の mode は新規
+    // 作成時のみ適用される ─ 既存ファイル上書き時は umask の名残で 0644 のまま
+    // になりうるので、毎回 chmod で強制する。
+    await writeFile(tempPath, JSON.stringify(store, null, 2), { mode: 0o600 });
+    try {
+      await chmod(tempPath, 0o600);
+    } catch {
+      /* permissions might already be correct, or fs doesn't support chmod */
+    }
+    await rename(tempPath, filePath);
+  } catch (err) {
+    try {
+      await unlink(tempPath);
+    } catch {
+      /* best-effort cleanup if rename never happened */
+    }
+    throw err;
   }
 }
 
@@ -120,24 +147,26 @@ export interface CreatePeerArgs {
 }
 
 export async function createPeer(args: CreatePeerArgs): Promise<StoredPeer> {
-  const store = await load();
-  const id = generateId();
-  const existing = await listPeers();
-  const order = existing.reduce((max, p) => Math.max(max, p.order), 0) + 1;
+  return withMutationLock(async () => {
+    const store = await load();
+    const id = generateId();
+    const existing = await listPeers();
+    const order = existing.reduce((max, p) => Math.max(max, p.order), 0) + 1;
 
-  const peer: StoredPeer = {
-    id,
-    nickname: args.nickname,
-    url: args.url,
-    color: args.color ?? pickColor(existing),
-    order,
-    wsToken: args.wsToken,
-    lastSeenAt: new Date().toISOString(),
-  };
+    const peer: StoredPeer = {
+      id,
+      nickname: args.nickname,
+      url: args.url,
+      color: args.color ?? pickColor(existing),
+      order,
+      wsToken: args.wsToken,
+      lastSeenAt: new Date().toISOString(),
+    };
 
-  store.peers.push(peer);
-  await save(store);
-  return peer;
+    store.peers.push(peer);
+    await save(store);
+    return peer;
+  });
 }
 
 export interface UpdatePeerArgs {
@@ -147,78 +176,88 @@ export interface UpdatePeerArgs {
 }
 
 export async function updatePeer(id: string, args: UpdatePeerArgs): Promise<StoredPeer | null> {
-  if (id === LOCAL_PEER_ID) {
-    // local peer は nickname/color のみ編集可。 token は持たない
-    const store = await load();
-    let local = store.peers.find(p => p.id === LOCAL_PEER_ID);
-    if (!local) {
-      local = localPeer();
-      store.peers.push(local);
+  return withMutationLock(async () => {
+    if (id === LOCAL_PEER_ID) {
+      // local peer は nickname/color のみ編集可。 token は持たない
+      const store = await load();
+      let local = store.peers.find(p => p.id === LOCAL_PEER_ID);
+      if (!local) {
+        local = localPeer();
+        store.peers.push(local);
+      }
+      if (args.nickname !== undefined) local.nickname = args.nickname;
+      if (args.color !== undefined) local.color = args.color;
+      await save(store);
+      return local;
     }
-    if (args.nickname !== undefined) local.nickname = args.nickname;
-    if (args.color !== undefined) local.color = args.color;
+
+    const store = await load();
+    const peer = store.peers.find(p => p.id === id);
+    if (!peer) return null;
+
+    if (args.nickname !== undefined) peer.nickname = args.nickname;
+    if (args.color !== undefined) peer.color = args.color;
+    if (args.wsToken !== undefined) {
+      peer.wsToken = args.wsToken;
+      peer.lastSeenAt = new Date().toISOString();
+      peer.lastErrorAt = undefined;
+      peer.lastErrorMessage = undefined;
+    }
+
     await save(store);
-    return local;
-  }
-
-  const store = await load();
-  const peer = store.peers.find(p => p.id === id);
-  if (!peer) return null;
-
-  if (args.nickname !== undefined) peer.nickname = args.nickname;
-  if (args.color !== undefined) peer.color = args.color;
-  if (args.wsToken !== undefined) {
-    peer.wsToken = args.wsToken;
-    peer.lastSeenAt = new Date().toISOString();
-    peer.lastErrorAt = undefined;
-    peer.lastErrorMessage = undefined;
-  }
-
-  await save(store);
-  return peer;
+    return peer;
+  });
 }
 
 export async function deletePeer(id: string): Promise<boolean> {
-  if (id === LOCAL_PEER_ID) return false; // self は削除不可
-  const store = await load();
-  const before = store.peers.length;
-  store.peers = store.peers.filter(p => p.id !== id);
-  if (store.peers.length === before) return false;
-  await save(store);
-  return true;
+  return withMutationLock(async () => {
+    if (id === LOCAL_PEER_ID) return false; // self は削除不可
+    const store = await load();
+    const before = store.peers.length;
+    store.peers = store.peers.filter(p => p.id !== id);
+    if (store.peers.length === before) return false;
+    await save(store);
+    return true;
+  });
 }
 
 export async function setPeerOrder(orderedIds: string[]): Promise<void> {
-  const store = await load();
-  const indexById = new Map(orderedIds.map((id, i) => [id, i]));
-  // 配列に含まれない peer は末尾に追いやる
-  const maxIndex = orderedIds.length;
-  for (const peer of store.peers) {
-    const idx = indexById.get(peer.id);
-    peer.order = idx !== undefined ? idx : maxIndex + peer.order;
-  }
-  await save(store);
+  return withMutationLock(async () => {
+    const store = await load();
+    const indexById = new Map(orderedIds.map((id, i) => [id, i]));
+    // 配列に含まれない peer は末尾に追いやる
+    const maxIndex = orderedIds.length;
+    for (const peer of store.peers) {
+      const idx = indexById.get(peer.id);
+      peer.order = idx !== undefined ? idx : maxIndex + peer.order;
+    }
+    await save(store);
+  });
 }
 
 export async function recordPeerSuccess(id: string): Promise<void> {
   if (id === LOCAL_PEER_ID) return;
-  const store = await load();
-  const peer = store.peers.find(p => p.id === id);
-  if (!peer) return;
-  peer.lastSeenAt = new Date().toISOString();
-  peer.lastErrorAt = undefined;
-  peer.lastErrorMessage = undefined;
-  await save(store);
+  return withMutationLock(async () => {
+    const store = await load();
+    const peer = store.peers.find(p => p.id === id);
+    if (!peer) return;
+    peer.lastSeenAt = new Date().toISOString();
+    peer.lastErrorAt = undefined;
+    peer.lastErrorMessage = undefined;
+    await save(store);
+  });
 }
 
 export async function recordPeerFailure(id: string, message: string): Promise<void> {
   if (id === LOCAL_PEER_ID) return;
-  const store = await load();
-  const peer = store.peers.find(p => p.id === id);
-  if (!peer) return;
-  peer.lastErrorAt = new Date().toISOString();
-  peer.lastErrorMessage = message;
-  await save(store);
+  return withMutationLock(async () => {
+    const store = await load();
+    const peer = store.peers.find(p => p.id === id);
+    if (!peer) return;
+    peer.lastErrorAt = new Date().toISOString();
+    peer.lastErrorMessage = message;
+    await save(store);
+  });
 }
 
 /**
@@ -231,9 +270,11 @@ export async function getCrossPeerSessionOrder(): Promise<string[]> {
 }
 
 export async function setCrossPeerSessionOrder(order: string[]): Promise<void> {
-  const store = await load();
-  store.sessionOrder = order;
-  await save(store);
+  return withMutationLock(async () => {
+    const store = await load();
+    store.sessionOrder = order;
+    await save(store);
+  });
 }
 
 export type { StoredPeer };


### PR DESCRIPTION
## Summary

\`routes/peers.ts\` fans out per-peer fetches with \`Promise.all\` and every completion calls \`recordPeerSuccess\` / \`recordPeerFailure\`. Each did a fresh load→mutate→save with no serialisation, so two concurrent completions could read the same on-disk snapshot, each apply only its own field, and the second save silently overwrote the first peer's update. The same race could clobber a freshly-issued \`wsToken\` (token reset to a stale value, breaking auth until re-login). Worse, save() rewrote the file in place — a crash mid-write could truncate \`peers.json\` and lose **every** wsToken at once.

This PR:
- Adds a module-level mutation mutex (chained promise queue) and wraps every mutator with it so load→mutate→save runs as one atomic step.
- Rewrites \`save()\` to use temp-file + rename for crash safety.
- Keeps pure readers lock-free.

## Test plan
- [x] \`bun test src/services/__tests__/peer-registry-lock.test.ts\` — 2 pass (20 interleaved success/failure ops on 2 peers keep both, atomic-write under 50 concurrent ops yields a valid JSON file).
- [x] Backend lint / typecheck pass

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)