### PR TITLE
Release v0.1.166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.166] - 2026-05-31
+
+v0.1.165 で追加した「Claudeアプリで開く」がモバイルで表示されない/開けない不具合を修正。
+
+### Fixed
+- **「Claudeアプリで開く」がモバイルで動作しない問題を修正 (#303)**: モバイルは desktop/tablet とは別レイアウト（`App.tsx` の overlayBar / `openSessions`）を使うが、そこへ `bridgeSessionId` を流しておらずボタンも未設置だった（v0.1.165 は `DesktopLayout`+`PaneContainer` 経路のみ対応）。加えて `window.open(url, "_blank", "noopener,noreferrer")` の windowFeatures 文字列がモバイル Safari でポップアップ扱いとなりブロックされ、開けなかった。`App.tsx` の `OpenSession` 型 / `apiToOpenSession` / モバイル live-update マージに `bridgeSessionId` を追加し、モバイルのターミナルツールバー（overlayBar）に「Claudeアプリで開く」アイコンボタンを追加。共有ユーティリティ `openClaudeAppSession()` を新設して `window.open(url, "_blank")`（features 文字列なし）+ `opener=null` に統一し、`SessionList`/`PaneContainer` のインライン実装も置換。dev 実機（390×844 モバイルビューポート）でツールバー・リストのタップ選択メニュー双方が正しい URL を開くことを確認 (`frontend/src/App.tsx`, `frontend/src/utils/claude-app.ts`, `frontend/src/components/SessionList.tsx`, `frontend/src/components/PaneContainer.tsx`)
+
 ## [0.1.165] - 2026-05-31
 
 Remote Control が有効なセッションから、対応する Claude アプリのクラウドセッションへジャンプする導線を追加。

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.165",
+  "version": "0.1.166",
   "generated": "2026-05-31",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.165",
+  "version": "0.1.166",
   "generated": "2026-05-31",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.165",
+  "version": "0.1.166",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes

- fix(sessions): 「Claudeアプリで開く」がモバイルで表示されない/開けない不具合を修正 (#303)
  - モバイルツールバーにボタン追加 + `bridgeSessionId` をモバイル経路へ透過、window.open の features 文字列を除去（モバイル Safari のポップアップブロック回避）

## Notes

dev 実機（390×844 モバイルビューポート）+ adversarial review 検証済み。CHANGELOG 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)