### PR TITLE
Release v0.1.176

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.176] - 2026-06-10
+
+ダッシュボードの Model Usage 表示を改善し、未使用のコスト推定コードを削除。
+
+### Fixed
+- **Model Usage に生のモデルIDが表示される**: モデル表示名の整形が opus/sonnet 決め打ちだったため、`claude-haiku-4-5-20251001` などが生IDのまま折り返して表示されていた。任意のファミリーに対応する整形に一般化（"Haiku 4.5"、"Fable 5" 等。`backend/src/services/stats-service.ts`）
+- **macOS で file-service テストが失敗する**: `/var` → `/private/var` symlink 解決により `validatePath` の realpath 出力と期待値が不一致だった。テストの `testDir` を `realpath` で解決するように修正（`backend/tests/unit/file-service.test.ts`）
+
+### Changed
+- **Model Usage チャートの改善**: 使用量降順ソート、凡例の折り返し対応、ファミリー単位カラーパレットの循環割り当て（新モデル追加時もコード変更不要）、凡例の数値をバーと同じ基準（in+out+cache read）に統一しパーセンテージを追加（`frontend/src/components/dashboard/ModelUsageChart.tsx`）
+- **デッドコード削除**: 未使用の `PRICING` テーブル・`getCostEstimates()`・`CostEstimate` 型・`DashboardResponse.costEstimates`・i18n `costEstimate` ラベルを削除。実際のコスト計算は `AnthropicModels` + `SessionMetricsService` 系統が担当
+
 ## [0.1.175] - 2026-06-09
 
 ソフトキーボードの Shift+Tab を修正。

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.175",
+  "version": "0.1.176",
   "generated": "2026-06-10",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
@@ -131,11 +131,26 @@
     "transport": "Multiplexed WebSocket /ws/mux + tmux -CC control mode。ターミナル表示はサーバーサイドスクロールバック方式: tmux capture-pane による PaneViewport フレーム (rows 行 + cursor/modes + offset) を配信し、フロントは VT シーケンスへ変換して xterm.js (scrollback:0) に書き込む render-only 構成"
   },
   "workspaces": [
-    { "name": "backend", "desc": "Hono API サーバ (Bun)。tmux 制御・履歴・peer 連携・CLI (cchub) を提供" },
-    { "name": "frontend", "desc": "React SPA。タブレット/モバイル/デスクトップの3レイアウト" },
-    { "name": "shared", "desc": "Zod スキーマと型 (types.ts)。backend / frontend / tui が共有" },
-    { "name": "tui", "desc": "cchub tui (Ink + React)。ローカル専用のセッション一覧/履歴検索、入室は native tmux attach" },
-    { "name": "glasses", "desc": "EVEN G2 グラスアプリ (EvenHub SDK → out.ehpk)。型は手動複製のため WS プロトコル変更時は要追従" }
+    {
+      "name": "backend",
+      "desc": "Hono API サーバ (Bun)。tmux 制御・履歴・peer 連携・CLI (cchub) を提供"
+    },
+    {
+      "name": "frontend",
+      "desc": "React SPA。タブレット/モバイル/デスクトップの3レイアウト"
+    },
+    {
+      "name": "shared",
+      "desc": "Zod スキーマと型 (types.ts)。backend / frontend / tui が共有"
+    },
+    {
+      "name": "tui",
+      "desc": "cchub tui (Ink + React)。ローカル専用のセッション一覧/履歴検索、入室は native tmux attach"
+    },
+    {
+      "name": "glasses",
+      "desc": "EVEN G2 グラスアプリ (EvenHub SDK → out.ehpk)。型は手動複製のため WS プロトコル変更時は要追従"
+    }
   ],
   "diagram": [
     " Clients",
@@ -163,7 +178,10 @@
         "name": "TmuxControlSession",
         "file": "backend/src/services/tmux-control.ts",
         "summary": "tmux -CC (control mode) を管理するコア。%output (octal) / %layout-change / %begin / %end / %error / %exit を解析し、FIFO コマンドキュー + 直列化ロックでコマンド送信。raw byte 処理で分割 UTF-8 を保持。クライアント消滅後 30s のグレースピリオド、deviceType (mobile/desktop) 別のクライアント追跡を提供",
-        "deps": ["TmuxLayoutParser", "TmuxOctalDecoder"]
+        "deps": [
+          "TmuxLayoutParser",
+          "TmuxOctalDecoder"
+        ]
       },
       {
         "name": "TmuxService",
@@ -187,7 +205,9 @@
         "name": "PaneViewport",
         "file": "backend/src/services/pane-viewport.ts",
         "summary": "capture-pane -e -p -S/-E でペインの viewport (可視領域 + scrollback offset) を取得。tmux が表示と履歴の single source of truth。非 altScreen TUI (Claude Code 等) には padFill: 末尾 blank 行を cursor 行まで trim し scrollback を prepend して「void」を見せない。ペイン状態 (permission_prompt / ask_user_question / processing / idle) の regex 検出も提供",
-        "deps": ["ViewportCursorPolicy"]
+        "deps": [
+          "ViewportCursorPolicy"
+        ]
       },
       {
         "name": "ViewportCursorPolicy",
@@ -271,7 +291,9 @@
         "name": "SessionMetricsService",
         "file": "backend/src/services/session-metrics.ts",
         "summary": "JSONL からセッション毎のコンテキストトークン (最終ターンの input + cache_creation + cache_read)・合計トークンを集計 (mtime+size キャッシュ)。ps によるプロセスツリー RSS 取得 (1s cache)",
-        "deps": ["AnthropicModels"]
+        "deps": [
+          "AnthropicModels"
+        ]
       },
       {
         "name": "CodexService",
@@ -289,7 +311,9 @@
         "name": "CodexHistoryService",
         "file": "backend/src/services/codex-history.ts",
         "summary": "~/.codex/sessions の日付パーティション木 (YYYY/MM/DD/rollout-*.jsonl) を mtime ベースのファイル毎キャッシュ付きでスキャンし、cwd でグループ化して Claude Code 履歴と統合表示",
-        "deps": ["CodexConversationService"]
+        "deps": [
+          "CodexConversationService"
+        ]
       },
       {
         "name": "CodexUsageService",
@@ -301,7 +325,10 @@
         "name": "ConversationWatcher",
         "file": "backend/src/services/conversation-watcher.ts",
         "summary": "Claude Code / Codex の JSONL を fs.watch + 150ms デバウンスで監視し、新規ターンのみを WebSocket 購読者へ通知。mtime 追跡で冗長パースを回避",
-        "deps": ["ClaudeCodeService", "SessionHistoryService"]
+        "deps": [
+          "ClaudeCodeService",
+          "SessionHistoryService"
+        ]
       },
       {
         "name": "HookStatusService",
@@ -325,13 +352,18 @@
         "name": "PeerAuth",
         "file": "backend/src/services/peer-auth.ts",
         "summary": "peer への代理ログイン (POST /api/auth/login、5s timeout)。取得した JWT を保存して以降の API/WS に使用し、401 時は unauthorized として記録。/health で疎通確認",
-        "deps": ["PeerRegistry", "PeerUrl"]
+        "deps": [
+          "PeerRegistry",
+          "PeerUrl"
+        ]
       },
       {
         "name": "PeerDiscovery",
         "file": "backend/src/services/peer-discovery.ts",
         "summary": "`tailscale status --json` で tailnet の online peer を列挙し、各 :5923/health を 3s timeout で並列 probe。cchub が動いていれば version 付き DiscoveredPeer として返す",
-        "deps": ["PeerRegistry"]
+        "deps": [
+          "PeerRegistry"
+        ]
       },
       {
         "name": "PeerUrl",
@@ -341,167 +373,1152 @@
       }
     ],
     "routes": [
-      { "method": "GET", "path": "/health", "group": "System", "description": "ヘルスチェック。status と version を返す。認証不要 (peer discovery が利用)", "file": "backend/src/index.ts" },
-      { "method": "GET", "path": "/clear-cache", "group": "System", "description": "Service Worker 登録解除とキャッシュクリアを行う HTML ページ。認証不要", "file": "backend/src/index.ts" },
-      { "method": "GET", "path": "/api/images/:filename", "group": "System", "description": "アップロード画像の配信。認証不要", "file": "backend/src/index.ts" },
-      { "method": "WS", "path": "/ws/mux", "group": "System", "description": "多重化ターミナル WebSocket。viewport 配信・入力・レイアウト制御・会話ストリーム。token クエリで peer からの Bearer 認証に対応", "file": "backend/src/routes/terminal-mux.ts" },
-      { "method": "GET", "path": "/api/auth/required", "group": "Auth", "description": "パスワード認証が有効かどうかを返す", "file": "backend/src/routes/auth.ts" },
-      { "method": "POST", "path": "/api/auth/login", "group": "Auth", "description": "サーバパスワードでログインし JWT トークンを返す。認証不要", "file": "backend/src/routes/auth.ts" },
-      { "method": "POST", "path": "/api/auth/logout", "group": "Auth", "description": "ログアウト (ステートレス JWT のためダミー)", "file": "backend/src/routes/auth.ts" },
-      { "method": "GET", "path": "/api/auth/me", "group": "Auth", "description": "現在のユーザー情報を返す。認証必須", "file": "backend/src/routes/auth.ts" },
-      { "method": "GET", "path": "/api/sessions", "group": "Sessions", "description": "全 tmux セッション一覧 (Claude Code 状態・ペイン情報付き)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions", "group": "Sessions", "description": "新規セッション作成。agent (claude/codex), name, workingDir, initialPrompt 指定可", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/:id", "group": "Sessions", "description": "セッション詳細を取得", "file": "backend/src/routes/sessions.ts" },
-      { "method": "DELETE", "path": "/api/sessions/:id", "group": "Sessions", "description": "tmux セッションを kill。last-known 情報は保持", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/resume", "group": "Sessions", "description": "セッション内でエージェントを resume (claude -r / codex resume)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "PUT", "path": "/api/sessions/:id/theme", "group": "Sessions", "description": "セッションのカラーテーマを設定", "file": "backend/src/routes/sessions.ts" },
-      { "method": "PUT", "path": "/api/sessions/:id/title", "group": "Sessions", "description": "セッションのカスタムタイトルを設定", "file": "backend/src/routes/sessions.ts" },
-      { "method": "PUT", "path": "/api/sessions/order", "group": "Sessions", "description": "セッション表示順を保存", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/:id/copy-mode", "group": "Sessions", "description": "tmux copy mode の選択状態を取得", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/focus", "group": "Sessions", "description": "ペインにフォーカス ({ paneId })", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/close", "group": "Sessions", "description": "ペインを閉じる。最後の 1 枚は拒否", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/split", "group": "Sessions", "description": "ペイン分割 ({ paneId, direction: 'h'|'v' })", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/respawn", "group": "Sessions", "description": "dead ペインを respawn", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/input", "group": "Sessions", "description": "ペインへ REST で入力送信 (cchub send / peer が使用)。wait=true で送信後の viewport スナップショットを返す", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/:id/panes/:paneId/viewport", "group": "Sessions", "description": "ペイン viewport を REST で取得 (cchub peek が使用)。lines クエリで末尾行数指定", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/prompt", "group": "Sessions", "description": "アクティブペインへプロンプトテキストを送信", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/clipboard", "group": "Sessions", "description": "tmux グローバルペーストバッファの内容を取得", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history", "group": "Session History", "description": "最近のセッション履歴。metadata クエリでメタデータの遅延ロード可", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/projects", "group": "Session History", "description": "プロジェクト一覧 (Claude Code + Codex 統合)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/projects/:dirName", "group": "Session History", "description": "プロジェクト内のセッション一覧", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/search", "group": "Session History", "description": "全プロジェクト横断のセッション検索 (q, limit)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/search/stream", "group": "Session History", "description": "検索結果の SSE ストリーミング配信", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/:sessionId/conversation", "group": "Session History", "description": "セッションの会話を取得。agent=codex / projectDirName / last クエリ対応", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/history/metadata", "group": "Session History", "description": "指定 sessionIds のメタデータを遅延ロード", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/history/resume", "group": "Session History", "description": "履歴からセッションを resume (新規 tmux セッション作成)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/prompts/search", "group": "Session History", "description": "プロンプト履歴の検索 (q, limit)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/files/list", "group": "Files", "description": "ディレクトリ一覧。sessionWorkingDir 配下に限定", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/read", "group": "Files", "description": "ファイル内容を取得 (サイズ制限あり。画像/メディアはメタデータのみ)", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/raw", "group": "Files", "description": "ファイルをインライン配信 (<img>/<video>/<audio> 用)。Range / 206 対応", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/download", "group": "Files", "description": "ファイルを添付ダウンロード (Bun.file ストリーミング)", "file": "backend/src/routes/files.ts" },
-      { "method": "POST", "path": "/api/files/upload", "group": "Files", "description": "multipart/form-data でファイル (複数可) をアップロード", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/browse", "group": "Files", "description": "ホームディレクトリ配下をセッション非依存でブラウズ", "file": "backend/src/routes/files.ts" },
-      { "method": "POST", "path": "/api/files/mkdir", "group": "Files", "description": "ディレクトリ作成 (ホーム配下のみ)", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/changes/:sessionWorkingDir", "group": "Files", "description": "JSONL 由来の Claude Code ファイル変更一覧", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/git-changes/:workingDir", "group": "Files", "description": "git status --porcelain による変更ファイル一覧 (ブランチ情報付き)", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/git-diff/:workingDir", "group": "Files", "description": "指定ファイルの unified diff (staged クエリ対応)", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/language", "group": "Files", "description": "ファイルパスから言語識別子・isImage・isText を判定", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/images/:filename", "group": "Files", "description": "会話用アップロード画像の配信", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/peers", "group": "Peers", "description": "登録済み peer 一覧 (self 含む) を返す", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/discover", "group": "Peers", "description": "Tailscale tailnet 内で稼働中の cchub を検出", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers", "group": "Peers", "description": "peer を登録 (nickname, url, password, color)。代理ログインして JWT を保存", "file": "backend/src/routes/peers.ts" },
-      { "method": "PATCH", "path": "/api/peers/:id", "group": "Peers", "description": "peer の nickname / color / password を更新", "file": "backend/src/routes/peers.ts" },
-      { "method": "DELETE", "path": "/api/peers/:id", "group": "Peers", "description": "peer を削除 (local は削除不可)", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers/:id/verify", "group": "Peers", "description": "peer の疎通・認証を再確認しレイテンシを返す", "file": "backend/src/routes/peers.ts" },
-      { "method": "PUT", "path": "/api/peers/order", "group": "Peers", "description": "peer の表示順を保存", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/session-order", "group": "Peers", "description": "peer 横断のセッション表示順を取得", "file": "backend/src/routes/peers.ts" },
-      { "method": "PUT", "path": "/api/peers/session-order", "group": "Peers", "description": "peer 横断のセッション表示順を保存", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/sessions", "group": "Peers", "description": "全 peer のアクティブセッションをマージして返す (peer 毎のエラー併載)", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/history/projects", "group": "Peers", "description": "全 peer のプロジェクト履歴をマージして返す", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/history/:peerId/projects/:dirName", "group": "Peers", "description": "指定 peer のプロジェクト内セッション一覧", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/history/:peerId/:sessionId/conversation", "group": "Peers", "description": "指定 peer のセッション会話を取得", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers/history/:peerId/resume", "group": "Peers", "description": "指定 peer 上でセッションを resume", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/:peerId/dashboard", "group": "Peers", "description": "指定 peer (または self) のダッシュボード情報を取得", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/:peerId/files/browse", "group": "Peers", "description": "peer 上のディレクトリブラウズ (プロキシ)", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers/:peerId/files/mkdir", "group": "Peers", "description": "peer 上にディレクトリ作成 (プロキシ)", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers/:peerId/upload/image", "group": "Peers", "description": "画像アップロードを peer へ転送し、peer 上の絶対パスを返す", "file": "backend/src/routes/peers.ts" },
-      { "method": "ALL", "path": "/api/peers/:peerId/files/*", "group": "Peers", "description": "Files API の汎用プロキシ (list / read / raw / download / upload / language / changes / git-changes / git-diff / images を peer へ透過転送)", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/dashboard", "group": "Dashboard", "description": "ダッシュボード情報 (使用量リミット、統計、コスト推定、システムメトリクス、使用量履歴、接続クライアント数)", "file": "backend/src/routes/dashboard.ts" },
-      { "method": "POST", "path": "/api/upload/image", "group": "Upload", "description": "画像アップロード (PNG/JPEG/GIF/WebP, max 10MB)。ローカルパスを返す", "file": "backend/src/routes/upload.ts" },
-      { "method": "POST", "path": "/api/notify", "group": "Notify", "description": "Claude Code / Codex の hook イベントを受信し WebSocket でブロードキャスト。認証不要 (ローカル hook から呼ばれる)", "file": "backend/src/routes/notify.ts" },
-      { "method": "GET", "path": "/api/notify/hook-status", "group": "Notify", "description": "Claude / Codex の hook 設定に cchub notify が登録済みかを確認。missing イベント一覧を返す", "file": "backend/src/routes/notify.ts" },
-      { "method": "POST", "path": "/api/logs", "group": "Logs", "description": "フロントエンドのログを受信し /tmp/cc-hub-browser.log に追記。認証不要", "file": "backend/src/routes/logs.ts" },
-      { "method": "GET", "path": "/api/logs", "group": "Logs", "description": "ブラウザログファイルをテキストで返す", "file": "backend/src/routes/logs.ts" },
-      { "method": "DELETE", "path": "/api/logs", "group": "Logs", "description": "ブラウザログをクリア", "file": "backend/src/routes/logs.ts" }
+      {
+        "method": "GET",
+        "path": "/health",
+        "group": "System",
+        "description": "ヘルスチェック。status と version を返す。認証不要 (peer discovery が利用)",
+        "file": "backend/src/index.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/clear-cache",
+        "group": "System",
+        "description": "Service Worker 登録解除とキャッシュクリアを行う HTML ページ。認証不要",
+        "file": "backend/src/index.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/images/:filename",
+        "group": "System",
+        "description": "アップロード画像の配信。認証不要",
+        "file": "backend/src/index.ts"
+      },
+      {
+        "method": "WS",
+        "path": "/ws/mux",
+        "group": "System",
+        "description": "多重化ターミナル WebSocket。viewport 配信・入力・レイアウト制御・会話ストリーム。token クエリで peer からの Bearer 認証に対応",
+        "file": "backend/src/routes/terminal-mux.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/auth/required",
+        "group": "Auth",
+        "description": "パスワード認証が有効かどうかを返す",
+        "file": "backend/src/routes/auth.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/auth/login",
+        "group": "Auth",
+        "description": "サーバパスワードでログインし JWT トークンを返す。認証不要",
+        "file": "backend/src/routes/auth.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/auth/logout",
+        "group": "Auth",
+        "description": "ログアウト (ステートレス JWT のためダミー)",
+        "file": "backend/src/routes/auth.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/auth/me",
+        "group": "Auth",
+        "description": "現在のユーザー情報を返す。認証必須",
+        "file": "backend/src/routes/auth.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions",
+        "group": "Sessions",
+        "description": "全 tmux セッション一覧 (Claude Code 状態・ペイン情報付き)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions",
+        "group": "Sessions",
+        "description": "新規セッション作成。agent (claude/codex), name, workingDir, initialPrompt 指定可",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/:id",
+        "group": "Sessions",
+        "description": "セッション詳細を取得",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/sessions/:id",
+        "group": "Sessions",
+        "description": "tmux セッションを kill。last-known 情報は保持",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/resume",
+        "group": "Sessions",
+        "description": "セッション内でエージェントを resume (claude -r / codex resume)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/sessions/:id/theme",
+        "group": "Sessions",
+        "description": "セッションのカラーテーマを設定",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/sessions/:id/title",
+        "group": "Sessions",
+        "description": "セッションのカスタムタイトルを設定",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/sessions/order",
+        "group": "Sessions",
+        "description": "セッション表示順を保存",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/:id/copy-mode",
+        "group": "Sessions",
+        "description": "tmux copy mode の選択状態を取得",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/focus",
+        "group": "Sessions",
+        "description": "ペインにフォーカス ({ paneId })",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/close",
+        "group": "Sessions",
+        "description": "ペインを閉じる。最後の 1 枚は拒否",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/split",
+        "group": "Sessions",
+        "description": "ペイン分割 ({ paneId, direction: 'h'|'v' })",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/respawn",
+        "group": "Sessions",
+        "description": "dead ペインを respawn",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/input",
+        "group": "Sessions",
+        "description": "ペインへ REST で入力送信 (cchub send / peer が使用)。wait=true で送信後の viewport スナップショットを返す",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/:id/panes/:paneId/viewport",
+        "group": "Sessions",
+        "description": "ペイン viewport を REST で取得 (cchub peek が使用)。lines クエリで末尾行数指定",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/prompt",
+        "group": "Sessions",
+        "description": "アクティブペインへプロンプトテキストを送信",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/clipboard",
+        "group": "Sessions",
+        "description": "tmux グローバルペーストバッファの内容を取得",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history",
+        "group": "Session History",
+        "description": "最近のセッション履歴。metadata クエリでメタデータの遅延ロード可",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/projects",
+        "group": "Session History",
+        "description": "プロジェクト一覧 (Claude Code + Codex 統合)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/projects/:dirName",
+        "group": "Session History",
+        "description": "プロジェクト内のセッション一覧",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/search",
+        "group": "Session History",
+        "description": "全プロジェクト横断のセッション検索 (q, limit)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/search/stream",
+        "group": "Session History",
+        "description": "検索結果の SSE ストリーミング配信",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/:sessionId/conversation",
+        "group": "Session History",
+        "description": "セッションの会話を取得。agent=codex / projectDirName / last クエリ対応",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/history/metadata",
+        "group": "Session History",
+        "description": "指定 sessionIds のメタデータを遅延ロード",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/history/resume",
+        "group": "Session History",
+        "description": "履歴からセッションを resume (新規 tmux セッション作成)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/prompts/search",
+        "group": "Session History",
+        "description": "プロンプト履歴の検索 (q, limit)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/list",
+        "group": "Files",
+        "description": "ディレクトリ一覧。sessionWorkingDir 配下に限定",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/read",
+        "group": "Files",
+        "description": "ファイル内容を取得 (サイズ制限あり。画像/メディアはメタデータのみ)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/raw",
+        "group": "Files",
+        "description": "ファイルをインライン配信 (<img>/<video>/<audio> 用)。Range / 206 対応",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/download",
+        "group": "Files",
+        "description": "ファイルを添付ダウンロード (Bun.file ストリーミング)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/files/upload",
+        "group": "Files",
+        "description": "multipart/form-data でファイル (複数可) をアップロード",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/browse",
+        "group": "Files",
+        "description": "ホームディレクトリ配下をセッション非依存でブラウズ",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/files/mkdir",
+        "group": "Files",
+        "description": "ディレクトリ作成 (ホーム配下のみ)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/changes/:sessionWorkingDir",
+        "group": "Files",
+        "description": "JSONL 由来の Claude Code ファイル変更一覧",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/git-changes/:workingDir",
+        "group": "Files",
+        "description": "git status --porcelain による変更ファイル一覧 (ブランチ情報付き)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/git-diff/:workingDir",
+        "group": "Files",
+        "description": "指定ファイルの unified diff (staged クエリ対応)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/language",
+        "group": "Files",
+        "description": "ファイルパスから言語識別子・isImage・isText を判定",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/images/:filename",
+        "group": "Files",
+        "description": "会話用アップロード画像の配信",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers",
+        "group": "Peers",
+        "description": "登録済み peer 一覧 (self 含む) を返す",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/discover",
+        "group": "Peers",
+        "description": "Tailscale tailnet 内で稼働中の cchub を検出",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers",
+        "group": "Peers",
+        "description": "peer を登録 (nickname, url, password, color)。代理ログインして JWT を保存",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/peers/:id",
+        "group": "Peers",
+        "description": "peer の nickname / color / password を更新",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/peers/:id",
+        "group": "Peers",
+        "description": "peer を削除 (local は削除不可)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers/:id/verify",
+        "group": "Peers",
+        "description": "peer の疎通・認証を再確認しレイテンシを返す",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/peers/order",
+        "group": "Peers",
+        "description": "peer の表示順を保存",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/session-order",
+        "group": "Peers",
+        "description": "peer 横断のセッション表示順を取得",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/peers/session-order",
+        "group": "Peers",
+        "description": "peer 横断のセッション表示順を保存",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/sessions",
+        "group": "Peers",
+        "description": "全 peer のアクティブセッションをマージして返す (peer 毎のエラー併載)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/history/projects",
+        "group": "Peers",
+        "description": "全 peer のプロジェクト履歴をマージして返す",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/history/:peerId/projects/:dirName",
+        "group": "Peers",
+        "description": "指定 peer のプロジェクト内セッション一覧",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/history/:peerId/:sessionId/conversation",
+        "group": "Peers",
+        "description": "指定 peer のセッション会話を取得",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers/history/:peerId/resume",
+        "group": "Peers",
+        "description": "指定 peer 上でセッションを resume",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/:peerId/dashboard",
+        "group": "Peers",
+        "description": "指定 peer (または self) のダッシュボード情報を取得",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/:peerId/files/browse",
+        "group": "Peers",
+        "description": "peer 上のディレクトリブラウズ (プロキシ)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers/:peerId/files/mkdir",
+        "group": "Peers",
+        "description": "peer 上にディレクトリ作成 (プロキシ)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers/:peerId/upload/image",
+        "group": "Peers",
+        "description": "画像アップロードを peer へ転送し、peer 上の絶対パスを返す",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "ALL",
+        "path": "/api/peers/:peerId/files/*",
+        "group": "Peers",
+        "description": "Files API の汎用プロキシ (list / read / raw / download / upload / language / changes / git-changes / git-diff / images を peer へ透過転送)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/dashboard",
+        "group": "Dashboard",
+        "description": "ダッシュボード情報 (使用量リミット、統計、コスト推定、システムメトリクス、使用量履歴、接続クライアント数)",
+        "file": "backend/src/routes/dashboard.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/upload/image",
+        "group": "Upload",
+        "description": "画像アップロード (PNG/JPEG/GIF/WebP, max 10MB)。ローカルパスを返す",
+        "file": "backend/src/routes/upload.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/notify",
+        "group": "Notify",
+        "description": "Claude Code / Codex の hook イベントを受信し WebSocket でブロードキャスト。認証不要 (ローカル hook から呼ばれる)",
+        "file": "backend/src/routes/notify.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/notify/hook-status",
+        "group": "Notify",
+        "description": "Claude / Codex の hook 設定に cchub notify が登録済みかを確認。missing イベント一覧を返す",
+        "file": "backend/src/routes/notify.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/logs",
+        "group": "Logs",
+        "description": "フロントエンドのログを受信し /tmp/cc-hub-browser.log に追記。認証不要",
+        "file": "backend/src/routes/logs.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/logs",
+        "group": "Logs",
+        "description": "ブラウザログファイルをテキストで返す",
+        "file": "backend/src/routes/logs.ts"
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/logs",
+        "group": "Logs",
+        "description": "ブラウザログをクリア",
+        "file": "backend/src/routes/logs.ts"
+      }
     ]
   },
   "frontend": {
     "components": [
-      { "name": "App", "file": "frontend/src/App.tsx", "summary": "ルートコンポーネント。mobile / tablet / desktop のデバイス判定でレイアウトを切り替え。認証・セッション管理・ファイルビューア・チャットビューを統合", "hooks": ["useAuth", "useSessions"], "parents": [] },
-      { "name": "DesktopLayout", "file": "frontend/src/components/DesktopLayout.tsx", "summary": "デスクトップ / タブレット向けメインレイアウト。tmux 制御モード統合、ペインツリー管理、キーボードショートカット", "hooks": ["useMultiplexedTerminal", "usePeerConnection", "useSessions", "usePeers"], "parents": ["App"] },
-      { "name": "TerminalPage", "file": "frontend/src/pages/TerminalPage.tsx", "summary": "モバイル向けターミナルページ。単一ペイン表示 + ペインタブバー + InputBar / ChatView 切替", "hooks": ["useMultiplexedTerminal"], "parents": ["App"] },
-      { "name": "PaneContainer", "file": "frontend/src/components/PaneContainer.tsx", "summary": "ペインツリーの再帰描画。ControlModeContext 経由で分割・クローズ・ズーム・リサイズ操作を提供", "hooks": [], "parents": ["DesktopLayout", "PaneContainer"] },
-      { "name": "Terminal", "file": "frontend/src/components/Terminal.tsx", "summary": "xterm.js ターミナル (WebGL、scrollback:0)。viewport フレームを VT シーケンスに変換して term.write() で反映。tmux サイズ同期 (setExactSize)、フォント調整、テキスト選択", "hooks": ["useSelectionMode"], "parents": ["PaneContainer", "TerminalPage"] },
-      { "name": "SelectionOverlay", "file": "frontend/src/components/SelectionOverlay.tsx", "summary": "タッチ選択オーバーレイ。開始/終了ハンドルのドラッグとコピー/キャンセル操作", "hooks": ["useSelectionMode"], "parents": ["Terminal"] },
-      { "name": "SessionList", "file": "frontend/src/components/SessionList.tsx", "summary": "セッション一覧 (Active / History / Dashboard タブ)。ペイン操作、ピンチズーム、History V1/V2 の分岐", "hooks": ["useHistoryV2Flag", "useSessionHistory"], "parents": ["App"] },
-      { "name": "SessionModal", "file": "frontend/src/components/SessionModal.tsx", "summary": "セッション選択モーダル (Ctrl+B)。ペイン数バッジと展開式ペイン一覧", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "SessionHistory", "file": "frontend/src/components/SessionHistory.tsx", "summary": "セッション履歴 V1 (プロジェクトグループ表示)。V2 安定化まで併存するレガシー実装", "hooks": [], "parents": ["SessionList"] },
-      { "name": "SessionHistoryV2", "file": "frontend/src/components/history/SessionHistoryV2.tsx", "summary": "セッション履歴 V2。フラットリスト + ファセット検索 + 仮想スクロール", "hooks": ["useFlatHistoryItems", "useHistoryActions"], "parents": ["SessionList"] },
-      { "name": "VirtualizedHistoryList", "file": "frontend/src/components/history/VirtualizedHistoryList.tsx", "summary": "大規模履歴の仮想化リスト描画", "hooks": [], "parents": ["SessionHistoryV2"] },
-      { "name": "HistoryRowV2", "file": "frontend/src/components/history/HistoryRowV2.tsx", "summary": "履歴 1 行。resume / 会話表示などのハンドラ", "hooks": [], "parents": ["VirtualizedHistoryList"] },
-      { "name": "HistoryFacetSidebar", "file": "frontend/src/components/history/HistoryFacetSidebar.tsx", "summary": "ファセットフィルタ (project / agent / status) のデスクトップ用サイドバー", "hooks": [], "parents": ["SessionHistoryV2"] },
-      { "name": "HistoryFacetDrawer", "file": "frontend/src/components/history/HistoryFacetDrawer.tsx", "summary": "ファセットフィルタのモバイル用ドロワー", "hooks": [], "parents": ["SessionHistoryV2"] },
-      { "name": "HistoryActiveChips", "file": "frontend/src/components/history/HistoryActiveChips.tsx", "summary": "適用中フィルタの chips 表示と解除", "hooks": [], "parents": ["SessionHistoryV2"] },
-      { "name": "ConversationViewer", "file": "frontend/src/components/ConversationViewer.tsx", "summary": "会話の Markdown レンダリング表示 (画像対応)。スクロール位置の復元・自動スクロール", "hooks": ["useScrollRatio"], "parents": ["ChatView", "SessionList"] },
-      { "name": "ChatView", "file": "frontend/src/components/chat/ChatView.tsx", "summary": "現在セッションの会話形式ビュー。「Chat」モード選択時にターミナル領域を置き換える", "hooks": ["useAgentConversation", "useInputEcho"], "parents": ["DesktopLayout", "TerminalPage"] },
-      { "name": "ChatComposer", "file": "frontend/src/components/chat/ChatComposer.tsx", "summary": "ChatView 用の複数行メッセージコンポーザ", "hooks": [], "parents": ["ChatView"] },
-      { "name": "InputBar", "file": "frontend/src/components/InputBar.tsx", "summary": "ターミナル上部の常設入力バー。プロンプト履歴、スラッシュコマンドピッカー、画像アップロード", "hooks": [], "parents": ["DesktopLayout", "TerminalPage"] },
-      { "name": "FloatingKeyboard", "file": "frontend/src/components/FloatingKeyboard.tsx", "summary": "タブレット用ドラッグ可能フローティングキーボード。最小化対応、入力モード別に位置を保存", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "Keyboard", "file": "frontend/src/components/Keyboard.tsx", "summary": "モバイル用仮想キーボード。長押しで記号入力、JA トグルで IME 切替", "hooks": [], "parents": ["InputBar", "TerminalPage"] },
-      { "name": "FileViewer", "file": "frontend/src/components/files/FileViewer.tsx", "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude/Git 変更トグル、ブラウザ履歴ナビ、アップロード/ダウンロード、peerId 指定でリモート peer のファイル取得", "hooks": ["useFileViewer", "useViewHistory", "useAuthBlobUrl"], "parents": ["DesktopLayout", "App"] },
-      { "name": "FileBrowser", "file": "frontend/src/components/files/FileBrowser.tsx", "summary": "ディレクトリツリーのナビゲーション", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "FileContentView", "file": "frontend/src/components/files/FileContentView.tsx", "summary": "ファイル内容を種別に応じて Code/Markdown/Image/Html ビューアへルーティング", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "ChangesView", "file": "frontend/src/components/files/ChangesView.tsx", "summary": "Claude Code / Git の変更ファイル一覧。ファイル毎の diff ナビゲーション", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "CodeViewer", "file": "frontend/src/components/files/CodeViewer.tsx", "summary": "シンタックスハイライト表示。word-wrap / フォントサイズ設定", "hooks": ["useViewerSettings"], "parents": ["FileContentView"] },
-      { "name": "DiffViewer", "file": "frontend/src/components/files/DiffViewer.tsx", "summary": "ファイル変更の side-by-side / unified diff 表示", "hooks": ["useViewerSettings"], "parents": ["FileContentView"] },
-      { "name": "MarkdownViewer", "file": "frontend/src/components/files/MarkdownViewer.tsx", "summary": "Markdown レンダリング", "hooks": ["useViewerSettings"], "parents": ["FileContentView"] },
-      { "name": "ImageViewer", "file": "frontend/src/components/files/ImageViewer.tsx", "summary": "画像プレビュー (ピンチズーム対応、大きい画像は /files/raw ストリーミング)", "hooks": ["usePinchZoom"], "parents": ["FileContentView"] },
-      { "name": "HtmlViewer", "file": "frontend/src/components/files/HtmlViewer.tsx", "summary": "HTML ファイルの iframe 表示 (認証付き blob URL)", "hooks": ["useAuthBlobUrl"], "parents": ["FileContentView"] },
-      { "name": "PromptComposer", "file": "frontend/src/components/files/PromptComposer.tsx", "summary": "ファイルからプロンプトテキストを組み立てる UI", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "Dashboard", "file": "frontend/src/components/dashboard/Dashboard.tsx", "summary": "ダッシュボードのメインコンテナ。使用量・統計・peer サーバ一覧", "hooks": ["useDashboard", "usePeers", "useTheme", "useUiScale"], "parents": ["SessionList", "DashboardPanel"] },
-      { "name": "DashboardPanel", "file": "frontend/src/components/DashboardPanel.tsx", "summary": "ダッシュボードのサイドパネルラッパ (Ctrl+Shift+B)", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "UsageLimits", "file": "frontend/src/components/dashboard/UsageLimits.tsx", "summary": "5時間 / 7日サイクルの使用量プログレスバー表示", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "DailyUsageChart", "file": "frontend/src/components/dashboard/DailyUsageChart.tsx", "summary": "日別のメッセージ数・セッション数バーチャート", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "ModelUsageChart", "file": "frontend/src/components/dashboard/ModelUsageChart.tsx", "summary": "モデル別トークン使用量の比較チャート", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "HourlyHeatmap", "file": "frontend/src/components/dashboard/HourlyHeatmap.tsx", "summary": "時間帯別アクティビティのヒートマップ", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "UsageChart", "file": "frontend/src/components/dashboard/UsageChart.tsx", "summary": "使用量履歴のラインチャート (リアルタイムスナップショット)", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "NetworkLatency", "file": "frontend/src/components/dashboard/NetworkLatency.tsx", "summary": "WebSocket / API レイテンシ表示", "hooks": ["useNetworkLatency"], "parents": ["Dashboard"] },
-      { "name": "ServerInfo", "file": "frontend/src/components/dashboard/ServerInfo.tsx", "summary": "サーバ情報とシステム詳細の表示", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "PeerServerCard", "file": "frontend/src/components/dashboard/PeerServerCard.tsx", "summary": "peer サーバ毎の情報カード (CPU / メモリ / 接続数)", "hooks": ["usePeerServerMetrics"], "parents": ["Dashboard"] },
-      { "name": "PeerManager", "file": "frontend/src/components/PeerManager.tsx", "summary": "peer サーバ管理 UI (登録・検証・自動検出・並べ替え・削除)", "hooks": ["usePeers"], "parents": ["App"] },
-      { "name": "LoginForm", "file": "frontend/src/components/LoginForm.tsx", "summary": "パスワード認証フォーム (パスワード設定時のみ表示)", "hooks": [], "parents": ["App"] },
-      { "name": "Onboarding", "file": "frontend/src/components/Onboarding.tsx", "summary": "初回ユーザー向けスポットライト式ウォークスルー (デバイス別ステップ)", "hooks": [], "parents": ["App", "DesktopLayout"] }
+      {
+        "name": "App",
+        "file": "frontend/src/App.tsx",
+        "summary": "ルートコンポーネント。mobile / tablet / desktop のデバイス判定でレイアウトを切り替え。認証・セッション管理・ファイルビューア・チャットビューを統合",
+        "hooks": [
+          "useAuth",
+          "useSessions"
+        ],
+        "parents": []
+      },
+      {
+        "name": "DesktopLayout",
+        "file": "frontend/src/components/DesktopLayout.tsx",
+        "summary": "デスクトップ / タブレット向けメインレイアウト。tmux 制御モード統合、ペインツリー管理、キーボードショートカット",
+        "hooks": [
+          "useMultiplexedTerminal",
+          "usePeerConnection",
+          "useSessions",
+          "usePeers"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "TerminalPage",
+        "file": "frontend/src/pages/TerminalPage.tsx",
+        "summary": "モバイル向けターミナルページ。単一ペイン表示 + ペインタブバー + InputBar / ChatView 切替",
+        "hooks": [
+          "useMultiplexedTerminal"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "PaneContainer",
+        "file": "frontend/src/components/PaneContainer.tsx",
+        "summary": "ペインツリーの再帰描画。ControlModeContext 経由で分割・クローズ・ズーム・リサイズ操作を提供",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout",
+          "PaneContainer"
+        ]
+      },
+      {
+        "name": "Terminal",
+        "file": "frontend/src/components/Terminal.tsx",
+        "summary": "xterm.js ターミナル (WebGL、scrollback:0)。viewport フレームを VT シーケンスに変換して term.write() で反映。tmux サイズ同期 (setExactSize)、フォント調整、テキスト選択",
+        "hooks": [
+          "useSelectionMode"
+        ],
+        "parents": [
+          "PaneContainer",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "SelectionOverlay",
+        "file": "frontend/src/components/SelectionOverlay.tsx",
+        "summary": "タッチ選択オーバーレイ。開始/終了ハンドルのドラッグとコピー/キャンセル操作",
+        "hooks": [
+          "useSelectionMode"
+        ],
+        "parents": [
+          "Terminal"
+        ]
+      },
+      {
+        "name": "SessionList",
+        "file": "frontend/src/components/SessionList.tsx",
+        "summary": "セッション一覧 (Active / History / Dashboard タブ)。ペイン操作、ピンチズーム、History V1/V2 の分岐",
+        "hooks": [
+          "useHistoryV2Flag",
+          "useSessionHistory"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "SessionModal",
+        "file": "frontend/src/components/SessionModal.tsx",
+        "summary": "セッション選択モーダル (Ctrl+B)。ペイン数バッジと展開式ペイン一覧",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "SessionHistory",
+        "file": "frontend/src/components/SessionHistory.tsx",
+        "summary": "セッション履歴 V1 (プロジェクトグループ表示)。V2 安定化まで併存するレガシー実装",
+        "hooks": [],
+        "parents": [
+          "SessionList"
+        ]
+      },
+      {
+        "name": "SessionHistoryV2",
+        "file": "frontend/src/components/history/SessionHistoryV2.tsx",
+        "summary": "セッション履歴 V2。フラットリスト + ファセット検索 + 仮想スクロール",
+        "hooks": [
+          "useFlatHistoryItems",
+          "useHistoryActions"
+        ],
+        "parents": [
+          "SessionList"
+        ]
+      },
+      {
+        "name": "VirtualizedHistoryList",
+        "file": "frontend/src/components/history/VirtualizedHistoryList.tsx",
+        "summary": "大規模履歴の仮想化リスト描画",
+        "hooks": [],
+        "parents": [
+          "SessionHistoryV2"
+        ]
+      },
+      {
+        "name": "HistoryRowV2",
+        "file": "frontend/src/components/history/HistoryRowV2.tsx",
+        "summary": "履歴 1 行。resume / 会話表示などのハンドラ",
+        "hooks": [],
+        "parents": [
+          "VirtualizedHistoryList"
+        ]
+      },
+      {
+        "name": "HistoryFacetSidebar",
+        "file": "frontend/src/components/history/HistoryFacetSidebar.tsx",
+        "summary": "ファセットフィルタ (project / agent / status) のデスクトップ用サイドバー",
+        "hooks": [],
+        "parents": [
+          "SessionHistoryV2"
+        ]
+      },
+      {
+        "name": "HistoryFacetDrawer",
+        "file": "frontend/src/components/history/HistoryFacetDrawer.tsx",
+        "summary": "ファセットフィルタのモバイル用ドロワー",
+        "hooks": [],
+        "parents": [
+          "SessionHistoryV2"
+        ]
+      },
+      {
+        "name": "HistoryActiveChips",
+        "file": "frontend/src/components/history/HistoryActiveChips.tsx",
+        "summary": "適用中フィルタの chips 表示と解除",
+        "hooks": [],
+        "parents": [
+          "SessionHistoryV2"
+        ]
+      },
+      {
+        "name": "ConversationViewer",
+        "file": "frontend/src/components/ConversationViewer.tsx",
+        "summary": "会話の Markdown レンダリング表示 (画像対応)。スクロール位置の復元・自動スクロール",
+        "hooks": [
+          "useScrollRatio"
+        ],
+        "parents": [
+          "ChatView",
+          "SessionList"
+        ]
+      },
+      {
+        "name": "ChatView",
+        "file": "frontend/src/components/chat/ChatView.tsx",
+        "summary": "現在セッションの会話形式ビュー。「Chat」モード選択時にターミナル領域を置き換える",
+        "hooks": [
+          "useAgentConversation",
+          "useInputEcho"
+        ],
+        "parents": [
+          "DesktopLayout",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "ChatComposer",
+        "file": "frontend/src/components/chat/ChatComposer.tsx",
+        "summary": "ChatView 用の複数行メッセージコンポーザ",
+        "hooks": [],
+        "parents": [
+          "ChatView"
+        ]
+      },
+      {
+        "name": "InputBar",
+        "file": "frontend/src/components/InputBar.tsx",
+        "summary": "ターミナル上部の常設入力バー。プロンプト履歴、スラッシュコマンドピッカー、画像アップロード",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "FloatingKeyboard",
+        "file": "frontend/src/components/FloatingKeyboard.tsx",
+        "summary": "タブレット用ドラッグ可能フローティングキーボード。最小化対応、入力モード別に位置を保存",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "Keyboard",
+        "file": "frontend/src/components/Keyboard.tsx",
+        "summary": "モバイル用仮想キーボード。長押しで記号入力、JA トグルで IME 切替",
+        "hooks": [],
+        "parents": [
+          "InputBar",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "FileViewer",
+        "file": "frontend/src/components/files/FileViewer.tsx",
+        "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude/Git 変更トグル、ブラウザ履歴ナビ、アップロード/ダウンロード、peerId 指定でリモート peer のファイル取得",
+        "hooks": [
+          "useFileViewer",
+          "useViewHistory",
+          "useAuthBlobUrl"
+        ],
+        "parents": [
+          "DesktopLayout",
+          "App"
+        ]
+      },
+      {
+        "name": "FileBrowser",
+        "file": "frontend/src/components/files/FileBrowser.tsx",
+        "summary": "ディレクトリツリーのナビゲーション",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "FileContentView",
+        "file": "frontend/src/components/files/FileContentView.tsx",
+        "summary": "ファイル内容を種別に応じて Code/Markdown/Image/Html ビューアへルーティング",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "ChangesView",
+        "file": "frontend/src/components/files/ChangesView.tsx",
+        "summary": "Claude Code / Git の変更ファイル一覧。ファイル毎の diff ナビゲーション",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "CodeViewer",
+        "file": "frontend/src/components/files/CodeViewer.tsx",
+        "summary": "シンタックスハイライト表示。word-wrap / フォントサイズ設定",
+        "hooks": [
+          "useViewerSettings"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "DiffViewer",
+        "file": "frontend/src/components/files/DiffViewer.tsx",
+        "summary": "ファイル変更の side-by-side / unified diff 表示",
+        "hooks": [
+          "useViewerSettings"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "MarkdownViewer",
+        "file": "frontend/src/components/files/MarkdownViewer.tsx",
+        "summary": "Markdown レンダリング",
+        "hooks": [
+          "useViewerSettings"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "ImageViewer",
+        "file": "frontend/src/components/files/ImageViewer.tsx",
+        "summary": "画像プレビュー (ピンチズーム対応、大きい画像は /files/raw ストリーミング)",
+        "hooks": [
+          "usePinchZoom"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "HtmlViewer",
+        "file": "frontend/src/components/files/HtmlViewer.tsx",
+        "summary": "HTML ファイルの iframe 表示 (認証付き blob URL)",
+        "hooks": [
+          "useAuthBlobUrl"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "PromptComposer",
+        "file": "frontend/src/components/files/PromptComposer.tsx",
+        "summary": "ファイルからプロンプトテキストを組み立てる UI",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "Dashboard",
+        "file": "frontend/src/components/dashboard/Dashboard.tsx",
+        "summary": "ダッシュボードのメインコンテナ。使用量・統計・peer サーバ一覧",
+        "hooks": [
+          "useDashboard",
+          "usePeers",
+          "useTheme",
+          "useUiScale"
+        ],
+        "parents": [
+          "SessionList",
+          "DashboardPanel"
+        ]
+      },
+      {
+        "name": "DashboardPanel",
+        "file": "frontend/src/components/DashboardPanel.tsx",
+        "summary": "ダッシュボードのサイドパネルラッパ (Ctrl+Shift+B)",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "UsageLimits",
+        "file": "frontend/src/components/dashboard/UsageLimits.tsx",
+        "summary": "5時間 / 7日サイクルの使用量プログレスバー表示",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "DailyUsageChart",
+        "file": "frontend/src/components/dashboard/DailyUsageChart.tsx",
+        "summary": "日別のメッセージ数・セッション数バーチャート",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "ModelUsageChart",
+        "file": "frontend/src/components/dashboard/ModelUsageChart.tsx",
+        "summary": "モデル別トークン使用量の比較チャート",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "HourlyHeatmap",
+        "file": "frontend/src/components/dashboard/HourlyHeatmap.tsx",
+        "summary": "時間帯別アクティビティのヒートマップ",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "UsageChart",
+        "file": "frontend/src/components/dashboard/UsageChart.tsx",
+        "summary": "使用量履歴のラインチャート (リアルタイムスナップショット)",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "NetworkLatency",
+        "file": "frontend/src/components/dashboard/NetworkLatency.tsx",
+        "summary": "WebSocket / API レイテンシ表示",
+        "hooks": [
+          "useNetworkLatency"
+        ],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "ServerInfo",
+        "file": "frontend/src/components/dashboard/ServerInfo.tsx",
+        "summary": "サーバ情報とシステム詳細の表示",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "PeerServerCard",
+        "file": "frontend/src/components/dashboard/PeerServerCard.tsx",
+        "summary": "peer サーバ毎の情報カード (CPU / メモリ / 接続数)",
+        "hooks": [
+          "usePeerServerMetrics"
+        ],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "PeerManager",
+        "file": "frontend/src/components/PeerManager.tsx",
+        "summary": "peer サーバ管理 UI (登録・検証・自動検出・並べ替え・削除)",
+        "hooks": [
+          "usePeers"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "LoginForm",
+        "file": "frontend/src/components/LoginForm.tsx",
+        "summary": "パスワード認証フォーム (パスワード設定時のみ表示)",
+        "hooks": [],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "Onboarding",
+        "file": "frontend/src/components/Onboarding.tsx",
+        "summary": "初回ユーザー向けスポットライト式ウォークスルー (デバイス別ステップ)",
+        "hooks": [],
+        "parents": [
+          "App",
+          "DesktopLayout"
+        ]
+      }
     ],
     "hooks": [
-      { "name": "useMultiplexedTerminal", "file": "frontend/src/hooks/useMultiplexedTerminal.ts", "summary": "/ws/mux への共有シングルトン WebSocket。自動再接続、keepalive ping、セッション購読、base64 入出力、viewport ディスパッチ。sendInput / resize / splitPane / requestViewport 等の操作 API を返す。peerWsBase 指定でリモート peer に接続" },
-      { "name": "useSessions", "file": "frontend/src/hooks/useSessions.ts", "summary": "アクティブセッションの状態管理。usePeerSessionsWatcher で複数 peer を集約し module-level cache を共有。createSession / deleteSession / updateSessionTheme API" },
-      { "name": "useSessionHistory", "file": "frontend/src/hooks/useSessionHistory.ts", "summary": "履歴ブラウジング。peer 横断の projects 取得、projectKey (peerId::dirName) 管理、SSE ストリーミング検索 (Bearer token 付与)、resumeSession / fetchConversation" },
-      { "name": "useFlatHistoryItems", "file": "frontend/src/hooks/useFlatHistoryItems.ts", "summary": "プロジェクトグループの履歴をフラット化して History V2 のフィルタ可能リストに変換。4 並行 hydration、更新日時降順ソート" },
-      { "name": "useHistoryActions", "file": "frontend/src/hooks/useHistoryActions.ts", "summary": "履歴の resume / ナビゲーション / 会話表示の共通ロジック (V1/V2 両ビューで使用)" },
-      { "name": "useHistoryV2Flag", "file": "frontend/src/hooks/useHistoryV2Flag.ts", "summary": "History V2 のフィーチャーフラグ。localStorage cchub-history-v2 (デフォルト ON)、storage イベント監視" },
-      { "name": "useDashboard", "file": "frontend/src/hooks/useDashboard.ts", "summary": "/api/dashboard のポーリング取得 (60s)。DashboardResponse を返す" },
-      { "name": "useFileViewer", "file": "frontend/src/hooks/useFileViewer.ts", "summary": "ファイルビューア状態。listDirectory / readFile / getChanges / getGitChanges / getGitDiff。peerId オプションでリモート peer のファイル取得" },
-      { "name": "useViewHistory", "file": "frontend/src/hooks/useViewHistory.ts", "summary": "ファイルビューアの戻るナビゲーション (browser/file/changes/diff の各 ViewMode)。in-memory スタック + window.history 同期" },
-      { "name": "useViewerSettings", "file": "frontend/src/hooks/useViewerSettings.ts", "summary": "ビューア設定。word-wrap (ファイル毎) と フォントサイズ (グローバル、8-32px) を localStorage に永続化" },
-      { "name": "useAuth", "file": "frontend/src/hooks/useAuth.ts", "summary": "認証状態管理。トークンを localStorage (cc-hub-token) に永続化、login / logout を提供" },
-      { "name": "useAuthBlobUrl", "file": "frontend/src/hooks/useAuthBlobUrl.ts", "summary": "認証ヘッダ付き fetch でリソースを取得し blob URL として返す (img / video / iframe の src 用)。自動 revoke" },
-      { "name": "useTheme", "file": "frontend/src/hooks/useTheme.ts", "summary": "ダーク / ライトテーマ切替 (localStorage cchub-theme)" },
-      { "name": "useUiScale", "file": "frontend/src/hooks/useUiScale.ts", "summary": "UI スケール倍率の永続化と CSS 変数への適用 (localStorage cchub-ui-scale)" },
-      { "name": "useNetworkLatency", "file": "frontend/src/hooks/useNetworkLatency.ts", "summary": "WebSocket / API レイテンシ計測 (30s 毎の /health ping、latency-store 購読)" },
-      { "name": "useLineSelection", "file": "frontend/src/hooks/useLineSelection.ts", "summary": "ファイルビューアの行範囲選択ユーティリティ" },
-      { "name": "useSelectionMode", "file": "frontend/src/hooks/useSelectionMode.ts", "summary": "SelectionOverlay 用のタッチ選択ステートマシン (開始/終了セル、ドラッグハンドル、クリップボードコピー)" },
-      { "name": "useInputEcho", "file": "frontend/src/hooks/useInputEcho.ts", "summary": "ターミナル非表示時に InputBar の入力を会話/チャットビューへエコー表示。矢印・Ctrl 等の特殊キーは記号表示" },
-      { "name": "useConversationStream", "file": "frontend/src/hooks/useConversationStream.ts", "summary": "/ws/mux の会話ストリーム購読 (subscribe-conversation)。増分の conversation-update を公開" },
-      { "name": "useAgentConversation", "file": "frontend/src/hooks/useAgentConversation.ts", "summary": "アクティブセッションの agent に応じて Claude (WebSocket ストリーム) / Codex (ポーリング) の会話ソースを選択する統合フック" },
-      { "name": "useCodexConversation", "file": "frontend/src/hooks/useCodexConversation.ts", "summary": "Codex 会話のポーリングローダ (5s 間隔、transcript + トークン使用量)" },
-      { "name": "usePeers", "file": "frontend/src/hooks/usePeers.ts", "summary": "peer 一覧の CRUD と状態管理 (5s ポーリング、module-level cache + broadcast)。addPeer / updatePeer / deletePeer / verifyPeer / reorderPeers" },
-      { "name": "usePeerConnection", "file": "frontend/src/hooks/usePeerConnection.ts", "summary": "セッションの peerId から接続情報 (wsBase / apiBase / token) を導出。リモート peer は peer.url から変換" },
-      { "name": "usePeerSessionsWatcher", "file": "frontend/src/hooks/usePeerSessionsWatcher.ts", "summary": "リモート peer 毎に /ws/mux への常時 WebSocket を張り、sessions-updated push と hook-event をポーリングなしで受信。自動再接続" },
-      { "name": "usePeerServerMetrics", "file": "frontend/src/hooks/usePeerServerMetrics.ts", "summary": "peer のダッシュボードメトリクス (systemMetrics / diskUsage / connectedClients) を 30s ポーリング" },
-      { "name": "usePinchZoom", "file": "frontend/src/hooks/usePinchZoom.ts", "summary": "2 本指ピンチズームのジェスチャ処理。min/max クランプ、transient (onChange) と persistent (onCommit) の分離" },
-      { "name": "useScrollRatio", "file": "frontend/src/hooks/useScrollRatio.ts", "summary": "スクロール要素の位置比率 (0..1) を追跡・復元" }
+      {
+        "name": "useMultiplexedTerminal",
+        "file": "frontend/src/hooks/useMultiplexedTerminal.ts",
+        "summary": "/ws/mux への共有シングルトン WebSocket。自動再接続、keepalive ping、セッション購読、base64 入出力、viewport ディスパッチ。sendInput / resize / splitPane / requestViewport 等の操作 API を返す。peerWsBase 指定でリモート peer に接続"
+      },
+      {
+        "name": "useSessions",
+        "file": "frontend/src/hooks/useSessions.ts",
+        "summary": "アクティブセッションの状態管理。usePeerSessionsWatcher で複数 peer を集約し module-level cache を共有。createSession / deleteSession / updateSessionTheme API"
+      },
+      {
+        "name": "useSessionHistory",
+        "file": "frontend/src/hooks/useSessionHistory.ts",
+        "summary": "履歴ブラウジング。peer 横断の projects 取得、projectKey (peerId::dirName) 管理、SSE ストリーミング検索 (Bearer token 付与)、resumeSession / fetchConversation"
+      },
+      {
+        "name": "useFlatHistoryItems",
+        "file": "frontend/src/hooks/useFlatHistoryItems.ts",
+        "summary": "プロジェクトグループの履歴をフラット化して History V2 のフィルタ可能リストに変換。4 並行 hydration、更新日時降順ソート"
+      },
+      {
+        "name": "useHistoryActions",
+        "file": "frontend/src/hooks/useHistoryActions.ts",
+        "summary": "履歴の resume / ナビゲーション / 会話表示の共通ロジック (V1/V2 両ビューで使用)"
+      },
+      {
+        "name": "useHistoryV2Flag",
+        "file": "frontend/src/hooks/useHistoryV2Flag.ts",
+        "summary": "History V2 のフィーチャーフラグ。localStorage cchub-history-v2 (デフォルト ON)、storage イベント監視"
+      },
+      {
+        "name": "useDashboard",
+        "file": "frontend/src/hooks/useDashboard.ts",
+        "summary": "/api/dashboard のポーリング取得 (60s)。DashboardResponse を返す"
+      },
+      {
+        "name": "useFileViewer",
+        "file": "frontend/src/hooks/useFileViewer.ts",
+        "summary": "ファイルビューア状態。listDirectory / readFile / getChanges / getGitChanges / getGitDiff。peerId オプションでリモート peer のファイル取得"
+      },
+      {
+        "name": "useViewHistory",
+        "file": "frontend/src/hooks/useViewHistory.ts",
+        "summary": "ファイルビューアの戻るナビゲーション (browser/file/changes/diff の各 ViewMode)。in-memory スタック + window.history 同期"
+      },
+      {
+        "name": "useViewerSettings",
+        "file": "frontend/src/hooks/useViewerSettings.ts",
+        "summary": "ビューア設定。word-wrap (ファイル毎) と フォントサイズ (グローバル、8-32px) を localStorage に永続化"
+      },
+      {
+        "name": "useAuth",
+        "file": "frontend/src/hooks/useAuth.ts",
+        "summary": "認証状態管理。トークンを localStorage (cc-hub-token) に永続化、login / logout を提供"
+      },
+      {
+        "name": "useAuthBlobUrl",
+        "file": "frontend/src/hooks/useAuthBlobUrl.ts",
+        "summary": "認証ヘッダ付き fetch でリソースを取得し blob URL として返す (img / video / iframe の src 用)。自動 revoke"
+      },
+      {
+        "name": "useTheme",
+        "file": "frontend/src/hooks/useTheme.ts",
+        "summary": "ダーク / ライトテーマ切替 (localStorage cchub-theme)"
+      },
+      {
+        "name": "useUiScale",
+        "file": "frontend/src/hooks/useUiScale.ts",
+        "summary": "UI スケール倍率の永続化と CSS 変数への適用 (localStorage cchub-ui-scale)"
+      },
+      {
+        "name": "useNetworkLatency",
+        "file": "frontend/src/hooks/useNetworkLatency.ts",
+        "summary": "WebSocket / API レイテンシ計測 (30s 毎の /health ping、latency-store 購読)"
+      },
+      {
+        "name": "useLineSelection",
+        "file": "frontend/src/hooks/useLineSelection.ts",
+        "summary": "ファイルビューアの行範囲選択ユーティリティ"
+      },
+      {
+        "name": "useSelectionMode",
+        "file": "frontend/src/hooks/useSelectionMode.ts",
+        "summary": "SelectionOverlay 用のタッチ選択ステートマシン (開始/終了セル、ドラッグハンドル、クリップボードコピー)"
+      },
+      {
+        "name": "useInputEcho",
+        "file": "frontend/src/hooks/useInputEcho.ts",
+        "summary": "ターミナル非表示時に InputBar の入力を会話/チャットビューへエコー表示。矢印・Ctrl 等の特殊キーは記号表示"
+      },
+      {
+        "name": "useConversationStream",
+        "file": "frontend/src/hooks/useConversationStream.ts",
+        "summary": "/ws/mux の会話ストリーム購読 (subscribe-conversation)。増分の conversation-update を公開"
+      },
+      {
+        "name": "useAgentConversation",
+        "file": "frontend/src/hooks/useAgentConversation.ts",
+        "summary": "アクティブセッションの agent に応じて Claude (WebSocket ストリーム) / Codex (ポーリング) の会話ソースを選択する統合フック"
+      },
+      {
+        "name": "useCodexConversation",
+        "file": "frontend/src/hooks/useCodexConversation.ts",
+        "summary": "Codex 会話のポーリングローダ (5s 間隔、transcript + トークン使用量)"
+      },
+      {
+        "name": "usePeers",
+        "file": "frontend/src/hooks/usePeers.ts",
+        "summary": "peer 一覧の CRUD と状態管理 (5s ポーリング、module-level cache + broadcast)。addPeer / updatePeer / deletePeer / verifyPeer / reorderPeers"
+      },
+      {
+        "name": "usePeerConnection",
+        "file": "frontend/src/hooks/usePeerConnection.ts",
+        "summary": "セッションの peerId から接続情報 (wsBase / apiBase / token) を導出。リモート peer は peer.url から変換"
+      },
+      {
+        "name": "usePeerSessionsWatcher",
+        "file": "frontend/src/hooks/usePeerSessionsWatcher.ts",
+        "summary": "リモート peer 毎に /ws/mux への常時 WebSocket を張り、sessions-updated push と hook-event をポーリングなしで受信。自動再接続"
+      },
+      {
+        "name": "usePeerServerMetrics",
+        "file": "frontend/src/hooks/usePeerServerMetrics.ts",
+        "summary": "peer のダッシュボードメトリクス (systemMetrics / diskUsage / connectedClients) を 30s ポーリング"
+      },
+      {
+        "name": "usePinchZoom",
+        "file": "frontend/src/hooks/usePinchZoom.ts",
+        "summary": "2 本指ピンチズームのジェスチャ処理。min/max クランプ、transient (onChange) と persistent (onCommit) の分離"
+      },
+      {
+        "name": "useScrollRatio",
+        "file": "frontend/src/hooks/useScrollRatio.ts",
+        "summary": "スクロール要素の位置比率 (0..1) を追跡・復元"
+      }
     ]
   },
   "websocket": {
     "endpoint": "/ws/mux",
     "description": "単一の多重化 WebSocket。クライアントは subscribe でセッション毎に購読し、ターミナル表示は PaneViewport フレーム (offset ベースのサーバーサイドスクロールバック) で配信。request-viewport への応答に加え、live (offset=0) 購読者には tmux 出力時に未要求 push もされる。全クライアント入力フレームは zod で検証 (#231)",
     "client_messages": {
-      "mux_level": ["subscribe", "unsubscribe", "subscribe-conversation", "unsubscribe-conversation"],
-      "per_session": ["input", "resize", "split", "close-pane", "resize-pane", "select-pane", "adjust-pane", "equalize-panes", "zoom-pane", "respawn-pane", "request-viewport", "ping", "client-info"]
+      "mux_level": [
+        "subscribe",
+        "unsubscribe",
+        "subscribe-conversation",
+        "unsubscribe-conversation"
+      ],
+      "per_session": [
+        "input",
+        "resize",
+        "split",
+        "close-pane",
+        "resize-pane",
+        "select-pane",
+        "adjust-pane",
+        "equalize-panes",
+        "zoom-pane",
+        "respawn-pane",
+        "request-viewport",
+        "ping",
+        "client-info"
+      ]
     },
     "server_messages": {
-      "mux_level": ["subscribed", "unsubscribed", "sessions-updated", "conversation-subscribed", "conversation-unsubscribed", "initial-conversation", "conversation-update"],
-      "per_session": ["layout", "viewport", "ready", "pong", "error", "new-session", "pane-dead", "hook-event"]
+      "mux_level": [
+        "subscribed",
+        "unsubscribed",
+        "sessions-updated",
+        "conversation-subscribed",
+        "conversation-unsubscribed",
+        "initial-conversation",
+        "conversation-update"
+      ],
+      "per_session": [
+        "layout",
+        "viewport",
+        "ready",
+        "pong",
+        "error",
+        "new-session",
+        "pane-dead",
+        "hook-event"
+      ]
     },
     "binary_format": "未使用 (全フレームが JSON テキスト。ペイン出力は viewport.lines に ANSI エンコード文字列で同梱)",
     "intervals": {
@@ -511,28 +1528,94 @@
     }
   },
   "types": [
-    { "name": "SessionResponse", "fields": "id, name, createdAt, lastAccessedAt, state, currentPath, agent, theme, customTitle" },
-    { "name": "ExtendedSessionResponse", "fields": "extends SessionResponse + indicatorState, ccSessionId, agentSessionId, currentCommand, paneTitle, ccSummary, ccFirstPrompt, ccRecap, waitingToolName, panes, messageCount, gitBranch, durationMinutes, metrics, peerId" },
-    { "name": "PaneInfo", "fields": "paneId, currentCommand, currentPath, title, agentName, agentColor, isActive, isDead, indicatorState, pid" },
-    { "name": "TmuxLayoutNode", "fields": "type ('leaf' | 'horizontal' | 'vertical'), width, height, x, y, paneId?, children?" },
-    { "name": "PaneViewport", "fields": "paneId, cols, rows, lines (ちょうど rows 行・ANSI エンコード), cursor (PaneCursor), modes (PaneModes), historySize, offset (0 = live edge), atTail" },
-    { "name": "PaneCursor", "fields": "x, y (0-based), visible (offset>0 では false)" },
-    { "name": "PaneModes", "fields": "altScreen (vim / htop 等の alternate screen 判定)" },
-    { "name": "ControlClientMessage", "fields": "input | resize | split | close-pane | resize-pane | select-pane | adjust-pane | equalize-panes | zoom-pane | respawn-pane | request-viewport | ping | client-info" },
-    { "name": "ControlServerMessage", "fields": "layout | viewport | ready | pong | error | new-session | pane-dead | hook-event" },
-    { "name": "MuxClientMessage", "fields": "subscribe | unsubscribe | subscribe-conversation | unsubscribe-conversation | (ControlClientMessage + sessionId)" },
-    { "name": "MuxServerMessage", "fields": "subscribed | unsubscribed | sessions-updated | conversation-* | initial-conversation | (ControlServerMessage + sessionId)" },
-    { "name": "Peer", "fields": "id ('local' | 'p_xxxx'), nickname, url ('self' | https URL), color, order" },
-    { "name": "PeerClientView", "fields": "extends Peer + wsToken (peer 直結 WS 用 Bearer), status, lastSeenAt, latencyMs, errorMessage" },
-    { "name": "DiscoveredPeer", "fields": "Tailscale 検出結果: host, url, version, alreadyRegistered" },
-    { "name": "HistorySession", "fields": "sessionId, projectPath, projectName, firstPrompt (旧称・実体は最終ユーザーメッセージ), lastPrompt, recap, recapAt, modified, messageCount, gitBranch, agent, peerId" },
-    { "name": "SessionMetrics", "fields": "contextTokens, contextMaxTokens, contextPercent, totalInputTokens, totalCacheCreationTokens, totalCacheReadTokens, totalOutputTokens, totalTokens, memoryRssBytes" },
-    { "name": "DashboardResponse", "fields": "usageLimits, usageLimitsStatus, codexUsageLimits, usageHistory, dailyActivity, modelUsage, costEstimates, hourlyActivity, version, systemMetrics, diskUsage, connectedClients" },
-    { "name": "ConversationMessage", "fields": "role, content, timestamp, thinking, toolUse, toolResult" },
-    { "name": "UsageLimits", "fields": "fiveHour (UsageCycleInfo), sevenDay (UsageCycleInfo)" },
-    { "name": "SessionState", "fields": "'idle' | 'working' | 'waiting_input' | 'waiting_permission' | 'disconnected' | 'lost'" },
-    { "name": "IndicatorState", "fields": "'processing' | 'waiting_input' | 'idle' | 'completed'" },
-    { "name": "AgentProvider", "fields": "'claude' | 'codex' (AGENT_PROVIDERS レジストリが resume コマンド等を定義)" }
+    {
+      "name": "SessionResponse",
+      "fields": "id, name, createdAt, lastAccessedAt, state, currentPath, agent, theme, customTitle"
+    },
+    {
+      "name": "ExtendedSessionResponse",
+      "fields": "extends SessionResponse + indicatorState, ccSessionId, agentSessionId, currentCommand, paneTitle, ccSummary, ccFirstPrompt, ccRecap, waitingToolName, panes, messageCount, gitBranch, durationMinutes, metrics, peerId"
+    },
+    {
+      "name": "PaneInfo",
+      "fields": "paneId, currentCommand, currentPath, title, agentName, agentColor, isActive, isDead, indicatorState, pid"
+    },
+    {
+      "name": "TmuxLayoutNode",
+      "fields": "type ('leaf' | 'horizontal' | 'vertical'), width, height, x, y, paneId?, children?"
+    },
+    {
+      "name": "PaneViewport",
+      "fields": "paneId, cols, rows, lines (ちょうど rows 行・ANSI エンコード), cursor (PaneCursor), modes (PaneModes), historySize, offset (0 = live edge), atTail"
+    },
+    {
+      "name": "PaneCursor",
+      "fields": "x, y (0-based), visible (offset>0 では false)"
+    },
+    {
+      "name": "PaneModes",
+      "fields": "altScreen (vim / htop 等の alternate screen 判定)"
+    },
+    {
+      "name": "ControlClientMessage",
+      "fields": "input | resize | split | close-pane | resize-pane | select-pane | adjust-pane | equalize-panes | zoom-pane | respawn-pane | request-viewport | ping | client-info"
+    },
+    {
+      "name": "ControlServerMessage",
+      "fields": "layout | viewport | ready | pong | error | new-session | pane-dead | hook-event"
+    },
+    {
+      "name": "MuxClientMessage",
+      "fields": "subscribe | unsubscribe | subscribe-conversation | unsubscribe-conversation | (ControlClientMessage + sessionId)"
+    },
+    {
+      "name": "MuxServerMessage",
+      "fields": "subscribed | unsubscribed | sessions-updated | conversation-* | initial-conversation | (ControlServerMessage + sessionId)"
+    },
+    {
+      "name": "Peer",
+      "fields": "id ('local' | 'p_xxxx'), nickname, url ('self' | https URL), color, order"
+    },
+    {
+      "name": "PeerClientView",
+      "fields": "extends Peer + wsToken (peer 直結 WS 用 Bearer), status, lastSeenAt, latencyMs, errorMessage"
+    },
+    {
+      "name": "DiscoveredPeer",
+      "fields": "Tailscale 検出結果: host, url, version, alreadyRegistered"
+    },
+    {
+      "name": "HistorySession",
+      "fields": "sessionId, projectPath, projectName, firstPrompt (旧称・実体は最終ユーザーメッセージ), lastPrompt, recap, recapAt, modified, messageCount, gitBranch, agent, peerId"
+    },
+    {
+      "name": "SessionMetrics",
+      "fields": "contextTokens, contextMaxTokens, contextPercent, totalInputTokens, totalCacheCreationTokens, totalCacheReadTokens, totalOutputTokens, totalTokens, memoryRssBytes"
+    },
+    {
+      "name": "DashboardResponse",
+      "fields": "usageLimits, usageLimitsStatus, codexUsageLimits, usageHistory, dailyActivity, modelUsage, costEstimates, hourlyActivity, version, systemMetrics, diskUsage, connectedClients"
+    },
+    {
+      "name": "ConversationMessage",
+      "fields": "role, content, timestamp, thinking, toolUse, toolResult"
+    },
+    {
+      "name": "UsageLimits",
+      "fields": "fiveHour (UsageCycleInfo), sevenDay (UsageCycleInfo)"
+    },
+    {
+      "name": "SessionState",
+      "fields": "'idle' | 'working' | 'waiting_input' | 'waiting_permission' | 'disconnected' | 'lost'"
+    },
+    {
+      "name": "IndicatorState",
+      "fields": "'processing' | 'waiting_input' | 'idle' | 'completed'"
+    },
+    {
+      "name": "AgentProvider",
+      "fields": "'claude' | 'codex' (AGENT_PROVIDERS レジストリが resume コマンド等を定義)"
+    }
   ],
   "data_flows": [
     {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.175",
+  "version": "0.1.176",
   "generated": "2026-06-10",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
@@ -10,11 +10,26 @@
     "transport": "Multiplexed WebSocket /ws/mux + tmux -CC control mode。ターミナル表示はサーバーサイドスクロールバック方式: tmux capture-pane による PaneViewport フレーム (rows 行 + cursor/modes + offset) を配信し、フロントは VT シーケンスへ変換して xterm.js (scrollback:0) に書き込む render-only 構成"
   },
   "workspaces": [
-    { "name": "backend", "desc": "Hono API サーバ (Bun)。tmux 制御・履歴・peer 連携・CLI (cchub) を提供" },
-    { "name": "frontend", "desc": "React SPA。タブレット/モバイル/デスクトップの3レイアウト" },
-    { "name": "shared", "desc": "Zod スキーマと型 (types.ts)。backend / frontend / tui が共有" },
-    { "name": "tui", "desc": "cchub tui (Ink + React)。ローカル専用のセッション一覧/履歴検索、入室は native tmux attach" },
-    { "name": "glasses", "desc": "EVEN G2 グラスアプリ (EvenHub SDK → out.ehpk)。型は手動複製のため WS プロトコル変更時は要追従" }
+    {
+      "name": "backend",
+      "desc": "Hono API サーバ (Bun)。tmux 制御・履歴・peer 連携・CLI (cchub) を提供"
+    },
+    {
+      "name": "frontend",
+      "desc": "React SPA。タブレット/モバイル/デスクトップの3レイアウト"
+    },
+    {
+      "name": "shared",
+      "desc": "Zod スキーマと型 (types.ts)。backend / frontend / tui が共有"
+    },
+    {
+      "name": "tui",
+      "desc": "cchub tui (Ink + React)。ローカル専用のセッション一覧/履歴検索、入室は native tmux attach"
+    },
+    {
+      "name": "glasses",
+      "desc": "EVEN G2 グラスアプリ (EvenHub SDK → out.ehpk)。型は手動複製のため WS プロトコル変更時は要追従"
+    }
   ],
   "diagram": [
     " Clients",
@@ -42,7 +57,10 @@
         "name": "TmuxControlSession",
         "file": "backend/src/services/tmux-control.ts",
         "summary": "tmux -CC (control mode) を管理するコア。%output (octal) / %layout-change / %begin / %end / %error / %exit を解析し、FIFO コマンドキュー + 直列化ロックでコマンド送信。raw byte 処理で分割 UTF-8 を保持。クライアント消滅後 30s のグレースピリオド、deviceType (mobile/desktop) 別のクライアント追跡を提供",
-        "deps": ["TmuxLayoutParser", "TmuxOctalDecoder"]
+        "deps": [
+          "TmuxLayoutParser",
+          "TmuxOctalDecoder"
+        ]
       },
       {
         "name": "TmuxService",
@@ -66,7 +84,9 @@
         "name": "PaneViewport",
         "file": "backend/src/services/pane-viewport.ts",
         "summary": "capture-pane -e -p -S/-E でペインの viewport (可視領域 + scrollback offset) を取得。tmux が表示と履歴の single source of truth。非 altScreen TUI (Claude Code 等) には padFill: 末尾 blank 行を cursor 行まで trim し scrollback を prepend して「void」を見せない。ペイン状態 (permission_prompt / ask_user_question / processing / idle) の regex 検出も提供",
-        "deps": ["ViewportCursorPolicy"]
+        "deps": [
+          "ViewportCursorPolicy"
+        ]
       },
       {
         "name": "ViewportCursorPolicy",
@@ -150,7 +170,9 @@
         "name": "SessionMetricsService",
         "file": "backend/src/services/session-metrics.ts",
         "summary": "JSONL からセッション毎のコンテキストトークン (最終ターンの input + cache_creation + cache_read)・合計トークンを集計 (mtime+size キャッシュ)。ps によるプロセスツリー RSS 取得 (1s cache)",
-        "deps": ["AnthropicModels"]
+        "deps": [
+          "AnthropicModels"
+        ]
       },
       {
         "name": "CodexService",
@@ -168,7 +190,9 @@
         "name": "CodexHistoryService",
         "file": "backend/src/services/codex-history.ts",
         "summary": "~/.codex/sessions の日付パーティション木 (YYYY/MM/DD/rollout-*.jsonl) を mtime ベースのファイル毎キャッシュ付きでスキャンし、cwd でグループ化して Claude Code 履歴と統合表示",
-        "deps": ["CodexConversationService"]
+        "deps": [
+          "CodexConversationService"
+        ]
       },
       {
         "name": "CodexUsageService",
@@ -180,7 +204,10 @@
         "name": "ConversationWatcher",
         "file": "backend/src/services/conversation-watcher.ts",
         "summary": "Claude Code / Codex の JSONL を fs.watch + 150ms デバウンスで監視し、新規ターンのみを WebSocket 購読者へ通知。mtime 追跡で冗長パースを回避",
-        "deps": ["ClaudeCodeService", "SessionHistoryService"]
+        "deps": [
+          "ClaudeCodeService",
+          "SessionHistoryService"
+        ]
       },
       {
         "name": "HookStatusService",
@@ -204,13 +231,18 @@
         "name": "PeerAuth",
         "file": "backend/src/services/peer-auth.ts",
         "summary": "peer への代理ログイン (POST /api/auth/login、5s timeout)。取得した JWT を保存して以降の API/WS に使用し、401 時は unauthorized として記録。/health で疎通確認",
-        "deps": ["PeerRegistry", "PeerUrl"]
+        "deps": [
+          "PeerRegistry",
+          "PeerUrl"
+        ]
       },
       {
         "name": "PeerDiscovery",
         "file": "backend/src/services/peer-discovery.ts",
         "summary": "`tailscale status --json` で tailnet の online peer を列挙し、各 :5923/health を 3s timeout で並列 probe。cchub が動いていれば version 付き DiscoveredPeer として返す",
-        "deps": ["PeerRegistry"]
+        "deps": [
+          "PeerRegistry"
+        ]
       },
       {
         "name": "PeerUrl",
@@ -220,167 +252,1152 @@
       }
     ],
     "routes": [
-      { "method": "GET", "path": "/health", "group": "System", "description": "ヘルスチェック。status と version を返す。認証不要 (peer discovery が利用)", "file": "backend/src/index.ts" },
-      { "method": "GET", "path": "/clear-cache", "group": "System", "description": "Service Worker 登録解除とキャッシュクリアを行う HTML ページ。認証不要", "file": "backend/src/index.ts" },
-      { "method": "GET", "path": "/api/images/:filename", "group": "System", "description": "アップロード画像の配信。認証不要", "file": "backend/src/index.ts" },
-      { "method": "WS", "path": "/ws/mux", "group": "System", "description": "多重化ターミナル WebSocket。viewport 配信・入力・レイアウト制御・会話ストリーム。token クエリで peer からの Bearer 認証に対応", "file": "backend/src/routes/terminal-mux.ts" },
-      { "method": "GET", "path": "/api/auth/required", "group": "Auth", "description": "パスワード認証が有効かどうかを返す", "file": "backend/src/routes/auth.ts" },
-      { "method": "POST", "path": "/api/auth/login", "group": "Auth", "description": "サーバパスワードでログインし JWT トークンを返す。認証不要", "file": "backend/src/routes/auth.ts" },
-      { "method": "POST", "path": "/api/auth/logout", "group": "Auth", "description": "ログアウト (ステートレス JWT のためダミー)", "file": "backend/src/routes/auth.ts" },
-      { "method": "GET", "path": "/api/auth/me", "group": "Auth", "description": "現在のユーザー情報を返す。認証必須", "file": "backend/src/routes/auth.ts" },
-      { "method": "GET", "path": "/api/sessions", "group": "Sessions", "description": "全 tmux セッション一覧 (Claude Code 状態・ペイン情報付き)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions", "group": "Sessions", "description": "新規セッション作成。agent (claude/codex), name, workingDir, initialPrompt 指定可", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/:id", "group": "Sessions", "description": "セッション詳細を取得", "file": "backend/src/routes/sessions.ts" },
-      { "method": "DELETE", "path": "/api/sessions/:id", "group": "Sessions", "description": "tmux セッションを kill。last-known 情報は保持", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/resume", "group": "Sessions", "description": "セッション内でエージェントを resume (claude -r / codex resume)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "PUT", "path": "/api/sessions/:id/theme", "group": "Sessions", "description": "セッションのカラーテーマを設定", "file": "backend/src/routes/sessions.ts" },
-      { "method": "PUT", "path": "/api/sessions/:id/title", "group": "Sessions", "description": "セッションのカスタムタイトルを設定", "file": "backend/src/routes/sessions.ts" },
-      { "method": "PUT", "path": "/api/sessions/order", "group": "Sessions", "description": "セッション表示順を保存", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/:id/copy-mode", "group": "Sessions", "description": "tmux copy mode の選択状態を取得", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/focus", "group": "Sessions", "description": "ペインにフォーカス ({ paneId })", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/close", "group": "Sessions", "description": "ペインを閉じる。最後の 1 枚は拒否", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/split", "group": "Sessions", "description": "ペイン分割 ({ paneId, direction: 'h'|'v' })", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/respawn", "group": "Sessions", "description": "dead ペインを respawn", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/panes/input", "group": "Sessions", "description": "ペインへ REST で入力送信 (cchub send / peer が使用)。wait=true で送信後の viewport スナップショットを返す", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/:id/panes/:paneId/viewport", "group": "Sessions", "description": "ペイン viewport を REST で取得 (cchub peek が使用)。lines クエリで末尾行数指定", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/:id/prompt", "group": "Sessions", "description": "アクティブペインへプロンプトテキストを送信", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/clipboard", "group": "Sessions", "description": "tmux グローバルペーストバッファの内容を取得", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history", "group": "Session History", "description": "最近のセッション履歴。metadata クエリでメタデータの遅延ロード可", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/projects", "group": "Session History", "description": "プロジェクト一覧 (Claude Code + Codex 統合)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/projects/:dirName", "group": "Session History", "description": "プロジェクト内のセッション一覧", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/search", "group": "Session History", "description": "全プロジェクト横断のセッション検索 (q, limit)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/search/stream", "group": "Session History", "description": "検索結果の SSE ストリーミング配信", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/history/:sessionId/conversation", "group": "Session History", "description": "セッションの会話を取得。agent=codex / projectDirName / last クエリ対応", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/history/metadata", "group": "Session History", "description": "指定 sessionIds のメタデータを遅延ロード", "file": "backend/src/routes/sessions.ts" },
-      { "method": "POST", "path": "/api/sessions/history/resume", "group": "Session History", "description": "履歴からセッションを resume (新規 tmux セッション作成)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/sessions/prompts/search", "group": "Session History", "description": "プロンプト履歴の検索 (q, limit)", "file": "backend/src/routes/sessions.ts" },
-      { "method": "GET", "path": "/api/files/list", "group": "Files", "description": "ディレクトリ一覧。sessionWorkingDir 配下に限定", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/read", "group": "Files", "description": "ファイル内容を取得 (サイズ制限あり。画像/メディアはメタデータのみ)", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/raw", "group": "Files", "description": "ファイルをインライン配信 (<img>/<video>/<audio> 用)。Range / 206 対応", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/download", "group": "Files", "description": "ファイルを添付ダウンロード (Bun.file ストリーミング)", "file": "backend/src/routes/files.ts" },
-      { "method": "POST", "path": "/api/files/upload", "group": "Files", "description": "multipart/form-data でファイル (複数可) をアップロード", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/browse", "group": "Files", "description": "ホームディレクトリ配下をセッション非依存でブラウズ", "file": "backend/src/routes/files.ts" },
-      { "method": "POST", "path": "/api/files/mkdir", "group": "Files", "description": "ディレクトリ作成 (ホーム配下のみ)", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/changes/:sessionWorkingDir", "group": "Files", "description": "JSONL 由来の Claude Code ファイル変更一覧", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/git-changes/:workingDir", "group": "Files", "description": "git status --porcelain による変更ファイル一覧 (ブランチ情報付き)", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/git-diff/:workingDir", "group": "Files", "description": "指定ファイルの unified diff (staged クエリ対応)", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/language", "group": "Files", "description": "ファイルパスから言語識別子・isImage・isText を判定", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/files/images/:filename", "group": "Files", "description": "会話用アップロード画像の配信", "file": "backend/src/routes/files.ts" },
-      { "method": "GET", "path": "/api/peers", "group": "Peers", "description": "登録済み peer 一覧 (self 含む) を返す", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/discover", "group": "Peers", "description": "Tailscale tailnet 内で稼働中の cchub を検出", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers", "group": "Peers", "description": "peer を登録 (nickname, url, password, color)。代理ログインして JWT を保存", "file": "backend/src/routes/peers.ts" },
-      { "method": "PATCH", "path": "/api/peers/:id", "group": "Peers", "description": "peer の nickname / color / password を更新", "file": "backend/src/routes/peers.ts" },
-      { "method": "DELETE", "path": "/api/peers/:id", "group": "Peers", "description": "peer を削除 (local は削除不可)", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers/:id/verify", "group": "Peers", "description": "peer の疎通・認証を再確認しレイテンシを返す", "file": "backend/src/routes/peers.ts" },
-      { "method": "PUT", "path": "/api/peers/order", "group": "Peers", "description": "peer の表示順を保存", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/session-order", "group": "Peers", "description": "peer 横断のセッション表示順を取得", "file": "backend/src/routes/peers.ts" },
-      { "method": "PUT", "path": "/api/peers/session-order", "group": "Peers", "description": "peer 横断のセッション表示順を保存", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/sessions", "group": "Peers", "description": "全 peer のアクティブセッションをマージして返す (peer 毎のエラー併載)", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/history/projects", "group": "Peers", "description": "全 peer のプロジェクト履歴をマージして返す", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/history/:peerId/projects/:dirName", "group": "Peers", "description": "指定 peer のプロジェクト内セッション一覧", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/history/:peerId/:sessionId/conversation", "group": "Peers", "description": "指定 peer のセッション会話を取得", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers/history/:peerId/resume", "group": "Peers", "description": "指定 peer 上でセッションを resume", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/:peerId/dashboard", "group": "Peers", "description": "指定 peer (または self) のダッシュボード情報を取得", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/peers/:peerId/files/browse", "group": "Peers", "description": "peer 上のディレクトリブラウズ (プロキシ)", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers/:peerId/files/mkdir", "group": "Peers", "description": "peer 上にディレクトリ作成 (プロキシ)", "file": "backend/src/routes/peers.ts" },
-      { "method": "POST", "path": "/api/peers/:peerId/upload/image", "group": "Peers", "description": "画像アップロードを peer へ転送し、peer 上の絶対パスを返す", "file": "backend/src/routes/peers.ts" },
-      { "method": "ALL", "path": "/api/peers/:peerId/files/*", "group": "Peers", "description": "Files API の汎用プロキシ (list / read / raw / download / upload / language / changes / git-changes / git-diff / images を peer へ透過転送)", "file": "backend/src/routes/peers.ts" },
-      { "method": "GET", "path": "/api/dashboard", "group": "Dashboard", "description": "ダッシュボード情報 (使用量リミット、統計、コスト推定、システムメトリクス、使用量履歴、接続クライアント数)", "file": "backend/src/routes/dashboard.ts" },
-      { "method": "POST", "path": "/api/upload/image", "group": "Upload", "description": "画像アップロード (PNG/JPEG/GIF/WebP, max 10MB)。ローカルパスを返す", "file": "backend/src/routes/upload.ts" },
-      { "method": "POST", "path": "/api/notify", "group": "Notify", "description": "Claude Code / Codex の hook イベントを受信し WebSocket でブロードキャスト。認証不要 (ローカル hook から呼ばれる)", "file": "backend/src/routes/notify.ts" },
-      { "method": "GET", "path": "/api/notify/hook-status", "group": "Notify", "description": "Claude / Codex の hook 設定に cchub notify が登録済みかを確認。missing イベント一覧を返す", "file": "backend/src/routes/notify.ts" },
-      { "method": "POST", "path": "/api/logs", "group": "Logs", "description": "フロントエンドのログを受信し /tmp/cc-hub-browser.log に追記。認証不要", "file": "backend/src/routes/logs.ts" },
-      { "method": "GET", "path": "/api/logs", "group": "Logs", "description": "ブラウザログファイルをテキストで返す", "file": "backend/src/routes/logs.ts" },
-      { "method": "DELETE", "path": "/api/logs", "group": "Logs", "description": "ブラウザログをクリア", "file": "backend/src/routes/logs.ts" }
+      {
+        "method": "GET",
+        "path": "/health",
+        "group": "System",
+        "description": "ヘルスチェック。status と version を返す。認証不要 (peer discovery が利用)",
+        "file": "backend/src/index.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/clear-cache",
+        "group": "System",
+        "description": "Service Worker 登録解除とキャッシュクリアを行う HTML ページ。認証不要",
+        "file": "backend/src/index.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/images/:filename",
+        "group": "System",
+        "description": "アップロード画像の配信。認証不要",
+        "file": "backend/src/index.ts"
+      },
+      {
+        "method": "WS",
+        "path": "/ws/mux",
+        "group": "System",
+        "description": "多重化ターミナル WebSocket。viewport 配信・入力・レイアウト制御・会話ストリーム。token クエリで peer からの Bearer 認証に対応",
+        "file": "backend/src/routes/terminal-mux.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/auth/required",
+        "group": "Auth",
+        "description": "パスワード認証が有効かどうかを返す",
+        "file": "backend/src/routes/auth.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/auth/login",
+        "group": "Auth",
+        "description": "サーバパスワードでログインし JWT トークンを返す。認証不要",
+        "file": "backend/src/routes/auth.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/auth/logout",
+        "group": "Auth",
+        "description": "ログアウト (ステートレス JWT のためダミー)",
+        "file": "backend/src/routes/auth.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/auth/me",
+        "group": "Auth",
+        "description": "現在のユーザー情報を返す。認証必須",
+        "file": "backend/src/routes/auth.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions",
+        "group": "Sessions",
+        "description": "全 tmux セッション一覧 (Claude Code 状態・ペイン情報付き)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions",
+        "group": "Sessions",
+        "description": "新規セッション作成。agent (claude/codex), name, workingDir, initialPrompt 指定可",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/:id",
+        "group": "Sessions",
+        "description": "セッション詳細を取得",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/sessions/:id",
+        "group": "Sessions",
+        "description": "tmux セッションを kill。last-known 情報は保持",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/resume",
+        "group": "Sessions",
+        "description": "セッション内でエージェントを resume (claude -r / codex resume)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/sessions/:id/theme",
+        "group": "Sessions",
+        "description": "セッションのカラーテーマを設定",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/sessions/:id/title",
+        "group": "Sessions",
+        "description": "セッションのカスタムタイトルを設定",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/sessions/order",
+        "group": "Sessions",
+        "description": "セッション表示順を保存",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/:id/copy-mode",
+        "group": "Sessions",
+        "description": "tmux copy mode の選択状態を取得",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/focus",
+        "group": "Sessions",
+        "description": "ペインにフォーカス ({ paneId })",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/close",
+        "group": "Sessions",
+        "description": "ペインを閉じる。最後の 1 枚は拒否",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/split",
+        "group": "Sessions",
+        "description": "ペイン分割 ({ paneId, direction: 'h'|'v' })",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/respawn",
+        "group": "Sessions",
+        "description": "dead ペインを respawn",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/panes/input",
+        "group": "Sessions",
+        "description": "ペインへ REST で入力送信 (cchub send / peer が使用)。wait=true で送信後の viewport スナップショットを返す",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/:id/panes/:paneId/viewport",
+        "group": "Sessions",
+        "description": "ペイン viewport を REST で取得 (cchub peek が使用)。lines クエリで末尾行数指定",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/:id/prompt",
+        "group": "Sessions",
+        "description": "アクティブペインへプロンプトテキストを送信",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/clipboard",
+        "group": "Sessions",
+        "description": "tmux グローバルペーストバッファの内容を取得",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history",
+        "group": "Session History",
+        "description": "最近のセッション履歴。metadata クエリでメタデータの遅延ロード可",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/projects",
+        "group": "Session History",
+        "description": "プロジェクト一覧 (Claude Code + Codex 統合)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/projects/:dirName",
+        "group": "Session History",
+        "description": "プロジェクト内のセッション一覧",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/search",
+        "group": "Session History",
+        "description": "全プロジェクト横断のセッション検索 (q, limit)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/search/stream",
+        "group": "Session History",
+        "description": "検索結果の SSE ストリーミング配信",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/history/:sessionId/conversation",
+        "group": "Session History",
+        "description": "セッションの会話を取得。agent=codex / projectDirName / last クエリ対応",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/history/metadata",
+        "group": "Session History",
+        "description": "指定 sessionIds のメタデータを遅延ロード",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/sessions/history/resume",
+        "group": "Session History",
+        "description": "履歴からセッションを resume (新規 tmux セッション作成)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/sessions/prompts/search",
+        "group": "Session History",
+        "description": "プロンプト履歴の検索 (q, limit)",
+        "file": "backend/src/routes/sessions.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/list",
+        "group": "Files",
+        "description": "ディレクトリ一覧。sessionWorkingDir 配下に限定",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/read",
+        "group": "Files",
+        "description": "ファイル内容を取得 (サイズ制限あり。画像/メディアはメタデータのみ)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/raw",
+        "group": "Files",
+        "description": "ファイルをインライン配信 (<img>/<video>/<audio> 用)。Range / 206 対応",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/download",
+        "group": "Files",
+        "description": "ファイルを添付ダウンロード (Bun.file ストリーミング)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/files/upload",
+        "group": "Files",
+        "description": "multipart/form-data でファイル (複数可) をアップロード",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/browse",
+        "group": "Files",
+        "description": "ホームディレクトリ配下をセッション非依存でブラウズ",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/files/mkdir",
+        "group": "Files",
+        "description": "ディレクトリ作成 (ホーム配下のみ)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/changes/:sessionWorkingDir",
+        "group": "Files",
+        "description": "JSONL 由来の Claude Code ファイル変更一覧",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/git-changes/:workingDir",
+        "group": "Files",
+        "description": "git status --porcelain による変更ファイル一覧 (ブランチ情報付き)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/git-diff/:workingDir",
+        "group": "Files",
+        "description": "指定ファイルの unified diff (staged クエリ対応)",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/language",
+        "group": "Files",
+        "description": "ファイルパスから言語識別子・isImage・isText を判定",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/files/images/:filename",
+        "group": "Files",
+        "description": "会話用アップロード画像の配信",
+        "file": "backend/src/routes/files.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers",
+        "group": "Peers",
+        "description": "登録済み peer 一覧 (self 含む) を返す",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/discover",
+        "group": "Peers",
+        "description": "Tailscale tailnet 内で稼働中の cchub を検出",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers",
+        "group": "Peers",
+        "description": "peer を登録 (nickname, url, password, color)。代理ログインして JWT を保存",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "PATCH",
+        "path": "/api/peers/:id",
+        "group": "Peers",
+        "description": "peer の nickname / color / password を更新",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/peers/:id",
+        "group": "Peers",
+        "description": "peer を削除 (local は削除不可)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers/:id/verify",
+        "group": "Peers",
+        "description": "peer の疎通・認証を再確認しレイテンシを返す",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/peers/order",
+        "group": "Peers",
+        "description": "peer の表示順を保存",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/session-order",
+        "group": "Peers",
+        "description": "peer 横断のセッション表示順を取得",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "PUT",
+        "path": "/api/peers/session-order",
+        "group": "Peers",
+        "description": "peer 横断のセッション表示順を保存",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/sessions",
+        "group": "Peers",
+        "description": "全 peer のアクティブセッションをマージして返す (peer 毎のエラー併載)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/history/projects",
+        "group": "Peers",
+        "description": "全 peer のプロジェクト履歴をマージして返す",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/history/:peerId/projects/:dirName",
+        "group": "Peers",
+        "description": "指定 peer のプロジェクト内セッション一覧",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/history/:peerId/:sessionId/conversation",
+        "group": "Peers",
+        "description": "指定 peer のセッション会話を取得",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers/history/:peerId/resume",
+        "group": "Peers",
+        "description": "指定 peer 上でセッションを resume",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/:peerId/dashboard",
+        "group": "Peers",
+        "description": "指定 peer (または self) のダッシュボード情報を取得",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/peers/:peerId/files/browse",
+        "group": "Peers",
+        "description": "peer 上のディレクトリブラウズ (プロキシ)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers/:peerId/files/mkdir",
+        "group": "Peers",
+        "description": "peer 上にディレクトリ作成 (プロキシ)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/peers/:peerId/upload/image",
+        "group": "Peers",
+        "description": "画像アップロードを peer へ転送し、peer 上の絶対パスを返す",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "ALL",
+        "path": "/api/peers/:peerId/files/*",
+        "group": "Peers",
+        "description": "Files API の汎用プロキシ (list / read / raw / download / upload / language / changes / git-changes / git-diff / images を peer へ透過転送)",
+        "file": "backend/src/routes/peers.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/dashboard",
+        "group": "Dashboard",
+        "description": "ダッシュボード情報 (使用量リミット、統計、コスト推定、システムメトリクス、使用量履歴、接続クライアント数)",
+        "file": "backend/src/routes/dashboard.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/upload/image",
+        "group": "Upload",
+        "description": "画像アップロード (PNG/JPEG/GIF/WebP, max 10MB)。ローカルパスを返す",
+        "file": "backend/src/routes/upload.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/notify",
+        "group": "Notify",
+        "description": "Claude Code / Codex の hook イベントを受信し WebSocket でブロードキャスト。認証不要 (ローカル hook から呼ばれる)",
+        "file": "backend/src/routes/notify.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/notify/hook-status",
+        "group": "Notify",
+        "description": "Claude / Codex の hook 設定に cchub notify が登録済みかを確認。missing イベント一覧を返す",
+        "file": "backend/src/routes/notify.ts"
+      },
+      {
+        "method": "POST",
+        "path": "/api/logs",
+        "group": "Logs",
+        "description": "フロントエンドのログを受信し /tmp/cc-hub-browser.log に追記。認証不要",
+        "file": "backend/src/routes/logs.ts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/logs",
+        "group": "Logs",
+        "description": "ブラウザログファイルをテキストで返す",
+        "file": "backend/src/routes/logs.ts"
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/logs",
+        "group": "Logs",
+        "description": "ブラウザログをクリア",
+        "file": "backend/src/routes/logs.ts"
+      }
     ]
   },
   "frontend": {
     "components": [
-      { "name": "App", "file": "frontend/src/App.tsx", "summary": "ルートコンポーネント。mobile / tablet / desktop のデバイス判定でレイアウトを切り替え。認証・セッション管理・ファイルビューア・チャットビューを統合", "hooks": ["useAuth", "useSessions"], "parents": [] },
-      { "name": "DesktopLayout", "file": "frontend/src/components/DesktopLayout.tsx", "summary": "デスクトップ / タブレット向けメインレイアウト。tmux 制御モード統合、ペインツリー管理、キーボードショートカット", "hooks": ["useMultiplexedTerminal", "usePeerConnection", "useSessions", "usePeers"], "parents": ["App"] },
-      { "name": "TerminalPage", "file": "frontend/src/pages/TerminalPage.tsx", "summary": "モバイル向けターミナルページ。単一ペイン表示 + ペインタブバー + InputBar / ChatView 切替", "hooks": ["useMultiplexedTerminal"], "parents": ["App"] },
-      { "name": "PaneContainer", "file": "frontend/src/components/PaneContainer.tsx", "summary": "ペインツリーの再帰描画。ControlModeContext 経由で分割・クローズ・ズーム・リサイズ操作を提供", "hooks": [], "parents": ["DesktopLayout", "PaneContainer"] },
-      { "name": "Terminal", "file": "frontend/src/components/Terminal.tsx", "summary": "xterm.js ターミナル (WebGL、scrollback:0)。viewport フレームを VT シーケンスに変換して term.write() で反映。tmux サイズ同期 (setExactSize)、フォント調整、テキスト選択", "hooks": ["useSelectionMode"], "parents": ["PaneContainer", "TerminalPage"] },
-      { "name": "SelectionOverlay", "file": "frontend/src/components/SelectionOverlay.tsx", "summary": "タッチ選択オーバーレイ。開始/終了ハンドルのドラッグとコピー/キャンセル操作", "hooks": ["useSelectionMode"], "parents": ["Terminal"] },
-      { "name": "SessionList", "file": "frontend/src/components/SessionList.tsx", "summary": "セッション一覧 (Active / History / Dashboard タブ)。ペイン操作、ピンチズーム、History V1/V2 の分岐", "hooks": ["useHistoryV2Flag", "useSessionHistory"], "parents": ["App"] },
-      { "name": "SessionModal", "file": "frontend/src/components/SessionModal.tsx", "summary": "セッション選択モーダル (Ctrl+B)。ペイン数バッジと展開式ペイン一覧", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "SessionHistory", "file": "frontend/src/components/SessionHistory.tsx", "summary": "セッション履歴 V1 (プロジェクトグループ表示)。V2 安定化まで併存するレガシー実装", "hooks": [], "parents": ["SessionList"] },
-      { "name": "SessionHistoryV2", "file": "frontend/src/components/history/SessionHistoryV2.tsx", "summary": "セッション履歴 V2。フラットリスト + ファセット検索 + 仮想スクロール", "hooks": ["useFlatHistoryItems", "useHistoryActions"], "parents": ["SessionList"] },
-      { "name": "VirtualizedHistoryList", "file": "frontend/src/components/history/VirtualizedHistoryList.tsx", "summary": "大規模履歴の仮想化リスト描画", "hooks": [], "parents": ["SessionHistoryV2"] },
-      { "name": "HistoryRowV2", "file": "frontend/src/components/history/HistoryRowV2.tsx", "summary": "履歴 1 行。resume / 会話表示などのハンドラ", "hooks": [], "parents": ["VirtualizedHistoryList"] },
-      { "name": "HistoryFacetSidebar", "file": "frontend/src/components/history/HistoryFacetSidebar.tsx", "summary": "ファセットフィルタ (project / agent / status) のデスクトップ用サイドバー", "hooks": [], "parents": ["SessionHistoryV2"] },
-      { "name": "HistoryFacetDrawer", "file": "frontend/src/components/history/HistoryFacetDrawer.tsx", "summary": "ファセットフィルタのモバイル用ドロワー", "hooks": [], "parents": ["SessionHistoryV2"] },
-      { "name": "HistoryActiveChips", "file": "frontend/src/components/history/HistoryActiveChips.tsx", "summary": "適用中フィルタの chips 表示と解除", "hooks": [], "parents": ["SessionHistoryV2"] },
-      { "name": "ConversationViewer", "file": "frontend/src/components/ConversationViewer.tsx", "summary": "会話の Markdown レンダリング表示 (画像対応)。スクロール位置の復元・自動スクロール", "hooks": ["useScrollRatio"], "parents": ["ChatView", "SessionList"] },
-      { "name": "ChatView", "file": "frontend/src/components/chat/ChatView.tsx", "summary": "現在セッションの会話形式ビュー。「Chat」モード選択時にターミナル領域を置き換える", "hooks": ["useAgentConversation", "useInputEcho"], "parents": ["DesktopLayout", "TerminalPage"] },
-      { "name": "ChatComposer", "file": "frontend/src/components/chat/ChatComposer.tsx", "summary": "ChatView 用の複数行メッセージコンポーザ", "hooks": [], "parents": ["ChatView"] },
-      { "name": "InputBar", "file": "frontend/src/components/InputBar.tsx", "summary": "ターミナル上部の常設入力バー。プロンプト履歴、スラッシュコマンドピッカー、画像アップロード", "hooks": [], "parents": ["DesktopLayout", "TerminalPage"] },
-      { "name": "FloatingKeyboard", "file": "frontend/src/components/FloatingKeyboard.tsx", "summary": "タブレット用ドラッグ可能フローティングキーボード。最小化対応、入力モード別に位置を保存", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "Keyboard", "file": "frontend/src/components/Keyboard.tsx", "summary": "モバイル用仮想キーボード。長押しで記号入力、JA トグルで IME 切替", "hooks": [], "parents": ["InputBar", "TerminalPage"] },
-      { "name": "FileViewer", "file": "frontend/src/components/files/FileViewer.tsx", "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude/Git 変更トグル、ブラウザ履歴ナビ、アップロード/ダウンロード、peerId 指定でリモート peer のファイル取得", "hooks": ["useFileViewer", "useViewHistory", "useAuthBlobUrl"], "parents": ["DesktopLayout", "App"] },
-      { "name": "FileBrowser", "file": "frontend/src/components/files/FileBrowser.tsx", "summary": "ディレクトリツリーのナビゲーション", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "FileContentView", "file": "frontend/src/components/files/FileContentView.tsx", "summary": "ファイル内容を種別に応じて Code/Markdown/Image/Html ビューアへルーティング", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "ChangesView", "file": "frontend/src/components/files/ChangesView.tsx", "summary": "Claude Code / Git の変更ファイル一覧。ファイル毎の diff ナビゲーション", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "CodeViewer", "file": "frontend/src/components/files/CodeViewer.tsx", "summary": "シンタックスハイライト表示。word-wrap / フォントサイズ設定", "hooks": ["useViewerSettings"], "parents": ["FileContentView"] },
-      { "name": "DiffViewer", "file": "frontend/src/components/files/DiffViewer.tsx", "summary": "ファイル変更の side-by-side / unified diff 表示", "hooks": ["useViewerSettings"], "parents": ["FileContentView"] },
-      { "name": "MarkdownViewer", "file": "frontend/src/components/files/MarkdownViewer.tsx", "summary": "Markdown レンダリング", "hooks": ["useViewerSettings"], "parents": ["FileContentView"] },
-      { "name": "ImageViewer", "file": "frontend/src/components/files/ImageViewer.tsx", "summary": "画像プレビュー (ピンチズーム対応、大きい画像は /files/raw ストリーミング)", "hooks": ["usePinchZoom"], "parents": ["FileContentView"] },
-      { "name": "HtmlViewer", "file": "frontend/src/components/files/HtmlViewer.tsx", "summary": "HTML ファイルの iframe 表示 (認証付き blob URL)", "hooks": ["useAuthBlobUrl"], "parents": ["FileContentView"] },
-      { "name": "PromptComposer", "file": "frontend/src/components/files/PromptComposer.tsx", "summary": "ファイルからプロンプトテキストを組み立てる UI", "hooks": [], "parents": ["FileViewer"] },
-      { "name": "Dashboard", "file": "frontend/src/components/dashboard/Dashboard.tsx", "summary": "ダッシュボードのメインコンテナ。使用量・統計・peer サーバ一覧", "hooks": ["useDashboard", "usePeers", "useTheme", "useUiScale"], "parents": ["SessionList", "DashboardPanel"] },
-      { "name": "DashboardPanel", "file": "frontend/src/components/DashboardPanel.tsx", "summary": "ダッシュボードのサイドパネルラッパ (Ctrl+Shift+B)", "hooks": [], "parents": ["DesktopLayout"] },
-      { "name": "UsageLimits", "file": "frontend/src/components/dashboard/UsageLimits.tsx", "summary": "5時間 / 7日サイクルの使用量プログレスバー表示", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "DailyUsageChart", "file": "frontend/src/components/dashboard/DailyUsageChart.tsx", "summary": "日別のメッセージ数・セッション数バーチャート", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "ModelUsageChart", "file": "frontend/src/components/dashboard/ModelUsageChart.tsx", "summary": "モデル別トークン使用量の比較チャート", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "HourlyHeatmap", "file": "frontend/src/components/dashboard/HourlyHeatmap.tsx", "summary": "時間帯別アクティビティのヒートマップ", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "UsageChart", "file": "frontend/src/components/dashboard/UsageChart.tsx", "summary": "使用量履歴のラインチャート (リアルタイムスナップショット)", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "NetworkLatency", "file": "frontend/src/components/dashboard/NetworkLatency.tsx", "summary": "WebSocket / API レイテンシ表示", "hooks": ["useNetworkLatency"], "parents": ["Dashboard"] },
-      { "name": "ServerInfo", "file": "frontend/src/components/dashboard/ServerInfo.tsx", "summary": "サーバ情報とシステム詳細の表示", "hooks": [], "parents": ["Dashboard"] },
-      { "name": "PeerServerCard", "file": "frontend/src/components/dashboard/PeerServerCard.tsx", "summary": "peer サーバ毎の情報カード (CPU / メモリ / 接続数)", "hooks": ["usePeerServerMetrics"], "parents": ["Dashboard"] },
-      { "name": "PeerManager", "file": "frontend/src/components/PeerManager.tsx", "summary": "peer サーバ管理 UI (登録・検証・自動検出・並べ替え・削除)", "hooks": ["usePeers"], "parents": ["App"] },
-      { "name": "LoginForm", "file": "frontend/src/components/LoginForm.tsx", "summary": "パスワード認証フォーム (パスワード設定時のみ表示)", "hooks": [], "parents": ["App"] },
-      { "name": "Onboarding", "file": "frontend/src/components/Onboarding.tsx", "summary": "初回ユーザー向けスポットライト式ウォークスルー (デバイス別ステップ)", "hooks": [], "parents": ["App", "DesktopLayout"] }
+      {
+        "name": "App",
+        "file": "frontend/src/App.tsx",
+        "summary": "ルートコンポーネント。mobile / tablet / desktop のデバイス判定でレイアウトを切り替え。認証・セッション管理・ファイルビューア・チャットビューを統合",
+        "hooks": [
+          "useAuth",
+          "useSessions"
+        ],
+        "parents": []
+      },
+      {
+        "name": "DesktopLayout",
+        "file": "frontend/src/components/DesktopLayout.tsx",
+        "summary": "デスクトップ / タブレット向けメインレイアウト。tmux 制御モード統合、ペインツリー管理、キーボードショートカット",
+        "hooks": [
+          "useMultiplexedTerminal",
+          "usePeerConnection",
+          "useSessions",
+          "usePeers"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "TerminalPage",
+        "file": "frontend/src/pages/TerminalPage.tsx",
+        "summary": "モバイル向けターミナルページ。単一ペイン表示 + ペインタブバー + InputBar / ChatView 切替",
+        "hooks": [
+          "useMultiplexedTerminal"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "PaneContainer",
+        "file": "frontend/src/components/PaneContainer.tsx",
+        "summary": "ペインツリーの再帰描画。ControlModeContext 経由で分割・クローズ・ズーム・リサイズ操作を提供",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout",
+          "PaneContainer"
+        ]
+      },
+      {
+        "name": "Terminal",
+        "file": "frontend/src/components/Terminal.tsx",
+        "summary": "xterm.js ターミナル (WebGL、scrollback:0)。viewport フレームを VT シーケンスに変換して term.write() で反映。tmux サイズ同期 (setExactSize)、フォント調整、テキスト選択",
+        "hooks": [
+          "useSelectionMode"
+        ],
+        "parents": [
+          "PaneContainer",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "SelectionOverlay",
+        "file": "frontend/src/components/SelectionOverlay.tsx",
+        "summary": "タッチ選択オーバーレイ。開始/終了ハンドルのドラッグとコピー/キャンセル操作",
+        "hooks": [
+          "useSelectionMode"
+        ],
+        "parents": [
+          "Terminal"
+        ]
+      },
+      {
+        "name": "SessionList",
+        "file": "frontend/src/components/SessionList.tsx",
+        "summary": "セッション一覧 (Active / History / Dashboard タブ)。ペイン操作、ピンチズーム、History V1/V2 の分岐",
+        "hooks": [
+          "useHistoryV2Flag",
+          "useSessionHistory"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "SessionModal",
+        "file": "frontend/src/components/SessionModal.tsx",
+        "summary": "セッション選択モーダル (Ctrl+B)。ペイン数バッジと展開式ペイン一覧",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "SessionHistory",
+        "file": "frontend/src/components/SessionHistory.tsx",
+        "summary": "セッション履歴 V1 (プロジェクトグループ表示)。V2 安定化まで併存するレガシー実装",
+        "hooks": [],
+        "parents": [
+          "SessionList"
+        ]
+      },
+      {
+        "name": "SessionHistoryV2",
+        "file": "frontend/src/components/history/SessionHistoryV2.tsx",
+        "summary": "セッション履歴 V2。フラットリスト + ファセット検索 + 仮想スクロール",
+        "hooks": [
+          "useFlatHistoryItems",
+          "useHistoryActions"
+        ],
+        "parents": [
+          "SessionList"
+        ]
+      },
+      {
+        "name": "VirtualizedHistoryList",
+        "file": "frontend/src/components/history/VirtualizedHistoryList.tsx",
+        "summary": "大規模履歴の仮想化リスト描画",
+        "hooks": [],
+        "parents": [
+          "SessionHistoryV2"
+        ]
+      },
+      {
+        "name": "HistoryRowV2",
+        "file": "frontend/src/components/history/HistoryRowV2.tsx",
+        "summary": "履歴 1 行。resume / 会話表示などのハンドラ",
+        "hooks": [],
+        "parents": [
+          "VirtualizedHistoryList"
+        ]
+      },
+      {
+        "name": "HistoryFacetSidebar",
+        "file": "frontend/src/components/history/HistoryFacetSidebar.tsx",
+        "summary": "ファセットフィルタ (project / agent / status) のデスクトップ用サイドバー",
+        "hooks": [],
+        "parents": [
+          "SessionHistoryV2"
+        ]
+      },
+      {
+        "name": "HistoryFacetDrawer",
+        "file": "frontend/src/components/history/HistoryFacetDrawer.tsx",
+        "summary": "ファセットフィルタのモバイル用ドロワー",
+        "hooks": [],
+        "parents": [
+          "SessionHistoryV2"
+        ]
+      },
+      {
+        "name": "HistoryActiveChips",
+        "file": "frontend/src/components/history/HistoryActiveChips.tsx",
+        "summary": "適用中フィルタの chips 表示と解除",
+        "hooks": [],
+        "parents": [
+          "SessionHistoryV2"
+        ]
+      },
+      {
+        "name": "ConversationViewer",
+        "file": "frontend/src/components/ConversationViewer.tsx",
+        "summary": "会話の Markdown レンダリング表示 (画像対応)。スクロール位置の復元・自動スクロール",
+        "hooks": [
+          "useScrollRatio"
+        ],
+        "parents": [
+          "ChatView",
+          "SessionList"
+        ]
+      },
+      {
+        "name": "ChatView",
+        "file": "frontend/src/components/chat/ChatView.tsx",
+        "summary": "現在セッションの会話形式ビュー。「Chat」モード選択時にターミナル領域を置き換える",
+        "hooks": [
+          "useAgentConversation",
+          "useInputEcho"
+        ],
+        "parents": [
+          "DesktopLayout",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "ChatComposer",
+        "file": "frontend/src/components/chat/ChatComposer.tsx",
+        "summary": "ChatView 用の複数行メッセージコンポーザ",
+        "hooks": [],
+        "parents": [
+          "ChatView"
+        ]
+      },
+      {
+        "name": "InputBar",
+        "file": "frontend/src/components/InputBar.tsx",
+        "summary": "ターミナル上部の常設入力バー。プロンプト履歴、スラッシュコマンドピッカー、画像アップロード",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "FloatingKeyboard",
+        "file": "frontend/src/components/FloatingKeyboard.tsx",
+        "summary": "タブレット用ドラッグ可能フローティングキーボード。最小化対応、入力モード別に位置を保存",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "Keyboard",
+        "file": "frontend/src/components/Keyboard.tsx",
+        "summary": "モバイル用仮想キーボード。長押しで記号入力、JA トグルで IME 切替",
+        "hooks": [],
+        "parents": [
+          "InputBar",
+          "TerminalPage"
+        ]
+      },
+      {
+        "name": "FileViewer",
+        "file": "frontend/src/components/files/FileViewer.tsx",
+        "summary": "ファイルブラウザ + コンテンツビューアのコンテナ。Claude/Git 変更トグル、ブラウザ履歴ナビ、アップロード/ダウンロード、peerId 指定でリモート peer のファイル取得",
+        "hooks": [
+          "useFileViewer",
+          "useViewHistory",
+          "useAuthBlobUrl"
+        ],
+        "parents": [
+          "DesktopLayout",
+          "App"
+        ]
+      },
+      {
+        "name": "FileBrowser",
+        "file": "frontend/src/components/files/FileBrowser.tsx",
+        "summary": "ディレクトリツリーのナビゲーション",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "FileContentView",
+        "file": "frontend/src/components/files/FileContentView.tsx",
+        "summary": "ファイル内容を種別に応じて Code/Markdown/Image/Html ビューアへルーティング",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "ChangesView",
+        "file": "frontend/src/components/files/ChangesView.tsx",
+        "summary": "Claude Code / Git の変更ファイル一覧。ファイル毎の diff ナビゲーション",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "CodeViewer",
+        "file": "frontend/src/components/files/CodeViewer.tsx",
+        "summary": "シンタックスハイライト表示。word-wrap / フォントサイズ設定",
+        "hooks": [
+          "useViewerSettings"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "DiffViewer",
+        "file": "frontend/src/components/files/DiffViewer.tsx",
+        "summary": "ファイル変更の side-by-side / unified diff 表示",
+        "hooks": [
+          "useViewerSettings"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "MarkdownViewer",
+        "file": "frontend/src/components/files/MarkdownViewer.tsx",
+        "summary": "Markdown レンダリング",
+        "hooks": [
+          "useViewerSettings"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "ImageViewer",
+        "file": "frontend/src/components/files/ImageViewer.tsx",
+        "summary": "画像プレビュー (ピンチズーム対応、大きい画像は /files/raw ストリーミング)",
+        "hooks": [
+          "usePinchZoom"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "HtmlViewer",
+        "file": "frontend/src/components/files/HtmlViewer.tsx",
+        "summary": "HTML ファイルの iframe 表示 (認証付き blob URL)",
+        "hooks": [
+          "useAuthBlobUrl"
+        ],
+        "parents": [
+          "FileContentView"
+        ]
+      },
+      {
+        "name": "PromptComposer",
+        "file": "frontend/src/components/files/PromptComposer.tsx",
+        "summary": "ファイルからプロンプトテキストを組み立てる UI",
+        "hooks": [],
+        "parents": [
+          "FileViewer"
+        ]
+      },
+      {
+        "name": "Dashboard",
+        "file": "frontend/src/components/dashboard/Dashboard.tsx",
+        "summary": "ダッシュボードのメインコンテナ。使用量・統計・peer サーバ一覧",
+        "hooks": [
+          "useDashboard",
+          "usePeers",
+          "useTheme",
+          "useUiScale"
+        ],
+        "parents": [
+          "SessionList",
+          "DashboardPanel"
+        ]
+      },
+      {
+        "name": "DashboardPanel",
+        "file": "frontend/src/components/DashboardPanel.tsx",
+        "summary": "ダッシュボードのサイドパネルラッパ (Ctrl+Shift+B)",
+        "hooks": [],
+        "parents": [
+          "DesktopLayout"
+        ]
+      },
+      {
+        "name": "UsageLimits",
+        "file": "frontend/src/components/dashboard/UsageLimits.tsx",
+        "summary": "5時間 / 7日サイクルの使用量プログレスバー表示",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "DailyUsageChart",
+        "file": "frontend/src/components/dashboard/DailyUsageChart.tsx",
+        "summary": "日別のメッセージ数・セッション数バーチャート",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "ModelUsageChart",
+        "file": "frontend/src/components/dashboard/ModelUsageChart.tsx",
+        "summary": "モデル別トークン使用量の比較チャート",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "HourlyHeatmap",
+        "file": "frontend/src/components/dashboard/HourlyHeatmap.tsx",
+        "summary": "時間帯別アクティビティのヒートマップ",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "UsageChart",
+        "file": "frontend/src/components/dashboard/UsageChart.tsx",
+        "summary": "使用量履歴のラインチャート (リアルタイムスナップショット)",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "NetworkLatency",
+        "file": "frontend/src/components/dashboard/NetworkLatency.tsx",
+        "summary": "WebSocket / API レイテンシ表示",
+        "hooks": [
+          "useNetworkLatency"
+        ],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "ServerInfo",
+        "file": "frontend/src/components/dashboard/ServerInfo.tsx",
+        "summary": "サーバ情報とシステム詳細の表示",
+        "hooks": [],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "PeerServerCard",
+        "file": "frontend/src/components/dashboard/PeerServerCard.tsx",
+        "summary": "peer サーバ毎の情報カード (CPU / メモリ / 接続数)",
+        "hooks": [
+          "usePeerServerMetrics"
+        ],
+        "parents": [
+          "Dashboard"
+        ]
+      },
+      {
+        "name": "PeerManager",
+        "file": "frontend/src/components/PeerManager.tsx",
+        "summary": "peer サーバ管理 UI (登録・検証・自動検出・並べ替え・削除)",
+        "hooks": [
+          "usePeers"
+        ],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "LoginForm",
+        "file": "frontend/src/components/LoginForm.tsx",
+        "summary": "パスワード認証フォーム (パスワード設定時のみ表示)",
+        "hooks": [],
+        "parents": [
+          "App"
+        ]
+      },
+      {
+        "name": "Onboarding",
+        "file": "frontend/src/components/Onboarding.tsx",
+        "summary": "初回ユーザー向けスポットライト式ウォークスルー (デバイス別ステップ)",
+        "hooks": [],
+        "parents": [
+          "App",
+          "DesktopLayout"
+        ]
+      }
     ],
     "hooks": [
-      { "name": "useMultiplexedTerminal", "file": "frontend/src/hooks/useMultiplexedTerminal.ts", "summary": "/ws/mux への共有シングルトン WebSocket。自動再接続、keepalive ping、セッション購読、base64 入出力、viewport ディスパッチ。sendInput / resize / splitPane / requestViewport 等の操作 API を返す。peerWsBase 指定でリモート peer に接続" },
-      { "name": "useSessions", "file": "frontend/src/hooks/useSessions.ts", "summary": "アクティブセッションの状態管理。usePeerSessionsWatcher で複数 peer を集約し module-level cache を共有。createSession / deleteSession / updateSessionTheme API" },
-      { "name": "useSessionHistory", "file": "frontend/src/hooks/useSessionHistory.ts", "summary": "履歴ブラウジング。peer 横断の projects 取得、projectKey (peerId::dirName) 管理、SSE ストリーミング検索 (Bearer token 付与)、resumeSession / fetchConversation" },
-      { "name": "useFlatHistoryItems", "file": "frontend/src/hooks/useFlatHistoryItems.ts", "summary": "プロジェクトグループの履歴をフラット化して History V2 のフィルタ可能リストに変換。4 並行 hydration、更新日時降順ソート" },
-      { "name": "useHistoryActions", "file": "frontend/src/hooks/useHistoryActions.ts", "summary": "履歴の resume / ナビゲーション / 会話表示の共通ロジック (V1/V2 両ビューで使用)" },
-      { "name": "useHistoryV2Flag", "file": "frontend/src/hooks/useHistoryV2Flag.ts", "summary": "History V2 のフィーチャーフラグ。localStorage cchub-history-v2 (デフォルト ON)、storage イベント監視" },
-      { "name": "useDashboard", "file": "frontend/src/hooks/useDashboard.ts", "summary": "/api/dashboard のポーリング取得 (60s)。DashboardResponse を返す" },
-      { "name": "useFileViewer", "file": "frontend/src/hooks/useFileViewer.ts", "summary": "ファイルビューア状態。listDirectory / readFile / getChanges / getGitChanges / getGitDiff。peerId オプションでリモート peer のファイル取得" },
-      { "name": "useViewHistory", "file": "frontend/src/hooks/useViewHistory.ts", "summary": "ファイルビューアの戻るナビゲーション (browser/file/changes/diff の各 ViewMode)。in-memory スタック + window.history 同期" },
-      { "name": "useViewerSettings", "file": "frontend/src/hooks/useViewerSettings.ts", "summary": "ビューア設定。word-wrap (ファイル毎) と フォントサイズ (グローバル、8-32px) を localStorage に永続化" },
-      { "name": "useAuth", "file": "frontend/src/hooks/useAuth.ts", "summary": "認証状態管理。トークンを localStorage (cc-hub-token) に永続化、login / logout を提供" },
-      { "name": "useAuthBlobUrl", "file": "frontend/src/hooks/useAuthBlobUrl.ts", "summary": "認証ヘッダ付き fetch でリソースを取得し blob URL として返す (img / video / iframe の src 用)。自動 revoke" },
-      { "name": "useTheme", "file": "frontend/src/hooks/useTheme.ts", "summary": "ダーク / ライトテーマ切替 (localStorage cchub-theme)" },
-      { "name": "useUiScale", "file": "frontend/src/hooks/useUiScale.ts", "summary": "UI スケール倍率の永続化と CSS 変数への適用 (localStorage cchub-ui-scale)" },
-      { "name": "useNetworkLatency", "file": "frontend/src/hooks/useNetworkLatency.ts", "summary": "WebSocket / API レイテンシ計測 (30s 毎の /health ping、latency-store 購読)" },
-      { "name": "useLineSelection", "file": "frontend/src/hooks/useLineSelection.ts", "summary": "ファイルビューアの行範囲選択ユーティリティ" },
-      { "name": "useSelectionMode", "file": "frontend/src/hooks/useSelectionMode.ts", "summary": "SelectionOverlay 用のタッチ選択ステートマシン (開始/終了セル、ドラッグハンドル、クリップボードコピー)" },
-      { "name": "useInputEcho", "file": "frontend/src/hooks/useInputEcho.ts", "summary": "ターミナル非表示時に InputBar の入力を会話/チャットビューへエコー表示。矢印・Ctrl 等の特殊キーは記号表示" },
-      { "name": "useConversationStream", "file": "frontend/src/hooks/useConversationStream.ts", "summary": "/ws/mux の会話ストリーム購読 (subscribe-conversation)。増分の conversation-update を公開" },
-      { "name": "useAgentConversation", "file": "frontend/src/hooks/useAgentConversation.ts", "summary": "アクティブセッションの agent に応じて Claude (WebSocket ストリーム) / Codex (ポーリング) の会話ソースを選択する統合フック" },
-      { "name": "useCodexConversation", "file": "frontend/src/hooks/useCodexConversation.ts", "summary": "Codex 会話のポーリングローダ (5s 間隔、transcript + トークン使用量)" },
-      { "name": "usePeers", "file": "frontend/src/hooks/usePeers.ts", "summary": "peer 一覧の CRUD と状態管理 (5s ポーリング、module-level cache + broadcast)。addPeer / updatePeer / deletePeer / verifyPeer / reorderPeers" },
-      { "name": "usePeerConnection", "file": "frontend/src/hooks/usePeerConnection.ts", "summary": "セッションの peerId から接続情報 (wsBase / apiBase / token) を導出。リモート peer は peer.url から変換" },
-      { "name": "usePeerSessionsWatcher", "file": "frontend/src/hooks/usePeerSessionsWatcher.ts", "summary": "リモート peer 毎に /ws/mux への常時 WebSocket を張り、sessions-updated push と hook-event をポーリングなしで受信。自動再接続" },
-      { "name": "usePeerServerMetrics", "file": "frontend/src/hooks/usePeerServerMetrics.ts", "summary": "peer のダッシュボードメトリクス (systemMetrics / diskUsage / connectedClients) を 30s ポーリング" },
-      { "name": "usePinchZoom", "file": "frontend/src/hooks/usePinchZoom.ts", "summary": "2 本指ピンチズームのジェスチャ処理。min/max クランプ、transient (onChange) と persistent (onCommit) の分離" },
-      { "name": "useScrollRatio", "file": "frontend/src/hooks/useScrollRatio.ts", "summary": "スクロール要素の位置比率 (0..1) を追跡・復元" }
+      {
+        "name": "useMultiplexedTerminal",
+        "file": "frontend/src/hooks/useMultiplexedTerminal.ts",
+        "summary": "/ws/mux への共有シングルトン WebSocket。自動再接続、keepalive ping、セッション購読、base64 入出力、viewport ディスパッチ。sendInput / resize / splitPane / requestViewport 等の操作 API を返す。peerWsBase 指定でリモート peer に接続"
+      },
+      {
+        "name": "useSessions",
+        "file": "frontend/src/hooks/useSessions.ts",
+        "summary": "アクティブセッションの状態管理。usePeerSessionsWatcher で複数 peer を集約し module-level cache を共有。createSession / deleteSession / updateSessionTheme API"
+      },
+      {
+        "name": "useSessionHistory",
+        "file": "frontend/src/hooks/useSessionHistory.ts",
+        "summary": "履歴ブラウジング。peer 横断の projects 取得、projectKey (peerId::dirName) 管理、SSE ストリーミング検索 (Bearer token 付与)、resumeSession / fetchConversation"
+      },
+      {
+        "name": "useFlatHistoryItems",
+        "file": "frontend/src/hooks/useFlatHistoryItems.ts",
+        "summary": "プロジェクトグループの履歴をフラット化して History V2 のフィルタ可能リストに変換。4 並行 hydration、更新日時降順ソート"
+      },
+      {
+        "name": "useHistoryActions",
+        "file": "frontend/src/hooks/useHistoryActions.ts",
+        "summary": "履歴の resume / ナビゲーション / 会話表示の共通ロジック (V1/V2 両ビューで使用)"
+      },
+      {
+        "name": "useHistoryV2Flag",
+        "file": "frontend/src/hooks/useHistoryV2Flag.ts",
+        "summary": "History V2 のフィーチャーフラグ。localStorage cchub-history-v2 (デフォルト ON)、storage イベント監視"
+      },
+      {
+        "name": "useDashboard",
+        "file": "frontend/src/hooks/useDashboard.ts",
+        "summary": "/api/dashboard のポーリング取得 (60s)。DashboardResponse を返す"
+      },
+      {
+        "name": "useFileViewer",
+        "file": "frontend/src/hooks/useFileViewer.ts",
+        "summary": "ファイルビューア状態。listDirectory / readFile / getChanges / getGitChanges / getGitDiff。peerId オプションでリモート peer のファイル取得"
+      },
+      {
+        "name": "useViewHistory",
+        "file": "frontend/src/hooks/useViewHistory.ts",
+        "summary": "ファイルビューアの戻るナビゲーション (browser/file/changes/diff の各 ViewMode)。in-memory スタック + window.history 同期"
+      },
+      {
+        "name": "useViewerSettings",
+        "file": "frontend/src/hooks/useViewerSettings.ts",
+        "summary": "ビューア設定。word-wrap (ファイル毎) と フォントサイズ (グローバル、8-32px) を localStorage に永続化"
+      },
+      {
+        "name": "useAuth",
+        "file": "frontend/src/hooks/useAuth.ts",
+        "summary": "認証状態管理。トークンを localStorage (cc-hub-token) に永続化、login / logout を提供"
+      },
+      {
+        "name": "useAuthBlobUrl",
+        "file": "frontend/src/hooks/useAuthBlobUrl.ts",
+        "summary": "認証ヘッダ付き fetch でリソースを取得し blob URL として返す (img / video / iframe の src 用)。自動 revoke"
+      },
+      {
+        "name": "useTheme",
+        "file": "frontend/src/hooks/useTheme.ts",
+        "summary": "ダーク / ライトテーマ切替 (localStorage cchub-theme)"
+      },
+      {
+        "name": "useUiScale",
+        "file": "frontend/src/hooks/useUiScale.ts",
+        "summary": "UI スケール倍率の永続化と CSS 変数への適用 (localStorage cchub-ui-scale)"
+      },
+      {
+        "name": "useNetworkLatency",
+        "file": "frontend/src/hooks/useNetworkLatency.ts",
+        "summary": "WebSocket / API レイテンシ計測 (30s 毎の /health ping、latency-store 購読)"
+      },
+      {
+        "name": "useLineSelection",
+        "file": "frontend/src/hooks/useLineSelection.ts",
+        "summary": "ファイルビューアの行範囲選択ユーティリティ"
+      },
+      {
+        "name": "useSelectionMode",
+        "file": "frontend/src/hooks/useSelectionMode.ts",
+        "summary": "SelectionOverlay 用のタッチ選択ステートマシン (開始/終了セル、ドラッグハンドル、クリップボードコピー)"
+      },
+      {
+        "name": "useInputEcho",
+        "file": "frontend/src/hooks/useInputEcho.ts",
+        "summary": "ターミナル非表示時に InputBar の入力を会話/チャットビューへエコー表示。矢印・Ctrl 等の特殊キーは記号表示"
+      },
+      {
+        "name": "useConversationStream",
+        "file": "frontend/src/hooks/useConversationStream.ts",
+        "summary": "/ws/mux の会話ストリーム購読 (subscribe-conversation)。増分の conversation-update を公開"
+      },
+      {
+        "name": "useAgentConversation",
+        "file": "frontend/src/hooks/useAgentConversation.ts",
+        "summary": "アクティブセッションの agent に応じて Claude (WebSocket ストリーム) / Codex (ポーリング) の会話ソースを選択する統合フック"
+      },
+      {
+        "name": "useCodexConversation",
+        "file": "frontend/src/hooks/useCodexConversation.ts",
+        "summary": "Codex 会話のポーリングローダ (5s 間隔、transcript + トークン使用量)"
+      },
+      {
+        "name": "usePeers",
+        "file": "frontend/src/hooks/usePeers.ts",
+        "summary": "peer 一覧の CRUD と状態管理 (5s ポーリング、module-level cache + broadcast)。addPeer / updatePeer / deletePeer / verifyPeer / reorderPeers"
+      },
+      {
+        "name": "usePeerConnection",
+        "file": "frontend/src/hooks/usePeerConnection.ts",
+        "summary": "セッションの peerId から接続情報 (wsBase / apiBase / token) を導出。リモート peer は peer.url から変換"
+      },
+      {
+        "name": "usePeerSessionsWatcher",
+        "file": "frontend/src/hooks/usePeerSessionsWatcher.ts",
+        "summary": "リモート peer 毎に /ws/mux への常時 WebSocket を張り、sessions-updated push と hook-event をポーリングなしで受信。自動再接続"
+      },
+      {
+        "name": "usePeerServerMetrics",
+        "file": "frontend/src/hooks/usePeerServerMetrics.ts",
+        "summary": "peer のダッシュボードメトリクス (systemMetrics / diskUsage / connectedClients) を 30s ポーリング"
+      },
+      {
+        "name": "usePinchZoom",
+        "file": "frontend/src/hooks/usePinchZoom.ts",
+        "summary": "2 本指ピンチズームのジェスチャ処理。min/max クランプ、transient (onChange) と persistent (onCommit) の分離"
+      },
+      {
+        "name": "useScrollRatio",
+        "file": "frontend/src/hooks/useScrollRatio.ts",
+        "summary": "スクロール要素の位置比率 (0..1) を追跡・復元"
+      }
     ]
   },
   "websocket": {
     "endpoint": "/ws/mux",
     "description": "単一の多重化 WebSocket。クライアントは subscribe でセッション毎に購読し、ターミナル表示は PaneViewport フレーム (offset ベースのサーバーサイドスクロールバック) で配信。request-viewport への応答に加え、live (offset=0) 購読者には tmux 出力時に未要求 push もされる。全クライアント入力フレームは zod で検証 (#231)",
     "client_messages": {
-      "mux_level": ["subscribe", "unsubscribe", "subscribe-conversation", "unsubscribe-conversation"],
-      "per_session": ["input", "resize", "split", "close-pane", "resize-pane", "select-pane", "adjust-pane", "equalize-panes", "zoom-pane", "respawn-pane", "request-viewport", "ping", "client-info"]
+      "mux_level": [
+        "subscribe",
+        "unsubscribe",
+        "subscribe-conversation",
+        "unsubscribe-conversation"
+      ],
+      "per_session": [
+        "input",
+        "resize",
+        "split",
+        "close-pane",
+        "resize-pane",
+        "select-pane",
+        "adjust-pane",
+        "equalize-panes",
+        "zoom-pane",
+        "respawn-pane",
+        "request-viewport",
+        "ping",
+        "client-info"
+      ]
     },
     "server_messages": {
-      "mux_level": ["subscribed", "unsubscribed", "sessions-updated", "conversation-subscribed", "conversation-unsubscribed", "initial-conversation", "conversation-update"],
-      "per_session": ["layout", "viewport", "ready", "pong", "error", "new-session", "pane-dead", "hook-event"]
+      "mux_level": [
+        "subscribed",
+        "unsubscribed",
+        "sessions-updated",
+        "conversation-subscribed",
+        "conversation-unsubscribed",
+        "initial-conversation",
+        "conversation-update"
+      ],
+      "per_session": [
+        "layout",
+        "viewport",
+        "ready",
+        "pong",
+        "error",
+        "new-session",
+        "pane-dead",
+        "hook-event"
+      ]
     },
     "binary_format": "未使用 (全フレームが JSON テキスト。ペイン出力は viewport.lines に ANSI エンコード文字列で同梱)",
     "intervals": {
@@ -390,28 +1407,94 @@
     }
   },
   "types": [
-    { "name": "SessionResponse", "fields": "id, name, createdAt, lastAccessedAt, state, currentPath, agent, theme, customTitle" },
-    { "name": "ExtendedSessionResponse", "fields": "extends SessionResponse + indicatorState, ccSessionId, agentSessionId, currentCommand, paneTitle, ccSummary, ccFirstPrompt, ccRecap, waitingToolName, panes, messageCount, gitBranch, durationMinutes, metrics, peerId" },
-    { "name": "PaneInfo", "fields": "paneId, currentCommand, currentPath, title, agentName, agentColor, isActive, isDead, indicatorState, pid" },
-    { "name": "TmuxLayoutNode", "fields": "type ('leaf' | 'horizontal' | 'vertical'), width, height, x, y, paneId?, children?" },
-    { "name": "PaneViewport", "fields": "paneId, cols, rows, lines (ちょうど rows 行・ANSI エンコード), cursor (PaneCursor), modes (PaneModes), historySize, offset (0 = live edge), atTail" },
-    { "name": "PaneCursor", "fields": "x, y (0-based), visible (offset>0 では false)" },
-    { "name": "PaneModes", "fields": "altScreen (vim / htop 等の alternate screen 判定)" },
-    { "name": "ControlClientMessage", "fields": "input | resize | split | close-pane | resize-pane | select-pane | adjust-pane | equalize-panes | zoom-pane | respawn-pane | request-viewport | ping | client-info" },
-    { "name": "ControlServerMessage", "fields": "layout | viewport | ready | pong | error | new-session | pane-dead | hook-event" },
-    { "name": "MuxClientMessage", "fields": "subscribe | unsubscribe | subscribe-conversation | unsubscribe-conversation | (ControlClientMessage + sessionId)" },
-    { "name": "MuxServerMessage", "fields": "subscribed | unsubscribed | sessions-updated | conversation-* | initial-conversation | (ControlServerMessage + sessionId)" },
-    { "name": "Peer", "fields": "id ('local' | 'p_xxxx'), nickname, url ('self' | https URL), color, order" },
-    { "name": "PeerClientView", "fields": "extends Peer + wsToken (peer 直結 WS 用 Bearer), status, lastSeenAt, latencyMs, errorMessage" },
-    { "name": "DiscoveredPeer", "fields": "Tailscale 検出結果: host, url, version, alreadyRegistered" },
-    { "name": "HistorySession", "fields": "sessionId, projectPath, projectName, firstPrompt (旧称・実体は最終ユーザーメッセージ), lastPrompt, recap, recapAt, modified, messageCount, gitBranch, agent, peerId" },
-    { "name": "SessionMetrics", "fields": "contextTokens, contextMaxTokens, contextPercent, totalInputTokens, totalCacheCreationTokens, totalCacheReadTokens, totalOutputTokens, totalTokens, memoryRssBytes" },
-    { "name": "DashboardResponse", "fields": "usageLimits, usageLimitsStatus, codexUsageLimits, usageHistory, dailyActivity, modelUsage, costEstimates, hourlyActivity, version, systemMetrics, diskUsage, connectedClients" },
-    { "name": "ConversationMessage", "fields": "role, content, timestamp, thinking, toolUse, toolResult" },
-    { "name": "UsageLimits", "fields": "fiveHour (UsageCycleInfo), sevenDay (UsageCycleInfo)" },
-    { "name": "SessionState", "fields": "'idle' | 'working' | 'waiting_input' | 'waiting_permission' | 'disconnected' | 'lost'" },
-    { "name": "IndicatorState", "fields": "'processing' | 'waiting_input' | 'idle' | 'completed'" },
-    { "name": "AgentProvider", "fields": "'claude' | 'codex' (AGENT_PROVIDERS レジストリが resume コマンド等を定義)" }
+    {
+      "name": "SessionResponse",
+      "fields": "id, name, createdAt, lastAccessedAt, state, currentPath, agent, theme, customTitle"
+    },
+    {
+      "name": "ExtendedSessionResponse",
+      "fields": "extends SessionResponse + indicatorState, ccSessionId, agentSessionId, currentCommand, paneTitle, ccSummary, ccFirstPrompt, ccRecap, waitingToolName, panes, messageCount, gitBranch, durationMinutes, metrics, peerId"
+    },
+    {
+      "name": "PaneInfo",
+      "fields": "paneId, currentCommand, currentPath, title, agentName, agentColor, isActive, isDead, indicatorState, pid"
+    },
+    {
+      "name": "TmuxLayoutNode",
+      "fields": "type ('leaf' | 'horizontal' | 'vertical'), width, height, x, y, paneId?, children?"
+    },
+    {
+      "name": "PaneViewport",
+      "fields": "paneId, cols, rows, lines (ちょうど rows 行・ANSI エンコード), cursor (PaneCursor), modes (PaneModes), historySize, offset (0 = live edge), atTail"
+    },
+    {
+      "name": "PaneCursor",
+      "fields": "x, y (0-based), visible (offset>0 では false)"
+    },
+    {
+      "name": "PaneModes",
+      "fields": "altScreen (vim / htop 等の alternate screen 判定)"
+    },
+    {
+      "name": "ControlClientMessage",
+      "fields": "input | resize | split | close-pane | resize-pane | select-pane | adjust-pane | equalize-panes | zoom-pane | respawn-pane | request-viewport | ping | client-info"
+    },
+    {
+      "name": "ControlServerMessage",
+      "fields": "layout | viewport | ready | pong | error | new-session | pane-dead | hook-event"
+    },
+    {
+      "name": "MuxClientMessage",
+      "fields": "subscribe | unsubscribe | subscribe-conversation | unsubscribe-conversation | (ControlClientMessage + sessionId)"
+    },
+    {
+      "name": "MuxServerMessage",
+      "fields": "subscribed | unsubscribed | sessions-updated | conversation-* | initial-conversation | (ControlServerMessage + sessionId)"
+    },
+    {
+      "name": "Peer",
+      "fields": "id ('local' | 'p_xxxx'), nickname, url ('self' | https URL), color, order"
+    },
+    {
+      "name": "PeerClientView",
+      "fields": "extends Peer + wsToken (peer 直結 WS 用 Bearer), status, lastSeenAt, latencyMs, errorMessage"
+    },
+    {
+      "name": "DiscoveredPeer",
+      "fields": "Tailscale 検出結果: host, url, version, alreadyRegistered"
+    },
+    {
+      "name": "HistorySession",
+      "fields": "sessionId, projectPath, projectName, firstPrompt (旧称・実体は最終ユーザーメッセージ), lastPrompt, recap, recapAt, modified, messageCount, gitBranch, agent, peerId"
+    },
+    {
+      "name": "SessionMetrics",
+      "fields": "contextTokens, contextMaxTokens, contextPercent, totalInputTokens, totalCacheCreationTokens, totalCacheReadTokens, totalOutputTokens, totalTokens, memoryRssBytes"
+    },
+    {
+      "name": "DashboardResponse",
+      "fields": "usageLimits, usageLimitsStatus, codexUsageLimits, usageHistory, dailyActivity, modelUsage, costEstimates, hourlyActivity, version, systemMetrics, diskUsage, connectedClients"
+    },
+    {
+      "name": "ConversationMessage",
+      "fields": "role, content, timestamp, thinking, toolUse, toolResult"
+    },
+    {
+      "name": "UsageLimits",
+      "fields": "fiveHour (UsageCycleInfo), sevenDay (UsageCycleInfo)"
+    },
+    {
+      "name": "SessionState",
+      "fields": "'idle' | 'working' | 'waiting_input' | 'waiting_permission' | 'disconnected' | 'lost'"
+    },
+    {
+      "name": "IndicatorState",
+      "fields": "'processing' | 'waiting_input' | 'idle' | 'completed'"
+    },
+    {
+      "name": "AgentProvider",
+      "fields": "'claude' | 'codex' (AGENT_PROVIDERS レジストリが resume コマンド等を定義)"
+    }
   ],
   "data_flows": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.175",
+  "version": "0.1.176",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: ダッシュボード Model Usage の生モデルID表示を修正（全ファミリー対応の表示名整形）
- feat: Model Usage チャート改善（使用量順ソート、凡例折り返し、ファミリー単位カラーパレット、パーセンテージ表示）
- chore: 未使用のコスト推定コード（PRICING / getCostEstimates / CostEstimate 型）を削除
- fix: macOS で file-service テストが symlink 解決で失敗する問題を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)