### PR TITLE
fix(dashboard): draw cumulative usage from cycle start without cross-cycle dips

### DIFF
--- a/backend/src/services/__tests__/usage-cycle-filter.test.ts
+++ b/backend/src/services/__tests__/usage-cycle-filter.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import type { UsageSnapshot } from "../../../../shared/types";
+import {
+	CYCLE_DROP_TOLERANCE,
+	filterToCurrentCycle,
+} from "../../../../shared/usage-cycle";
+
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+
+function snap(
+	timestamp: string,
+	sevenDayUtil: number,
+	fiveHourUtil = 0,
+): UsageSnapshot {
+	return {
+		timestamp,
+		fiveHour: { utilization: fiveHourUtil, resetsAt: "2026-05-30T06:00:00Z" },
+		sevenDay: { utilization: sevenDayUtil, resetsAt: "2026-05-30T06:00:00Z" },
+	};
+}
+
+const NOW = new Date("2026-05-30T05:11:00Z").getTime();
+const CYCLE_START = NOW - SEVEN_DAY_MS;
+
+describe("filterToCurrentCycle", () => {
+	test("empty input → empty output", () => {
+		expect(filterToCurrentCycle([], "sevenDay", CYCLE_START, NOW)).toEqual([]);
+	});
+
+	test("monotonic sequence → unchanged", () => {
+		const xs = [
+			snap("2026-05-29T12:00:00Z", 7),
+			snap("2026-05-29T18:00:00Z", 8),
+			snap("2026-05-30T00:00:00Z", 10),
+			snap("2026-05-30T05:00:00Z", 13),
+		];
+		expect(filterToCurrentCycle(xs, "sevenDay", CYCLE_START, NOW)).toEqual(xs);
+	});
+
+	test("real-data shape (18,18,18,18,7,7,8,9) → only post-drop segment", () => {
+		const xs = [
+			snap("2026-05-26T08:37:00Z", 18),
+			snap("2026-05-26T08:45:00Z", 18),
+			snap("2026-05-26T08:55:00Z", 18),
+			snap("2026-05-26T09:03:00Z", 18),
+			snap("2026-05-29T12:34:00Z", 7), // cycle boundary
+			snap("2026-05-29T13:00:00Z", 7),
+			snap("2026-05-30T00:00:00Z", 8),
+			snap("2026-05-30T05:00:00Z", 9),
+		];
+		const out = filterToCurrentCycle(xs, "sevenDay", CYCLE_START, NOW);
+		expect(out.length).toBe(4);
+		expect(out[0].sevenDay.utilization).toBe(7);
+		expect(out[out.length - 1].sevenDay.utilization).toBe(9);
+	});
+
+	test("two drops → only segment after the LAST drop", () => {
+		const xs = [
+			snap("2026-05-22T10:00:00Z", 15),
+			snap("2026-05-25T10:00:00Z", 4), // first drop
+			snap("2026-05-26T10:00:00Z", 12),
+			snap("2026-05-29T10:00:00Z", 3), // last drop (more recent)
+			snap("2026-05-30T05:00:00Z", 5),
+		];
+		const out = filterToCurrentCycle(xs, "sevenDay", CYCLE_START, NOW);
+		expect(out.length).toBe(2);
+		expect(out[0].sevenDay.utilization).toBe(3);
+		expect(out[1].sevenDay.utilization).toBe(5);
+	});
+
+	test(`drop within tolerance (${CYCLE_DROP_TOLERANCE} pts) is NOT treated as boundary`, () => {
+		const xs = [
+			snap("2026-05-29T12:00:00Z", 10),
+			snap("2026-05-29T18:00:00Z", 9), // -1, within tolerance
+			snap("2026-05-30T00:00:00Z", 11),
+		];
+		const out = filterToCurrentCycle(xs, "sevenDay", CYCLE_START, NOW);
+		expect(out.length).toBe(3);
+	});
+
+	test("drop exactly at tolerance is NOT a boundary; one past tolerance IS", () => {
+		const justInTolerance = [
+			snap("2026-05-29T12:00:00Z", 10),
+			snap("2026-05-29T18:00:00Z", 10 - CYCLE_DROP_TOLERANCE),
+		];
+		expect(
+			filterToCurrentCycle(justInTolerance, "sevenDay", CYCLE_START, NOW)
+				.length,
+		).toBe(2);
+
+		const pastTolerance = [
+			snap("2026-05-29T12:00:00Z", 10),
+			snap("2026-05-29T18:00:00Z", 10 - CYCLE_DROP_TOLERANCE - 1),
+		];
+		expect(
+			filterToCurrentCycle(pastTolerance, "sevenDay", CYCLE_START, NOW).length,
+		).toBe(1);
+	});
+
+	test("snapshots outside [cycleStart, now] are dropped", () => {
+		const xs = [
+			snap("2026-05-20T00:00:00Z", 5), // before cycleStart
+			snap("2026-05-25T00:00:00Z", 7),
+			snap("2026-06-30T00:00:00Z", 100), // after now
+		];
+		const out = filterToCurrentCycle(xs, "sevenDay", CYCLE_START, NOW);
+		expect(out.length).toBe(1);
+		expect(out[0].sevenDay.utilization).toBe(7);
+	});
+
+	test("unsorted input is sorted before drop detection", () => {
+		const xs = [
+			snap("2026-05-30T00:00:00Z", 8),
+			snap("2026-05-29T12:34:00Z", 7),
+			snap("2026-05-26T08:37:00Z", 18),
+			snap("2026-05-30T05:00:00Z", 9),
+		];
+		const out = filterToCurrentCycle(xs, "sevenDay", CYCLE_START, NOW);
+		expect(out.map((s) => s.sevenDay.utilization)).toEqual([7, 8, 9]);
+	});
+
+	test("5h chart with 0→0→0→N pattern is NOT treated as a drop", () => {
+		const fiveHourCycleStart = NOW - 5 * 60 * 60 * 1000;
+		const xs = [
+			snap("2026-05-30T00:15:00Z", 18, 0),
+			snap("2026-05-30T00:45:00Z", 18, 0),
+			snap("2026-05-30T01:15:00Z", 18, 0),
+			snap("2026-05-30T01:45:00Z", 18, 2),
+			snap("2026-05-30T02:15:00Z", 18, 5),
+		];
+		const out = filterToCurrentCycle(
+			xs,
+			"fiveHour",
+			fiveHourCycleStart,
+			NOW,
+		);
+		expect(out.length).toBe(5);
+	});
+
+	test("all-old-cycle data: returns just the last point as the surviving segment", () => {
+		const xs = [
+			snap("2026-05-26T08:37:00Z", 50),
+			snap("2026-05-26T09:03:00Z", 50),
+			snap("2026-05-26T09:10:00Z", 1),
+		];
+		const out = filterToCurrentCycle(xs, "sevenDay", CYCLE_START, NOW);
+		expect(out.length).toBe(1);
+		expect(out[0].sevenDay.utilization).toBe(1);
+	});
+});

--- a/frontend/src/components/dashboard/UsageChart.tsx
+++ b/frontend/src/components/dashboard/UsageChart.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { UsageSnapshot } from "../../../../shared/types";
+import { filterToCurrentCycle } from "../../../../shared/usage-cycle";
 
 function useIsLightMode() {
 	const [light, setLight] = useState(
@@ -90,20 +91,33 @@ export function UsageChart({
 		const cycleStart = resetTime - cycleDuration;
 		const nowRatio = (now - cycleStart) / cycleDuration;
 
-		const relevantSnapshots = snapshots
-			.filter((s) => {
-				const ts = new Date(s.timestamp).getTime();
-				return ts >= cycleStart && ts <= now;
-			})
-			.sort(
-				(a, b) =>
-					new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
-			);
+		// Drop cross-cycle pollution: Anthropic returns the same resetsAt for old
+		// snapshots after a boundary rolls over, so the only signal is a drop in
+		// utilization. See shared/usage-cycle.ts.
+		const relevantSnapshots = filterToCurrentCycle(
+			snapshots,
+			field,
+			cycleStart,
+			now,
+		);
 
 		// --- Actual usage points ---
-		// Use only real samples so empty/low-history cycles do not render an
-		// artificial vertical spike from the cycle start.
+		// Anchor at (cycleStart, 0%) when the first real sample is more than
+		// FIRST_GAP_THRESHOLD into the cycle (or there are no samples at all).
+		// Utilization is cumulative and a fresh cycle always starts at 0%, so this
+		// is the correct "interpolation" for missing early-cycle data. If the
+		// first real sample is already near cycleStart, no anchor is added —
+		// avoiding the artificial vertical spike the original code worried about.
+		const FIRST_GAP_THRESHOLD = 0.02;
+		const firstSurvivingTs = relevantSnapshots[0]
+			? new Date(relevantSnapshots[0].timestamp).getTime()
+			: now;
+		const firstRatio = (firstSurvivingTs - cycleStart) / cycleDuration;
+
 		const actualPoints: { x: number; y: number }[] = [];
+		if (relevantSnapshots.length === 0 || firstRatio > FIRST_GAP_THRESHOLD) {
+			actualPoints.push({ x: ratioToX(0), y: utilToY(0) });
+		}
 		for (const snap of relevantSnapshots) {
 			const ts = new Date(snap.timestamp).getTime();
 			const ratio = (ts - cycleStart) / cycleDuration;

--- a/shared/usage-cycle.ts
+++ b/shared/usage-cycle.ts
@@ -1,0 +1,49 @@
+import type { UsageSnapshot } from "./types";
+
+/**
+ * Anthropic's API reports the same `resetsAt` on all snapshots after a cycle
+ * rolls over, so we can't use resetsAt to attribute a snapshot to its origin
+ * cycle. The only signal is a drop in utilization larger than rounding noise:
+ * a cycle reset is the only mechanism that can cause cumulative utilization
+ * to decrease.
+ */
+export const CYCLE_DROP_TOLERANCE = 2;
+
+/**
+ * Return snapshots that belong to the cycle currently in progress.
+ *
+ * Walks the timestamp-sorted snapshots backwards, finds the LAST index where
+ * utilization drops by more than CYCLE_DROP_TOLERANCE versus its predecessor,
+ * and returns everything from that index onward. If no drop is found, returns
+ * all snapshots in the window.
+ *
+ * The window itself is `[cycleStart, now]` — anything outside is discarded.
+ */
+export function filterToCurrentCycle(
+	snapshots: UsageSnapshot[],
+	field: "fiveHour" | "sevenDay",
+	cycleStart: number,
+	now: number,
+): UsageSnapshot[] {
+	const inWindow = snapshots
+		.filter((s) => {
+			const ts = new Date(s.timestamp).getTime();
+			return ts >= cycleStart && ts <= now;
+		})
+		.sort(
+			(a, b) =>
+				new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+		);
+
+	let cycleStartIdx = 0;
+	for (let i = inWindow.length - 1; i >= 1; i--) {
+		const curr = inWindow[i][field].utilization;
+		const prev = inWindow[i - 1][field].utilization;
+		if (curr + CYCLE_DROP_TOLERANCE < prev) {
+			cycleStartIdx = i;
+			break;
+		}
+	}
+
+	return inWindow.slice(cycleStartIdx);
+}


### PR DESCRIPTION
## Summary

7日間サイクルのグラフが (a) **中央あたりから始まる** (b) **途中で減少する** という2つの症状を修正。

### 根本原因（実データから確定）
- 履歴の **index 4 で `sevenDay.utilization` が 18→7 に減少**（2026-05-29T12:34 のサイクル境界）
- 全32レコードの `resetsAt` がほぼ同じ（±2秒） — Anthropic API は **古いサイクルのスナップショットにも新しい resetsAt を返す** ため、resetsAt 一致では境界を判定できない
- → **唯一の手がかりは utilization の drop パターン**

### Fix

1. `shared/usage-cycle.ts` 新規追加: 純粋関数 `filterToCurrentCycle()` が時系列順で最後の drop (> CYCLE_DROP_TOLERANCE=2) 後のセグメントだけ返す
2. `UsageChart.tsx`: ↑のヘルパーで濾過 + 最初のサンプルが cycleStart から 2% 以上奥にある場合のみ `(cycleStart, 0%)` アンカーを prepend
3. monotonic envelope は使わない — フィルタが drop を除去済みなので生データそのまま描画

### Before / After
- Before: 7日サイクル → 18→7→8→… の **「減少→上昇」**、中央スタート
- After: 7日サイクル → 0%→...→13% の単調増加、左端スタート
- 5時間サイクルは visual 不変（drop パターンが無いので no-op）

## Test plan
- [x] `shared/usage-cycle.ts` のユニットテスト 10件全通過（実データ shape、tolerance 境界、2-drop の最後の境界、out-of-window、5h chart の 0→0→N が drop と誤判定されない、等）
- [x] backend test suite 248 件全通過
- [x] dev環境 agent-browser で実機確認 — 5h/7d 両方とも 0% スタート + 単調増加
- [x] `bun run lint` / `typecheck` 全パッケージ通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)