### PR TITLE
fix: getOrCreateControlSession の start() 失敗時にレジストリをロールバック (#331)

### DIFF
--- a/backend/src/services/__tests__/tmux-control-registry.test.ts
+++ b/backend/src/services/__tests__/tmux-control-registry.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'bun:test';
+import { TmuxControlSession, controlSessions, getOrCreateControlSession } from '../tmux-control';
+
+/**
+ * Regression test for #331: getOrCreateControlSession used to register the
+ * session in the global registry BEFORE awaiting start(). When start() threw
+ * (spawn failure, attach target gone, resource exhaustion), the broken entry
+ * stayed registered with isDestroyed=false, so every subsequent call returned
+ * the same dead instance and the tmux session became permanently unreachable.
+ */
+describe('getOrCreateControlSession', () => {
+  test('rolls back the registry entry when start() throws', async () => {
+    const sessionId = 'registry-rollback-test';
+    const originalStart = TmuxControlSession.prototype.start;
+    TmuxControlSession.prototype.start = async function () {
+      throw new Error('spawn failed');
+    };
+    try {
+      await expect(getOrCreateControlSession(sessionId)).rejects.toThrow('spawn failed');
+      // The failed session must not linger as a live-looking registry entry
+      expect(controlSessions.has(sessionId)).toBe(false);
+    } finally {
+      TmuxControlSession.prototype.start = originalStart;
+      controlSessions.get(sessionId)?.destroy();
+    }
+  });
+});

--- a/backend/src/services/tmux-control.ts
+++ b/backend/src/services/tmux-control.ts
@@ -1022,7 +1022,15 @@ export async function getOrCreateControlSession(sessionId: string): Promise<Tmux
 
   session = new TmuxControlSession(sessionId);
   controlSessions.set(sessionId, session);
-  await session.start();
+  try {
+    await session.start();
+  } catch (error) {
+    // Roll back the registry entry; otherwise a never-started session with
+    // isDestroyed=false would be returned forever, making the tmux session
+    // permanently unreachable (#331). destroy() also reaps a half-spawned proc.
+    session.destroy();
+    throw error;
+  }
   return session;
 }
 


### PR DESCRIPTION
## 概要
`getOrCreateControlSession` が `start()` の await 前に `controlSessions.set()` していたため、spawn 失敗等で `start()` が例外を投げると `isDestroyed=false` のゾンビエントリがレジストリに残り、以後そのセッションへの全アクセスが回復不能に死に続ける問題を修正。

## 変更内容
- `start()` を try/catch で囲み、失敗時に `session.destroy()` を呼んでレジストリから除去（destroy は部分起動した proc の後始末も行う）
- 回帰テスト追加: `start()` が throw した場合にレジストリにエントリが残らないこと

## 検証
- 新規テスト `tmux-control-registry.test.ts` パス
- `bun run test` 全パス（backend 261 / frontend 37 / tui 66）、`bun run lint` パス
- dev 環境で正常系を確認: control session 起動経由の `GET /api/sessions/linux/panes/%0/viewport` が 200 で内容取得、存在しないセッションは 404

Fixes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)