### PR TITLE
fix(sessions): pane list reachability for Remote Control + multi-window pane close

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -947,9 +947,12 @@ sessions.post('/:id/panes/close', async (c) => {
     return c.json({ error: 'Session not found' }, 404);
   }
 
-  // Check pane count - don't allow closing the last pane
+  // Check pane count - don't allow closing the last pane.
+  // Use `-s` so panes across ALL windows of the session are counted; without
+  // it tmux only lists the current window's panes, so a multi-window session
+  // (each window holding one pane) was mis-counted as 1 and wrongly refused.
   try {
-    const countProc = Bun.spawn(['tmux', 'list-panes', '-t', id, '-F', '#{pane_id}'], {
+    const countProc = Bun.spawn(['tmux', 'list-panes', '-s', '-t', id, '-F', '#{pane_id}'], {
       stdout: 'pipe',
       stderr: 'pipe',
     });

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -804,6 +804,12 @@ function SessionItem({
 		// terminal and opening the matching session in the Claude app.
 		if (session.bridgeSessionId) {
 			setShowJumpMenu((prev) => !prev);
+			// Multi-pane: also toggle the pane list so per-pane access (focus /
+			// close / split) stays reachable for Remote Control sessions instead
+			// of being shadowed by the jump menu's early return.
+			if (session.panes && session.panes.length > 1) {
+				setPanesExpanded((prev) => !prev);
+			}
 			return;
 		}
 


### PR DESCRIPTION
## 概要
セッション一覧の pane 操作に関する2件の不具合を修正。

## 修正
1. **2 paneでpaneにアクセスできない**（`41637d3` のデグレ）: Remote Control セッション（`bridgeSessionId` あり）を持つ複数paneセッションをタップすると jump menu のみ展開され、その下の pane一覧（focus/close/split）に到達できなくなっていた。`handleClick` の bridge 分岐で `panes>1` なら `setPanesExpanded` も実行し、jump menu と pane一覧の両方を展開する。
2. **close pane が効かない**（複数windowセッション・既存バグ）: 「最後のpaneは閉じない」ガードが `tmux list-panes -t <id>` で current window の pane しか数えず、複数window構成のセッション（各windowに1 pane）が count=1 と誤判定され、close が 400 で拒否されていた。`-s` を追加してセッション全体の pane を数える。

## 検証（dev実機 / モバイル）
- 修正1: 「開発起点 ~/repos」タップで jump menu と pane一覧が両方展開されることを確認
- 修正2: repos の pane を long press → 「閉じる」で実際に pane が消滅することを確認（tmux側でも `%50` 消滅を実証）
- `bun run lint`（backend）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)