### PR TITLE
fix: mux subscribe 失敗時に addClient() をロールバック (#332)

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -257,11 +257,14 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
     return;
   }
 
+  let controlSession: TmuxControlSession | null = null;
+  let clientAdded = false;
+  const cleanupFns: Array<() => void> = [];
   try {
-    const controlSession = await getOrCreateControlSession(sessionId);
+    controlSession = await getOrCreateControlSession(sessionId);
     controlSession.addClient();
+    clientAdded = true;
 
-    const cleanupFns: Array<() => void> = [];
     const sessions = await tmuxService.listSessions();
     const session = sessions.find(s => s.id === sessionId);
     const sub: MuxSubscription = {
@@ -352,7 +355,21 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
     });
   } catch (error) {
     console.error(`[mux] Failed to subscribe to ${sessionId}:`, error);
-    ws.send(JSON.stringify({ type: 'error', message: 'Failed to subscribe', sessionId }));
+    // Roll back whatever was set up before the failure. Without this the
+    // client count stays over-counted, the grace period never starts, and
+    // the tmux -CC subprocess lives forever (#332).
+    for (const fn of cleanupFns) {
+      try { fn(); } catch { /* ignore */ }
+    }
+    if (ws.data.subscriptions.get(sessionId)?.controlSession === controlSession) {
+      ws.data.subscriptions.delete(sessionId);
+    }
+    if (clientAdded && controlSession) {
+      controlSession.removeClient();
+    }
+    try {
+      ws.send(JSON.stringify({ type: 'error', message: 'Failed to subscribe', sessionId }));
+    } catch { /* disconnected */ }
   }
 }
 

--- a/backend/src/services/__tests__/tmux-control-registry.test.ts
+++ b/backend/src/services/__tests__/tmux-control-registry.test.ts
@@ -12,7 +12,7 @@ describe('getOrCreateControlSession', () => {
   test('rolls back the registry entry when start() throws', async () => {
     const sessionId = 'registry-rollback-test';
     const originalStart = TmuxControlSession.prototype.start;
-    TmuxControlSession.prototype.start = async function () {
+    TmuxControlSession.prototype.start = async () => {
       throw new Error('spawn failed');
     };
     try {


### PR DESCRIPTION
## 概要
`handleSubscribe` で `controlSession.addClient()` 後に例外が発生すると、catch がエラー送信のみでクライアントカウントが +1 のまま残り、全クライアント切断後もグレースピリオドが開始されず tmux -CC サブプロセスが永続リークする問題を修正。

## 変更内容
- catch ブロックで以下をロールバック:
  - `cleanupFns` に登録済みのリスナーを解除
  - 登録済みの subscription エントリを削除
  - `addClient()` 通過済みなら `removeClient()` を呼ぶ
- ws.send 自体の例外も握りつぶすようガード（切断済みクライアント対策）
- ついで: 前 PR のテストの function 式を arrow function に変更（Biome warning 解消）

## 検証
- dev 環境で WebSocket クライアントによる subscribe → layout/subscribed/viewport 受信、unsubscribe → unsubscribed、存在しないセッションへの subscribe → error を確認
- サーバログで `addClient linux: clients=1` → `removeClient linux: clients=0` のバランスを確認
- `tsc --noEmit` クリーン、`bun run lint` パス、`bun test` 261 pass

Fixes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)