### PR TITLE
fix(peers): offline peer no longer stalls history load (10s+ → ~1s)

### DIFF
--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -207,6 +207,19 @@ async function buildLocalHistoryProjects(): Promise<HistoryProjectsResp['project
   return Array.from(byDir.values()).sort((a, b) => a.projectName.localeCompare(b.projectName));
 }
 
+// A peer that errored within this window is skipped on the next fanout so a
+// single offline peer doesn't make every history load wait the full peerFetch
+// timeout. An explicit verify (recordPeerSuccess) or the cooldown expiring lets
+// it back in.
+const PEER_ERROR_COOLDOWN_MS = 60_000;
+const PEER_LIST_TIMEOUT_MS = 2_500;
+
+function peerRecentlyFailed(peer: { lastErrorAt?: string }): boolean {
+  if (!peer.lastErrorAt) return false;
+  const ts = new Date(peer.lastErrorAt).getTime();
+  return !Number.isNaN(ts) && Date.now() - ts < PEER_ERROR_COOLDOWN_MS;
+}
+
 // GET /api/peers/history/projects - 全 peer のプロジェクトを merge
 peers.get('/history/projects', async (c) => {
   const allPeers = await listPeers();
@@ -217,8 +230,21 @@ peers.get('/history/projects', async (c) => {
       let projects: HistoryProjectsResp['projects'];
       if (peer.url === SELF_PEER_URL) {
         projects = await buildLocalHistoryProjects();
+      } else if (peerRecentlyFailed(peer)) {
+        // Known-down peer: don't block the local list on its timeout.
+        errors.push({ peerId: peer.id, message: peer.lastErrorMessage || 'offline (skipped)' });
+        return [];
       } else {
-        const res = await peerFetch(peer.id, peer.url, peer.wsToken, '/api/sessions/history/projects');
+        // Short timeout: the project list is interactive and must not hang on a
+        // peer that's gone unreachable since the cooldown window.
+        const res = await peerFetch(
+          peer.id,
+          peer.url,
+          peer.wsToken,
+          '/api/sessions/history/projects',
+          undefined,
+          PEER_LIST_TIMEOUT_MS,
+        );
         if (!res.ok) {
           errors.push({ peerId: peer.id, message: `HTTP ${res.status}` });
           return [];

--- a/backend/src/services/peer-auth.ts
+++ b/backend/src/services/peer-auth.ts
@@ -173,6 +173,7 @@ export async function peerFetch(
   token: string | undefined,
   path: string,
   init?: RequestInit,
+  timeoutMs: number = VERIFY_TIMEOUT_MS,
 ): Promise<Response> {
   assertSafePeerUrl(url);
   const base = normalizePeerUrl(url);
@@ -183,7 +184,7 @@ export async function peerFetch(
   }
 
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   let response: Response;
   try {


### PR DESCRIPTION
## 履歴ロードが10秒以上かかる問題の修正

### 計測で特定した原因（[[profile before fixing]]）
履歴タブを開くと `/api/peers/history/projects` が **毎回ぴったり 5.0秒**かかっていた（ローカルのプロジェクト一覧自体は 0.007秒）。

- このルートは `Promise.all` で全 peer を並列取得するが、**オフラインの peer（makotomacbook-pro、Tailscale 応答なし）への `peerFetch` が 5秒タイムアウトを待つ**
- `Promise.all` は最も遅い peer に律速されるため、ローカルが即返っても全体が 5秒待ち
- health-check が無く、毎回 5秒タイムアウトを食らう設計だった
- これ + ハイドレーションで合計 10秒+

### 修正
- **直近60秒に失敗した peer をスキップ**（`recordPeerFailure` が `lastErrorAt` を記録済み。明示 verify か cooldown 経過で復帰）
- **リスト用に短い 2.5秒タイムアウト**（`peerFetch` に optional `timeoutMs` 追加、デフォルトは従来の5秒）。cooldown 明け初回の retry も律速しない

### 計測結果（オフライン peer 1台登録時）
| | Before | After |
|---|---|---|
| プロジェクト一覧 (初回/再試行) | 5.0s | **2.5s** |
| プロジェクト一覧 (cooldown スキップ) | 5.0s | **0.007s** |
| 履歴タブ全体ロード | 10s+ | **~0.9s** |

### 検証
- backend tsc / lint クリーン、全258テスト pass
- dev 実機: 履歴タブが <1秒でサイドバー+リスト表示

注: peer が復帰すると次の verify 成功（`recordPeerSuccess`）または60秒cooldown明けで一覧に再表示される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)