### PR TITLE
Release v0.1.174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.174] - 2026-06-07
+
+セッション一覧の pane 操作の不具合を2件修正。
+
+### Fixed
+- **2 paneでpaneにアクセスできない**: Remote Control セッション（`bridgeSessionId` あり）の複数paneセッションをセッション一覧でタップすると jump menu のみ展開され、その下の pane一覧（各paneの focus / close / split）に到達できなくなっていた問題を修正。jump menu と pane一覧の両方を展開するようにした（`41637d3` のデグレ。`frontend/src/components/SessionList.tsx`）
+- **複数windowセッションで pane を閉じられない**: 「最後のpaneは閉じない」判定が `tmux list-panes -t <id>` で現在の window の pane しか数えず、複数window構成のセッション（各 window が1 pane）が誤って count=1 と判定され close が 400 で拒否されていた問題を修正。`-s` を付けてセッション全体の pane を数えるようにした（`backend/src/routes/sessions.ts`）
+
 ## [0.1.173] - 2026-06-06
 
 `cchub tui` に popup サイドバー機能を追加。attach 中でもセッション一覧を即座に呼び出せるように。

--- a/architecture.html
+++ b/architecture.html
@@ -113,8 +113,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.173",
-  "generated": "2026-06-06",
+  "version": "0.1.174",
+  "generated": "2026-06-07",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.173",
-  "generated": "2026-06-06",
+  "version": "0.1.174",
+  "generated": "2026-06-07",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.173",
+  "version": "0.1.174",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(sessions): Remote Control 有効な複数paneセッションで pane一覧（focus/close/split）に到達できなかった問題を修正（`41637d3` のデグレ）
- fix(sessions): 複数windowセッションで pane を閉じられない問題を修正（`tmux list-panes` に `-s` 追加）
- chore: bump version to 0.1.174

## Notes
両修正は dev 実機（モバイル）で検証済み。詳細は #323。