### PR TITLE
fix: improve dashboard Model Usage display

### DIFF
--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -60,7 +60,6 @@ export async function buildDashboard(): Promise<DashboardResponse> {
     usageHistory,
     dailyActivity,
     modelUsage,
-    costEstimates: [],
     hourlyActivity,
     version: VERSION,
     systemMetrics,

--- a/backend/src/services/stats-service.ts
+++ b/backend/src/services/stats-service.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { DailyActivity, ModelUsage, CostEstimate } from '../../../shared/types';
+import type { DailyActivity, ModelUsage } from '../../../shared/types';
 
 interface StatsCache {
   version: number;
@@ -22,33 +22,6 @@ interface StatsCache {
   };
   hourCounts?: Record<string, number>;
 }
-
-// API reference pricing (per 1M tokens)
-const PRICING: Record<string, {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-}> = {
-  'claude-opus-4-5-20251101': {
-    input: 15.00 / 1_000_000,
-    output: 75.00 / 1_000_000,
-    cacheRead: 1.50 / 1_000_000,
-    cacheWrite: 18.75 / 1_000_000,
-  },
-  'claude-opus-4-6': {
-    input: 15.00 / 1_000_000,
-    output: 75.00 / 1_000_000,
-    cacheRead: 1.50 / 1_000_000,
-    cacheWrite: 18.75 / 1_000_000,
-  },
-  'claude-sonnet-4-5-20250929': {
-    input: 3.00 / 1_000_000,
-    output: 15.00 / 1_000_000,
-    cacheRead: 0.30 / 1_000_000,
-    cacheWrite: 3.75 / 1_000_000,
-  },
-};
 
 export class StatsService {
   private claudeDir: string;
@@ -99,41 +72,16 @@ export class StatsService {
     }));
   }
 
-  async getCostEstimates(): Promise<CostEstimate[]> {
-    const stats = await this.readStatsCache();
-    if (!stats?.modelUsage) {
-      return [];
-    }
-
-    return Object.entries(stats.modelUsage).map(([model, usage]) => {
-      const pricing = PRICING[model] || PRICING['claude-sonnet-4-5-20250929'];
-
-      const inputCost = usage.inputTokens * pricing.input;
-      const outputCost = usage.outputTokens * pricing.output;
-      const cacheReadCost = usage.cacheReadInputTokens * pricing.cacheRead;
-      const cacheWriteCost = usage.cacheCreationInputTokens * pricing.cacheWrite;
-
-      return {
-        model: this.getModelDisplayName(model),
-        inputCost: Math.round(inputCost * 100) / 100,
-        outputCost: Math.round(outputCost * 100) / 100,
-        cacheReadCost: Math.round(cacheReadCost * 100) / 100,
-        cacheWriteCost: Math.round(cacheWriteCost * 100) / 100,
-        totalCost: Math.round((inputCost + outputCost + cacheReadCost + cacheWriteCost) * 100) / 100,
-      };
-    });
-  }
-
   private getModelDisplayName(modelId: string): string {
-    // Extract version from model ID (e.g., "claude-opus-4-6" -> "4.6", "claude-opus-4-5-20251101" -> "4.5")
-    const match = modelId.match(/claude-(opus|sonnet)-(\d+)-(\d+)/);
+    // Extract family and version from model ID for any family
+    // (e.g., "claude-opus-4-5-20251101" -> "Opus 4.5", "claude-haiku-4-5-20251001" -> "Haiku 4.5",
+    //  "claude-fable-5" -> "Fable 5")
+    const match = modelId.match(/claude-([a-z]+)-(\d+)(?:-(\d{1,2})(?:-|$))?/);
     if (match) {
       const [, family, major, minor] = match;
-      const name = family === 'opus' ? 'Opus' : 'Sonnet';
-      return `${name} ${major}.${minor}`;
+      const name = family.charAt(0).toUpperCase() + family.slice(1);
+      return minor !== undefined ? `${name} ${major}.${minor}` : `${name} ${major}`;
     }
-    if (modelId.includes('opus')) return 'Opus';
-    if (modelId.includes('sonnet')) return 'Sonnet';
     return modelId;
   }
 

--- a/backend/tests/unit/file-service.test.ts
+++ b/backend/tests/unit/file-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
 import { FileService } from '../../src/services/file-service';
-import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { mkdtemp, realpath, writeFile, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -10,8 +10,10 @@ describe('FileService', () => {
 
   beforeAll(async () => {
     fileService = new FileService();
-    // Create a temporary test directory
-    testDir = await mkdtemp(join(tmpdir(), 'cchub-test-'));
+    // Create a temporary test directory.
+    // Resolve symlinks (e.g. macOS /var -> /private/var) so comparisons
+    // against validatePath's realpath output are stable
+    testDir = await realpath(await mkdtemp(join(tmpdir(), 'cchub-test-')));
 
     // Create test files and directories
     await mkdir(join(testDir, 'subdir'));

--- a/backend/tests/unit/stats-service.test.ts
+++ b/backend/tests/unit/stats-service.test.ts
@@ -43,20 +43,26 @@ describe('StatsService', () => {
     });
   });
 
-  describe('getCostEstimates', () => {
-    test('should return an array', async () => {
-      const costs = await statsService.getCostEstimates();
-      expect(Array.isArray(costs)).toBe(true);
+  describe('getModelDisplayName', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: testing private method
+    const displayName = (id: string) => (statsService as any).getModelDisplayName(id);
+
+    test('formats opus/sonnet with dated suffix', () => {
+      expect(displayName('claude-opus-4-5-20251101')).toBe('Opus 4.5');
+      expect(displayName('claude-sonnet-4-5-20250929')).toBe('Sonnet 4.5');
     });
 
-    test('should return items with correct structure', async () => {
-      const costs = await statsService.getCostEstimates();
-      if (costs.length > 0) {
-        expect(costs[0]).toHaveProperty('model');
-        expect(costs[0]).toHaveProperty('totalCost');
-        expect(costs[0]).toHaveProperty('inputCost');
-        expect(costs[0]).toHaveProperty('outputCost');
-      }
+    test('formats versions without date suffix', () => {
+      expect(displayName('claude-opus-4-6')).toBe('Opus 4.6');
+    });
+
+    test('formats haiku and other families', () => {
+      expect(displayName('claude-haiku-4-5-20251001')).toBe('Haiku 4.5');
+      expect(displayName('claude-fable-5')).toBe('Fable 5');
+    });
+
+    test('returns unknown IDs as-is', () => {
+      expect(displayName('some-other-model')).toBe('some-other-model');
     });
   });
 

--- a/frontend/src/components/dashboard/ModelUsageChart.tsx
+++ b/frontend/src/components/dashboard/ModelUsageChart.tsx
@@ -17,6 +17,31 @@ function formatTokens(tokens: number): string {
 	return tokens.toString();
 }
 
+// Shades per model family; versions within a family cycle through shades
+const FAMILY_SHADES: Record<string, string[]> = {
+	opus: ["bg-fuchsia-500", "bg-purple-500", "bg-violet-400", "bg-indigo-500"],
+	sonnet: ["bg-blue-500", "bg-sky-400", "bg-cyan-500"],
+	haiku: ["bg-emerald-500", "bg-teal-400", "bg-green-500"],
+	fable: ["bg-amber-500", "bg-orange-400"],
+	other: ["bg-gray-500", "bg-slate-400", "bg-zinc-400"],
+};
+
+function buildColorMap(models: string[]): Map<string, string> {
+	const familyCounts: Record<string, number> = {};
+	const map = new Map<string, string>();
+	for (const model of models) {
+		const family =
+			Object.keys(FAMILY_SHADES).find((f) =>
+				model.toLowerCase().includes(f),
+			) ?? "other";
+		const shades = FAMILY_SHADES[family];
+		const index = familyCounts[family] ?? 0;
+		familyCounts[family] = index + 1;
+		map.set(model, shades[index % shades.length]);
+	}
+	return map;
+}
+
 export function ModelUsageChart({ data }: ModelUsageChartProps) {
 	if (data.length === 0) {
 		return (
@@ -26,19 +51,12 @@ export function ModelUsageChart({ data }: ModelUsageChartProps) {
 		);
 	}
 
-	const total = data.reduce(
-		(sum, m) => sum + m.totalTokensIn + m.totalTokensOut + m.totalCacheRead,
-		0,
-	);
+	const modelTotal = (m: ModelUsage) =>
+		m.totalTokensIn + m.totalTokensOut + m.totalCacheRead;
 
-	const getColor = (model: string): string => {
-		if (model === "Opus 4.5") return "bg-fuchsia-500";
-		if (model === "Opus 4.6") return "bg-violet-400";
-		if (model === "Opus 4.7") return "bg-indigo-500";
-		if (model.startsWith("Opus")) return "bg-purple-500";
-		if (model.startsWith("Sonnet")) return "bg-blue-500";
-		return "bg-gray-500";
-	};
+	const sorted = [...data].sort((a, b) => modelTotal(b) - modelTotal(a));
+	const total = sorted.reduce((sum, m) => sum + modelTotal(m), 0);
+	const colorMap = buildColorMap(sorted.map((m) => m.model));
 
 	return (
 		<div className="p-3 bg-th-surface rounded-md">
@@ -46,33 +64,40 @@ export function ModelUsageChart({ data }: ModelUsageChartProps) {
 
 			{/* Bar chart */}
 			<div className="h-4 bg-th-surface-hover rounded-full overflow-hidden flex">
-				{data.map((model) => {
-					const modelTotal =
-						model.totalTokensIn + model.totalTokensOut + model.totalCacheRead;
-					const pct = (modelTotal / total) * 100;
+				{sorted.map((model) => {
+					const pct = (modelTotal(model) / total) * 100;
 					if (pct < 1) return null;
 					return (
 						<div
 							key={model.model}
-							className={`${getColor(model.model)} h-full`}
+							className={`${colorMap.get(model.model)} h-full`}
 							style={{ width: `${pct}%` }}
-							title={`${model.model}: ${formatTokens(modelTotal)} tokens`}
+							title={`${model.model}: ${formatTokens(modelTotal(model))} tokens (${pct.toFixed(1)}%)`}
 						/>
 					);
 				})}
 			</div>
 
 			{/* Legend */}
-			<div className="mt-2 flex gap-3 text-xs">
-				{data.map((model) => (
-					<div key={model.model} className="flex items-center gap-1">
-						<div className={`w-2 h-2 rounded-full ${getColor(model.model)}`} />
-						<span className="text-th-text-secondary">{model.model}</span>
-						<span className="text-th-text-muted">
-							{formatTokens(model.totalTokensOut)}
-						</span>
-					</div>
-				))}
+			<div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+				{sorted.map((model) => {
+					const pct = (modelTotal(model) / total) * 100;
+					return (
+						<div
+							key={model.model}
+							className="flex items-center gap-1 whitespace-nowrap"
+							title={`${model.model}: in ${formatTokens(model.totalTokensIn)} / out ${formatTokens(model.totalTokensOut)} / cache ${formatTokens(model.totalCacheRead)}`}
+						>
+							<div
+								className={`w-2 h-2 rounded-full shrink-0 ${colorMap.get(model.model)}`}
+							/>
+							<span className="text-th-text-secondary">{model.model}</span>
+							<span className="text-th-text-muted">
+								{formatTokens(modelTotal(model))} ({pct.toFixed(0)}%)
+							</span>
+						</div>
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -117,7 +117,6 @@
 		"limitPrediction": "Limit Prediction",
 		"dailyStats": "Daily Activity",
 		"modelUsage": "Model Usage",
-		"costEstimate": "Cost Estimate",
 		"messages": "Messages",
 		"sessions": "Sessions",
 		"tokens": "Tokens",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -117,7 +117,6 @@
 		"limitPrediction": "リミット到達予測",
 		"dailyStats": "日別アクティビティ",
 		"modelUsage": "モデル使用量",
-		"costEstimate": "コスト推定",
 		"messages": "メッセージ",
 		"sessions": "セッション",
 		"tokens": "トークン",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -399,15 +399,6 @@ export interface ModelUsage {
   totalCacheWrite: number;
 }
 
-export interface CostEstimate {
-  model: string;
-  inputCost: number;
-  outputCost: number;
-  cacheReadCost: number;
-  cacheWriteCost: number;
-  totalCost: number;
-}
-
 // Usage limits from Anthropic API
 export interface UsageCycleInfo {
   utilization: number;
@@ -488,7 +479,6 @@ export interface DashboardResponse {
   usageHistory: UsageSnapshot[]; // Usage history for line chart
   dailyActivity: DailyActivity[];
   modelUsage: ModelUsage[];
-  costEstimates: CostEstimate[];
   hourlyActivity?: Record<number, number>; // Phase 3: Hour (0-23) -> session count
   version?: string; // CC Hub version
   systemMetrics?: SystemMetrics; // System CPU/memory metrics


### PR DESCRIPTION
## Summary
- ダッシュボードの Model Usage 表示を改善
  - モデル表示名の整形を全ファミリー対応に一般化（`claude-haiku-4-5-20251001` → "Haiku 4.5"、`claude-fable-5` → "Fable 5"）
  - 使用量降順ソート、凡例の折り返し対応、ファミリー単位のカラーパレット循環割り当て
  - 凡例の数値をバーと同じ基準（in+out+cache read）に統一し、パーセンテージを追加
- デッドコード削除: `PRICING` テーブル、`getCostEstimates()`、`CostEstimate` 型、`DashboardResponse.costEstimates`、未使用 i18n ラベル（実際のコスト計算は `AnthropicModels` + `SessionMetricsService` 系統が担当）
- macOS の `/var` symlink 解決で落ちていた file-service テストを修正

## Test plan
- [x] `bun run test` 全パス（backend 260 / frontend 37 / tui 66）
- [x] `bun run lint` 通過
- [x] 表示名整形の回帰テストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)