### PR TITLE
fix: git-changes / git-diff の workingDir に isAllowedSessionDir ガードを追加 (#337)

### DIFF
--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -162,6 +162,10 @@ files.get('/git-changes/:workingDir', async (c) => {
     return c.json({ error: 'Missing workingDir parameter' }, 400);
   }
 
+  if (!(await isAllowedSessionDir(workingDir))) {
+    return c.json({ error: 'Access denied' }, 403);
+  }
+
   try {
     // Get current branch
     const branchProc = Bun.spawn(['git', '-C', workingDir, 'rev-parse', '--abbrev-ref', 'HEAD'], {
@@ -247,6 +251,10 @@ files.get('/git-diff/:workingDir', async (c) => {
     return c.json({ error: 'Missing workingDir or path parameter' }, 400);
   }
 
+  if (!(await isAllowedSessionDir(workingDir))) {
+    return c.json({ error: 'Access denied' }, 403);
+  }
+
   try {
     const args = ['git', '-C', workingDir, 'diff'];
     if (staged) {
@@ -266,7 +274,14 @@ files.get('/git-diff/:workingDir', async (c) => {
       // For untracked files, generate a "new file" diff
       try {
         const fullPath = join(workingDir, filePath);
-        const content = await readFile(fullPath, 'utf-8');
+        // Confine the fallback read to the (session-validated) workingDir so a
+        // relative path like "../../etc/passwd" can't escape it
+        const realFullPath = await realpath(fullPath);
+        const realWorkingDir = await realpath(workingDir);
+        if (realFullPath !== realWorkingDir && !realFullPath.startsWith(`${realWorkingDir}/`)) {
+          return c.json({ error: 'Access denied' }, 403);
+        }
+        const content = await readFile(realFullPath, 'utf-8');
         const lines = content.split('\n');
         const fakeDiff = [
           `--- /dev/null`,


### PR DESCRIPTION
## 概要
`GET /api/files/git-changes/:workingDir` と `GET /api/files/git-diff/:workingDir` が client 指定の `workingDir` を無検証で `git -C` に渡していた問題を修正。

## 変更内容
- 両エンドポイントの冒頭に `/files/list` / `/files/read` と同じ `isAllowedSessionDir(workingDir)` ガードを追加（許可外は 403）
- git-diff の untracked ファイル fallback 読み取り（`join(workingDir, filePath)` → `readFile`）に realpath ベースの封じ込めチェックを追加し、`../../etc/passwd` のような相対パスエスケープを遮断（#266 の untracked 分岐の指摘もカバー）

## 検証（dev 環境で curl）
- `git-changes/%2Fetc` → **403** Access denied
- `git-changes/<実セッションdir>` → **200** （branch / changes 正常）
- `git-diff/<実セッションdir>?path=<変更ファイル>` → **200** （diff 正常）
- `git-diff/%2Ftmp?path=x` → **403**
- `git-diff/<実セッションdir>?path=../../../etc/hostname` → **403**
- `bun run test`（backend 260 pass / frontend 37 pass / tui 66 pass）、`bun run lint` 全パス

Fixes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)