### PR TITLE
feat(history): types + V2 flag foundation (PR1/6)

### DIFF
--- a/frontend/src/hooks/useHistoryV2Flag.ts
+++ b/frontend/src/hooks/useHistoryV2Flag.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "cchub-history-v2";
+
+function readFlag(): boolean {
+	try {
+		return localStorage.getItem(STORAGE_KEY) === "true";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Session History V2 feature flag.
+ *
+ * Reads `cchub-history-v2` from localStorage and returns whether the new
+ * faceted/virtualized history UI should be shown. Listens for the storage
+ * event so toggling the flag in another tab updates this one live.
+ *
+ * Default is `false` (opt-in). PR6 will flip the unset default to `true`.
+ */
+export function useHistoryV2Flag(): boolean {
+	const [enabled, setEnabled] = useState<boolean>(() => readFlag());
+
+	useEffect(() => {
+		function onStorage(e: StorageEvent) {
+			if (e.key === STORAGE_KEY || e.key === null) {
+				setEnabled(readFlag());
+			}
+		}
+		window.addEventListener("storage", onStorage);
+		return () => {
+			window.removeEventListener("storage", onStorage);
+		};
+	}, []);
+
+	return enabled;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -528,8 +528,15 @@ export interface HistorySession {
   sessionId: string;
   projectPath: string;
   projectName: string;
+  /** Historical misnomer: the backend populates this from the LAST user message, not the first. Prefer `lastPrompt` once it is populated (V2). Will be marked `@deprecated` after the frontend reads `lastPrompt` with a `firstPrompt` fallback, and removed after V2 ships. */
   firstPrompt?: string;
+  /** The most recent user message in the session, used as the preview when no recap exists. Replaces the misnamed `firstPrompt`. */
+  lastPrompt?: string;
   summary?: string;
+  /** Latest recap (auto `away_summary` or manual `/recap`), used as the preview when present. Claude-only; codex sessions leave this undefined. */
+  recap?: string;
+  /** ISO timestamp of the recap that produced `recap`. */
+  recapAt?: string;
   modified: string;
   // Phase 2 additions
   startTime?: string;
@@ -562,6 +569,8 @@ export interface PeerHistoryProject {
   peerId: string;
   peerNickname?: string;
   peerColor?: string;
+  /** Reserved for a future cwd-based grouping (resolves the `/` and `.` -> `-` encoding collision). Populated by the backend in a later PR; safe to ignore until then. */
+  cwdKey?: string;
 }
 
 export interface PeerHistoryProjectsResponse {


### PR DESCRIPTION
## Option B (Faceted/Virtualized Session History) — PR 1 of 6

型定義と feature flag の土台のみ。**ランタイム挙動の変化なし**（新フィールドは全て optional、フックはまだどこからも import されていない）。

### 変更
- **`shared/types.ts`**
  - `HistorySession`: `lastPrompt?` / `recap?` / `recapAt?` を追加
  - `firstPrompt` は残置。実体が「最後のユーザー入力」である旨を JSDoc で明記。`@deprecated` は後続 PR に後ろ倒し（現状 31 箇所が現役で読むため、先行付与すると誤った取り消し線警告になる）
  - `PeerHistoryProject`: `cwdKey?` を追加（将来の cwd ベースグルーピング用予約、`/`+`.`→`-` エンコード衝突の解消）
- **`frontend/src/hooks/useHistoryV2Flag.ts`** (新規)
  - `localStorage["cchub-history-v2"]` で V1/V2 を切り替える gate。default false（opt-in、PR6 で true へ）
  - try/catch ガード + storage イベントでタブ間同期。`useTheme`/`uiScale` の規約に準拠

### レビュー
マルチエージェントの adversarial review（Zod同期 / フック正当性 / 後方互換）を実施し、指摘 2 件を反映:
1. `@deprecated` の先行付与を撤回（説明文 JSDoc に変更）
2. localStorage 読み取りを try/catch で保護（private browsing でのレンダークラッシュ防止）

Zod スキーマは `HistorySession`/`PeerHistoryProject` に存在せず（`c.json()` 素通し + `JSON.parse() as` 消費）、型追加だけで後方互換は健全。

### 検証
- `bunx biome check` ✅ exit 0
- frontend / backend `tsc --noEmit` ✅（自分のファイルはエラーゼロ。既存の notify.ts/send.ts エラーは PR1 無関係）
- dev 環境で既存 History UI が不変であることを確認予定

### 後続 PR
- PR2: backend `recap-scanner` 抽出 + recap/lastPrompt を 4 経路に流す
- PR3: 既存 V1 で recap 表示 + i18n キー
- PR4: `VirtualizedHistoryList` + `HistoryFacetBar` + 補助フック
- PR5: `SessionHistoryV2` + flag gate
- PR6: default true → V1 削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)