### PR TITLE
feat(history): facet chips + date buckets (PR5/6)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "bun test src/",
+    "test": "TZ=UTC bun test src/",
     "test:e2e": "playwright test",
     "lint": "bunx @biomejs/biome lint src/",
     "typecheck": "tsgo --noEmit"

--- a/frontend/src/components/history/HistoryFacetBar.tsx
+++ b/frontend/src/components/history/HistoryFacetBar.tsx
@@ -1,0 +1,104 @@
+import { useTranslation } from "react-i18next";
+import type {
+	HistoryAgentFilter,
+	HistoryFilter,
+	HistoryPeriodFilter,
+} from "../../utils/historyBuckets";
+
+interface HistoryFacetBarProps {
+	filter: HistoryFilter;
+	onChange: (next: HistoryFilter) => void;
+}
+
+interface ChipProps {
+	active: boolean;
+	color: "violet" | "cyan" | "emerald" | "amber" | "zinc";
+	onClick: () => void;
+	children: React.ReactNode;
+}
+
+const ACTIVE_CLASS: Record<ChipProps["color"], string> = {
+	violet: "border-violet-400/40 bg-violet-400/15 text-violet-200",
+	cyan: "border-cyan-400/40 bg-cyan-400/15 text-cyan-200",
+	emerald: "border-emerald-400/40 bg-emerald-400/15 text-emerald-200",
+	amber: "border-amber-400/40 bg-amber-400/15 text-amber-200",
+	zinc: "border-white/20 bg-white/10 text-zinc-100",
+};
+
+function Chip({ active, color, onClick, children }: ChipProps) {
+	return (
+		<button
+			type="button"
+			aria-pressed={active}
+			onClick={onClick}
+			className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-1 rounded-full border text-[11px] font-medium transition-colors ${
+				active
+					? ACTIVE_CLASS[color]
+					: "border-white/10 text-zinc-400 hover:text-zinc-200 hover:border-white/20"
+			}`}
+		>
+			{active && (
+				<span className="w-1 h-1 rounded-full bg-current" aria-hidden="true" />
+			)}
+			{children}
+		</button>
+	);
+}
+
+/**
+ * Horizontal scrollable chip bar for the V2 history view. Agent and period are
+ * single-select within their axis (tapping the active chip clears it); Active
+ * is a boolean toggle. All filtering is client-side.
+ */
+export function HistoryFacetBar({ filter, onChange }: HistoryFacetBarProps) {
+	const { t } = useTranslation();
+	const setAgent = (agent: HistoryAgentFilter) =>
+		onChange({ ...filter, agent: filter.agent === agent ? null : agent });
+	const setPeriod = (period: HistoryPeriodFilter) =>
+		onChange({ ...filter, period: filter.period === period ? null : period });
+	const toggleActive = () =>
+		onChange({ ...filter, activeOnly: !filter.activeOnly });
+
+	return (
+		<div className="flex gap-1.5 overflow-x-auto pb-1 -mx-3 px-3 [scrollbar-width:thin]">
+			<Chip
+				active={filter.agent === "claude"}
+				color="violet"
+				onClick={() => setAgent("claude")}
+			>
+				Claude
+			</Chip>
+			<Chip
+				active={filter.agent === "codex"}
+				color="cyan"
+				onClick={() => setAgent("codex")}
+			>
+				Codex
+			</Chip>
+			<Chip active={filter.activeOnly} color="emerald" onClick={toggleActive}>
+				{t("session.activeSessions")}
+			</Chip>
+			<Chip
+				active={filter.period === "24h"}
+				color="amber"
+				onClick={() => setPeriod("24h")}
+			>
+				24h
+			</Chip>
+			<Chip
+				active={filter.period === "7d"}
+				color="amber"
+				onClick={() => setPeriod("7d")}
+			>
+				7d
+			</Chip>
+			<Chip
+				active={filter.period === "30d"}
+				color="amber"
+				onClick={() => setPeriod("30d")}
+			>
+				30d
+			</Chip>
+		</div>
+	);
+}

--- a/frontend/src/components/history/SessionHistoryV2.tsx
+++ b/frontend/src/components/history/SessionHistoryV2.tsx
@@ -1,11 +1,22 @@
 import { Search, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { HistorySession, SessionResponse } from "../../../../shared/types";
-import { useFlatHistoryItems } from "../../hooks/useFlatHistoryItems";
+import type { SessionResponse } from "../../../../shared/types";
+import {
+	sessionDedupeKey,
+	useFlatHistoryItems,
+} from "../../hooks/useFlatHistoryItems";
 import { useHistoryActions } from "../../hooks/useHistoryActions";
 import { useSessionHistory } from "../../hooks/useSessionHistory";
+import {
+	applyHistoryFilter,
+	bucketizeHistory,
+	EMPTY_HISTORY_FILTER,
+	type HistoryFilter,
+	isFilterActive,
+} from "../../utils/historyBuckets";
 import { ConversationViewer } from "../ConversationViewer";
+import { HistoryFacetBar } from "./HistoryFacetBar";
 import { VirtualizedHistoryList } from "./VirtualizedHistoryList";
 
 interface ActiveSession extends SessionResponse {
@@ -85,8 +96,51 @@ export function SessionHistoryV2({
 		return () => clearTimeout(handle);
 	}, [searchInput, searchSessions]);
 
+	// Client-side facet filter (agent / period / active).
+	const [filter, setFilter] = useState<HistoryFilter>(EMPTY_HISTORY_FILTER);
+
 	const isSearchMode = searchQuery.trim().length > 0;
-	const listItems: HistorySession[] = isSearchMode ? searchResults : items;
+	const sourceItems = isSearchMode ? searchResults : items;
+
+	// filter -> sort -> bucketize into header+session rows for the virtualizer.
+	const rows = useMemo(() => {
+		const now = Date.now();
+		const filtered = applyHistoryFilter(
+			sourceItems,
+			filter,
+			activeCcSessionIds,
+			now,
+		);
+		// The flat list is already modified-DESC, but search results arrive in SSE
+		// order (Codex first, then Claude dir-by-dir) — sort so bucket headers
+		// don't repeat / collide on keys.
+		const ordered = isSearchMode
+			? [...filtered].sort(
+					(a, b) =>
+						new Date(b.modified).getTime() - new Date(a.modified).getTime(),
+				)
+			: filtered;
+		return bucketizeHistory(
+			ordered,
+			isSearchMode ? undefined : dirNameBySession,
+			sessionDedupeKey,
+			t,
+			now,
+		);
+	}, [
+		sourceItems,
+		filter,
+		activeCcSessionIds,
+		isSearchMode,
+		dirNameBySession,
+		t,
+	]);
+
+	const filterActive = isFilterActive(filter);
+	const sessionCount = rows.reduce(
+		(n, r) => (r.kind === "session" ? n + 1 : n),
+		0,
+	);
 
 	if (isLoadingProjects) {
 		return (
@@ -129,6 +183,11 @@ export function SessionHistoryV2({
 				</div>
 			</div>
 
+			{/* Facet chips */}
+			<div className="px-3 pb-1 shrink-0">
+				<HistoryFacetBar filter={filter} onChange={setFilter} />
+			</div>
+
 			{/* Status line: search count or hydration progress */}
 			<div className="px-3 pb-1.5 shrink-0 text-[11px] text-zinc-500">
 				{isSearchMode ? (
@@ -137,13 +196,13 @@ export function SessionHistoryV2({
 					) : (
 						t("history.searchResults", {
 							query: searchQuery,
-							count: searchResults.length,
+							count: sessionCount,
 						})
 					)
 				) : isHydrating ? (
 					t("history.indexing", { done: hydratedCount, total: totalCount })
 				) : (
-					t("history.sessionsCount", { count: items.length })
+					t("history.sessionsCount", { count: sessionCount })
 				)}
 			</div>
 
@@ -162,25 +221,26 @@ export function SessionHistoryV2({
 
 			{/* Virtualized list */}
 			<div className="flex-1 min-h-0">
-				{listItems.length === 0 ? (
+				{rows.length === 0 ? (
 					<div className="p-4 text-center text-th-text-muted text-sm">
 						{isSearchMode
 							? t("history.noSearchResults")
-							: t("history.noSessions")}
+							: filterActive
+								? t("history.noFilterMatches")
+								: t("history.noSessions")}
 					</div>
 				) : (
 					<VirtualizedHistoryList
-						// Remount on mode flip so scrollTop + measurement cache reset;
-						// otherwise a stale offset can leave the list blank after the
-						// item set shrinks (flat -> search).
-						key={isSearchMode ? "search" : "flat"}
-						items={listItems}
+						// Remount on mode flip AND on filter change so scrollTop +
+						// measurement cache reset; otherwise a stale offset can leave the
+						// list blank after the row set shrinks (e.g. applying a facet).
+						key={isSearchMode ? "search" : `flat:${JSON.stringify(filter)}`}
+						rows={rows}
 						activeCcSessionIds={activeCcSessionIds}
 						resumingId={resumingId}
 						onTap={handleTap}
 						onResume={handleResume}
 						onNavigate={handleNavigate}
-						dirNameBySession={isSearchMode ? undefined : dirNameBySession}
 					/>
 				)}
 			</div>
@@ -191,7 +251,7 @@ export function SessionHistoryV2({
 						selectedSession.summary ||
 						selectedSession.lastPrompt ||
 						selectedSession.firstPrompt ||
-						"No title"
+						t("history.noTitle")
 					}
 					subtitle={selectedSession.projectName}
 					messages={conversation}

--- a/frontend/src/components/history/VirtualizedHistoryList.tsx
+++ b/frontend/src/components/history/VirtualizedHistoryList.tsx
@@ -1,51 +1,48 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useRef } from "react";
 import type { HistorySession } from "../../../../shared/types";
-import { sessionDedupeKey } from "../../hooks/useFlatHistoryItems";
+import type { HistoryListRow } from "../../utils/historyBuckets";
 import { HistoryRowV2 } from "./HistoryRowV2";
 
 interface VirtualizedHistoryListProps {
-	items: HistorySession[];
+	rows: HistoryListRow[];
 	activeCcSessionIds: Set<string>;
 	resumingId: string | null;
 	onTap: (session: HistorySession, projectDirName?: string) => void;
 	onResume: (session: HistorySession) => void;
 	onNavigate: (session: HistorySession) => void;
-	/** Maps a session's dedupe key to its project dir, so taps can scope the
-	 * conversation fetch. Undefined in search mode (results span projects). */
-	dirNameBySession?: Map<string, string>;
 }
 
 /**
- * Virtualized flat list of history rows. Uses an internal scroll container as
- * the scrollElement (same pattern as ConversationViewer). measureElement is NOT
- * corrected for the SessionList contentScale transform: ResizeObserver reports
- * the pre-transform layout size, so the virtualizer's math stays correct under
- * pinch-zoom.
+ * Virtualized history list with inline date-bucket headers. Uses an internal
+ * scroll container as the scrollElement (same pattern as ConversationViewer).
+ * measureElement is NOT corrected for the SessionList contentScale transform:
+ * ResizeObserver reports the pre-transform layout size, so the virtualizer's
+ * math stays correct under pinch-zoom.
  */
 export function VirtualizedHistoryList({
-	items,
+	rows,
 	activeCcSessionIds,
 	resumingId,
 	onTap,
 	onResume,
 	onNavigate,
-	dirNameBySession,
 }: VirtualizedHistoryListProps) {
 	const parentRef = useRef<HTMLDivElement>(null);
 
 	const virtualizer = useVirtualizer({
-		count: items.length,
+		count: rows.length,
 		getScrollElement: () => parentRef.current,
-		// Rows vary: a plain prompt row is ~66px, a 3-line recap row ~108px.
-		// measureElement corrects these; the estimates just minimize first-paint
-		// scroll jump.
-		estimateSize: (index) => (items[index]?.recap ? 108 : 66),
-		overscan: 12,
-		getItemKey: (index) => {
-			const s = items[index];
-			return s ? sessionDedupeKey(s) : index;
+		// header ~30px; plain prompt row ~66px; 3-line recap row ~108px.
+		// measureElement corrects these; estimates just minimize first-paint jump.
+		estimateSize: (index) => {
+			const row = rows[index];
+			if (!row) return 66;
+			if (row.kind === "header") return 30;
+			return row.session.recap ? 108 : 66;
 		},
+		overscan: 12,
+		getItemKey: (index) => rows[index]?.key ?? index,
 	});
 
 	return (
@@ -67,24 +64,29 @@ export function VirtualizedHistoryList({
 					}}
 				>
 					{virtualizer.getVirtualItems().map((virtualRow) => {
-						const session = items[virtualRow.index];
-						if (!session) return null;
+						const row = rows[virtualRow.index];
+						if (!row) return null;
 						return (
 							<div
 								key={virtualRow.key}
 								data-index={virtualRow.index}
 								ref={virtualizer.measureElement}
 							>
-								<HistoryRowV2
-									session={session}
-									isActive={activeCcSessionIds.has(session.sessionId)}
-									isResuming={resumingId === session.sessionId}
-									onTap={() =>
-										onTap(session, dirNameBySession?.get(sessionDedupeKey(session)))
-									}
-									onResume={() => onResume(session)}
-									onNavigate={() => onNavigate(session)}
-								/>
+								{row.kind === "header" ? (
+									<div className="flex items-center justify-between px-3 pt-2.5 pb-1 text-[10.5px] uppercase tracking-wider text-zinc-500">
+										<span>{row.label}</span>
+										<span className="tabular-nums">{row.count}</span>
+									</div>
+								) : (
+									<HistoryRowV2
+										session={row.session}
+										isActive={activeCcSessionIds.has(row.session.sessionId)}
+										isResuming={resumingId === row.session.sessionId}
+										onTap={() => onTap(row.session, row.dirName)}
+										onResume={() => onResume(row.session)}
+										onNavigate={() => onNavigate(row.session)}
+									/>
+								)}
 							</div>
 						);
 					})}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -99,7 +99,8 @@
 		"bucketToday": "Today",
 		"bucketYesterday": "Yesterday",
 		"bucketThisWeek": "This week",
-		"bucketEarlier": "Earlier"
+		"bucketEarlier": "Earlier",
+		"noTitle": "(no title)"
 	},
 	"dashboard": {
 		"title": "Dashboard",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -99,7 +99,8 @@
 		"bucketToday": "今日",
 		"bucketYesterday": "昨日",
 		"bucketThisWeek": "今週",
-		"bucketEarlier": "それ以前"
+		"bucketEarlier": "それ以前",
+		"noTitle": "(タイトルなし)"
 	},
 	"dashboard": {
 		"title": "ダッシュボード",

--- a/frontend/src/utils/historyBuckets.test.ts
+++ b/frontend/src/utils/historyBuckets.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import type { HistorySession } from "../../../shared/types";
+import {
+	applyHistoryFilter,
+	bucketizeHistory,
+	EMPTY_HISTORY_FILTER,
+	isFilterActive,
+} from "./historyBuckets";
+
+const NOW = new Date("2026-05-30T12:00:00Z").getTime();
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function snap(
+	id: string,
+	modifiedMs: number,
+	agent: "claude" | "codex" = "claude",
+): HistorySession {
+	return {
+		sessionId: id,
+		projectPath: `/home/m0a/${id}`,
+		projectName: `~/${id}`,
+		modified: new Date(modifiedMs).toISOString(),
+		agent,
+	};
+}
+
+const keyOf = (s: HistorySession) => `local:${s.sessionId}`;
+const t = (k: string) => k;
+
+describe("isFilterActive", () => {
+	test("empty filter is inactive", () => {
+		expect(isFilterActive(EMPTY_HISTORY_FILTER)).toBe(false);
+	});
+	test("any axis set makes it active", () => {
+		expect(isFilterActive({ ...EMPTY_HISTORY_FILTER, agent: "codex" })).toBe(
+			true,
+		);
+		expect(isFilterActive({ ...EMPTY_HISTORY_FILTER, period: "7d" })).toBe(true);
+		expect(isFilterActive({ ...EMPTY_HISTORY_FILTER, activeOnly: true })).toBe(
+			true,
+		);
+	});
+});
+
+describe("applyHistoryFilter", () => {
+	const items = [
+		snap("a", NOW - HOUR, "claude"),
+		snap("b", NOW - 2 * DAY, "codex"),
+		snap("c", NOW - 10 * DAY, "claude"),
+	];
+
+	test("no filter returns all", () => {
+		expect(
+			applyHistoryFilter(items, EMPTY_HISTORY_FILTER, new Set(), NOW),
+		).toHaveLength(3);
+	});
+
+	test("agent filter", () => {
+		const out = applyHistoryFilter(
+			items,
+			{ ...EMPTY_HISTORY_FILTER, agent: "codex" },
+			new Set(),
+			NOW,
+		);
+		expect(out.map((s) => s.sessionId)).toEqual(["b"]);
+	});
+
+	test("period 24h keeps only the last day", () => {
+		const out = applyHistoryFilter(
+			items,
+			{ ...EMPTY_HISTORY_FILTER, period: "24h" },
+			new Set(),
+			NOW,
+		);
+		expect(out.map((s) => s.sessionId)).toEqual(["a"]);
+	});
+
+	test("activeOnly keeps only sessions in the active set", () => {
+		const out = applyHistoryFilter(
+			items,
+			{ ...EMPTY_HISTORY_FILTER, activeOnly: true },
+			new Set(["c"]),
+			NOW,
+		);
+		expect(out.map((s) => s.sessionId)).toEqual(["c"]);
+	});
+
+	test("filters compose (AND)", () => {
+		const out = applyHistoryFilter(
+			[snap("x", NOW - HOUR, "claude"), snap("y", NOW - HOUR, "codex")],
+			{ agent: "claude", period: "24h", activeOnly: false },
+			new Set(),
+			NOW,
+		);
+		expect(out.map((s) => s.sessionId)).toEqual(["x"]);
+	});
+});
+
+describe("bucketizeHistory", () => {
+	test("groups into date buckets with headers and counts", () => {
+		const items = [
+			snap("today1", NOW - HOUR),
+			snap("today2", NOW - 2 * HOUR),
+			snap("yest", NOW - 28 * HOUR),
+			snap("week", NOW - 4 * DAY),
+			snap("old", NOW - 20 * DAY),
+		];
+		const rows = bucketizeHistory(items, undefined, keyOf, t, NOW);
+		const headers = rows.filter((r) => r.kind === "header");
+		expect(headers.map((h) => (h.kind === "header" ? h.label : ""))).toEqual([
+			"history.bucketToday",
+			"history.bucketYesterday",
+			"history.bucketThisWeek",
+			"history.bucketEarlier",
+		]);
+		const todayHeader = headers[0];
+		expect(todayHeader.kind === "header" && todayHeader.count).toBe(2);
+		// 4 headers + 5 sessions
+		expect(rows).toHaveLength(9);
+	});
+
+	test("attaches dirName from the lookup map", () => {
+		const items = [snap("s1", NOW - HOUR)];
+		const dirMap = new Map([["local:s1", "-home-m0a-proj"]]);
+		const rows = bucketizeHistory(items, dirMap, keyOf, t, NOW);
+		const sessionRow = rows.find((r) => r.kind === "session");
+		expect(sessionRow?.kind === "session" && sessionRow.dirName).toBe(
+			"-home-m0a-proj",
+		);
+	});
+
+	test("empty input yields no rows", () => {
+		expect(bucketizeHistory([], undefined, keyOf, t, NOW)).toHaveLength(0);
+	});
+
+	test("out-of-order input still yields one header per bucket in canonical order", () => {
+		// Simulates SSE search results: not globally date-sorted.
+		const items = [
+			snap("old", NOW - 20 * DAY),
+			snap("today1", NOW - HOUR),
+			snap("yest", NOW - 28 * HOUR),
+			snap("today2", NOW - 2 * HOUR),
+		];
+		const rows = bucketizeHistory(items, undefined, keyOf, t, NOW);
+		const headers = rows.filter((r) => r.kind === "header");
+		// Exactly one header per non-empty bucket, in canonical order.
+		expect(headers.map((h) => (h.kind === "header" ? h.label : ""))).toEqual([
+			"history.bucketToday",
+			"history.bucketYesterday",
+			"history.bucketEarlier",
+		]);
+		// No duplicate row keys (would break React + virtualizer).
+		const keys = rows.map((r) => r.key);
+		expect(new Set(keys).size).toBe(keys.length);
+		// Today bucket groups both today sessions.
+		const todayHeader = headers[0];
+		expect(todayHeader.kind === "header" && todayHeader.count).toBe(2);
+	});
+});

--- a/frontend/src/utils/historyBuckets.ts
+++ b/frontend/src/utils/historyBuckets.ts
@@ -1,0 +1,137 @@
+import type { HistorySession } from "../../../shared/types";
+
+type TFunction = (key: string, options?: Record<string, unknown>) => string;
+
+export type HistoryAgentFilter = "claude" | "codex" | null;
+export type HistoryPeriodFilter = "24h" | "7d" | "30d" | null;
+
+export interface HistoryFilter {
+	agent: HistoryAgentFilter;
+	period: HistoryPeriodFilter;
+	activeOnly: boolean;
+}
+
+export const EMPTY_HISTORY_FILTER: HistoryFilter = {
+	agent: null,
+	period: null,
+	activeOnly: false,
+};
+
+export function isFilterActive(f: HistoryFilter): boolean {
+	return f.agent !== null || f.period !== null || f.activeOnly;
+}
+
+const PERIOD_MS: Record<NonNullable<HistoryPeriodFilter>, number> = {
+	"24h": 24 * 60 * 60 * 1000,
+	"7d": 7 * 24 * 60 * 60 * 1000,
+	"30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Apply the client-side facet filter (agent / period / active-only) to a list
+ * of sessions. Pure; `now` is injected for testability.
+ */
+export function applyHistoryFilter(
+	items: HistorySession[],
+	filter: HistoryFilter,
+	activeCcSessionIds: Set<string>,
+	now: number,
+): HistorySession[] {
+	if (!isFilterActive(filter)) return items;
+	return items.filter((s) => {
+		if (filter.agent && (s.agent ?? "claude") !== filter.agent) return false;
+		if (filter.activeOnly && !activeCcSessionIds.has(s.sessionId)) return false;
+		if (filter.period) {
+			const ts = new Date(s.modified).getTime();
+			if (Number.isNaN(ts)) return true; // unparseable date: don't hide
+			if (now - ts > PERIOD_MS[filter.period]) return false;
+		}
+		return true;
+	});
+}
+
+export type HistoryListRow =
+	| { kind: "header"; key: string; label: string; count: number }
+	| {
+			kind: "session";
+			key: string;
+			session: HistorySession;
+			dirName?: string;
+	  };
+
+type BucketId = "today" | "yesterday" | "week" | "earlier";
+
+function startOfDay(ms: number): number {
+	const d = new Date(ms);
+	d.setHours(0, 0, 0, 0);
+	return d.getTime();
+}
+
+function bucketOf(modifiedMs: number, now: number): BucketId {
+	if (Number.isNaN(modifiedMs)) return "earlier";
+	const todayStart = startOfDay(now);
+	const yesterdayStart = todayStart - 24 * 60 * 60 * 1000;
+	const weekStart = todayStart - 6 * 24 * 60 * 60 * 1000;
+	if (modifiedMs >= todayStart) return "today";
+	if (modifiedMs >= yesterdayStart) return "yesterday";
+	if (modifiedMs >= weekStart) return "week";
+	return "earlier";
+}
+
+const BUCKET_LABEL_KEY: Record<BucketId, string> = {
+	today: "history.bucketToday",
+	yesterday: "history.bucketYesterday",
+	week: "history.bucketThisWeek",
+	earlier: "history.bucketEarlier",
+};
+
+const BUCKET_ORDER: BucketId[] = ["today", "yesterday", "week", "earlier"];
+
+/**
+ * Turn a session list into virtualizer rows with inline date bucket headers
+ * (Today / Yesterday / This week / Earlier), each header carrying its count.
+ *
+ * Order-independent: sessions are partitioned by bucket and emitted in the
+ * canonical bucket order, so each header appears exactly once even if the input
+ * isn't globally sorted (e.g. SSE search results). Within a bucket, input order
+ * is preserved — callers pass modified-DESC for a newest-first feel.
+ */
+export function bucketizeHistory(
+	items: HistorySession[],
+	dirNameBySession: Map<string, string> | undefined,
+	keyOf: (s: HistorySession) => string,
+	t: TFunction,
+	now: number,
+): HistoryListRow[] {
+	const grouped: Record<BucketId, HistorySession[]> = {
+		today: [],
+		yesterday: [],
+		week: [],
+		earlier: [],
+	};
+	for (const s of items) {
+		grouped[bucketOf(new Date(s.modified).getTime(), now)].push(s);
+	}
+
+	const rows: HistoryListRow[] = [];
+	for (const b of BUCKET_ORDER) {
+		const bucketItems = grouped[b];
+		if (bucketItems.length === 0) continue;
+		rows.push({
+			kind: "header",
+			key: `header:${b}`,
+			label: t(BUCKET_LABEL_KEY[b]),
+			count: bucketItems.length,
+		});
+		for (const session of bucketItems) {
+			const key = keyOf(session);
+			rows.push({
+				kind: "session",
+				key,
+				session,
+				dirName: dirNameBySession?.get(key),
+			});
+		}
+	}
+	return rows;
+}


### PR DESCRIPTION
## Option B — PR 5 of 6 (frontend, flag-gated)

V2 履歴ビューにクライアントサイドのファセット絞り込みと日付バケット見出しを追加。V1 不変。

### 新規
- `utils/historyBuckets.ts` — `applyHistoryFilter`（agent/期間/active の AND）+ `bucketizeHistory`（今日/昨日/今週/それ以前、カウント付き）。バケット分割方式で入力順に依存せずヘッダ重複しない
- `components/history/HistoryFacetBar.tsx` — チップ行（Claude/Codex/Active/24h/7d/30d、軸内排他 + Active トグル）
- `utils/historyBuckets.test.ts` — 11ケース（未ソート入力含む）

### 変更
- `VirtualizedHistoryList` — header|session 行対応
- `SessionHistoryV2` — フィルタ state + facet bar + filter→sort→bucketize、フィルタ後カウント、noFilterMatches 空状態
- `package.json` — test を `TZ=UTC` 固定（バケット境界の決定性）

### Adversarial review 反映（needs-work → 全解消）
- **must-fix**: 検索結果を modified-DESC ソート + bucketize を順序非依存化（マルチエージェント検索での**バケットヘッダ重複 + React key 衝突**。Codex 単一の dev 検証で見逃していた）
- **must-fix**: remount key にフィルタを含め、ファセット変更でスクロールリセット（行数激減時の空白リスト解消）
- **should-fix**: ステータス行をフィルタ後カウントに / aria-pressed 追加 / 実効 `[scrollbar-width:thin]` / Active を i18n / history.noTitle 追加

### 検証
- 単体テスト 11/11（TZ=UTC）、lint/tsc/build クリーン
- **dev 実機**: Codex 絞り込み・24h 絞り込み・日付バケット・**混在50件検索でヘッダ重複ゼロ**・下スクロール後フィルタで scrollTop=0 リセット

### 後続
- PR6: default ON + V1 削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)