### PR TITLE
Release v0.1.173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.173] - 2026-06-06
+
+`cchub tui` に popup サイドバー機能を追加。attach 中でもセッション一覧を即座に呼び出せるように。
+
+### Added
+- **TUI: popup モード (`cchub tui --popup`)**: tmux `display-popup` から呼び出される単発モード。Enter で `tmux switch-client` してそのまま終了するので popup が自動で閉じる（`tui/src/index.ts`, `tui/src/tmux/attach.ts`）
+- **tmux F11 バインド (no-prefix)**: 左端 50col × 全高の popup サイドバーとして session list を表示。`CCHUB_TMUX_CONFIG` に同梱されサーバ起動時に自動 source される（`backend/src/services/tmux.ts`）
+- **tmux F12 バインド (no-prefix)**: detach-client（cchub TUI 一覧へ戻る）を `CCHUB_TMUX_CONFIG` 側にも追加。従来は attach 時に `preAttachCommands` で都度設定していたが、サーバレベルで常時有効に
+- **status-bar クリックボタン**: cchub TUI 経由で attach 中、status-right に `#[range=user|sessions,reverse] ≡ cchub` のクリック可能ボタンを表示。マウスクリックで F11 と同じ popup を開く。`MouseDown1Status` の `if-shell` フィルタで他の status クリックには影響しない（`tui/src/tmux/attach.ts`: `attachStatusRight`、`backend/src/services/tmux.ts`）
+
+### Notes
+- popup binding は `cchub` バイナリを PATH 経由で呼び出すため、本リリースを `cchub update` で適用したホストでのみ自動的に F11 / クリックボタンが有効になる
+- 既存の F12（一覧へ戻る）の挙動は変わらず
+
 ## [0.1.172] - 2026-06-06
 
 モバイルのファイルViewer フッターのタップ性改善 ＋ アーキテクチャ情報の更新。

--- a/architecture.html
+++ b/architecture.html
@@ -113,7 +113,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.172",
+  "version": "0.1.173",
   "generated": "2026-06-06",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.172",
+  "version": "0.1.173",
   "generated": "2026-06-06",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {

--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -28,6 +28,7 @@ interface CliOptions {
   sendWaitMs?: number;
   sendLines?: number;
   peekTarget?: string;
+  tuiPopup?: boolean;
 }
 
 function printHelp(): void {
@@ -79,6 +80,12 @@ send options:
 
 peek options:
   --lines <n>            Trailing rows to include in viewport (default 20)
+
+tui options:
+  --popup                One-shot mode for tmux display-popup: Enter switches
+                         the current client to the selected session and exits
+                         (the popup closes automatically). Bound to F11 by
+                         CC Hub's tmux config.
 
 ${t('cli.examples')}
   ${t('cli.exampleStart')}
@@ -144,6 +151,9 @@ export function parseArgs(args: string[]): CliOptions {
       }
       case 'tui':
         options.command = 'tui';
+        break;
+      case '--popup':
+        options.tuiPopup = true;
         break;
       case '--stdin':
         options.sendStdin = true;
@@ -371,7 +381,11 @@ async function runStatus(): Promise<void> {
 
 async function runTuiCommand(options: CliOptions): Promise<void> {
   const { runTui } = await import('./commands/tui');
-  await runTui({ port: options.port, host: options.host });
+  await runTui({
+    port: options.port,
+    host: options.host,
+    popup: options.tuiPopup ?? false,
+  });
 }
 
 async function runDebug(options: CliOptions): Promise<void> {

--- a/backend/src/commands/tui.ts
+++ b/backend/src/commands/tui.ts
@@ -9,11 +9,13 @@ import { startTui } from '../../../tui/src/index';
 export interface RunTuiOptions {
   port: number;
   host: string;
+  /** tmux の display-popup から呼ばれた場合の単発モード（switch-client → 終了）。 */
+  popup?: boolean;
 }
 
 export async function runTui(options: RunTuiOptions): Promise<void> {
   // `-H` の既定はサーバの bind 用 `0.0.0.0`。TUI は接続側なので localhost へ正規化する
   // （明示指定された host はそのまま尊重）。
   const host = options.host === '0.0.0.0' ? '127.0.0.1' : options.host;
-  await startTui({ port: options.port, host });
+  await startTui({ port: options.port, host, popup: options.popup ?? false });
 }

--- a/backend/src/services/tmux.ts
+++ b/backend/src/services/tmux.ts
@@ -54,6 +54,20 @@ set -g set-clipboard on
 
 # Keep panes alive after process exits (dead pane mode)
 set -g remain-on-exit on
+
+# F11 (no-prefix): show CC Hub session list as a left-edge popup sidebar.
+# Selecting a session calls switch-client; the popup closes automatically.
+bind-key -n F11 display-popup -E -B -w 50 -h "100%" -x 0 -y 0 "cchub tui --popup"
+
+# F12 (no-prefix): detach from the current session back to the cchub TUI list.
+# (Also re-applied per-attach by tui/src/tmux/attach.ts as a safety net.)
+bind-key -n F12 detach-client
+
+# Mouse click on status-bar "≡ cchub" button → open session popup.
+# The button itself (with #[range=user|sessions]) is set per-attach by
+# tui/src/tmux/attach.ts so we don't clobber the user's global status-right.
+# MouseDown1Status fires for any status click; if-shell filters by range name.
+bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},sessions}" "display-popup -E -B -w 50 -h 100% -x 0 -y 0 'cchub tui --popup'"
 `;
 
 /** Parsed process info from a single `ps` call, shared across consumers */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.172",
+  "version": "0.1.173",
   "private": true,
   "workspaces": [
     "backend",

--- a/tui/src/index.ts
+++ b/tui/src/index.ts
@@ -8,7 +8,7 @@ import { resolveToken } from './api/auth';
 import { type ApiClient, createClient } from './api/client';
 import { getSessions } from './api/sessions';
 import { Root } from './components/Root';
-import { attachSession } from './tmux/attach';
+import { attachSession, switchClient } from './tmux/attach';
 import type { ListAction } from './types';
 
 const ALT_ON = '\x1b[?1049h';
@@ -17,6 +17,12 @@ const ALT_OFF = '\x1b[?1049l';
 export interface StartTuiOptions {
   port: number;
   host: string;
+  /**
+   * popup モード: tmux の display-popup から呼ばれる前提。alt-screen はスキップし、
+   * Enter で `tmux switch-client` してそのまま 1 回で終了する（popup も同時に閉じる）。
+   * detach ループはしない。
+   */
+  popup?: boolean;
 }
 
 function isLocalHost(host: string): boolean {
@@ -101,7 +107,17 @@ export async function startTui(opts: StartTuiOptions): Promise<void> {
     process.exit(1);
   }
 
-  // alt-screen ループ: 一覧 → Enter で入室（alt 退出 → tmux attach 子プロセス → alt 復帰）→ q で終了。
+  // popup モード: display-popup 自身が overlay として描画される（独自の alt-screen 不要）。
+  // Enter で switch-client → popup は呼出側 client に紐付くので自動で閉じる。1 回で終了。
+  if (opts.popup) {
+    const action = await renderRootOnce(client, baseUrl, token);
+    if (action.type === 'attach') {
+      switchClient(action.sessionName);
+    }
+    return;
+  }
+
+  // 通常モード: alt-screen ループ。一覧 → Enter で入室（alt 退出 → tmux attach → alt 復帰）→ q で終了。
   process.on('exit', () => {
     try {
       process.stdout.write(ALT_OFF);
@@ -125,15 +141,17 @@ export async function startTui(opts: StartTuiOptions): Promise<void> {
   }
 }
 
-// `bun run src/index.ts [-p <port>] [-H <host>]` で直接起動された場合の引数処理。
+// `bun run src/index.ts [-p <port>] [-H <host>] [--popup]` で直接起動された場合の引数処理。
 if (import.meta.main) {
   const argv = process.argv.slice(2);
   let port = 5923;
   let host = '127.0.0.1';
+  let popup = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if ((a === '-p' || a === '--port') && argv[i + 1]) port = Number.parseInt(argv[++i], 10);
     else if ((a === '-H' || a === '--host') && argv[i + 1]) host = argv[++i];
+    else if (a === '--popup') popup = true;
   }
-  await startTui({ port, host });
+  await startTui({ port, host, popup });
 }

--- a/tui/src/tmux/__tests__/attach.test.ts
+++ b/tui/src/tmux/__tests__/attach.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { planAttach, preAttachCommands, RETURN_KEY } from '../attach';
+import {
+  attachStatusRight,
+  planAttach,
+  planSwitchClient,
+  preAttachCommands,
+  RETURN_KEY,
+} from '../attach';
 
 describe('planAttach', () => {
   test('非ネスト（TMUX 未設定）: そのまま attach', () => {
@@ -34,5 +40,30 @@ describe('preAttachCommands', () => {
   test('戻りキーは差し替え可能', () => {
     const cmds = preAttachCommands('s', 'F8');
     expect(cmds).toContainEqual(['bind-key', '-n', 'F8', 'detach-client']);
+  });
+});
+
+describe('attachStatusRight', () => {
+  test('クリック可能ボタン (range=user|sessions) + 戻りキーヒントを含む', () => {
+    const s = attachStatusRight();
+    expect(s).toContain('#[range=user|sessions');
+    expect(s).toContain('#[norange,default]');
+    expect(s).toContain('≡ cchub');
+    expect(s).toContain(`${RETURN_KEY} で一覧へ戻る`);
+  });
+
+  test('戻りキーは差し替え可能', () => {
+    expect(attachStatusRight('F8')).toContain('F8 で一覧へ戻る');
+  });
+});
+
+describe('planSwitchClient', () => {
+  test('preAttachCommands → switch-client の順で発行する', () => {
+    const cmds = planSwitchClient('proj-2');
+    // 末尾が switch-client（popup が閉じる前に事前 set-option を流し終える必要がある）
+    expect(cmds[cmds.length - 1]).toEqual(['switch-client', '-t', 'proj-2']);
+    // 事前設定も同じ列に含まれている
+    expect(cmds).toContainEqual(['set-option', '-t', 'proj-2', 'window-size', 'latest']);
+    expect(cmds).toContainEqual(['bind-key', '-n', RETURN_KEY, 'detach-client']);
   });
 });

--- a/tui/src/tmux/attach.ts
+++ b/tui/src/tmux/attach.ts
@@ -38,6 +38,16 @@ export function preAttachCommands(sessionName: string, returnKey: string = RETUR
   ];
 }
 
+/**
+ * 入室中に表示する status-right 文字列（純粋関数）。
+ * `#[range=user|sessions]` でクリック可能領域を定義する。CCHUB_TMUX_CONFIG 側の
+ * `MouseDown1Status` バインドが mouse_status_range='sessions' を検知して popup を開く。
+ * 反転表示でボタンであることを明示し、F12 ヒントも併記する。
+ */
+export function attachStatusRight(returnKey: string = RETURN_KEY): string {
+  return `#[range=user|sessions,reverse] ≡ cchub #[norange,default]  ${returnKey} で一覧へ戻る `;
+}
+
 function runTmux(args: string[]): void {
   try {
     Bun.spawnSync(['tmux', ...args], { stdout: 'ignore', stderr: 'ignore' });
@@ -60,6 +70,37 @@ function captureOption(sessionName: string, name: string): string | null {
   }
 }
 
+/**
+ * popup モード用に流す tmux コマンド列（純粋関数）:
+ *   preAttachCommands（サイズ追従 + 戻りキー）+ `switch-client -t <name>`。
+ * 順序が大事。switch-client が呼ばれた瞬間に popup は閉じる（= 呼出元プロセスが
+ * 子の終了で消える）ので、事前 set-option は switch-client より前に出すこと。
+ */
+export function planSwitchClient(sessionName: string): string[][] {
+  return [...preAttachCommands(sessionName), ['switch-client', '-t', sessionName]];
+}
+
+/**
+ * popup モード用: 既存の tmux クライアントを `sessionName` に切替える。
+ * `display-popup` の中から呼ばれる想定で、`switch-client` 完了と同時に popup は
+ * 閉じる（呼出側プロセス＝popupコマンドが終了する）。
+ *
+ * 戻り値は最後の tmux コマンド（switch-client）の exit code（成功=0）。
+ */
+export function switchClient(sessionName: string): number {
+  const plan = planSwitchClient(sessionName);
+  let lastCode = 0;
+  for (const args of plan) {
+    try {
+      const proc = Bun.spawnSync(['tmux', ...args], { stdout: 'pipe', stderr: 'pipe' });
+      lastCode = proc.exitCode ?? 1;
+    } catch {
+      lastCode = 1;
+    }
+  }
+  return lastCode;
+}
+
 /** 子プロセスを stdio 継承で起動し、detach（= RETURN_KEY 等）まで同期的に待つ。 */
 export function attachSession(sessionName: string, tmuxEnv: string | undefined = process.env.TMUX): void {
   const plan = planAttach(sessionName, tmuxEnv);
@@ -72,9 +113,10 @@ export function attachSession(sessionName: string, tmuxEnv: string | undefined =
   // サイズ追従 + 戻りキーを準備。
   for (const args of preAttachCommands(sessionName)) runTmux(args);
 
-  // 入室中は status バーに戻り方を常時表示（元の値を退避して復帰後に戻す）。
+  // 入室中は status バーに「≡ cchub」ボタン + 戻り方ヒントを表示（クリックで popup）。
+  // 元の値は退避して detach 後に復帰する。
   const originalStatusRight = captureOption(sessionName, 'status-right');
-  runTmux(['set-option', '-t', sessionName, 'status-right', ` ${RETURN_KEY} で cchub の一覧へ戻る `]);
+  runTmux(['set-option', '-t', sessionName, 'status-right', attachStatusRight()]);
 
   // mouse を on にして、ホスト端末が alt-screen で wheel を ↑/↓ に変換して
   // Claude Code (Ink) の入力履歴ナビにすり替わるのを防ぐ。tmux がマウスを掴めば


### PR DESCRIPTION
## Changes
- feat(tui): popup sidebar mode (`cchub tui --popup`) — Enter で switch-client、popup 自動close
- feat(tmux): F11 bind (no-prefix) で session list を左端 50col × 全高の popup として表示
- feat(tmux): F12 bind を `CCHUB_TMUX_CONFIG` 側にも追加（サーバ起動時から常時有効）
- feat(tmux): cchub TUI 経由で attach 中、status-right に `≡ cchub` クリック可能ボタン。`MouseDown1Status` + `if-shell` で他の status クリックには影響しない

## Notes
- 本リリースを `cchub update` で適用したホストでのみ F11 / クリックボタンが自動有効
- 既存の F12（一覧へ戻る）の挙動は変わらず

🤖 Generated with [Claude Code](https://claude.com/claude-code)