### PR TITLE
feat(history): default V2 history ON (PR6/6)

### DIFF
--- a/frontend/src/hooks/useHistoryV2Flag.ts
+++ b/frontend/src/hooks/useHistoryV2Flag.ts
@@ -4,9 +4,11 @@ const STORAGE_KEY = "cchub-history-v2";
 
 function readFlag(): boolean {
 	try {
-		return localStorage.getItem(STORAGE_KEY) === "true";
+		// Default ON: V2 is the canonical history view. Only an explicit "false"
+		// opts back into the legacy V1 list (escape hatch while V2 bakes).
+		return localStorage.getItem(STORAGE_KEY) !== "false";
 	} catch {
-		return false;
+		return true;
 	}
 }
 
@@ -17,7 +19,8 @@ function readFlag(): boolean {
  * faceted/virtualized history UI should be shown. Listens for the storage
  * event so toggling the flag in another tab updates this one live.
  *
- * Default is `false` (opt-in). PR6 will flip the unset default to `true`.
+ * Default is ON; setting `cchub-history-v2` to "false" opts back into the
+ * legacy V1 list during the V2 bake-in.
  */
 export function useHistoryV2Flag(): boolean {
 	const [enabled, setEnabled] = useState<boolean>(() => readFlag());


### PR DESCRIPTION
## Option B — PR 6 of 6 (default flip)

`useHistoryV2Flag` のデフォルトを反転。未設定の `cchub-history-v2` が **V2（ファセット + 仮想化リスト）** を返すようになる。`false` を明示セットすると従来の V1 に戻る（V2 安定までの退避路）。

V1 コードの完全削除は、V2 が本番で安定したことを確認してから別途実施する。

### 変更
- `useHistoryV2Flag`: 未設定 → true（V2）、`"false"` のみ V1。例外時も true。

### 検証（dev 実機）
- 未設定 localStorage（新規ユーザー相当）→ V2 表示（ファセットチップ + 日付バケット + 16行仮想化）✅
- `cchub-history-v2=false` → V1 プロジェクトツリー表示 ✅

### Option B 完了
| PR | 内容 |
|---|---|
| #290 | 型（lastPrompt/recap/cwdKey）+ flag フック |
| #291 | backend: recap-scanner + recap/lastPrompt を wire に |
| #292 | V1 で recap 表示 + V2 用 i18n |
| #293 | 仮想化フラットリスト（flag 裏） |
| #294 | ファセットチップ + 日付バケット |
| #295 | **V2 デフォルト化（本PR）** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)