### PR TITLE
fix(dashboard): prevent 'Now'/'Reset' label overlap in usage chart

### DIFF
--- a/frontend/src/components/dashboard/UsageChart.tsx
+++ b/frontend/src/components/dashboard/UsageChart.tsx
@@ -370,27 +370,47 @@ export function UsageChart({
 					strokeWidth="1"
 				/>
 
-				{/* "Now" label */}
-				<text
-					x={currentPoint.x}
-					y={CHART_HEIGHT - 2}
-					textAnchor="middle"
-					fill={isLight ? "#6b7280" : "#9ca3af"}
-					fontSize="6"
-				>
-					{t("dashboard.chartNow")}
-				</text>
-
-				{/* "Reset" label */}
-				<text
-					x={PADDING.left + INNER_W}
-					y={CHART_HEIGHT - 2}
-					textAnchor="end"
-					fill="#6b7280"
-					fontSize="6"
-				>
-					{t("dashboard.chartReset")}
-				</text>
+				{/* "Now" + "Reset" labels — collapse to a combined label when the
+				    current point is near the right edge to avoid overlap. */}
+				{(() => {
+					const chartRight = PADDING.left + INNER_W;
+					const distFromLeft = currentPoint.x - PADDING.left;
+					const distFromRight = chartRight - currentPoint.x;
+					const minDist = 28;
+					const nowAnchor =
+						distFromLeft < minDist
+							? "start"
+							: distFromRight < minDist
+								? "end"
+								: "middle";
+					const showResetLabel = distFromRight >= minDist;
+					return (
+						<>
+							<text
+								x={currentPoint.x}
+								y={CHART_HEIGHT - 2}
+								textAnchor={nowAnchor}
+								fill={isLight ? "#6b7280" : "#9ca3af"}
+								fontSize="6"
+							>
+								{showResetLabel
+									? t("dashboard.chartNow")
+									: `${t("dashboard.chartNow")} / ${t("dashboard.chartReset")}`}
+							</text>
+							{showResetLabel && (
+								<text
+									x={chartRight}
+									y={CHART_HEIGHT - 2}
+									textAnchor="end"
+									fill="#6b7280"
+									fontSize="6"
+								>
+									{t("dashboard.chartReset")}
+								</text>
+							)}
+						</>
+					);
+				})()}
 			</svg>
 			<div className={`text-[10px] mt-0.5 ${getStatusTextColor(status)}`}>
 				{statusMessage}


### PR DESCRIPTION
## Summary
- 7日間サイクルなど、現在位置がリセット直前のとき「現在」と「リセット」ラベルが重なって判読不能になっていた
- ラベル間距離が < 28px のときは「現在 / リセット」に統合
- 余裕があるときは従来通り両ラベルを別表示
- 同時に、現在位置が左端/右端に近い場合の textAnchor も start/end に切り替えてはみ出しを防止

## Before / After
- Before: 「リセ✁現在」のように重なっていた（添付スクショ参照）
- After: 7日間サイクル → 「現在 / リセット」統合ラベル、5時間サイクル → 従来通り別ラベル

## Test plan
- [x] dev環境で `bun run dev` → ダッシュボード開く
- [x] agent-browser で両サイクル表示を確認（5h「現在/リセット」別表示、7d「現在 / リセット」統合表示）
- [x] `bun run --filter frontend typecheck` / `lint` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)