### PR TITLE
fix(history): show modified, not recapAt, as V2 row time

### DIFF
--- a/frontend/src/components/history/HistoryRowV2.tsx
+++ b/frontend/src/components/history/HistoryRowV2.tsx
@@ -101,11 +101,11 @@ export function HistoryRowV2({
 
 					<div className="flex items-center gap-3 mt-1.5 text-[11px] text-zinc-600">
 						<span>
-							{formatRelativeTime(
-								session.recapAt || session.modified,
-								t,
-								i18n.language,
-							)}
+							{/* Show `modified` — the same key the list is sorted and
+							    bucketed by. Using recapAt here made the times look
+							    out of order (a recap can be days older than the last
+							    activity). */}
+							{formatRelativeTime(session.modified, t, i18n.language)}
 						</span>
 						{duration && (
 							<span className="inline-flex items-center gap-1">


### PR DESCRIPTION
## 不具合修正

V2 履歴リストは `modified`（最終更新）でソート・日付バケットしているのに、各行は `recapAt || modified` を表示していた。recap はセッションの最終活動より数日前に生成されることがある（例: ai-manga-lab は modified=2026-05-26 だが recapAt=2026-05-18、6日ズレ）ため、**表示時刻が順不同に見え**、行のバケット（今週/それ以前）と表示日付が食い違っていた。

タブレット画像で「5日前 → 2026/5/18 → 6日前」と非単調に見えていたのがこれ。

### 修正
`HistoryRowV2` の行時刻を `session.modified` に統一（ソート/バケットと一致）。

### 検証（dev 実機）
- 行時刻が単調降順に: 34秒前 → 36分前 → … → 1日前 → 2日前 → 3日前
- ai-manga-lab が「3日前」(modified 5/26) と正しく表示（旧: recapAt 2026/5/18）
- 「今日 7」等の日付バケットと表示時刻が一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)