### PR TITLE
fix(files): Markdown画像のpeer対応 ＆ バイナリのbase64流し込み防止

### DIFF
--- a/frontend/src/components/files/FileContentView.tsx
+++ b/frontend/src/components/files/FileContentView.tsx
@@ -1,3 +1,5 @@
+import { Download, FileText } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import type { FileChange, FileContent } from "../../../../shared/types";
 import type { SelectedGitDiff, ViewMode } from "../../hooks/useViewHistory";
 import { CodeViewer } from "./CodeViewer";
@@ -29,6 +31,10 @@ interface FileContentViewProps {
 	/** Switch a markdown/html source view into preview mode. */
 	onEnablePreview: () => void;
 	sessionWorkingDir: string;
+	/** API prefix matching the peer (`/api/files` or `/api/peers/<id>/files`). */
+	filesApiBase: string;
+	/** Download the current file (used by the binary placeholder). */
+	onDownload?: () => void;
 }
 
 function MediaContent({
@@ -68,6 +74,37 @@ function MediaContent({
 	);
 }
 
+function BinaryPlaceholder({
+	file,
+	onDownload,
+}: {
+	file: FileContent;
+	onDownload?: () => void;
+}) {
+	const { t } = useTranslation();
+	return (
+		<div className="flex flex-col items-center justify-center h-full gap-3 p-6 text-th-text-muted">
+			<FileText className="w-12 h-12" strokeWidth={1.5} />
+			<div className="text-center">
+				<div className="text-sm text-th-text-secondary break-all">
+					{getFileName(file.path)}
+				</div>
+				<div className="text-xs mt-1">{t("files.binaryNotSupported")}</div>
+			</div>
+			{onDownload && (
+				<button
+					type="button"
+					onClick={onDownload}
+					className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded bg-th-surface-hover hover:bg-th-surface-active text-th-text transition-colors"
+				>
+					<Download className="w-4 h-4" />
+					{t("files.download")}
+				</button>
+			)}
+		</div>
+	);
+}
+
 /**
  * The single source of truth for rendering file/diff content. Both the
  * wide (two-pane) and mobile (single-pane) layouts of FileViewer render this,
@@ -86,6 +123,8 @@ export function FileContentView({
 	onCopyPrompt,
 	onEnablePreview,
 	sessionWorkingDir,
+	filesApiBase,
+	onDownload,
 }: FileContentViewProps) {
 	if (viewMode === "file" && selectedFile) {
 		const path = selectedFile.path;
@@ -115,6 +154,7 @@ export function FileContentView({
 					onScrollRatioChange={onScrollRatioChange}
 					filePath={path}
 					sessionWorkingDir={sessionWorkingDir}
+					filesApiBase={filesApiBase}
 				/>
 			);
 		}
@@ -123,6 +163,12 @@ export function FileContentView({
 			return (
 				<HtmlViewer content={selectedFile.content} fileName={getFileName(path)} />
 			);
+		}
+
+		// Non-image binary (PDF/zip/…): the backend returns base64. Don't dump it
+		// into the code viewer — offer a download instead.
+		if (selectedFile.encoding === "base64") {
+			return <BinaryPlaceholder file={selectedFile} onDownload={onDownload} />;
 		}
 
 		return (

--- a/frontend/src/components/files/FileViewer.tsx
+++ b/frontend/src/components/files/FileViewer.tsx
@@ -680,6 +680,8 @@ export function FileViewer({
 											onCopyPrompt={onCopyPrompt}
 											onEnablePreview={enablePreviewMode}
 											sessionWorkingDir={sessionWorkingDir}
+											filesApiBase={filesApiBase}
+											onDownload={handleDownloadFile}
 										/>
 									</div>
 								</>
@@ -752,6 +754,8 @@ export function FileViewer({
 							onCopyPrompt={onCopyPrompt}
 							onEnablePreview={enablePreviewMode}
 							sessionWorkingDir={sessionWorkingDir}
+							filesApiBase={filesApiBase}
+							onDownload={handleDownloadFile}
 						/>
 					)}
 

--- a/frontend/src/components/files/MarkdownViewer.tsx
+++ b/frontend/src/components/files/MarkdownViewer.tsx
@@ -18,10 +18,13 @@ interface MarkdownViewerProps {
 	onScrollRatioChange?: (ratio: number) => void;
 	filePath?: string;
 	sessionWorkingDir?: string;
+	/** API prefix matching the peer (`/api/files` or `/api/peers/<id>/files`). */
+	filesApiBase?: string;
 }
 
 function resolveImageSrc(
 	src: string,
+	filesApiBase: string,
 	filePath?: string,
 	sessionWorkingDir?: string,
 ): string {
@@ -42,7 +45,7 @@ function resolveImageSrc(
 		}
 		absPath = parts.join("/");
 	}
-	return `/api/files/raw?path=${encodeURIComponent(absPath)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`;
+	return `${filesApiBase}/raw?path=${encodeURIComponent(absPath)}&sessionWorkingDir=${encodeURIComponent(sessionWorkingDir)}`;
 }
 
 export function MarkdownViewer({
@@ -52,6 +55,7 @@ export function MarkdownViewer({
 	onScrollRatioChange,
 	filePath,
 	sessionWorkingDir,
+	filesApiBase = "/api/files",
 }: MarkdownViewerProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const { fontSize, setFontSize, commitFontSize, resetFontSize } =
@@ -187,6 +191,7 @@ export function MarkdownViewer({
 						<img
 							src={resolveImageSrc(
 								typeof src === "string" ? src : "",
+								filesApiBase,
 								filePath,
 								sessionWorkingDir,
 							)}
@@ -214,7 +219,7 @@ export function MarkdownViewer({
 				{content}
 			</ReactMarkdown>
 		),
-		[content, filePath, sessionWorkingDir],
+		[content, filePath, sessionWorkingDir, filesApiBase],
 	);
 
 	return (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -176,7 +176,9 @@
 		"reload": "Reload",
 		"listView": "List view",
 		"treeView": "Tree view",
-		"changedFiles": "Changed Files"
+		"changedFiles": "Changed Files",
+		"download": "Download",
+		"binaryNotSupported": "Binary file — preview not supported"
 	},
 	"conversation": {
 		"title": "Conversation",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -176,7 +176,9 @@
 		"reload": "リロード",
 		"listView": "一覧表示",
 		"treeView": "ツリー表示",
-		"changedFiles": "変更ファイル"
+		"changedFiles": "変更ファイル",
+		"download": "ダウンロード",
+		"binaryNotSupported": "バイナリファイルはプレビューできません"
 	},
 	"conversation": {
 		"title": "会話",


### PR DESCRIPTION
## 概要

#313 の実装。ファイルViewer のバグ2件を修正。

## 1. Markdown画像の peer 対応

`MarkdownViewer.resolveImageSrc` が `/api/files/raw` を固定しており、remote peer のセッションで Markdown 内画像が 404/401 になっていた。`filesApiBase`（`/api/peers/<id>/files`）を FileContentView → MarkdownViewer へ渡して解決。

## 2. 非画像バイナリの base64 流し込み防止

backend は非テキストを base64 で返すが、frontend はガードが無く CodeViewer に流していた（PDF/zip 等が base64 ダンプ表示）。FileContentView で `encoding === "base64"` の場合、バイナリプレースホルダ（プレビュー不可＋ダウンロード）を表示（image/media はその前段で処理済み）。

## 受け入れ条件

- [x] remote peer で Markdown 内のローカル画像が表示される（URLを filesApiBase 経由に。local 回帰なしを実機確認、peer はURL構築で担保）
- [x] PDF/バイナリを開いても base64 ダンプにならずプレースホルダ＋ダウンロード導線
- [x] `bun run lint` パス／`tsgo --noEmit` EXIT=0
- [x] dev環境で実機確認

## 検証（dev 5173/3456）

- `binary-test.bin` → BinaryPlaceholder（「バイナリファイルはプレビューできません」＋ダウンロードボタン）、base64ダンプ無し
- `img-test.md` → Preview → 画像が `/api/files/raw?path=.../sample.png` 経由で `complete=true`（ロード成功）

i18n: `files.download` / `files.binaryNotSupported` を ja/en に追加。

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)