### PR TITLE
fix(files): clamp Range and materialise the slice so Content-Length is honest

### DIFF
--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -485,15 +485,45 @@ files.get('/raw', async (c) => {
     const mime = file.type || 'application/octet-stream';
     const totalSize = stats.size;
 
-    // Support Range requests for video/audio seeking and progressive playback
+    // Support Range requests for video/audio seeking and progressive playback.
+    // Validate and clamp: Bun.file().slice happily returns a BunFile whose
+    // declared .size is the requested chunk but streams fewer bytes if the
+    // range goes past EOF, so an un-clamped Content-Length would lie and
+    // keep-alive clients would hang waiting for promised bytes. #253
     const rangeHeader = c.req.header('Range');
     if (rangeHeader) {
-      const match = rangeHeader.match(/bytes=(\d+)-(\d*)/);
+      const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/);
       if (match) {
-        const start = parseInt(match[1], 10);
-        const end = match[2] ? parseInt(match[2], 10) : totalSize - 1;
+        const start = Number.parseInt(match[1] as string, 10);
+        const requestedEnd = match[2]
+          ? Number.parseInt(match[2], 10)
+          : totalSize - 1;
+        const unsatisfiable =
+          !Number.isFinite(start) ||
+          !Number.isFinite(requestedEnd) ||
+          start < 0 ||
+          start >= totalSize ||
+          start > requestedEnd;
+        if (unsatisfiable) {
+          return new Response(null, {
+            status: 416,
+            headers: {
+              'Content-Range': `bytes */${totalSize}`,
+              'Accept-Ranges': 'bytes',
+            },
+          });
+        }
+        const end = Math.min(requestedEnd, totalSize - 1);
         const chunkSize = end - start + 1;
-        return new Response(file.slice(start, end + 1), {
+        // Materialise the slice into an ArrayBuffer. Passing the BunFile slice
+        // directly to Response makes Bun's HTTP layer fall back to chunked
+        // encoding *and* stream the entire underlying file (the slice bound is
+        // dropped at the transport layer), so Content-Length doesn't match the
+        // body and the response is unusable for video seeking. Buffering the
+        // chunk (capped at totalSize - start by the clamp above) gives Bun a
+        // sized body it streams correctly. #253
+        const chunk = await file.slice(start, end + 1).arrayBuffer();
+        return new Response(chunk, {
           status: 206,
           headers: {
             'Content-Type': mime,


### PR DESCRIPTION
## Summary

\`/files/raw\`'s Range handler had two bugs that combined to break video seeking and could framing-desync HTTP/1.1 keep-alive clients:

1. start / end were never validated or clamped to \`[0, totalSize-1]\` and there was no \`start >= totalSize\` / \`start > end\` check. \`Range: bytes=10000-20000\` on a 905-byte file replied 206 with bogus \`Content-Range: bytes 10000-20000/905\` and effectively zero body instead of 416. \`Range: bytes=0-99999\` advertised \`Content-Length: 100000\` while only sending 905 bytes — under keep-alive the client waits for the rest forever.
2. Passing \`Bun.file(path).slice(start, end+1)\` directly to the Response constructor made Bun's HTTP layer fall back to chunked encoding **and** stream the entire underlying file — the slice bound was silently dropped at the transport. (Confirmed via dev curl: requesting bytes=0-49 produced Content-Range 0-49/905 with a body of 905 bytes.)

This PR:
- Returns 416 with \`Content-Range: bytes */<totalSize>\` when start is past EOF / start > end / NaN.
- Clamps \`end\` to \`totalSize - 1\` so Content-Length always matches the body length.
- Materialises the BunFile slice into an ArrayBuffer so Bun honours the byte range.

## Test plan
Verified end-to-end via \`bun run dev:auth\` against this repo's package.json (905 bytes):
- [x] \`bytes=0-49\`        → 206, body=50, Content-Length=50
- [x] \`bytes=500-\`        → 206, body=405, Content-Length=405
- [x] \`bytes=0-99999\`     → 206, body=905, Content-Length=905 (clamped)
- [x] \`bytes=10000-20000\` → 416, Content-Range \`bytes */905\`, empty body
- [x] no Range             → 200 with full file
- [x] Backend lint / typecheck pass

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)