### PR TITLE
Release v0.1.172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.172] - 2026-06-06
+
+モバイルのファイルViewer フッターのタップ性改善 ＋ アーキテクチャ情報の更新。
+
+### Fixed
+- **モバイル: ファイルViewer フッターのボタンが小さく操作しづらい問題を改善**: Row1 のアイコンボタン（戻る / アップロード / 隠しファイル / ダウンロード / 閉じる）を下段セッションバー並み（`p-1.5`→`p-2.5`、アイコン 16px→20px）に拡大し、タブ・Source/Preview を `text-sm` 化。横幅対策にタイトル幅を 120px→84px に詰め、overflow なしを実機確認（`frontend/src/components/files/FileViewer.tsx`）
+
+### Changed
+- **architecture: ファイルViewer 脱モノリス (#311-#314) を反映**: 新規 `FileContentView` / `ChangesView` コンポーネントと `useViewerSettings` / `usePinchZoom` / `useScrollRatio` / `useViewHistory` フックを追加し、FileViewer / CodeViewer / DiffViewer / MarkdownViewer の説明と親子関係を更新（`architecture.json`, `architecture.html`）
+
 ## [0.1.171] - 2026-06-05
 
 ファイルViewer の作り込み（Phase 1-4）。共通化による脱モノリス・重複解消に加え、Markdown画像の peer 対応・バイナリ表示ガード・i18n 配線を実施。

--- a/architecture.html
+++ b/architecture.html
@@ -113,8 +113,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.171",
-  "generated": "2026-06-05",
+  "version": "0.1.172",
+  "generated": "2026-06-06",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",
@@ -862,9 +862,10 @@
       {
         "name": "FileViewer",
         "file": "frontend/src/components/files/FileViewer.tsx",
-        "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude 変更 / Git 変更トグル、ブラウザ履歴ナビ、アップロード / ダウンロード、動画 / 音声再生。v0.1.108 で選択ファイル highlight + スクロール保持を実装",
+        "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。脱モノリスでレイアウト + 状態のオーケストレーションに縮小し、描画分岐は FileContentView、変更一覧は ChangesView、戻るナビは useViewHistory に分離 (#312)。Claude / Git 変更トグル、アップロード / ダウンロード、wide(2ペイン) / mobile(1ペイン) の 2 レイアウト",
         "hooks": [
-          "useFileViewer"
+          "useFileViewer",
+          "useViewHistory"
         ],
         "parents": [
           "DesktopLayout",
@@ -881,21 +882,46 @@
         ]
       },
       {
-        "name": "CodeViewer",
-        "file": "frontend/src/components/files/CodeViewer.tsx",
-        "summary": "シンタックスハイライト付きコード表示",
+        "name": "FileContentView",
+        "file": "frontend/src/components/files/FileContentView.tsx",
+        "summary": "image / media / markdown / html / code / diff の描画スイッチを 1 箇所に集約し、wide / mobile 両レイアウトから呼ぶ。非画像バイナリ (encoding=base64) はプレビュー不可プレースホルダ + ダウンロードに振り分け (#312 / #313)",
         "hooks": [],
         "parents": [
           "FileViewer"
         ]
       },
       {
-        "name": "DiffViewer",
-        "file": "frontend/src/components/files/DiffViewer.tsx",
-        "summary": "ファイル変更のサイドバイサイド diff 表示",
+        "name": "ChangesView",
+        "file": "frontend/src/components/files/ChangesView.tsx",
+        "summary": "Claude 変更 / Git 変更の一覧 (list / tree 表示)。TreeView / buildTree / gitStatusLabel を内包し、FileViewer 末尾から分離 (#312)",
         "hooks": [],
         "parents": [
           "FileViewer"
+        ]
+      },
+      {
+        "name": "CodeViewer",
+        "file": "frontend/src/components/files/CodeViewer.tsx",
+        "summary": "シンタックスハイライト付きコード表示。設定 (word-wrap / font-size)・ピンチズーム・スクロール復元を共通フックに、ハイライトを utils/highlight に委譲 (#311)",
+        "hooks": [
+          "useViewerSettings",
+          "usePinchZoom",
+          "useScrollRatio"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "DiffViewer",
+        "file": "frontend/src/components/files/DiffViewer.tsx",
+        "summary": "ファイル変更のサイドバイサイド diff 表示。共通化に伴い font-size / ピンチズームを追加し、word-wrap・ハイライトを 3 ビューアで統一 (#311)",
+        "hooks": [
+          "useViewerSettings",
+          "usePinchZoom"
+        ],
+        "parents": [
+          "FileContentView"
         ]
       },
       {
@@ -904,16 +930,20 @@
         "summary": "画像プレビュー + ズーム (/files/raw ストリーミング利用)",
         "hooks": [],
         "parents": [
-          "FileViewer"
+          "FileContentView"
         ]
       },
       {
         "name": "MarkdownViewer",
         "file": "frontend/src/components/files/MarkdownViewer.tsx",
-        "summary": "Markdown レンダリング",
-        "hooks": [],
+        "summary": "Markdown レンダリング。共通フックで font-size / ピンチズーム / スクロール復元を統一 (#311)。画像 src は filesApiBase 経由で remote peer に対応 (#313)",
+        "hooks": [
+          "useViewerSettings",
+          "usePinchZoom",
+          "useScrollRatio"
+        ],
         "parents": [
-          "FileViewer"
+          "FileContentView"
         ]
       },
       {
@@ -922,7 +952,7 @@
         "summary": "HTML ファイルを iframe でレンダリング",
         "hooks": [],
         "parents": [
-          "FileViewer"
+          "FileContentView"
         ]
       },
       {
@@ -931,7 +961,8 @@
         "summary": "コードビューアで選択した行をプロンプトとしてフォーマットして送信する UI パネル",
         "hooks": [],
         "parents": [
-          "FileViewer"
+          "CodeViewer",
+          "DiffViewer"
         ]
       },
       {
@@ -987,6 +1018,26 @@
         "name": "useFileViewer",
         "file": "frontend/src/hooks/useFileViewer.ts",
         "summary": "ファイルビューア状態管理 (listDirectory / readFile / getGitDiff 等の API 呼び出しラップ)"
+      },
+      {
+        "name": "useViewerSettings",
+        "file": "frontend/src/hooks/useViewerSettings.ts",
+        "summary": "ファイル別 word-wrap + グローバル font-size を localStorage 永続化で一元管理 (3 ビューア共通) (#311)"
+      },
+      {
+        "name": "usePinchZoom",
+        "file": "frontend/src/hooks/usePinchZoom.ts",
+        "summary": "2 本指ピンチでフォントサイズを変更 (リスナーは要素ライフタイムに 1 度だけバインド) (#311)"
+      },
+      {
+        "name": "useScrollRatio",
+        "file": "frontend/src/hooks/useScrollRatio.ts",
+        "summary": "マウント時に scroll 比を復元し、スクロールに応じて親へ ratio を通知 (#311)"
+      },
+      {
+        "name": "useViewHistory",
+        "file": "frontend/src/hooks/useViewHistory.ts",
+        "summary": "ファイルビューアの戻るナビ。window.history と同期した view スタックで、ブラウザバック / Escape / アプリ内戻るを処理 (#312)"
       },
       {
         "name": "useAuth",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.171",
-  "generated": "2026-06-05",
+  "version": "0.1.172",
+  "generated": "2026-06-06",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",
@@ -749,9 +749,10 @@
       {
         "name": "FileViewer",
         "file": "frontend/src/components/files/FileViewer.tsx",
-        "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude 変更 / Git 変更トグル、ブラウザ履歴ナビ、アップロード / ダウンロード、動画 / 音声再生。v0.1.108 で選択ファイル highlight + スクロール保持を実装",
+        "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。脱モノリスでレイアウト + 状態のオーケストレーションに縮小し、描画分岐は FileContentView、変更一覧は ChangesView、戻るナビは useViewHistory に分離 (#312)。Claude / Git 変更トグル、アップロード / ダウンロード、wide(2ペイン) / mobile(1ペイン) の 2 レイアウト",
         "hooks": [
-          "useFileViewer"
+          "useFileViewer",
+          "useViewHistory"
         ],
         "parents": [
           "DesktopLayout",
@@ -768,21 +769,46 @@
         ]
       },
       {
-        "name": "CodeViewer",
-        "file": "frontend/src/components/files/CodeViewer.tsx",
-        "summary": "シンタックスハイライト付きコード表示",
+        "name": "FileContentView",
+        "file": "frontend/src/components/files/FileContentView.tsx",
+        "summary": "image / media / markdown / html / code / diff の描画スイッチを 1 箇所に集約し、wide / mobile 両レイアウトから呼ぶ。非画像バイナリ (encoding=base64) はプレビュー不可プレースホルダ + ダウンロードに振り分け (#312 / #313)",
         "hooks": [],
         "parents": [
           "FileViewer"
         ]
       },
       {
-        "name": "DiffViewer",
-        "file": "frontend/src/components/files/DiffViewer.tsx",
-        "summary": "ファイル変更のサイドバイサイド diff 表示",
+        "name": "ChangesView",
+        "file": "frontend/src/components/files/ChangesView.tsx",
+        "summary": "Claude 変更 / Git 変更の一覧 (list / tree 表示)。TreeView / buildTree / gitStatusLabel を内包し、FileViewer 末尾から分離 (#312)",
         "hooks": [],
         "parents": [
           "FileViewer"
+        ]
+      },
+      {
+        "name": "CodeViewer",
+        "file": "frontend/src/components/files/CodeViewer.tsx",
+        "summary": "シンタックスハイライト付きコード表示。設定 (word-wrap / font-size)・ピンチズーム・スクロール復元を共通フックに、ハイライトを utils/highlight に委譲 (#311)",
+        "hooks": [
+          "useViewerSettings",
+          "usePinchZoom",
+          "useScrollRatio"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "DiffViewer",
+        "file": "frontend/src/components/files/DiffViewer.tsx",
+        "summary": "ファイル変更のサイドバイサイド diff 表示。共通化に伴い font-size / ピンチズームを追加し、word-wrap・ハイライトを 3 ビューアで統一 (#311)",
+        "hooks": [
+          "useViewerSettings",
+          "usePinchZoom"
+        ],
+        "parents": [
+          "FileContentView"
         ]
       },
       {
@@ -791,16 +817,20 @@
         "summary": "画像プレビュー + ズーム (/files/raw ストリーミング利用)",
         "hooks": [],
         "parents": [
-          "FileViewer"
+          "FileContentView"
         ]
       },
       {
         "name": "MarkdownViewer",
         "file": "frontend/src/components/files/MarkdownViewer.tsx",
-        "summary": "Markdown レンダリング",
-        "hooks": [],
+        "summary": "Markdown レンダリング。共通フックで font-size / ピンチズーム / スクロール復元を統一 (#311)。画像 src は filesApiBase 経由で remote peer に対応 (#313)",
+        "hooks": [
+          "useViewerSettings",
+          "usePinchZoom",
+          "useScrollRatio"
+        ],
         "parents": [
-          "FileViewer"
+          "FileContentView"
         ]
       },
       {
@@ -809,7 +839,7 @@
         "summary": "HTML ファイルを iframe でレンダリング",
         "hooks": [],
         "parents": [
-          "FileViewer"
+          "FileContentView"
         ]
       },
       {
@@ -818,7 +848,8 @@
         "summary": "コードビューアで選択した行をプロンプトとしてフォーマットして送信する UI パネル",
         "hooks": [],
         "parents": [
-          "FileViewer"
+          "CodeViewer",
+          "DiffViewer"
         ]
       },
       {
@@ -874,6 +905,26 @@
         "name": "useFileViewer",
         "file": "frontend/src/hooks/useFileViewer.ts",
         "summary": "ファイルビューア状態管理 (listDirectory / readFile / getGitDiff 等の API 呼び出しラップ)"
+      },
+      {
+        "name": "useViewerSettings",
+        "file": "frontend/src/hooks/useViewerSettings.ts",
+        "summary": "ファイル別 word-wrap + グローバル font-size を localStorage 永続化で一元管理 (3 ビューア共通) (#311)"
+      },
+      {
+        "name": "usePinchZoom",
+        "file": "frontend/src/hooks/usePinchZoom.ts",
+        "summary": "2 本指ピンチでフォントサイズを変更 (リスナーは要素ライフタイムに 1 度だけバインド) (#311)"
+      },
+      {
+        "name": "useScrollRatio",
+        "file": "frontend/src/hooks/useScrollRatio.ts",
+        "summary": "マウント時に scroll 比を復元し、スクロールに応じて親へ ratio を通知 (#311)"
+      },
+      {
+        "name": "useViewHistory",
+        "file": "frontend/src/hooks/useViewHistory.ts",
+        "summary": "ファイルビューアの戻るナビ。window.history と同期した view スタックで、ブラウザバック / Escape / アプリ内戻るを処理 (#312)"
       },
       {
         "name": "useAuth",

--- a/frontend/src/components/files/FileViewer.tsx
+++ b/frontend/src/components/files/FileViewer.tsx
@@ -789,11 +789,11 @@ export function FileViewer({
 							<button
 								type="button"
 								onClick={handleBack}
-								className="p-1.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 rounded transition-colors"
+								className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 rounded transition-colors"
 							>
-								<ArrowLeft className="w-4 h-4" />
+								<ArrowLeft className="w-5 h-5" />
 							</button>
-							<h2 className="text-[13px] font-medium text-zinc-300 truncate max-w-[120px]">
+							<h2 className="text-[13px] font-medium text-zinc-300 truncate max-w-[84px]">
 								{viewMode === "browser"
 									? t("files.title")
 									: viewMode === "changes"
@@ -812,7 +812,7 @@ export function FileViewer({
 								<button
 									type="button"
 									onClick={handleShowBrowser}
-									className={`px-2.5 py-1 text-xs rounded font-medium transition-colors ${
+									className={`px-2.5 py-1.5 text-sm rounded font-medium transition-colors ${
 										viewMode === "browser" || viewMode === "file"
 											? "bg-white/[0.08] text-zinc-300"
 											: "text-zinc-600 hover:text-zinc-400"
@@ -823,7 +823,7 @@ export function FileViewer({
 								<button
 									type="button"
 									onClick={handleShowChanges}
-									className={`px-2.5 py-1 text-xs rounded font-medium transition-colors ${
+									className={`px-2.5 py-1.5 text-sm rounded font-medium transition-colors ${
 										viewMode === "changes" || viewMode === "diff"
 											? "bg-white/[0.08] text-zinc-300"
 											: "text-zinc-600 hover:text-zinc-400"
@@ -841,7 +841,7 @@ export function FileViewer({
 									<button
 										type="button"
 										onClick={togglePreviewMode}
-										className={`px-2.5 py-1 text-xs rounded font-medium transition-colors ${previewMode ? "bg-blue-600 text-white" : "bg-white/[0.04] hover:bg-white/[0.08] text-zinc-500"}`}
+										className={`px-2.5 py-1.5 text-sm rounded font-medium transition-colors ${previewMode ? "bg-blue-600 text-white" : "bg-white/[0.04] hover:bg-white/[0.08] text-zinc-500"}`}
 									>
 										{previewMode ? t("files.source") : t("files.preview")}
 									</button>
@@ -854,14 +854,14 @@ export function FileViewer({
 										type="button"
 										onClick={handleUploadClick}
 										disabled={uploading}
-										className="p-1.5 rounded text-zinc-500 hover:text-zinc-300 transition-colors disabled:opacity-50"
+										className="p-2.5 rounded text-zinc-500 hover:text-zinc-300 transition-colors disabled:opacity-50"
 										title={
 											uploading
 												? t("files.uploading")
 												: t("files.uploadTo", { path: currentPath })
 										}
 									>
-										<Upload className="w-4 h-4" />
+										<Upload className="w-5 h-5" />
 									</button>
 									<input
 										ref={uploadInputRef}
@@ -873,13 +873,13 @@ export function FileViewer({
 									<button
 										type="button"
 										onClick={() => setShowHidden(!showHidden)}
-										className={`p-1.5 rounded transition-colors ${showHidden ? "bg-blue-600 text-white" : "text-zinc-500 hover:text-zinc-300"}`}
+										className={`p-2.5 rounded transition-colors ${showHidden ? "bg-blue-600 text-white" : "text-zinc-500 hover:text-zinc-300"}`}
 										title={t("files.showHidden")}
 									>
 										{showHidden ? (
-											<Eye className="w-4 h-4" />
+											<Eye className="w-5 h-5" />
 										) : (
-											<EyeOff className="w-4 h-4" />
+											<EyeOff className="w-5 h-5" />
 										)}
 									</button>
 								</>
@@ -890,10 +890,10 @@ export function FileViewer({
 								<button
 									type="button"
 									onClick={handleDownloadFile}
-									className="p-1.5 rounded text-zinc-500 hover:text-zinc-300 transition-colors"
+									className="p-2.5 rounded text-zinc-500 hover:text-zinc-300 transition-colors"
 									title={t("files.download")}
 								>
-									<Download className="w-4 h-4" />
+									<Download className="w-5 h-5" />
 								</button>
 							)}
 
@@ -901,9 +901,9 @@ export function FileViewer({
 							<button
 								type="button"
 								onClick={onClose}
-								className="p-1.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
+								className="p-2.5 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
 							>
-								<X className="w-4 h-4" />
+								<X className="w-5 h-5" />
 							</button>
 						</div>
 					</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.171",
+  "version": "0.1.172",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes

- **fix(mobile)**: ファイルViewer フッターのボタンを下段セッションバー並みに拡大（タップ領域 ~28px→~36px）。タブ・Source/Preview を text-sm 化、タイトル幅を詰めて overflow 回避
- **docs(architecture)**: ファイルViewer 脱モノリス (#311-#314) を `architecture.json` / `architecture.html` に反映（FileContentView/ChangesView + 4フック追加、viewer の summary・親子関係更新）

## Notes

- mobile フッターは dev（Tailscale ドメイン, 390px）で browser/file 両モード・overflow なしを実機確認
- architecture は JSON valid + html 再埋め込み（38196 chars）確認済み
- `bun run lint` / `tsgo --noEmit` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)