### PR TITLE
Release v0.1.169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.169] - 2026-06-05
+
+モバイル Web UI: セッション操作バーのアイコンを押しやすく。
+
+### Fixed
+- **モバイル: セッション操作バー（overlayBar）のアイコンがタップしづらい問題を修正**: タップ領域を ~40px → ~44px（iOS 推奨最小）へ拡大し、アイコン色を明るく（zinc-500 → zinc-300）して視認性を改善。幅のはみ出し対策として右アクション群を `shrink-0`、セッション名の最大幅を 140px → 84px に調整（`frontend/src/App.tsx`）
+
 ## [0.1.168] - 2026-06-04
 
 `cchub tui` の改善: カード形式の一覧・縦スクロール・1キーで戻る・`/compact` 送信。

--- a/architecture.html
+++ b/architecture.html
@@ -113,8 +113,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.168",
-  "generated": "2026-06-04",
+  "version": "0.1.169",
+  "generated": "2026-06-05",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.168",
-  "generated": "2026-06-04",
+  "version": "0.1.169",
+  "generated": "2026-06-05",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -979,7 +979,7 @@ export function App() {
 								: "bg-zinc-600"
 					}`}
 				/>
-				<span className="text-[13px] font-medium text-white truncate max-w-[140px]">
+				<span className="text-[13px] font-medium text-white truncate max-w-[84px]">
 					{activeSession?.name || "-"}
 				</span>
 				<ChevronDown className="w-3 h-3 text-zinc-500" />
@@ -988,13 +988,13 @@ export function App() {
 			<div className="flex-1" />
 
 			{/* Right: Core actions */}
-			<div className="flex items-center gap-1">
+			<div className="flex items-center gap-1 shrink-0">
 				{activeSession?.ccSessionId &&
 					(showConversation ? (
 						<button
 							type="button"
 							onClick={() => setShowConversation(false)}
-							className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
+							className="p-3 text-zinc-300 hover:text-white active:text-white transition-colors"
 							title="ターミナルに切替"
 							aria-label="Switch to Terminal"
 							data-onboarding="conversation"
@@ -1005,7 +1005,7 @@ export function App() {
 						<button
 							type="button"
 							onClick={handleShowConversation}
-							className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
+							className="p-3 text-zinc-300 hover:text-white active:text-white transition-colors"
 							title="会話履歴に切替"
 							aria-label="Switch to Chat"
 							data-onboarding="conversation"
@@ -1020,7 +1020,7 @@ export function App() {
 							const id = activeSession.bridgeSessionId;
 							if (id) openClaudeAppSession(id);
 						}}
-						className="p-2.5 text-violet-400/80 hover:text-violet-300 active:text-violet-200 transition-colors"
+						className="p-3 text-violet-400 hover:text-violet-300 active:text-violet-200 transition-colors"
 						title={t("session.openInClaudeApp")}
 						aria-label={t("session.openInClaudeApp")}
 					>
@@ -1038,7 +1038,7 @@ export function App() {
 							apiSessions.find((s) => s.id === activeSessionId)?.peerId;
 						openFileViewer(activeSession?.currentPath || "/", peerId);
 					}}
-					className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
+					className="p-3 text-zinc-300 hover:text-white active:text-white transition-colors"
 					title="ファイルブラウザ"
 					data-onboarding="file-browser"
 				>
@@ -1047,7 +1047,7 @@ export function App() {
 				<button
 					type="button"
 					onClick={() => setShowMobileDashboard(true)}
-					className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
+					className="p-3 text-zinc-300 hover:text-white active:text-white transition-colors"
 					title="ダッシュボード"
 				>
 					<BarChart3 className="w-5 h-5" />
@@ -1055,7 +1055,7 @@ export function App() {
 				<button
 					type="button"
 					onClick={handleReload}
-					className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
+					className="p-3 text-zinc-300 hover:text-white active:text-white transition-colors"
 					title="リロード"
 					data-onboarding="reload"
 				>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.168",
+  "version": "0.1.169",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(mobile): セッション操作バー（overlayBar）のアイコンを押しやすく（タップ領域 40→44px、視認性向上、はみ出し対策）

## Notes
- ユーザ報告「操作アイコンが小さくて押せない」への対応。実機タップ感はモバイルで確認予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)