### PR TITLE
fix(sessions): show "Open in Claude app" on mobile + reliable open

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@
 import {
 	BarChart3,
 	ChevronDown,
+	ExternalLink,
 	FileText,
 	MessageSquare,
 	RotateCw,
@@ -29,6 +30,7 @@ import { Onboarding, useOnboarding } from "./components/Onboarding";
 import { SessionList } from "./components/SessionList";
 import type { TerminalRef } from "./components/Terminal";
 import { getTerminalThemes } from "./components/terminal-themes";
+import { openClaudeAppSession } from "./utils/claude-app";
 import { useAuth } from "./hooks/useAuth";
 import { useSessions } from "./hooks/useSessions";
 import { TerminalPage } from "./pages/TerminalPage";
@@ -96,6 +98,9 @@ interface OpenSession {
 	state: SessionState;
 	currentPath?: string;
 	ccSessionId?: string;
+	// Remote Control deep-link target (`session_…`). Present only while Remote
+	// Control is active; drives the "Open in Claude app" button.
+	bridgeSessionId?: string;
 	agent?: AgentProvider;
 	agentSessionId?: string;
 	currentCommand?: string;
@@ -113,6 +118,7 @@ function apiToOpenSession(s: ExtendedSessionResponse): OpenSession {
 		state: s.state,
 		currentPath: s.currentPath,
 		ccSessionId: s.ccSessionId,
+		bridgeSessionId: s.bridgeSessionId,
 		agent: s.agent,
 		agentSessionId: s.agentSessionId,
 		currentCommand: s.currentCommand,
@@ -430,6 +436,7 @@ export function App() {
 					theme: apiSession.theme,
 					currentCommand: apiSession.currentCommand,
 					ccSessionId: apiSession.ccSessionId,
+					bridgeSessionId: apiSession.bridgeSessionId,
 					agent: apiSession.agent,
 					agentSessionId: apiSession.agentSessionId,
 					panes: apiSession.panes,
@@ -1006,6 +1013,20 @@ export function App() {
 							<MessageSquare className="w-5 h-5" />
 						</button>
 					))}
+				{activeSession?.bridgeSessionId && (
+					<button
+						type="button"
+						onClick={() => {
+							const id = activeSession.bridgeSessionId;
+							if (id) openClaudeAppSession(id);
+						}}
+						className="p-2.5 text-violet-400/80 hover:text-violet-300 active:text-violet-200 transition-colors"
+						title={t("session.openInClaudeApp")}
+						aria-label={t("session.openInClaudeApp")}
+					>
+						<ExternalLink className="w-5 h-5" />
+					</button>
+				)}
 				<button
 					type="button"
 					onClick={() => {

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -14,6 +14,7 @@ import type {
 	SessionTheme,
 } from "../../../shared/types";
 import { authFetch } from "../services/api";
+import { openClaudeAppSession } from "../utils/claude-app";
 import { toHomeShortPath } from "../utils/path";
 import { ChatView } from "./chat/ChatView";
 import type { ControlModeConfig } from "./Terminal";
@@ -383,11 +384,7 @@ function TerminalPane({
 								e.stopPropagation();
 								const bridgeId = session.bridgeSessionId;
 								if (!bridgeId) return;
-								window.open(
-									`https://claude.ai/code/${encodeURIComponent(bridgeId)}`,
-									"_blank",
-									"noopener,noreferrer",
-								);
+								openClaudeAppSession(bridgeId);
 							}}
 							className={`${isTablet ? "p-2" : "p-1"} rounded transition-colors text-violet-300/80 hover:text-violet-200 hover:bg-violet-500/10`}
 							title={t("session.openInClaudeApp")}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -36,6 +36,7 @@ import {
 	type SessionResponse,
 	type SessionTheme,
 } from "../../../shared/types";
+import { openClaudeAppSession } from "../utils/claude-app";
 import { usePeers } from "../hooks/usePeers";
 import {
 	applyLocalSessionOrder,
@@ -1162,11 +1163,7 @@ function SessionItem({
 							const bridgeId = extSession.bridgeSessionId;
 							if (!bridgeId) return;
 							setShowJumpMenu(false);
-							window.open(
-								`https://claude.ai/code/${encodeURIComponent(bridgeId)}`,
-								"_blank",
-								"noopener,noreferrer",
-							);
+							openClaudeAppSession(bridgeId);
 						}}
 						className="inline-flex items-center gap-2 px-3 py-2 rounded-md text-[13px] text-violet-200 bg-violet-500/15 hover:bg-violet-500/25 transition-colors"
 					>

--- a/frontend/src/utils/claude-app.ts
+++ b/frontend/src/utils/claude-app.ts
@@ -1,0 +1,15 @@
+/**
+ * Open the Remote Control cloud session that matches a local Claude Code
+ * session in the Claude app / browser.
+ *
+ * Uses a plain `window.open(url, "_blank")` WITHOUT a windowFeatures string:
+ * passing `"noopener,noreferrer"` makes mobile Safari (and some in-app
+ * browsers) treat the call as a blocked popup, so nothing opens. We harden the
+ * opener afterwards instead, which keeps the new-tab navigation reliable on
+ * mobile while still severing `window.opener`.
+ */
+export function openClaudeAppSession(bridgeSessionId: string): void {
+	const url = `https://claude.ai/code/${encodeURIComponent(bridgeSessionId)}`;
+	const opened = window.open(url, "_blank");
+	if (opened) opened.opener = null;
+}


### PR DESCRIPTION
## 問題

v0.1.165 で入れた「Claudeアプリで開く」が**モバイルで表示されない / 開けない**。原因2点:

1. **モバイルは別レイアウト**（`App.tsx` の overlayBar / openSessions）を使うのに、そこへ `bridgeSessionId` を流しておらず、ボタンも未設置だった（desktop/tablet の `DesktopLayout`+`PaneContainer` しか対応していなかった）。
2. `window.open(url, "_blank", "noopener,noreferrer")` の **features 文字列**がモバイル Safari でポップアップ扱いとなりブロックされ、開かない。

## 修正

- **App.tsx**: `OpenSession` 型 / `apiToOpenSession` / モバイル live-update マージに `bridgeSessionId` を追加。モバイルのターミナルツールバー（overlayBar）に「Claudeアプリで開く」アイコンボタンを追加（bridge ありのみ）。
- **新 util `openClaudeAppSession()`**: `window.open(url, "_blank")`（features 文字列なし）+ `opener = null`。既存の動作する `handleOpenUrl` と同じパターン。
- **SessionList / PaneContainer**: インラインの window.open を共通 util に置換。

## 検証

- dev 実機（agent-browser, **390×844 モバイルビューポート**）:
  - ターミナルツールバーにアプリアイコンが表示され、正しい URL を `window.open`
  - セッションリストのタップ → 選択メニュー → 正しい URL
  - コンソールエラー無し
- typecheck / lint / test（frontend 37）green

🤖 Generated with [Claude Code](https://claude.com/claude-code)