### PR TITLE
feat(history): recap + lastPrompt on HistorySession (PR2/6)

### DIFF
--- a/backend/src/services/__tests__/recap-scanner.test.ts
+++ b/backend/src/services/__tests__/recap-scanner.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { parseRecapFromLines } from "../../utils/recap-scanner";
+
+function jsonl(...entries: unknown[]): string[] {
+	return entries.map((e) => JSON.stringify(e));
+}
+
+const userRecapTrigger = {
+	type: "user",
+	message: {
+		content: [
+			{ type: "text", text: "<command-name>/recap</command-name>" },
+		],
+	},
+};
+
+describe("parseRecapFromLines", () => {
+	test("empty input → null", () => {
+		expect(parseRecapFromLines([])).toBeNull();
+	});
+
+	test("away_summary is picked up and the config hint is stripped", () => {
+		const lines = jsonl({
+			type: "system",
+			subtype: "away_summary",
+			content: "進捗まとめ: PR2 を実装中。 (disable recaps in /config)",
+			timestamp: "2026-05-30T10:00:00Z",
+		});
+		const recap = parseRecapFromLines(lines);
+		expect(recap).toEqual({
+			content: "進捗まとめ: PR2 を実装中。",
+			timestamp: "2026-05-30T10:00:00Z",
+		});
+	});
+
+	test("local_command recap requires a preceding /recap user trigger", () => {
+		const withTrigger = jsonl(userRecapTrigger, {
+			type: "system",
+			subtype: "local_command",
+			content: "<local-command-stdout>手動 recap 本文</local-command-stdout>",
+			timestamp: "2026-05-30T11:00:00Z",
+		});
+		expect(parseRecapFromLines(withTrigger)).toEqual({
+			content: "手動 recap 本文",
+			timestamp: "2026-05-30T11:00:00Z",
+		});
+
+		// Same local_command WITHOUT the preceding /recap trigger is ignored.
+		const withoutTrigger = jsonl({
+			type: "system",
+			subtype: "local_command",
+			content: "<local-command-stdout>別コマンドの出力</local-command-stdout>",
+			timestamp: "2026-05-30T11:00:00Z",
+		});
+		expect(parseRecapFromLines(withoutTrigger)).toBeNull();
+	});
+
+	test("local_command API Error output is skipped", () => {
+		const lines = jsonl(userRecapTrigger, {
+			type: "system",
+			subtype: "local_command",
+			content: "<local-command-stdout>API Error: 529 overloaded</local-command-stdout>",
+			timestamp: "2026-05-30T11:00:00Z",
+		});
+		expect(parseRecapFromLines(lines)).toBeNull();
+	});
+
+	test("most recent recap wins when both sources are present", () => {
+		const lines = jsonl(
+			{
+				type: "system",
+				subtype: "away_summary",
+				content: "古い自動 recap",
+				timestamp: "2026-05-30T09:00:00Z",
+			},
+			userRecapTrigger,
+			{
+				type: "system",
+				subtype: "local_command",
+				content: "<local-command-stdout>新しい手動 recap</local-command-stdout>",
+				timestamp: "2026-05-30T12:00:00Z",
+			},
+		);
+		expect(parseRecapFromLines(lines)?.content).toBe("新しい手動 recap");
+	});
+
+	test("a later away_summary overrides an earlier one", () => {
+		const lines = jsonl(
+			{
+				type: "system",
+				subtype: "away_summary",
+				content: "1回目",
+				timestamp: "2026-05-30T09:00:00Z",
+			},
+			{
+				type: "system",
+				subtype: "away_summary",
+				content: "2回目",
+				timestamp: "2026-05-30T10:00:00Z",
+			},
+		);
+		expect(parseRecapFromLines(lines)?.content).toBe("2回目");
+	});
+
+	test("an away_summary between /recap and its local_command clears the trigger", () => {
+		const lines = jsonl(
+			userRecapTrigger,
+			{
+				type: "system",
+				subtype: "away_summary",
+				content: "自動まとめ",
+				timestamp: "2026-05-30T10:00:00Z",
+			},
+			{
+				type: "system",
+				subtype: "local_command",
+				content: "<local-command-stdout>trigger を奪われた出力</local-command-stdout>",
+				timestamp: "2026-05-30T11:00:00Z",
+			},
+		);
+		// The away_summary consumes the pending trigger, so the local_command is
+		// NOT treated as a recap; the away_summary itself is the latest recap.
+		expect(parseRecapFromLines(lines)?.content).toBe("自動まとめ");
+	});
+
+	test("a non-/recap user entry clears a pending trigger", () => {
+		const lines = jsonl(
+			userRecapTrigger,
+			{ type: "user", message: { content: "ふつうの発言" } },
+			{
+				type: "system",
+				subtype: "local_command",
+				content: "<local-command-stdout>これは recap ではない</local-command-stdout>",
+				timestamp: "2026-05-30T11:00:00Z",
+			},
+		);
+		expect(parseRecapFromLines(lines)).toBeNull();
+	});
+
+	test("invalid JSON lines are skipped without throwing", () => {
+		const lines = [
+			"not json",
+			"",
+			JSON.stringify({
+				type: "system",
+				subtype: "away_summary",
+				content: "壊れた行のあとの recap",
+				timestamp: "2026-05-30T10:00:00Z",
+			}),
+		];
+		expect(parseRecapFromLines(lines)?.content).toBe("壊れた行のあとの recap");
+	});
+
+	test("empty away_summary content does not produce a recap", () => {
+		const lines = jsonl({
+			type: "system",
+			subtype: "away_summary",
+			content: " (disable recaps in /config)",
+			timestamp: "2026-05-30T10:00:00Z",
+		});
+		expect(parseRecapFromLines(lines)).toBeNull();
+	});
+});

--- a/backend/src/services/claude-code.ts
+++ b/backend/src/services/claude-code.ts
@@ -4,43 +4,8 @@ import { homedir } from 'node:os';
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { claudeProjectDirName } from '../utils/claude-project-path';
-
-/**
- * Read last N lines from a file without spawning a subprocess.
- * Reads from the end of the file in chunks, retrying with larger chunks
- * when initial estimate doesn't capture enough lines (Claude Code JSONL
- * lines can be 2KB+ when they contain large tool results).
- */
-async function readLastLines(filePath: string, lineCount: number): Promise<string> {
-  try {
-    const file = Bun.file(filePath);
-    const size = file.size;
-    if (size === 0) return '';
-
-    let bytesPerLine = 2048;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const chunkSize = Math.min(size, lineCount * bytesPerLine);
-      const buffer = await file.slice(size - chunkSize, size).text();
-      const lines = buffer.split('\n');
-      // Drop incomplete first line unless we read the entire file
-      if (chunkSize < size) lines.shift();
-      if (lines.length >= lineCount || chunkSize >= size) {
-        return lines.slice(-lineCount).join('\n');
-      }
-      bytesPerLine *= 4; // 2K → 8K → 32K
-    }
-    // Last resort: read entire file
-    const buffer = await file.text();
-    return buffer.split('\n').slice(-lineCount).join('\n');
-  } catch {
-    return '';
-  }
-}
-
-interface RecapEntry {
-  content: string;
-  timestamp: string;
-}
+import { readLastLines } from '../utils/read-last-lines';
+import { type RecapEntry, scanLastRecap } from '../utils/recap-scanner';
 
 interface ClaudeCodeSession {
   sessionId: string;
@@ -300,76 +265,6 @@ export class ClaudeCodeService {
   }
 
   /**
-   * Read the latest recap from a jsonl file. Two sources:
-   *   1. system/away_summary — auto-emitted by Claude Code after the terminal has been
-   *      unfocused for ≥3 minutes.
-   *   2. system/local_command — output of a manual `/recap` slash command. Detected by
-   *      checking that the preceding user entry contains <command-name>/recap</command-name>.
-   * Returns whichever is most recent.
-   */
-  private async readLastRecap(filePath: string): Promise<RecapEntry | null> {
-    try {
-      const text = await readLastLines(filePath, 300);
-      if (!text) return null;
-
-      const lines = text.trim().split('\n');
-      let pendingRecapTrigger = false; // true when the most recent user entry was /recap
-      let lastRecap: RecapEntry | null = null;
-
-      for (const line of lines) {
-        let entry: Record<string, unknown>;
-        try {
-          entry = JSON.parse(line);
-        } catch {
-          continue;
-        }
-
-        // Track /recap slash command triggers from user entries.
-        if (entry.type === 'user') {
-          const message = entry.message as { content?: unknown } | undefined;
-          const content = message?.content;
-          let text = '';
-          if (typeof content === 'string') {
-            text = content;
-          } else if (Array.isArray(content)) {
-            const block = content.find((b): b is { type: string; text: string } =>
-              typeof b === 'object' && b !== null && (b as { type?: string }).type === 'text'
-            );
-            text = block?.text || '';
-          }
-          pendingRecapTrigger = /<command-name>\/?recap<\/command-name>/.test(text);
-          continue;
-        }
-
-        if (entry.type !== 'system') continue;
-        const content = entry.content;
-        if (typeof content !== 'string' || content.length === 0) continue;
-        const timestamp = (entry.timestamp as string) || '';
-
-        if (entry.subtype === 'away_summary') {
-          // Strip the trailing "(disable recaps in /config)" hint Claude Code appends.
-          const cleaned = content.replace(/\s*\(disable recaps in \/config\)\s*$/, '').trim();
-          if (cleaned) lastRecap = { content: cleaned, timestamp };
-        } else if (entry.subtype === 'local_command' && pendingRecapTrigger) {
-          const cleaned = content
-            .replace(/^<local-command-stdout>/, '')
-            .replace(/<\/local-command-stdout>$/, '')
-            .trim();
-          // Skip error outputs (e.g. "API Error: 529 ..." when the recap call fails)
-          if (cleaned && !cleaned.startsWith('API Error')) {
-            lastRecap = { content: cleaned, timestamp };
-          }
-          pendingRecapTrigger = false;
-        }
-      }
-
-      return lastRecap;
-    } catch {
-      return null;
-    }
-  }
-
-  /**
    * Check if the session is waiting for user input by reading the jsonl file
    * Returns the tool name if waiting, null otherwise
    */
@@ -619,7 +514,7 @@ export class ClaudeCodeService {
         this.readLastUserMessage(filePath),
         this.checkWaitingState(filePath),
         this.readFirstMessageId(filePath),
-        this.readLastRecap(filePath),
+        scanLastRecap(filePath),
       ]);
 
       const data: ClaudeCodeSession = {
@@ -768,7 +663,7 @@ export class ClaudeCodeService {
                 this.checkWaitingState(filePath),
                 this.readLastUserMessage(filePath),
                 this.readFirstMessageId(filePath),
-                this.readLastRecap(filePath),
+                scanLastRecap(filePath),
               ]);
 
               return {
@@ -793,7 +688,7 @@ export class ClaudeCodeService {
               this.readLastUserMessage(filePath),
               this.checkWaitingState(filePath),
               this.readFirstMessageId(filePath),
-              this.readLastRecap(filePath),
+              scanLastRecap(filePath),
             ]);
 
             return {
@@ -924,7 +819,7 @@ export class ClaudeCodeService {
                 this.readLastUserMessage(filePath),
                 this.checkWaitingState(filePath),
                 this.readFirstMessageId(filePath),
-                this.readLastRecap(filePath),
+                scanLastRecap(filePath),
               ]);
 
               return {

--- a/backend/src/services/codex-history.ts
+++ b/backend/src/services/codex-history.ts
@@ -228,6 +228,9 @@ export class CodexHistoryService {
       projectPath: r.cwd,
       projectName: r.cwd.replace(/^\/home\/[^/]+\//, '~/'),
       firstPrompt: r.firstPrompt,
+      lastPrompt: r.firstPrompt,
+      // Codex transcripts have no recap (Claude-only feature).
+      recap: undefined,
       modified: r.modified,
       agent: 'codex',
     };

--- a/backend/src/services/session-history.ts
+++ b/backend/src/services/session-history.ts
@@ -4,6 +4,8 @@ import { createInterface } from 'node:readline';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { HistorySession } from '../../../shared/types';
+import { readLastLines } from '../utils/read-last-lines';
+import { scanLastRecap } from '../utils/recap-scanner';
 
 export type { HistorySession };
 
@@ -31,6 +33,18 @@ interface SessionMetadata {
   messageCount: number;
   gitBranch?: string;
   firstMessageUuid?: string;  // For session matching
+}
+
+/**
+ * Recaps are used as a one-line preview in the history list, so the full
+ * (often multi-paragraph) text doesn't need to ship in list responses. Cap it
+ * to keep `/history/projects/:dir` payloads small even for big projects.
+ */
+const RECAP_PREVIEW_MAX = 300;
+function truncateRecap(content: string): string {
+  return content.length > RECAP_PREVIEW_MAX
+    ? `${content.slice(0, RECAP_PREVIEW_MAX)}…`
+    : content;
 }
 
 export interface ToolUseInfo {
@@ -93,13 +107,10 @@ export class SessionHistoryService {
    */
   private async readLastUserMessage(filePath: string): Promise<string | null> {
     try {
-      const proc = Bun.spawn(['tail', '-n', '500', filePath], {
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-      const text = await new Response(proc.stdout).text();
-      const exitCode = await proc.exited;
-      if (exitCode !== 0) return null;
+      // readLastLines (no subprocess, split-UTF-8 safe) replaces the old
+      // `tail -n 500` spawn — same window, shell-independent.
+      const text = await readLastLines(filePath, 500);
+      if (!text) return null;
 
       const lines = text.trim().split('\n').reverse();
       for (const line of lines) {
@@ -355,22 +366,33 @@ export class SessionHistoryService {
       const files = await readdir(projectDir);
       const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
 
-      for (const file of jsonlFiles) {
-        const jsonlPath = join(projectDir, file);
-        const basicInfo = await this.scanJsonlForBasicInfo(jsonlPath);
+      // Process files concurrently: each does a header scan + a recap tail read.
+      // Serial awaits here blocked the request for ~2 reads × N sessions.
+      const built = await Promise.all(
+        jsonlFiles.map(async (file): Promise<HistorySession | null> => {
+          const jsonlPath = join(projectDir, file);
+          const basicInfo = await this.scanJsonlForBasicInfo(jsonlPath);
 
-        // Skip sessions with no user messages
-        if (basicInfo?.lastPrompt) {
+          // Skip sessions with no user messages
+          if (!basicInfo?.lastPrompt) return null;
+
           const projectName = basicInfo.projectPath.replace(/^\/home\/[^/]+\//, '~/');
+          const recap = await scanLastRecap(jsonlPath);
 
-          sessions.push({
+          return {
             sessionId: basicInfo.sessionId,
             projectPath: basicInfo.projectPath,
             projectName,
             firstPrompt: basicInfo.lastPrompt,
+            lastPrompt: basicInfo.lastPrompt,
+            recap: recap ? truncateRecap(recap.content) : undefined,
+            recapAt: recap?.timestamp,
             modified: basicInfo.modified,
-          });
-        }
+          };
+        }),
+      );
+      for (const s of built) {
+        if (s) sessions.push(s);
       }
 
       // Sort by modified date (newest first)
@@ -384,6 +406,9 @@ export class SessionHistoryService {
   async getRecentSessions(limit: number = 20, includeMetadata: boolean = false): Promise<HistorySession[]> {
     const sessions: HistorySession[] = [];
     const seenSessionIds = new Set<string>();
+    // Track each session's jsonl path so recap can be fetched only for the
+    // final sliced set (avoids a second tail read across every scanned file).
+    const sessionPaths = new Map<string, string>();
 
     try {
       const projectDirs = await readdir(this.projectsDir);
@@ -402,6 +427,7 @@ export class SessionHistoryService {
             // Skip sessions with no user messages (empty/abandoned sessions)
             if (basicInfo?.lastPrompt && !seenSessionIds.has(basicInfo.sessionId)) {
               seenSessionIds.add(basicInfo.sessionId);
+              sessionPaths.set(basicInfo.sessionId, jsonlPath);
 
               const projectName = basicInfo.projectPath.replace(/^\/home\/[^/]+\//, '~/');
 
@@ -409,7 +435,8 @@ export class SessionHistoryService {
                 sessionId: basicInfo.sessionId,
                 projectPath: basicInfo.projectPath,
                 projectName,
-                firstPrompt: basicInfo.lastPrompt,  // Now using lastPrompt
+                firstPrompt: basicInfo.lastPrompt,
+                lastPrompt: basicInfo.lastPrompt,
                 modified: basicInfo.modified,
               };
 
@@ -439,7 +466,22 @@ export class SessionHistoryService {
       }
 
       sessions.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
-      return sessions.slice(0, limit);
+      const top = sessions.slice(0, limit);
+
+      // Attach recap only to the returned set, in parallel.
+      await Promise.all(
+        top.map(async (session) => {
+          const path = sessionPaths.get(session.sessionId);
+          if (!path) return;
+          const recap = await scanLastRecap(path);
+          if (recap) {
+            session.recap = truncateRecap(recap.content);
+            session.recapAt = recap.timestamp;
+          }
+        }),
+      );
+
+      return top;
     } catch {
       return [];
     }
@@ -797,11 +839,14 @@ export class SessionHistoryService {
               const searchText = `${projectName} ${basicInfo.lastPrompt}`.toLowerCase();
 
               if (searchText.includes(normalizedQuery)) {
+                // recap intentionally omitted on both search paths — avoid an
+                // extra tail-read per result. Search matches title/prompt only.
                 results.push({
                   sessionId: basicInfo.sessionId,
                   projectPath: basicInfo.projectPath,
                   projectName,
                   firstPrompt: basicInfo.lastPrompt,
+                  lastPrompt: basicInfo.lastPrompt,
                   modified: basicInfo.modified,
                 });
               }
@@ -902,6 +947,7 @@ export class SessionHistoryService {
                   projectPath: basicInfo.projectPath,
                   projectName,
                   firstPrompt: matchSnippet,
+                  lastPrompt: matchSnippet,
                   modified: basicInfo.modified,
                 };
               }

--- a/backend/src/utils/read-last-lines.ts
+++ b/backend/src/utils/read-last-lines.ts
@@ -1,0 +1,36 @@
+/**
+ * Read the last N lines from a file without spawning a subprocess.
+ * Reads from the end of the file in chunks, retrying with larger chunks
+ * when the initial estimate doesn't capture enough lines (Claude Code JSONL
+ * lines can be 2KB+ when they contain large tool results).
+ *
+ * Returns an empty string on any error (missing file, permission, etc.).
+ */
+export async function readLastLines(
+	filePath: string,
+	lineCount: number,
+): Promise<string> {
+	try {
+		const file = Bun.file(filePath);
+		const size = file.size;
+		if (size === 0) return "";
+
+		let bytesPerLine = 2048;
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const chunkSize = Math.min(size, lineCount * bytesPerLine);
+			const buffer = await file.slice(size - chunkSize, size).text();
+			const lines = buffer.split("\n");
+			// Drop incomplete first line unless we read the entire file
+			if (chunkSize < size) lines.shift();
+			if (lines.length >= lineCount || chunkSize >= size) {
+				return lines.slice(-lineCount).join("\n");
+			}
+			bytesPerLine *= 4; // 2K → 8K → 32K
+		}
+		// Last resort: read entire file
+		const buffer = await file.text();
+		return buffer.split("\n").slice(-lineCount).join("\n");
+	} catch {
+		return "";
+	}
+}

--- a/backend/src/utils/recap-scanner.ts
+++ b/backend/src/utils/recap-scanner.ts
@@ -1,0 +1,95 @@
+import { readLastLines } from "./read-last-lines";
+
+export interface RecapEntry {
+	content: string;
+	timestamp: string;
+}
+
+/** How many trailing lines of a jsonl file are scanned for a recap. */
+export const RECAP_SCAN_LINES = 300;
+
+/**
+ * Parse the latest recap out of already-read jsonl lines. Two sources:
+ *   1. system/away_summary — auto-emitted by Claude Code after the terminal has
+ *      been unfocused for ≥3 minutes.
+ *   2. system/local_command — output of a manual `/recap` slash command,
+ *      detected by checking that the preceding user entry contains
+ *      `<command-name>/recap</command-name>`.
+ * Returns whichever appears most recently in the scanned window.
+ *
+ * Pure (no I/O) so it can be unit-tested with synthetic lines.
+ */
+export function parseRecapFromLines(lines: string[]): RecapEntry | null {
+	let pendingRecapTrigger = false; // true when the most recent user entry was /recap
+	let lastRecap: RecapEntry | null = null;
+
+	for (const line of lines) {
+		let entry: Record<string, unknown>;
+		try {
+			entry = JSON.parse(line);
+		} catch {
+			continue;
+		}
+
+		// Track /recap slash command triggers from user entries.
+		if (entry.type === "user") {
+			const message = entry.message as { content?: unknown } | undefined;
+			const content = message?.content;
+			let text = "";
+			if (typeof content === "string") {
+				text = content;
+			} else if (Array.isArray(content)) {
+				const block = content.find(
+					(b): b is { type: string; text: string } =>
+						typeof b === "object" &&
+						b !== null &&
+						(b as { type?: string }).type === "text",
+				);
+				text = block?.text || "";
+			}
+			pendingRecapTrigger = /<command-name>\/?recap<\/command-name>/.test(text);
+			continue;
+		}
+
+		if (entry.type !== "system") continue;
+		const content = entry.content;
+		if (typeof content !== "string" || content.length === 0) continue;
+		const timestamp = (entry.timestamp as string) || "";
+
+		if (entry.subtype === "away_summary") {
+			// Strip the trailing "(disable recaps in /config)" hint Claude Code appends.
+			const cleaned = content
+				.replace(/\s*\(disable recaps in \/config\)\s*$/, "")
+				.trim();
+			if (cleaned) lastRecap = { content: cleaned, timestamp };
+			// An auto-summary is not the output of a /recap command, so it ends any
+			// pending trigger — a later local_command must have its own /recap user
+			// entry to count.
+			pendingRecapTrigger = false;
+		} else if (entry.subtype === "local_command" && pendingRecapTrigger) {
+			const cleaned = content
+				.replace(/^<local-command-stdout>/, "")
+				.replace(/<\/local-command-stdout>$/, "")
+				.trim();
+			// Skip error outputs (e.g. "API Error: 529 ..." when the recap call fails)
+			if (cleaned && !cleaned.startsWith("API Error")) {
+				lastRecap = { content: cleaned, timestamp };
+			}
+			pendingRecapTrigger = false;
+		}
+	}
+
+	return lastRecap;
+}
+
+/**
+ * Read the latest recap from a session jsonl file. Returns null when the file
+ * has no recap or cannot be read. Claude-only; codex transcripts have no recap.
+ */
+export async function scanLastRecap(
+	filePath: string,
+): Promise<RecapEntry | null> {
+	const text = await readLastLines(filePath, RECAP_SCAN_LINES);
+	if (!text) return null;
+	return parseRecapFromLines(text.trim().split("\n"));
+}


### PR DESCRIPTION
## Option B — PR 2 of 6 (backend)

`HistorySession` の `recap`/`recapAt`/`lastPrompt`（PR1 で型追加済み）にバックエンドが実値を流す。**フロントは未変更**（V1 は引き続き firstPrompt 表示）だが、新フィールドが wire に乗る。

### 変更
**ユーティリティ抽出（重複排除）**
- `backend/src/utils/read-last-lines.ts` — `readLastLines` を claude-code.ts から切り出し
- `backend/src/utils/recap-scanner.ts` — `parseRecapFromLines`（純粋）+ `scanLastRecap`（I/O）、`RecapEntry` 型

**SessionHistoryService**
- 4経路すべてに `lastPrompt` 設定
- `getProjectSessions` / `getRecentSessions` に `recap`/`recapAt` 設定（search 2経路は I/O二重化回避で recap 除外）
- recap は 300字プレビューに truncate
- `getProjectSessions` を Promise.all で並列化（旧: 全ファイル直列 await）
- `getRecentSessions` は slice(limit) 後の top-N のみ recap 取得
- `readLastUserMessage` の `tail` サブプロセスを `readLastLines` に置換（最後の tail spawn を排除、split-UTF-8 安全）

**codex-history.ts** — `lastPrompt` ミラー + `recap: undefined`（Claude 限定機能）

### レビュー反映（adversarial review 3観点 → ship-with-fixes / blocker 0）
1. `getProjectSessions` の N+1 I/O → Promise.all 並列化
2. recap ペイロード肥大 → 300字 truncate
3. `readLastUserMessage` の tail サブプロセス残存 → readLastLines に統一
4. away_summary が `/recap` trigger をリセットしない動作差異 → 修正 + テスト追加

### 検証
- recap-scanner 単体テスト ✅ 10/10
- backend 全テスト ✅ 258/258
- Biome lint ✅ / backend tsc ✅（既存 notify/send 2件のみ）
- **dev 実機**: `/api/sessions/history/projects/:dir` が recap/lastPrompt を返す（22件中13件に recap、truncate 済み）。search 経路は lastPrompt あり・recap なし（設計通り）。履歴タブ UI 退行なし

### 後続
- PR3: フロント V1 で recap 表示（amber 3行）+ i18n キー
- PR4-6: 仮想化 + ファセット + flag 切替

🤖 Generated with [Claude Code](https://claude.com/claude-code)