### PR TITLE
feat(history): responsive multi-column cards in V2 list

### DIFF
--- a/frontend/src/components/history/HistoryRowV2.tsx
+++ b/frontend/src/components/history/HistoryRowV2.tsx
@@ -55,7 +55,7 @@ export function HistoryRowV2({
 	return (
 		<div
 			onClick={onTap}
-			className="group px-3 py-2.5 hover:bg-white/[0.04] cursor-pointer transition-colors border-b border-white/[0.04]"
+			className="group h-full px-3 py-2.5 rounded-md border border-white/[0.06] hover:bg-white/[0.04] cursor-pointer transition-colors"
 			style={
 				showPeer && session.peerColor
 					? { borderLeft: `3px solid ${session.peerColor}`, paddingLeft: 9 }

--- a/frontend/src/components/history/VirtualizedHistoryList.tsx
+++ b/frontend/src/components/history/VirtualizedHistoryList.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useRef } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { HistorySession } from "../../../../shared/types";
 import type { HistoryListRow } from "../../utils/historyBuckets";
 import { HistoryRowV2 } from "./HistoryRowV2";
@@ -13,12 +13,27 @@ interface VirtualizedHistoryListProps {
 	onNavigate: (session: HistorySession) => void;
 }
 
+type SessionRow = Extract<HistoryListRow, { kind: "session" }>;
+type PackedRow =
+	| Extract<HistoryListRow, { kind: "header" }>
+	| { kind: "group"; key: string; items: SessionRow[] };
+
+/** Pick a column count from the available width (1 / 2 / 3). */
+function columnsForWidth(width: number): number {
+	if (width >= 1400) return 3;
+	if (width >= 640) return 2;
+	return 1;
+}
+
 /**
- * Virtualized history list with inline date-bucket headers. Uses an internal
- * scroll container as the scrollElement (same pattern as ConversationViewer).
- * measureElement is NOT corrected for the SessionList contentScale transform:
- * ResizeObserver reports the pre-transform layout size, so the virtualizer's
- * math stays correct under pinch-zoom.
+ * Virtualized history list. Date-bucket headers span the full width; session
+ * cards are packed into responsive rows of 1–3 columns so recaps don't run
+ * edge-to-edge on wide screens.
+ *
+ * Uses an internal scroll container as the scrollElement (same pattern as
+ * ConversationViewer). measureElement is NOT corrected for the SessionList
+ * contentScale transform: ResizeObserver reports the pre-transform layout size,
+ * so the virtualizer's math stays correct under pinch-zoom.
  */
 export function VirtualizedHistoryList({
 	rows,
@@ -29,20 +44,65 @@ export function VirtualizedHistoryList({
 	onNavigate,
 }: VirtualizedHistoryListProps) {
 	const parentRef = useRef<HTMLDivElement>(null);
+	const [columns, setColumns] = useState(1);
+
+	// useLayoutEffect: read the width and set columns synchronously before paint
+	// so there's no 1-column flash. Only reset scroll when the column COUNT
+	// actually changes (repacking shifts row indices/keys), not on every resize.
+	useLayoutEffect(() => {
+		const el = parentRef.current;
+		if (!el) return;
+		let prev = columnsForWidth(el.clientWidth);
+		setColumns(prev);
+		const ro = new ResizeObserver(() => {
+			const next = columnsForWidth(el.clientWidth);
+			if (next !== prev) {
+				prev = next;
+				setColumns(next);
+				el.scrollTop = 0;
+			}
+		});
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, []);
+
+	// Pack consecutive session rows into groups of `columns`; headers stay solo.
+	const packed = useMemo<PackedRow[]>(() => {
+		const out: PackedRow[] = [];
+		let i = 0;
+		while (i < rows.length) {
+			const row = rows[i];
+			if (row.kind === "header") {
+				out.push(row);
+				i++;
+				continue;
+			}
+			const group: SessionRow[] = [];
+			while (
+				i < rows.length &&
+				rows[i].kind === "session" &&
+				group.length < columns
+			) {
+				group.push(rows[i] as SessionRow);
+				i++;
+			}
+			out.push({ kind: "group", key: `g:${group.map((g) => g.key).join("|")}`, items: group });
+		}
+		return out;
+	}, [rows, columns]);
 
 	const virtualizer = useVirtualizer({
-		count: rows.length,
+		count: packed.length,
 		getScrollElement: () => parentRef.current,
-		// header ~30px; plain prompt row ~66px; 3-line recap row ~108px.
-		// measureElement corrects these; estimates just minimize first-paint jump.
 		estimateSize: (index) => {
-			const row = rows[index];
-			if (!row) return 66;
+			const row = packed[index];
+			if (!row) return 90;
 			if (row.kind === "header") return 30;
-			return row.session.recap ? 108 : 66;
+			// A card row is as tall as its tallest card; recap cards are taller.
+			return row.items.some((s) => s.session.recap) ? 120 : 78;
 		},
-		overscan: 12,
-		getItemKey: (index) => rows[index]?.key ?? index,
+		overscan: 8,
+		getItemKey: (index) => packed[index]?.key ?? index,
 	});
 
 	return (
@@ -64,7 +124,7 @@ export function VirtualizedHistoryList({
 					}}
 				>
 					{virtualizer.getVirtualItems().map((virtualRow) => {
-						const row = rows[virtualRow.index];
+						const row = packed[virtualRow.index];
 						if (!row) return null;
 						return (
 							<div
@@ -78,14 +138,24 @@ export function VirtualizedHistoryList({
 										<span className="tabular-nums">{row.count}</span>
 									</div>
 								) : (
-									<HistoryRowV2
-										session={row.session}
-										isActive={activeCcSessionIds.has(row.session.sessionId)}
-										isResuming={resumingId === row.session.sessionId}
-										onTap={() => onTap(row.session, row.dirName)}
-										onResume={() => onResume(row.session)}
-										onNavigate={() => onNavigate(row.session)}
-									/>
+									<div
+										className="grid gap-2 px-2 py-1"
+										style={{
+											gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+										}}
+									>
+										{row.items.map((s) => (
+											<HistoryRowV2
+												key={s.key}
+												session={s.session}
+												isActive={activeCcSessionIds.has(s.session.sessionId)}
+												isResuming={resumingId === s.session.sessionId}
+												onTap={() => onTap(s.session, s.dirName)}
+												onResume={() => onResume(s.session)}
+												onNavigate={() => onNavigate(s.session)}
+											/>
+										))}
+									</div>
 								)}
 							</div>
 						);


### PR DESCRIPTION
## タブレット表示改善（マルチカラム化）

ワイド画面で履歴が単一の全幅カラム = recap が端から端まで伸びて「文字の壁」に見える問題（タブレットで顕著）を解消。セッションを **レスポンシブな 1 / 2 / 3 カラムのカードグリッド**に。日付バケット見出しは全幅のまま。

### 変更
- **HistoryRowV2**: 全幅 `border-b` 行 → 角丸ボーダーのカード（`h-full` でグリッド行内の高さ揃え）
- **VirtualizedHistoryList**: コンテナ幅を ResizeObserver で測り、連続するセッション行を `columns` 個ずつグループ化して CSS グリッド描画。仮想化は維持（グループが仮想行）

### レビュー反映（blocker 1 + major 1）
- `useLayoutEffect` で初期列数を同期取得 → マウント時の1列フラッシュ解消
- 列数が**実際に変わった時だけ** scrollTop=0 リセット → リサイズ後の stale offset / 空白リスト防止

### 検証（dev 実機）
- コンテナ ~1012px で 2 カラム、各グリッド行に 2 カード
- スクロール仮想化維持（DOM <40行）
- ピンチズーム（contentScale 1.25）下でも grid 維持・ウィンドウシフト正常
- カードタップでモーダル

ブレークポイント: `<640px` 1列 / `≥640px` 2列 / `≥1400px` 3列

🤖 Generated with [Claude Code](https://claude.com/claude-code)