### PR TITLE
feat(sessions): "Open in Claude app" button via Remote Control bridge

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -135,6 +135,10 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     .map(s => s.currentPath);
   const codexThreadsByPath = await codexService.getThreadsForPaths(codexPaths);
 
+  // Remote Control deep-link map: Claude Code sessionId -> bridgeSessionId.
+  // Read once per build (cheap: a handful of small ~/.claude/sessions/*.json).
+  const bridgeSessionIds = await claudeCodeService.getBridgeSessionIds();
+
   const order = await getSessionOrder();
 
   const results = await Promise.all(tmuxSessions.map(async (s) => {
@@ -252,6 +256,10 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       ccRecapAt: includeClaudeInfo && isExactPathMatch ? ccSession?.lastRecap?.timestamp : undefined,
       indicatorState: sessionIndicatorState,
       ccSessionId: includeClaudeInfo ? ccSession?.sessionId : undefined,
+      bridgeSessionId:
+        includeClaudeInfo && ccSession?.sessionId
+          ? bridgeSessionIds.get(ccSession.sessionId)
+          : undefined,
       agentSessionId: includeCodexInfo ? codexThread?.sessionId : undefined,
       messageCount: includeClaudeInfo ? ccSession?.messageCount : undefined,
       gitBranch: includeClaudeInfo ? ccSession?.gitBranch : includeCodexInfo ? codexThread?.gitBranch : undefined,
@@ -330,6 +338,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       ccRecapAt: undefined,
       indicatorState: undefined,
       ccSessionId: lost.ccSessionId,
+      bridgeSessionId: undefined,
       agentSessionId: lost.agentSessionId,
       messageCount: undefined,
       gitBranch: undefined,

--- a/backend/src/services/claude-code.ts
+++ b/backend/src/services/claude-code.ts
@@ -91,6 +91,44 @@ export class ClaudeCodeService {
   }
 
   /**
+   * Read `~/.claude/sessions/<pid>.json` state files and build a map from the
+   * Claude Code session id (the `.jsonl` UUID) to its Remote Control
+   * `bridgeSessionId` (`session_…`). Only sessions with Remote Control active
+   * carry a non-null `bridgeSessionId`; others are skipped. Used to surface an
+   * "Open in Claude app" deep link (`https://claude.ai/code/<bridgeSessionId>`).
+   */
+  async getBridgeSessionIds(): Promise<Map<string, string>> {
+    const map = new Map<string, string>();
+    const dir = join(homedir(), '.claude', 'sessions');
+    let files: string[];
+    try {
+      files = await readdir(dir);
+    } catch {
+      return map; // dir may not exist (Remote Control never used)
+    }
+    await Promise.all(
+      files
+        .filter((f) => f.endsWith('.json'))
+        .map(async (f) => {
+          try {
+            const raw = await readFile(join(dir, f), 'utf-8');
+            const data = JSON.parse(raw) as { sessionId?: unknown; bridgeSessionId?: unknown };
+            if (
+              typeof data.sessionId === 'string' &&
+              typeof data.bridgeSessionId === 'string' &&
+              data.bridgeSessionId.length > 0
+            ) {
+              map.set(data.sessionId, data.bridgeSessionId);
+            }
+          } catch {
+            // ignore unreadable / malformed individual files
+          }
+        }),
+    );
+    return map;
+  }
+
+  /**
    * Convert a path to Claude Code project directory name
    * e.g., /home/m0a/cchub -> -home-m0a-cchub
    */

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -287,6 +287,7 @@ export function DesktopLayout({
 								agentSessionId: apiSession.agentSessionId,
 								panes: apiSession.panes,
 								peerId: apiSession.peerId ?? propSession.peerId,
+								bridgeSessionId: apiSession.bridgeSessionId,
 							}
 						: {
 								id: apiSession.id,
@@ -300,6 +301,7 @@ export function DesktopLayout({
 								theme: apiSession.theme,
 								panes: apiSession.panes,
 								peerId: apiSession.peerId,
+								bridgeSessionId: apiSession.bridgeSessionId,
 							};
 				})
 			: propSessions;

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -1,6 +1,10 @@
 /** biome-ignore-all lint/correctness/useExhaustiveDependencies: depends on refs and setters that React guarantees stable; adding them would cause unintended re-runs */
 /** biome-ignore-all lint/a11y/noStaticElementInteractions lint/a11y/useKeyWithClickEvents: legacy click-on-div UI; keyboard navigation provided via main shortcuts */
-import { MessageSquare, Terminal as TerminalIcon } from "lucide-react";
+import {
+	ExternalLink,
+	MessageSquare,
+	Terminal as TerminalIcon,
+} from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type {
@@ -35,6 +39,9 @@ interface ExtendedSession {
 	state: SessionState;
 	currentPath?: string;
 	ccSessionId?: string;
+	// Remote Control deep-link target (`session_…`). Present only while Remote
+	// Control is active; drives the "Open in Claude app" header button.
+	bridgeSessionId?: string;
 	agent?: AgentProvider;
 	agentSessionId?: string;
 	currentCommand?: string;
@@ -368,6 +375,30 @@ function TerminalPane({
 							</button>
 						);
 					})()}
+					{/* Open the matching Remote Control session in the Claude app */}
+					{session?.bridgeSessionId && (
+						<button
+							type="button"
+							onClick={(e) => {
+								e.stopPropagation();
+								const bridgeId = session.bridgeSessionId;
+								if (!bridgeId) return;
+								window.open(
+									`https://claude.ai/code/${encodeURIComponent(bridgeId)}`,
+									"_blank",
+									"noopener,noreferrer",
+								);
+							}}
+							className={`${isTablet ? "p-2" : "p-1"} rounded transition-colors text-violet-300/80 hover:text-violet-200 hover:bg-violet-500/10`}
+							title={t("session.openInClaudeApp")}
+							aria-label={t("session.openInClaudeApp")}
+						>
+							<ExternalLink
+								className={isTablet ? "w-4 h-4" : "w-[14px] h-[14px]"}
+							/>
+						</button>
+					)}
+
 					{/* File browser button (desktop only) */}
 					{!isTablet && session?.currentPath && !showConversation && (
 						<button

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -7,6 +7,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import {
+	ArrowRight,
 	ChevronLeft,
 	ChevronRight,
 	ExternalLink,
@@ -789,6 +790,7 @@ function SessionItem({
 	};
 
 	const [panesExpanded, setPanesExpanded] = useState(false);
+	const [showJumpMenu, setShowJumpMenu] = useState(false);
 
 	const handleClick = () => {
 		if (longPressFiredRef.current) {
@@ -796,6 +798,13 @@ function SessionItem({
 			return;
 		}
 		longPressFiredRef.current = false;
+
+		// Remote Control session: let the user choose between jumping to the CC Hub
+		// terminal and opening the matching session in the Claude app.
+		if (session.bridgeSessionId) {
+			setShowJumpMenu((prev) => !prev);
+			return;
+		}
 
 		// Multi-pane session: toggle pane list to show per-pane status
 		if (session.panes && session.panes.length > 1) {
@@ -1028,31 +1037,6 @@ function SessionItem({
 								</span>
 							);
 						})()}
-
-					{/* Remote Control: open the matching session in the Claude app */}
-					{extSession.bridgeSessionId && (
-						<button
-							type="button"
-							title={t("session.openInClaudeApp")}
-							aria-label={t("session.openInClaudeApp")}
-							onClick={(e) => {
-								e.stopPropagation();
-								const bridgeId = extSession.bridgeSessionId;
-								if (!bridgeId) return;
-								window.open(
-									`https://claude.ai/code/${encodeURIComponent(bridgeId)}`,
-									"_blank",
-									"noopener,noreferrer",
-								);
-							}}
-							onMouseDown={(e) => e.stopPropagation()}
-							onTouchStart={(e) => e.stopPropagation()}
-							className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] text-violet-300 bg-violet-500/15 hover:bg-violet-500/25 transition-colors shrink-0"
-						>
-							<ExternalLink className="w-3 h-3" />
-							{t("session.openInClaudeApp")}
-						</button>
-					)}
 				</div>
 
 				{/* Auto recap (away_summary) — timestamp shown inline at the tail */}
@@ -1152,6 +1136,45 @@ function SessionItem({
 					</div>
 				)}
 			</div>
+
+			{/* Jump menu (Remote Control): choose CC Hub terminal vs the Claude app */}
+			{showJumpMenu && extSession.bridgeSessionId && (
+				<div
+					className="mx-4 mb-3 pt-2 border-t border-white/[0.06] flex flex-col gap-1"
+					onClick={(e) => e.stopPropagation()}
+					onMouseDown={(e) => e.stopPropagation()}
+					onTouchStart={(e) => e.stopPropagation()}
+				>
+					<button
+						type="button"
+						onClick={() => {
+							setShowJumpMenu(false);
+							onSelect(session);
+						}}
+						className="inline-flex items-center gap-2 px-3 py-2 rounded-md text-[13px] text-zinc-200 bg-white/[0.04] hover:bg-white/[0.08] transition-colors"
+					>
+						<ArrowRight className="w-3.5 h-3.5 text-zinc-400" />
+						{t("session.goToTerminal")}
+					</button>
+					<button
+						type="button"
+						onClick={() => {
+							const bridgeId = extSession.bridgeSessionId;
+							if (!bridgeId) return;
+							setShowJumpMenu(false);
+							window.open(
+								`https://claude.ai/code/${encodeURIComponent(bridgeId)}`,
+								"_blank",
+								"noopener,noreferrer",
+							);
+						}}
+						className="inline-flex items-center gap-2 px-3 py-2 rounded-md text-[13px] text-violet-200 bg-violet-500/15 hover:bg-violet-500/25 transition-colors"
+					>
+						<ExternalLink className="w-3.5 h-3.5" />
+						{t("session.openInClaudeApp")}
+					</button>
+				</div>
+			)}
 
 			{/* Pane list (expandable, shows per-pane status indicators) */}
 			{panesExpanded && extSession.panes && extSession.panes.length > 1 && (

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -9,6 +9,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
 	ChevronLeft,
 	ChevronRight,
+	ExternalLink,
 	Folder,
 	GripVertical,
 	Play,
@@ -1027,6 +1028,31 @@ function SessionItem({
 								</span>
 							);
 						})()}
+
+					{/* Remote Control: open the matching session in the Claude app */}
+					{extSession.bridgeSessionId && (
+						<button
+							type="button"
+							title={t("session.openInClaudeApp")}
+							aria-label={t("session.openInClaudeApp")}
+							onClick={(e) => {
+								e.stopPropagation();
+								const bridgeId = extSession.bridgeSessionId;
+								if (!bridgeId) return;
+								window.open(
+									`https://claude.ai/code/${encodeURIComponent(bridgeId)}`,
+									"_blank",
+									"noopener,noreferrer",
+								);
+							}}
+							onMouseDown={(e) => e.stopPropagation()}
+							onTouchStart={(e) => e.stopPropagation()}
+							className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] text-violet-300 bg-violet-500/15 hover:bg-violet-500/25 transition-colors shrink-0"
+						>
+							<ExternalLink className="w-3 h-3" />
+							{t("session.openInClaudeApp")}
+						</button>
+					)}
 				</div>
 
 				{/* Auto recap (away_summary) — timestamp shown inline at the tail */}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -38,6 +38,7 @@
 		"resume": "Resume",
 		"resuming": "Resuming...",
 		"navigate": "Go to",
+		"openInClaudeApp": "Open in Claude app",
 		"colorTheme": "Color Theme",
 		"customTitle": "Custom Title",
 		"customTitlePlaceholder": "Enter title (empty for auto)",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -38,6 +38,7 @@
 		"resume": "Resume",
 		"resuming": "Resuming...",
 		"navigate": "Go to",
+		"goToTerminal": "Go to this terminal",
 		"openInClaudeApp": "Open in Claude app",
 		"colorTheme": "Color Theme",
 		"customTitle": "Custom Title",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -38,6 +38,7 @@
 		"resume": "再開",
 		"resuming": "再開中...",
 		"navigate": "移動",
+		"openInClaudeApp": "Claudeアプリで開く",
 		"colorTheme": "テーマカラー",
 		"customTitle": "カスタムタイトル",
 		"customTitlePlaceholder": "タイトルを入力（空で自動）",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -38,6 +38,7 @@
 		"resume": "再開",
 		"resuming": "再開中...",
 		"navigate": "移動",
+		"goToTerminal": "このターミナルへ移動",
 		"openInClaudeApp": "Claudeアプリで開く",
 		"colorTheme": "テーマカラー",
 		"customTitle": "カスタムタイトル",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -499,6 +499,13 @@ export interface DashboardResponse {
 export interface ExtendedSessionResponse extends SessionResponse {
   indicatorState?: IndicatorState;
   ccSessionId?: string;
+  /**
+   * Remote Control bridge session id (`session_…`) read from
+   * `~/.claude/sessions/<pid>.json`. Present only while Remote Control is active
+   * for this session. The frontend builds `https://claude.ai/code/<id>` from it
+   * for the "Open in Claude app" link.
+   */
+  bridgeSessionId?: string;
   agentSessionId?: string;
   currentCommand?: string;
   paneTitle?: string;


### PR DESCRIPTION
## 概要

Remote Control が有効なセッションについて、**CC Hub のターミナルへ移動するか / Claude アプリで開くかを選べる**ようにする。`https://claude.ai/code/<bridgeSessionId>` へのディープリンク。

## UX（design feedback 反映）

- **セッションリスト**: bridge ありのセッションを**タップ → 選択メニュー**「このターミナルへ移動 / Claudeアプリで開く」。bridge 無しは従来通り直接ターミナルへ。
- **ターミナル表示中**: ペインヘッダー（PaneContainer）に「Claudeアプリで開く」アイコンボタンを追加（bridge ありのアクティブセッションのみ）。desktop / tablet 両対応。表示中のターミナルからアプリへジャンプできる。

## 仕組み

- **backend**: `~/.claude/sessions/<pid>.json` を読み `sessionId → bridgeSessionId` を構築し、`buildSessionsList()` で各セッションに `bridgeSessionId` を付与（`sessionId` 完全一致のみ）。Remote Control 非アクティブは未設定。
- **shared**: `ExtendedSessionResponse.bridgeSessionId?`.
- **frontend**: `SessionList`（タップ選択メニュー）/ `PaneContainer`（ヘッダーボタン）/ `DesktopLayout`（prop↔api セッション merge に `bridgeSessionId` を透過）。URL は `encodeURIComponent` 経由。
- **i18n**: `session.openInClaudeApp` / `session.goToTerminal`（en/ja）。

## 検証

- typecheck / lint / unit tests（backend 258・frontend 37）green
- dev 実機（agent-browser, Tailscale IP）:
  - backend は Remote Control 稼働中の `cchub-work-1` のみ `bridgeSessionId` を返す
  - リストでタップ → 選択メニュー表示 → 「このターミナルへ移動」でペインが当該セッションに切替 → ヘッダーにアプリボタン出現
  - メニュー項目・ヘッダーボタン双方が正しい `https://claude.ai/code/<id>` を `window.open`、コンソールエラー無し
- adversarial code review 通過

## 既知の制約

Claude Code 側のネイティブ・アプリディープリンクは未実装（issue #48220）のため、現状モバイルでもタップ時は一旦ブラウザで claude.ai/code が開く。将来 `claude://` スキームが入れば URL 差し替えで対応可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)