### PR TITLE
feat(history): flag-gated virtualized V2 list (PR4/6)

### DIFF
--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -96,10 +96,12 @@ function formatTokenCount(n: number): string {
 	return `${(n / 1_000_000).toFixed(1)}M`;
 }
 
+import { useHistoryV2Flag } from "../hooks/useHistoryV2Flag";
 import { useSessionHistory } from "../hooks/useSessionHistory";
 import { authFetch } from "../services/api";
 import { ConversationViewer } from "./ConversationViewer";
 import { SessionHistory } from "./SessionHistory";
+import { SessionHistoryV2 } from "./history/SessionHistoryV2";
 
 const API_BASE = import.meta.env.VITE_API_URL || "";
 
@@ -1283,6 +1285,7 @@ export function SessionList({
 	const [activeTab, setActiveTab] = useState<"sessions" | "history">(
 		"sessions",
 	);
+	const historyV2 = useHistoryV2Flag();
 	const [showSearch, setShowSearch] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [hookConfigured, setHookConfigured] = useState<boolean | null>(null);
@@ -1872,17 +1875,30 @@ export function SessionList({
 						</div>
 					)}
 
-					{activeTab === "history" && (
-						<div className="h-full overflow-y-auto overscroll-contain">
-							<SessionHistory
-								onSelectSession={onSelectSession}
-								onSessionResumed={() => {
-									setActiveTab("sessions");
-								}}
-								activeSessions={sessions}
-							/>
-						</div>
-					)}
+					{activeTab === "history" &&
+						(historyV2 ? (
+							// V2 owns its own internal scroll container, so the host
+							// wrapper must not add a second one.
+							<div className="h-full overflow-hidden">
+								<SessionHistoryV2
+									onSelectSession={onSelectSession}
+									onSessionResumed={() => {
+										setActiveTab("sessions");
+									}}
+									activeSessions={sessions}
+								/>
+							</div>
+						) : (
+							<div className="h-full overflow-y-auto overscroll-contain">
+								<SessionHistory
+									onSelectSession={onSelectSession}
+									onSessionResumed={() => {
+										setActiveTab("sessions");
+									}}
+									activeSessions={sessions}
+								/>
+							</div>
+						))}
 				</div>
 			</div>
 

--- a/frontend/src/components/history/HistoryRowV2.tsx
+++ b/frontend/src/components/history/HistoryRowV2.tsx
@@ -1,0 +1,158 @@
+/** biome-ignore-all lint/a11y/noStaticElementInteractions lint/a11y/useKeyWithClickEvents: legacy click-on-div row UI shared with V1; keyboard navigation provided via main shortcuts */
+import { Clock, FolderOpen, MessageCircle, Tag } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { HistorySession } from "../../../../shared/types";
+import { formatDuration, formatRelativeTime } from "../../utils/format";
+
+interface HistoryRowV2Props {
+	session: HistorySession;
+	isActive: boolean;
+	isResuming: boolean;
+	onTap: () => void;
+	onResume: () => void;
+	onNavigate: () => void;
+}
+
+/**
+ * One row of the flat (V2) history list. Unlike V1's HistoryItem this always
+ * shows the project as a breadcrumb (the list is cross-project) and renders the
+ * recap as an amber preview when present.
+ */
+export function HistoryRowV2({
+	session,
+	isActive,
+	isResuming,
+	onTap,
+	onResume,
+	onNavigate,
+}: HistoryRowV2Props) {
+	const { t, i18n } = useTranslation();
+
+	const displayText =
+		session.lastPrompt ||
+		session.firstPrompt ||
+		session.summary ||
+		"No description";
+	const truncatedText =
+		displayText.length > 70 ? `${displayText.substring(0, 70)}…` : displayText;
+
+	const duration = formatDuration(session.durationMinutes, t);
+	const agent = session.agent ?? "claude";
+	const agentBadge =
+		agent === "codex"
+			? {
+					label: "Codex",
+					className: "text-cyan-300 bg-cyan-400/10 border-cyan-400/20",
+				}
+			: {
+					label: "Claude",
+					className: "text-violet-300 bg-violet-400/10 border-violet-400/20",
+				};
+
+	const showPeer =
+		session.peerId && session.peerId !== "local" && session.peerNickname;
+
+	return (
+		<div
+			onClick={onTap}
+			className="group px-3 py-2.5 hover:bg-white/[0.04] cursor-pointer transition-colors border-b border-white/[0.04]"
+			style={
+				showPeer && session.peerColor
+					? { borderLeft: `3px solid ${session.peerColor}`, paddingLeft: 9 }
+					: undefined
+			}
+		>
+			<div className="flex items-start justify-between gap-3">
+				<div className="flex-1 min-w-0">
+					<div className="flex items-center gap-2 text-[10.5px] text-zinc-500 mb-0.5">
+						<FolderOpen className="w-3 h-3 shrink-0" />
+						<span className="truncate">{session.projectName}</span>
+						<span
+							className={`shrink-0 inline-flex items-center px-1.5 py-px rounded border text-[10px] font-medium ${agentBadge.className}`}
+						>
+							{agentBadge.label}
+						</span>
+						{showPeer && (
+							<span
+								className="shrink-0 inline-flex items-center gap-1 px-1.5 py-px rounded-full text-[9.5px]"
+								style={{
+									backgroundColor: `${session.peerColor}26`,
+									color: session.peerColor,
+								}}
+							>
+								<span
+									className="w-1 h-1 rounded-full"
+									style={{ backgroundColor: session.peerColor }}
+								/>
+								{session.peerNickname}
+							</span>
+						)}
+					</div>
+
+					{session.recap ? (
+						<p className="text-[12.5px] text-amber-200 leading-relaxed line-clamp-3">
+							{session.recap}
+						</p>
+					) : (
+						<p className="text-[13px] text-zinc-300 leading-snug truncate">
+							{truncatedText}
+						</p>
+					)}
+
+					<div className="flex items-center gap-3 mt-1.5 text-[11px] text-zinc-600">
+						<span>
+							{formatRelativeTime(
+								session.recapAt || session.modified,
+								t,
+								i18n.language,
+							)}
+						</span>
+						{duration && (
+							<span className="inline-flex items-center gap-1">
+								<Clock className="w-3 h-3" />
+								{duration}
+							</span>
+						)}
+						{session.messageCount !== undefined && session.messageCount > 0 && (
+							<span className="inline-flex items-center gap-1">
+								<MessageCircle className="w-3 h-3" />
+								{session.messageCount}
+							</span>
+						)}
+						{session.gitBranch && (
+							<span className="inline-flex items-center gap-1 text-purple-500 truncate max-w-[120px]">
+								<Tag className="w-3 h-3" />
+								{session.gitBranch}
+							</span>
+						)}
+					</div>
+				</div>
+
+				{isActive ? (
+					<button
+						type="button"
+						onClick={(e) => {
+							e.stopPropagation();
+							onNavigate();
+						}}
+						className="shrink-0 mt-0.5 px-2.5 py-1 text-[11px] font-medium text-zinc-500 hover:text-zinc-300 bg-white/[0.04] hover:bg-white/[0.08] rounded-md transition-colors"
+					>
+						{t("session.navigate")}
+					</button>
+				) : (
+					<button
+						type="button"
+						onClick={(e) => {
+							e.stopPropagation();
+							onResume();
+						}}
+						disabled={isResuming}
+						className="shrink-0 mt-0.5 px-2.5 py-1 text-[11px] font-medium text-zinc-500 hover:text-zinc-300 bg-white/[0.04] hover:bg-white/[0.08] rounded-md transition-colors disabled:opacity-50"
+					>
+						{isResuming ? "..." : t("session.resume")}
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/history/SessionHistoryV2.tsx
+++ b/frontend/src/components/history/SessionHistoryV2.tsx
@@ -1,0 +1,207 @@
+import { Search, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { HistorySession, SessionResponse } from "../../../../shared/types";
+import { useFlatHistoryItems } from "../../hooks/useFlatHistoryItems";
+import { useHistoryActions } from "../../hooks/useHistoryActions";
+import { useSessionHistory } from "../../hooks/useSessionHistory";
+import { ConversationViewer } from "../ConversationViewer";
+import { VirtualizedHistoryList } from "./VirtualizedHistoryList";
+
+interface ActiveSession extends SessionResponse {
+	ccSessionId?: string;
+}
+
+interface SessionHistoryV2Props {
+	onSessionResumed?: () => void;
+	onSelectSession?: (session: SessionResponse) => void;
+	activeSessions?: ActiveSession[];
+}
+
+/**
+ * V2 history view: one virtualized, cross-project flat list with incremental
+ * search. Facets / sort / date buckets land in a later PR; this is the
+ * flag-gated foundation (cchub-history-v2).
+ */
+export function SessionHistoryV2({
+	onSessionResumed,
+	onSelectSession,
+	activeSessions = [],
+}: SessionHistoryV2Props) {
+	const { t } = useTranslation();
+	const {
+		projects,
+		isLoadingProjects,
+		sessionsByProject,
+		fetchProjectSessions,
+		refreshAllLoadedProjects,
+		searchResults,
+		isSearching,
+		searchQuery,
+		searchSessions,
+		resumeSession,
+		fetchConversation,
+		error,
+	} = useSessionHistory();
+
+	const { items, dirNameBySession, isHydrating, hydratedCount, totalCount } =
+		useFlatHistoryItems({
+			projects,
+			sessionsByProject,
+			fetchProjectSessions,
+		});
+
+	const {
+		resumingId,
+		resumeError,
+		selectedSession,
+		conversation,
+		loadingConversation,
+		activeCcSessionIds,
+		handleResume,
+		handleNavigate,
+		handleTap,
+		closeModal,
+		dismissError,
+	} = useHistoryActions({
+		activeSessions,
+		onSelectSession,
+		onSessionResumed,
+		resumeSession,
+		fetchConversation,
+		refreshAllLoadedProjects,
+	});
+
+	// Incremental search: debounce keystrokes into the existing SSE search.
+	// Always route through searchSessions (it handles the empty-query case by
+	// aborting the in-flight stream + clearing results + isSearching=false);
+	// calling clearSearch() here would leak the SSE stream and pin isSearching.
+	const [searchInput, setSearchInput] = useState("");
+	useEffect(() => {
+		const q = searchInput.trim();
+		const handle = setTimeout(() => {
+			searchSessions(q);
+		}, 150);
+		return () => clearTimeout(handle);
+	}, [searchInput, searchSessions]);
+
+	const isSearchMode = searchQuery.trim().length > 0;
+	const listItems: HistorySession[] = isSearchMode ? searchResults : items;
+
+	if (isLoadingProjects) {
+		return (
+			<div className="p-4 text-center text-th-text-muted text-sm">
+				{t("history.loadingHistory")}
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="p-4 text-center text-red-400 text-sm">
+				{t("common.error")}: {error}
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col h-full">
+			{/* Search */}
+			<div className="px-3 pt-3 pb-2 shrink-0">
+				<div className="relative max-w-sm">
+					<Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-600" />
+					<input
+						type="text"
+						value={searchInput}
+						onChange={(e) => setSearchInput(e.target.value)}
+						placeholder={t("history.searchPlaceholder")}
+						className="w-full pl-9 pr-3 py-1.5 bg-white/[0.04] border border-white/[0.06] rounded-md text-[13px] text-white placeholder:text-zinc-700 focus:outline-none focus:border-white/[0.12] transition-colors"
+					/>
+					{searchInput && (
+						<button
+							type="button"
+							onClick={() => setSearchInput("")}
+							className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-zinc-600 hover:text-zinc-400"
+						>
+							<X className="w-3.5 h-3.5" />
+						</button>
+					)}
+				</div>
+			</div>
+
+			{/* Status line: search count or hydration progress */}
+			<div className="px-3 pb-1.5 shrink-0 text-[11px] text-zinc-500">
+				{isSearchMode ? (
+					isSearching ? (
+						t("history.searching")
+					) : (
+						t("history.searchResults", {
+							query: searchQuery,
+							count: searchResults.length,
+						})
+					)
+				) : isHydrating ? (
+					t("history.indexing", { done: hydratedCount, total: totalCount })
+				) : (
+					t("history.sessionsCount", { count: items.length })
+				)}
+			</div>
+
+			{resumeError && (
+				<div className="mx-3 mb-2 px-3 py-2 bg-red-900/50 text-red-300 text-xs flex items-center justify-between rounded shrink-0">
+					<span>{resumeError}</span>
+					<button
+						type="button"
+						onClick={dismissError}
+						className="text-red-400 hover:text-red-200 ml-2"
+					>
+						×
+					</button>
+				</div>
+			)}
+
+			{/* Virtualized list */}
+			<div className="flex-1 min-h-0">
+				{listItems.length === 0 ? (
+					<div className="p-4 text-center text-th-text-muted text-sm">
+						{isSearchMode
+							? t("history.noSearchResults")
+							: t("history.noSessions")}
+					</div>
+				) : (
+					<VirtualizedHistoryList
+						// Remount on mode flip so scrollTop + measurement cache reset;
+						// otherwise a stale offset can leave the list blank after the
+						// item set shrinks (flat -> search).
+						key={isSearchMode ? "search" : "flat"}
+						items={listItems}
+						activeCcSessionIds={activeCcSessionIds}
+						resumingId={resumingId}
+						onTap={handleTap}
+						onResume={handleResume}
+						onNavigate={handleNavigate}
+						dirNameBySession={isSearchMode ? undefined : dirNameBySession}
+					/>
+				)}
+			</div>
+
+			{selectedSession && (
+				<ConversationViewer
+					title={
+						selectedSession.summary ||
+						selectedSession.lastPrompt ||
+						selectedSession.firstPrompt ||
+						"No title"
+					}
+					subtitle={selectedSession.projectName}
+					messages={conversation}
+					isLoading={loadingConversation}
+					onClose={closeModal}
+					onResume={() => handleResume(selectedSession)}
+					isResuming={resumingId === selectedSession.sessionId}
+					scrollToBottom={true}
+				/>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/components/history/VirtualizedHistoryList.tsx
+++ b/frontend/src/components/history/VirtualizedHistoryList.tsx
@@ -1,0 +1,95 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useRef } from "react";
+import type { HistorySession } from "../../../../shared/types";
+import { sessionDedupeKey } from "../../hooks/useFlatHistoryItems";
+import { HistoryRowV2 } from "./HistoryRowV2";
+
+interface VirtualizedHistoryListProps {
+	items: HistorySession[];
+	activeCcSessionIds: Set<string>;
+	resumingId: string | null;
+	onTap: (session: HistorySession, projectDirName?: string) => void;
+	onResume: (session: HistorySession) => void;
+	onNavigate: (session: HistorySession) => void;
+	/** Maps a session's dedupe key to its project dir, so taps can scope the
+	 * conversation fetch. Undefined in search mode (results span projects). */
+	dirNameBySession?: Map<string, string>;
+}
+
+/**
+ * Virtualized flat list of history rows. Uses an internal scroll container as
+ * the scrollElement (same pattern as ConversationViewer). measureElement is NOT
+ * corrected for the SessionList contentScale transform: ResizeObserver reports
+ * the pre-transform layout size, so the virtualizer's math stays correct under
+ * pinch-zoom.
+ */
+export function VirtualizedHistoryList({
+	items,
+	activeCcSessionIds,
+	resumingId,
+	onTap,
+	onResume,
+	onNavigate,
+	dirNameBySession,
+}: VirtualizedHistoryListProps) {
+	const parentRef = useRef<HTMLDivElement>(null);
+
+	const virtualizer = useVirtualizer({
+		count: items.length,
+		getScrollElement: () => parentRef.current,
+		// Rows vary: a plain prompt row is ~66px, a 3-line recap row ~108px.
+		// measureElement corrects these; the estimates just minimize first-paint
+		// scroll jump.
+		estimateSize: (index) => (items[index]?.recap ? 108 : 66),
+		overscan: 12,
+		getItemKey: (index) => {
+			const s = items[index];
+			return s ? sessionDedupeKey(s) : index;
+		},
+	});
+
+	return (
+		<div ref={parentRef} className="h-full overflow-y-auto overscroll-contain">
+			<div
+				style={{
+					height: `${virtualizer.getTotalSize()}px`,
+					width: "100%",
+					position: "relative",
+				}}
+			>
+				<div
+					style={{
+						position: "absolute",
+						top: 0,
+						left: 0,
+						width: "100%",
+						transform: `translateY(${virtualizer.getVirtualItems()[0]?.start ?? 0}px)`,
+					}}
+				>
+					{virtualizer.getVirtualItems().map((virtualRow) => {
+						const session = items[virtualRow.index];
+						if (!session) return null;
+						return (
+							<div
+								key={virtualRow.key}
+								data-index={virtualRow.index}
+								ref={virtualizer.measureElement}
+							>
+								<HistoryRowV2
+									session={session}
+									isActive={activeCcSessionIds.has(session.sessionId)}
+									isResuming={resumingId === session.sessionId}
+									onTap={() =>
+										onTap(session, dirNameBySession?.get(sessionDedupeKey(session)))
+									}
+									onResume={() => onResume(session)}
+									onNavigate={() => onNavigate(session)}
+								/>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/hooks/useFlatHistoryItems.ts
+++ b/frontend/src/hooks/useFlatHistoryItems.ts
@@ -1,0 +1,129 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { HistorySession } from "../../../shared/types";
+import { type ProjectInfo, projectKey } from "./useSessionHistory";
+
+const HYDRATION_CONCURRENCY = 4;
+
+interface UseFlatHistoryItemsArgs {
+	projects: ProjectInfo[];
+	sessionsByProject: Map<string, HistorySession[]>;
+	fetchProjectSessions: (peerId: string, dirName: string) => Promise<void>;
+}
+
+interface FlatHistoryItems {
+	/** All loaded sessions across every project, newest first. */
+	items: HistorySession[];
+	/** Maps each session's dedupe key (`${peerId}:${sessionId}`) to the project
+	 * directory name it came from, so conversation fetches can be scoped to one
+	 * dir instead of scanning all of them. */
+	dirNameBySession: Map<string, string>;
+	/** Projects whose sessions have been loaded so far. */
+	hydratedCount: number;
+	/** Total number of projects to load. */
+	totalCount: number;
+	/** True while background hydration is still in flight. */
+	isHydrating: boolean;
+}
+
+/** Stable dedupe / lookup key for a session across project buckets. */
+export function sessionDedupeKey(s: HistorySession): string {
+	return `${s.peerId ?? "local"}:${s.sessionId}`;
+}
+
+/**
+ * Flattens every project's sessions into a single modified-DESC list, kicking
+ * off background hydration (4-concurrent) of all projects when the History tab
+ * mounts. Facet counts / filters (PR5) sit on top of this flat list.
+ */
+export function useFlatHistoryItems({
+	projects,
+	sessionsByProject,
+	fetchProjectSessions,
+}: UseFlatHistoryItemsArgs): FlatHistoryItems {
+	const [hydratedKeys, setHydratedKeys] = useState<Set<string>>(new Set());
+	// Guard so each (peer,dir) is only requested once per mount.
+	const requestedRef = useRef<Set<string>>(new Set());
+	// fetchProjectSessions changes identity whenever sessionsByProject updates
+	// (it's loaded into the cache). Hold it in a ref so hydration is driven only
+	// by `projects` and isn't cancelled mid-flight after each project loads.
+	const fetchRef = useRef(fetchProjectSessions);
+	fetchRef.current = fetchProjectSessions;
+
+	useEffect(() => {
+		let cancelled = false;
+		// Reset progress tracking so counts stay consistent if the project list
+		// changes identity (e.g. the poller returns an updated set).
+		requestedRef.current = new Set();
+		setHydratedKeys(new Set());
+		// Newest projects first so the top of the list fills in immediately.
+		const ordered = [...projects].sort((a, b) => {
+			const am = a.latestModified ? Date.parse(a.latestModified) : 0;
+			const bm = b.latestModified ? Date.parse(b.latestModified) : 0;
+			return bm - am;
+		});
+
+		async function hydrate() {
+			let cursor = 0;
+			async function worker() {
+				while (!cancelled && cursor < ordered.length) {
+					const project = ordered[cursor++];
+					const key = projectKey(project.peerId, project.dirName);
+					if (requestedRef.current.has(key)) continue;
+					requestedRef.current.add(key);
+					try {
+						await fetchRef.current(project.peerId, project.dirName);
+					} catch {
+						// Individual project failures are non-fatal; skip.
+					}
+					if (!cancelled) {
+						setHydratedKeys((prev) => {
+							const next = new Set(prev);
+							next.add(key);
+							return next;
+						});
+					}
+				}
+			}
+			await Promise.all(
+				Array.from({ length: HYDRATION_CONCURRENCY }, () => worker()),
+			);
+		}
+
+		hydrate();
+		return () => {
+			cancelled = true;
+		};
+	}, [projects]);
+
+	const { items, dirNameBySession } = useMemo(() => {
+		const all: HistorySession[] = [];
+		const dirNames = new Map<string, string>();
+		const seen = new Set<string>();
+		for (const [mapKey, list] of sessionsByProject.entries()) {
+			// mapKey is `${peerId}::${dirName}` (see projectKey).
+			const dirName = mapKey.split("::")[1] ?? "";
+			for (const s of list) {
+				// A session can appear under multiple project buckets (e.g. symlinked
+				// dirs). Keep whichever occurrence arrives first during hydration; the
+				// sort below orders by modified date regardless.
+				const dedupeKey = sessionDedupeKey(s);
+				if (seen.has(dedupeKey)) continue;
+				seen.add(dedupeKey);
+				if (dirName) dirNames.set(dedupeKey, dirName);
+				all.push(s);
+			}
+		}
+		all.sort(
+			(a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime(),
+		);
+		return { items: all, dirNameBySession: dirNames };
+	}, [sessionsByProject]);
+
+	return {
+		items,
+		dirNameBySession,
+		hydratedCount: hydratedKeys.size,
+		totalCount: projects.length,
+		isHydrating: projects.length > 0 && hydratedKeys.size < projects.length,
+	};
+}

--- a/frontend/src/hooks/useHistoryActions.ts
+++ b/frontend/src/hooks/useHistoryActions.ts
@@ -1,0 +1,201 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type {
+	ConversationMessage,
+	HistorySession,
+	SessionResponse,
+} from "../../../shared/types";
+import { useSessionHistory } from "./useSessionHistory";
+import { authFetch } from "../services/api";
+
+const API_BASE = import.meta.env.VITE_API_URL || "";
+
+// Active session carries the Claude Code session id used to match history rows.
+interface ActiveSession extends SessionResponse {
+	ccSessionId?: string;
+}
+
+interface UseHistoryActionsArgs {
+	activeSessions: ActiveSession[];
+	onSelectSession?: (session: SessionResponse) => void;
+	onSessionResumed?: () => void;
+	resumeSession: ReturnType<typeof useSessionHistory>["resumeSession"];
+	fetchConversation: ReturnType<typeof useSessionHistory>["fetchConversation"];
+	refreshAllLoadedProjects: ReturnType<
+		typeof useSessionHistory
+	>["refreshAllLoadedProjects"];
+}
+
+/**
+ * Resume / navigate / open-conversation behavior shared by the history views.
+ * Extracted from the V1 SessionHistory so the V2 (faceted) view can reuse the
+ * exact same resume sequence, active-session matching, and modal lifecycle.
+ *
+ * NOTE: V1 still has its own inline copy of this logic; both are kept until V1
+ * is removed (PR6), at which point only this hook remains.
+ */
+export function useHistoryActions({
+	activeSessions,
+	onSelectSession,
+	onSessionResumed,
+	resumeSession,
+	fetchConversation,
+	refreshAllLoadedProjects,
+}: UseHistoryActionsArgs) {
+	const { t } = useTranslation();
+
+	// useSessionHistory recreates these callbacks whenever sessionsByProject /
+	// loadingProjects change (i.e. on every project load during hydration). Hold
+	// them in refs so the handlers below keep a stable identity and don't churn
+	// the (virtualized) rows' props mid-hydration.
+	const resumeRef = useRef(resumeSession);
+	resumeRef.current = resumeSession;
+	const fetchConvRef = useRef(fetchConversation);
+	fetchConvRef.current = fetchConversation;
+	const refreshRef = useRef(refreshAllLoadedProjects);
+	refreshRef.current = refreshAllLoadedProjects;
+	const selectRef = useRef(onSelectSession);
+	selectRef.current = onSelectSession;
+	const resumedRef = useRef(onSessionResumed);
+	resumedRef.current = onSessionResumed;
+
+	const [resumingId, setResumingId] = useState<string | null>(null);
+	const [resumeError, setResumeError] = useState<string | null>(null);
+	const [selectedSession, setSelectedSession] =
+		useState<HistorySession | null>(null);
+	const [conversation, setConversation] = useState<ConversationMessage[]>([]);
+	const [loadingConversation, setLoadingConversation] = useState(false);
+
+	const activeCcSessionIds = useMemo(() => {
+		const ids = new Set<string>();
+		for (const s of activeSessions) {
+			if (s.ccSessionId) ids.add(s.ccSessionId);
+		}
+		return ids;
+	}, [activeSessions]);
+
+	const sessionsByCcId = useMemo(() => {
+		const map = new Map<string, SessionResponse[]>();
+		for (const s of activeSessions) {
+			if (s.ccSessionId) {
+				const list = map.get(s.ccSessionId) || [];
+				list.push(s);
+				map.set(s.ccSessionId, list);
+			}
+		}
+		return map;
+	}, [activeSessions]);
+
+	const findActiveSession = useCallback(
+		(historySession: HistorySession): SessionResponse | undefined => {
+			const candidates = sessionsByCcId.get(historySession.sessionId);
+			if (!candidates || candidates.length === 0) return undefined;
+			if (candidates.length === 1) return candidates[0];
+			const projectBasename =
+				historySession.projectPath.split("/").pop() || "";
+			return (
+				candidates.find((s) => s.name === projectBasename) || candidates[0]
+			);
+		},
+		[sessionsByCcId],
+	);
+
+	const handleResume = useCallback(
+		async (session: HistorySession) => {
+			setResumingId(session.sessionId);
+			setResumeError(null);
+			try {
+				const result = await resumeRef.current(
+					session.sessionId,
+					session.projectPath,
+					session.agent,
+					session.peerId,
+				);
+
+				if (result) {
+					await new Promise((resolve) => setTimeout(resolve, 1000));
+
+					const response = await authFetch(`${API_BASE}/api/sessions`);
+					let foundSession: SessionResponse | undefined;
+					if (response.ok) {
+						const data = await response.json();
+						foundSession = data.sessions?.find(
+							(s: { id: string }) => s.id === result.tmuxSessionId,
+						);
+					}
+
+					if (selectRef.current && foundSession)
+						selectRef.current(foundSession);
+					if (resumedRef.current) resumedRef.current();
+					await refreshRef.current();
+				}
+				setSelectedSession(null);
+			} catch (err) {
+				const error = err as Error & {
+					data?: { error?: string; existingSession?: string };
+				};
+				if (error.data?.error === "duplicate_working_dir") {
+					setResumeError(
+						t("session.duplicateWorkingDir", {
+							name: error.data.existingSession || "",
+						}),
+					);
+				} else {
+					setResumeError(t("session.resumeFailed"));
+				}
+			} finally {
+				setResumingId(null);
+			}
+		},
+		[t],
+	);
+
+	const handleNavigate = useCallback(
+		(session: HistorySession) => {
+			const activeSession = findActiveSession(session);
+			if (activeSession && selectRef.current) {
+				selectRef.current(activeSession);
+				if (resumedRef.current) resumedRef.current();
+			}
+		},
+		[findActiveSession],
+	);
+
+	const handleTap = useCallback(
+		async (session: HistorySession, projectDirName?: string) => {
+			setSelectedSession(session);
+			setLoadingConversation(true);
+			setConversation([]);
+			try {
+				const messages = await fetchConvRef.current(
+					session.sessionId,
+					projectDirName,
+					session.agent,
+					session.peerId,
+				);
+				setConversation(messages);
+			} finally {
+				setLoadingConversation(false);
+			}
+		},
+		[],
+	);
+
+	const closeModal = useCallback(() => setSelectedSession(null), []);
+	const dismissError = useCallback(() => setResumeError(null), []);
+
+	return {
+		resumingId,
+		resumeError,
+		selectedSession,
+		conversation,
+		loadingConversation,
+		activeCcSessionIds,
+		findActiveSession,
+		handleResume,
+		handleNavigate,
+		handleTap,
+		closeModal,
+		dismissError,
+	};
+}

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -19,3 +19,20 @@ export function formatRelativeTime(
 	const dateLocale = locale === "ja" ? "ja-JP" : "en-US";
 	return new Date(ts).toLocaleDateString(dateLocale);
 }
+
+/**
+ * Format a duration in minutes into a localized "Xm" / "Xh Ym" / "Xh" string.
+ * Returns null for zero/undefined so callers can omit the field entirely.
+ */
+export function formatDuration(
+	minutes: number | undefined,
+	t: TFunction,
+): string | null {
+	if (!minutes || minutes <= 0) return null;
+	if (minutes < 60) return t("time.minutes", { count: minutes });
+	const hours = Math.floor(minutes / 60);
+	const mins = minutes % 60;
+	return mins > 0
+		? t("time.hoursMinutes", { hours, minutes: mins })
+		: t("time.hours", { count: hours });
+}


### PR DESCRIPTION
## Option B — PR 4 of 6 (frontend, flag-gated)

`cchub-history-v2` フラグ（default OFF）の裏に V2 履歴ビューを追加。**クロスプロジェクトの仮想化フラットリスト + 増分検索**。ファセット/ソート/日付バケットは PR5。フラグ OFF 時 V1 はバイト同一。

> 注: 当初計画では PR4=部品追加(未マウント)・PR5=マウントだったが、ユーザー指定の「ピンチズーム検証を PR4 必須 exit にする」を満たすには V2 がマウント可能=動く必要があるため、**PR4 で flag 付きの動く V2** とし、ファセット類を PR5 に再配分した。

### 新規
- `hooks/useFlatHistoryItems` — 全プロジェクトを4並列で背景ハイドレーション、modified降順フラットリスト + sessionId→dirName ルックアップ + 進捗
- `hooks/useHistoryActions` — resume/navigate/tap/モーダルを V1 から共有化（V1 不変、PR6 で重複解消）。不安定な useSessionHistory コールバックは ref で安定化
- `components/history/HistoryRowV2` — フラット行（プロジェクトパンくず + agent + peer stripe + amber recap）
- `components/history/VirtualizedHistoryList` — @tanstack/react-virtual（内部 scrollElement、ConversationViewer と同パターン）。contentScale 補正なし（ResizeObserver は pre-transform サイズ）。モード切替で key 再マウントしスクロールリセット
- `components/history/SessionHistoryV2` — シェル（debounce 検索を searchSessions 経由、仮想化リスト、モーダル）

### 変更
- `utils/format` — 共有 formatDuration 追加
- `SessionList` — 履歴タブを useHistoryV2Flag でゲート（V2 は自前スクロールのため host は overflow-hidden）

### Adversarial review 反映（ship-with-fixes / blocker 0）
- **must-fix**: 空クエリを searchSessions 経由に（SSE リーク + isSearching 固着の解消）
- **must-fix**: モード切替で list を再マウント（stale scrollTop による空白リスト解消）
- **should-fix**: projectDirName を渡し会話取得を1ディレクトリに限定（V1 parity）
- **should-fix**: action handler を ref で安定化（ハイドレーション中の無駄レンダリング抑制）

### 検証（dev 実機）
- 100+ セッション仮想化（DOM ~15行、totalHeight ~8000px）
- **ピンチズーム**: scale(1.3) 下でウィンドウシフト・行重なりなし
- 修正確認: 下スクロール後の検索で空白にならず scrollTop=0 リセット、クリアで「101件」復帰・固着なし
- モーダル開閉・増分検索（19件）・flag OFF で V1 復帰

🤖 Generated with [Claude Code](https://claude.com/claude-code)