### PR TITLE
Release v0.1.175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.175] - 2026-06-09
+
+ソフトキーボードの Shift+Tab を修正。
+
+### Fixed
+- **ソフトキーボードの Shift+Tab が効かない**: `TAB` キーはアクションバーにあり `ActionButton` 経由で `onSend("\t")` を直接送るため、`⇧` モディファイアを無視して常に素の `\t`（hex `09`）を送っていた。`sendKeyPress` 側にあった Shift+Tab→VT back-tab（CSI Z, `\x1b[Z`）処理は TAB に到達できず dead code だった。`ActionButton` で `⇧`+TAB のとき CSI Z を送るようにし（Claude Code の auto-mode / plan-mode / accept-edits 循環が効くように）、`⇧` 押下中はラベルを「⇧TAB」に変更（`frontend/src/components/Keyboard.tsx`）
+
 ## [0.1.174] - 2026-06-07
 
 セッション一覧の pane 操作の不具合を2件修正。

--- a/architecture.html
+++ b/architecture.html
@@ -113,8 +113,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.174",
-  "generated": "2026-06-07",
+  "version": "0.1.175",
+  "generated": "2026-06-09",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.174",
-  "generated": "2026-06-07",
+  "version": "0.1.175",
+  "generated": "2026-06-09",
   "summary": "Web-based terminal session manager for Claude Code. Runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/frontend/src/components/Keyboard.tsx
+++ b/frontend/src/components/Keyboard.tsx
@@ -401,6 +401,13 @@ export function Keyboard({
 				onUrlExtract?.();
 			} else if (keyDef.key === "MODE_SWITCH") {
 				onModeSwitch?.();
+			} else if (keyDef.key === "\t" && shiftPressed) {
+				// Shift+Tab → VT back-tab (CSI Z). TAB lives in the action bar and
+				// is sent directly from here, so the shift modifier toggled in the
+				// main keyboard would otherwise be ignored. Claude Code uses
+				// back-tab to cycle auto-mode / plan-mode / accept-edits.
+				onSend("\x1b[Z");
+				setShiftPressed(false);
 			} else {
 				onSend(keyDef.key);
 			}
@@ -441,7 +448,7 @@ export function Keyboard({
 				className={`${compact ? "h-[26px] text-[10px]" : "h-[30px] text-[11px]"} min-w-[34px] px-1.5 flex items-center justify-center rounded-md font-medium select-none ${getBgColor()}`}
 				data-onboarding={getOnboardingAttr()}
 			>
-				{keyDef.label}
+				{keyDef.key === "\t" && shiftPressed ? "⇧TAB" : keyDef.label}
 			</button>
 		);
 	};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.174",
+  "version": "0.1.175",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(keyboard): ソフトキーボードの Shift+Tab が VT back-tab（CSI Z, `\x1b[Z`）を送るように修正

## 詳細
`TAB` はアクションバーにあり `ActionButton` 経由で `onSend("\t")` を直接送っていたため、`⇧` モディファイアが無視され常に素の `\t`（hex `09`）が送られていた。`sendKeyPress` 側にあった Shift+Tab→CSI Z 処理は TAB に到達できず dead code だった。`ActionButton` で `⇧`+TAB のとき CSI Z を送るようにし（Claude Code の auto-mode / plan-mode / accept-edits 循環が効くように）、`⇧` 押下中はラベルを「⇧TAB」に変更。

## Notes
- dev 環境（実機ソフトキーボード）で ⇧+TAB → `hex=1b5b5a` 送出を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)