### PR TITLE
fix(metrics): share Claude project-dir encoder, fix dot-in-path paths

### DIFF
--- a/backend/src/services/claude-code.ts
+++ b/backend/src/services/claude-code.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
+import { claudeProjectDirName } from '../utils/claude-project-path';
 
 /**
  * Read last N lines from a file without spawning a subprocess.
@@ -129,10 +130,7 @@ export class ClaudeCodeService {
    * e.g., /home/m0a/cchub -> -home-m0a-cchub
    */
   private pathToProjectName(path: string): string {
-    // Claude Code stores project dirs with both '/' and '.' collapsed to '-'
-    // (e.g. /Users/m0a/repo/github.com/m0a/cc-hub → -Users-m0a-repo-github-com-m0a-cc-hub).
-    // Match that convention so exact-path lookups succeed for paths with dots.
-    return path.replace(/[/.]/g, '-');
+    return claudeProjectDirName(path);
   }
 
   /**

--- a/backend/src/services/codex-history.ts
+++ b/backend/src/services/codex-history.ts
@@ -4,6 +4,7 @@ import { createInterface } from 'node:readline';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { ConversationMessage, HistorySession } from '../../../shared/types';
+import { claudeProjectDirName } from '../utils/claude-project-path';
 import { CodexConversationService } from './codex-conversation';
 import type { ProjectInfo } from './session-history';
 
@@ -21,7 +22,7 @@ interface RolloutInfo {
  * sessions for the same project bucket share one ProjectInfo entry.
  */
 function encodeCwd(cwd: string): string {
-  return cwd.replace(/\//g, '-');
+  return claudeProjectDirName(cwd);
 }
 
 /**

--- a/backend/src/services/conversation-watcher.ts
+++ b/backend/src/services/conversation-watcher.ts
@@ -5,6 +5,7 @@ import { homedir } from 'node:os';
 import { SessionHistoryService } from './session-history';
 import { ClaudeCodeService } from './claude-code';
 import type { ConversationMessage } from '../../../shared/types';
+import { claudeProjectDirName } from '../utils/claude-project-path';
 
 type ConversationListener = (newMessages: ConversationMessage[]) => void;
 
@@ -13,7 +14,7 @@ const claudeCodeService = new ClaudeCodeService();
 const claudeProjectsDir = join(homedir(), '.claude', 'projects');
 
 function pathToProjectName(path: string): string {
-  return path.replace(/\//g, '-');
+  return claudeProjectDirName(path);
 }
 
 export class ConversationWatcher {

--- a/backend/src/services/file-change-tracker.ts
+++ b/backend/src/services/file-change-tracker.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 import type { FileChange } from '../../../shared/types';
+import { claudeProjectDirName } from '../utils/claude-project-path';
 
 interface ToolUseBlock {
   type: 'tool_use';
@@ -36,7 +37,7 @@ export class FileChangeTracker {
    * e.g., /home/m0a/cchub -> -home-m0a-cchub
    */
   private pathToProjectName(path: string): string {
-    return path.replace(/\//g, '-');
+    return claudeProjectDirName(path);
   }
 
   /**

--- a/backend/src/services/session-metrics.ts
+++ b/backend/src/services/session-metrics.ts
@@ -3,13 +3,13 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { createInterface } from 'node:readline';
 import type { SessionMetrics } from '../../../shared/types';
+import { claudeProjectDirName } from '../utils/claude-project-path';
 import { getMaxInputTokens } from './anthropic-models';
 
 const CONTEXT_MAX_DEFAULT = 200_000;
 
 function pathToProjectDir(workingDir: string): string {
-  const dirName = workingDir.replace(/\//g, '-');
-  return path.join(os.homedir(), '.claude', 'projects', dirName);
+  return path.join(os.homedir(), '.claude', 'projects', claudeProjectDirName(workingDir));
 }
 
 interface ProcessTable {

--- a/backend/src/utils/__tests__/claude-project-path.test.ts
+++ b/backend/src/utils/__tests__/claude-project-path.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'bun:test';
+import { claudeProjectDirName } from '../claude-project-path';
+
+// The five Claude-projects callers (session-metrics, file-change-tracker,
+// conversation-watcher, codex-history, claude-code) all now share this
+// helper; lock down its contract so a future refactor can't silently break
+// paths-containing-dots again. #252
+describe('claudeProjectDirName', () => {
+  test('collapses both slashes and dots', () => {
+    expect(claudeProjectDirName('/home/m0a/repo/github.com/m0a/cc-hub')).toBe(
+      '-home-m0a-repo-github-com-m0a-cc-hub',
+    );
+    expect(claudeProjectDirName('/Users/x/.config/foo')).toBe('-Users-x--config-foo');
+  });
+
+  test('plain ASCII path without dots is slash-collapsed', () => {
+    expect(claudeProjectDirName('/home/m0a/cchub')).toBe('-home-m0a-cchub');
+  });
+
+  test('empty string maps to empty string', () => {
+    expect(claudeProjectDirName('')).toBe('');
+  });
+
+  test('dot-only segments are still flattened', () => {
+    expect(claudeProjectDirName('a.b.c')).toBe('a-b-c');
+  });
+});

--- a/backend/src/utils/claude-project-path.ts
+++ b/backend/src/utils/claude-project-path.ts
@@ -1,0 +1,11 @@
+/**
+ * Convert a working directory to the per-project bucket name Claude Code uses
+ * under `~/.claude/projects/<bucket>/`. Claude collapses BOTH path separators
+ * and dots in the project name (e.g. `github.com/m0a/cc-hub` →
+ * `github-com-m0a-cc-hub`), so a slash-only normalisation misses every path
+ * containing a dot — silently breaking metrics, file-change tracking,
+ * conversation watching, and history grouping for those projects. #252
+ */
+export function claudeProjectDirName(workingDir: string): string {
+	return workingDir.replace(/[/.]/g, '-');
+}


### PR DESCRIPTION
## Summary

\`session-metrics.ts\` only collapsed slashes (\`workingDir.replace(/\\//g, '-')\`), but Claude Code stores its project buckets with **both** '/' and '.' collapsed to '-' (e.g. \`/Users/m0a/repo/github.com/m0a/cc-hub\` → \`-Users-m0a-repo-github-com-m0a-cc-hub\`). For any working directory containing a dot — \`github.com\`, \`.config\`, \`cc-hub.local\`, anything under a hidden dotdir — the slash-only encoding pointed at a directory that didn't exist, so \`readJsonlUsage\` silently returned null and \`contextTokens\` / \`contextPercent\` / \`totalTokens\` disappeared from the UI.

The same mistake existed in \`file-change-tracker.ts:39\`, \`conversation-watcher.ts:16\`, and \`codex-history.ts:24\` (whose own comment described the bucket Claude uses). Only \`claude-code.ts\` had the right regex.

This PR adds \`backend/src/utils/claude-project-path.ts\` with \`claudeProjectDirName\` and routes all five callers through it so they can't drift again.

## Test plan
- [x] \`bun test src/utils/__tests__/claude-project-path.test.ts\` — 4 pass
- [x] Backend lint / typecheck pass

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)