### PR TITLE
Release v0.1.170

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.170] - 2026-06-05
+
+`cchub tui` で attach 後にトラックパッドスクロールが入力履歴ナビになる問題を修正。
+
+### Fixed
+- **`cchub tui`: attach 後のトラックパッドスクロールが Claude Code の入力履歴ナビに化ける問題を修正**: web UI (`tmux -CC`) は attach 時にセッション単位で `mouse off` を立てるため、その後 `cchub tui` から `tmux attach` するとセッションは mouse off のまま。alt-screen 中のホスト端末（iTerm/Terminal.app）は wheel を ↑/↓ キーに変換し、Claude Code (Ink) がそれを履歴ナビとして拾っていた。`cchub tui` の attach 前に `set-option mouse on`、detach 後に元の値へ復元するようにし、attach 中は tmux が wheel を copy-mode スクロールに振り向け、ホスト端末も wheel→arrow 変換を停止する（`tui/src/tmux/attach.ts`）
+
 ## [0.1.169] - 2026-06-05
 
 モバイル Web UI: セッション操作バーのアイコンを押しやすく。

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.169",
+  "version": "0.1.170",
   "generated": "2026-06-05",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.169",
+  "version": "0.1.170",
   "generated": "2026-06-05",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.169",
+  "version": "0.1.170",
   "private": true,
   "workspaces": [
     "backend",

--- a/tui/src/tmux/attach.ts
+++ b/tui/src/tmux/attach.ts
@@ -46,10 +46,10 @@ function runTmux(args: string[]): void {
   }
 }
 
-/** セッションの status-right を取得（未設定なら null）。 */
-function captureStatusRight(sessionName: string): string | null {
+/** セッションのオプション値を取得（未設定なら null）。 */
+function captureOption(sessionName: string, name: string): string | null {
   try {
-    const proc = Bun.spawnSync(['tmux', 'show-options', '-t', sessionName, '-v', 'status-right'], {
+    const proc = Bun.spawnSync(['tmux', 'show-options', '-t', sessionName, '-v', name], {
       stdout: 'pipe',
       stderr: 'ignore',
     });
@@ -73,8 +73,16 @@ export function attachSession(sessionName: string, tmuxEnv: string | undefined =
   for (const args of preAttachCommands(sessionName)) runTmux(args);
 
   // 入室中は status バーに戻り方を常時表示（元の値を退避して復帰後に戻す）。
-  const originalStatusRight = captureStatusRight(sessionName);
+  const originalStatusRight = captureOption(sessionName, 'status-right');
   runTmux(['set-option', '-t', sessionName, 'status-right', ` ${RETURN_KEY} で cchub の一覧へ戻る `]);
+
+  // mouse を on にして、ホスト端末が alt-screen で wheel を ↑/↓ に変換して
+  // Claude Code (Ink) の入力履歴ナビにすり替わるのを防ぐ。tmux がマウスを掴めば
+  // wheel は tmux 自身の copy-mode スクロールに行き、ホスト端末も wheel→arrow
+  // 変換をやめる。web UI (tmux -CC) 側は attach 時に mouse off を明示するので
+  // ここでの設定は web 側に影響しない（detach 後は元の値へ復元する）。
+  const originalMouse = captureOption(sessionName, 'mouse');
+  runTmux(['set-option', '-t', sessionName, 'mouse', 'on']);
 
   Bun.spawnSync([plan.command, ...plan.args], {
     stdio: ['inherit', 'inherit', 'inherit'],
@@ -84,4 +92,8 @@ export function attachSession(sessionName: string, tmuxEnv: string | undefined =
   // status-right を元へ戻す（未設定だったら継承に戻す）。
   if (originalStatusRight === null) runTmux(['set-option', '-t', sessionName, '-u', 'status-right']);
   else runTmux(['set-option', '-t', sessionName, 'status-right', originalStatusRight]);
+
+  // mouse 設定を元へ戻す。
+  if (originalMouse === null) runTmux(['set-option', '-t', sessionName, '-u', 'mouse']);
+  else runTmux(['set-option', '-t', sessionName, 'mouse', originalMouse]);
 }


### PR DESCRIPTION
## Changes

### Fixed
- **`cchub tui`: attach 後のトラックパッドスクロールが Claude Code の入力履歴ナビに化ける問題を修正**: web UI (`tmux -CC`) は attach 時にセッション単位で `mouse off` を立てるため、その後 `cchub tui` から `tmux attach` するとセッションは mouse off のまま。alt-screen 中のホスト端末は wheel を ↑/↓ キーに変換し、Claude Code (Ink) がそれを履歴ナビとして拾っていた。`cchub tui` の attach 前に `set-option mouse on`、detach 後に元の値へ復元するようにし、attach 中は tmux が wheel を copy-mode スクロールに振り向け、ホスト端末も wheel→arrow 変換を停止する（`tui/src/tmux/attach.ts`）

## Notes
- 既存の `captureStatusRight` を汎用化 (`captureOption(name)`) し、`mouse` も同じ save/restore パターンを適用
- web UI (`tmux -CC`) は attach 時に `mouse off` を必ず再設定するため、本変更は web UI 側に副作用なし
- 手元の dev 環境（`bun tui/src/index.ts`）でトラックパッドスクロールが履歴ナビに化けないこと、tmux copy-mode に入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)