### PR TITLE
fix(sessions): reject SEP-poisoned session names and harden tmux parser

### DIFF
--- a/backend/src/services/__tests__/session-name-validation.test.ts
+++ b/backend/src/services/__tests__/session-name-validation.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'bun:test';
+import { CreateSessionSchema } from '../../../../shared/types';
+
+// CreateSessionSchema.name guards against SEP-collisions in tmux list-panes
+// output. The defense-in-depth parser check in tmux.ts:listSessions complements
+// this for any pre-existing sessions, but the schema is the primary line of
+// defense for newly-created sessions. #250
+describe('CreateSessionSchema.name', () => {
+  test('accepts alphanumerics, dot, underscore, hyphen', () => {
+    for (const name of ['linux', 'cchub-work-1', 'my.session', 'A_B-C.1']) {
+      expect(CreateSessionSchema.safeParse({ name }).success).toBe(true);
+    }
+  });
+
+  test('rejects names containing the tmux parser sentinel pipes/tildes', () => {
+    const poisoned = [
+      'weird||~~||name',
+      'weird||~~||name||~~||%99||~~||pwned',
+      'has|pipe',
+      'has~tilde',
+    ];
+    for (const name of poisoned) {
+      const r = CreateSessionSchema.safeParse({ name });
+      expect(r.success).toBe(false);
+    }
+  });
+
+  test('rejects whitespace, slashes, and other punctuation', () => {
+    for (const name of ['has space', 'has/slash', 'has:colon', 'has\\backslash', 'has\nnewline']) {
+      expect(CreateSessionSchema.safeParse({ name }).success).toBe(false);
+    }
+  });
+
+  test('still accepts an absent name (optional)', () => {
+    expect(CreateSessionSchema.safeParse({}).success).toBe(true);
+  });
+
+  test('respects the existing length cap', () => {
+    const ok = 'a'.repeat(64);
+    const bad = 'a'.repeat(65);
+    expect(CreateSessionSchema.safeParse({ name: ok }).success).toBe(true);
+    expect(CreateSessionSchema.safeParse({ name: bad }).success).toBe(false);
+  });
+});

--- a/backend/src/services/tmux.ts
+++ b/backend/src/services/tmux.ts
@@ -289,6 +289,19 @@ export class TmuxService {
             const parts = line.split(SEP);
             if (parts.length >= 9) {
               const [sessionName, paneId, command, title, tty, active, dead, pidStr, ...pathParts] = parts;
+              // Defense-in-depth against SEP collisions in session names:
+              // CreateSessionSchema rejects names containing the sentinel, but
+              // pre-existing sessions can still poison the split and shift
+              // every field by one or more positions. paneId is always
+              // `%<digits>` (tmux contract). If the slot doesn't match, the
+              // line is suspect — skip rather than misattribute the pane to
+              // a phantom session. #250
+              if (!paneId || !/^%\d+$/.test(paneId)) {
+                console.warn(
+                  `[tmux] dropping list-panes line with malformed pane id (likely session-name SEP collision): ${line}`,
+                );
+                return;
+              }
               // Path might contain SEP (extremely unlikely), so join the rest
               const panePath = pathParts.join(SEP);
               const isActive = active === '1';

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -162,8 +162,18 @@ export interface SessionMetrics {
   memoryRssBytes?: number;             // total RSS across session's panes
 }
 
+// Session names land in tmux and downstream parsers split list-panes output on
+// a multi-char sentinel ('||~~||'). Allowing arbitrary characters in `name`
+// lets a request like `weird||~~||name` shift every parsed field and silently
+// misattribute panes to phantom sessions. Tighten to the same alphabet used
+// by SessionIdSchema so the parser invariant holds. #250
 export const CreateSessionSchema = z.object({
-  name: z.string().min(1).max(64).optional(),
+  name: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[A-Za-z0-9._-]+$/, 'Session name must be alphanumerics, dot, underscore, or hyphen')
+    .optional(),
   workingDir: z.string().optional(),
   initialPrompt: z.string().max(1000).optional(),
   agent: z.enum(AGENT_PROVIDER_IDS).optional().default(DEFAULT_AGENT_PROVIDER),


### PR DESCRIPTION
## Summary

\`listSessions()\` parses tmux \`list-panes\` output by splitting each line on a multi-char sentinel (\`||~~||\`) and destructuring 9 fields. Session names were user-controlled (\`CreateSessionSchema\` only bounded length, no charset) and tmux does NOT strip \`|\` or \`~\` from session names, so a name like \`weird||~~||name\` shifted every parsed field by two positions. paneId became \`name\`, the pane was silently misattributed to a phantom session \`weird\`, and the real session got zero panes — no agent detection, no preview, broken pane operations.

This PR:
- **Primary fix**: tightens \`CreateSessionSchema.name\` to \`/^[A-Za-z0-9._-]+$/\` (same alphabet as \`SessionIdSchema\`), so new names cannot collide with the parser sentinel.
- **Defense in depth**: the list-panes parser now validates \`paneId\` against \`/^%\\d+$/\` (tmux's documented contract) and drops + warns when the slot holds anything else — catches pre-existing sessions whose names predate the schema.

## Test plan
- [x] \`bun test src/services/__tests__/session-name-validation.test.ts\` — 5 pass
- [x] Backend lint / typecheck pass

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)