### PR TITLE
fix: セッションメタデータ永続化に atomic write + mutation lock を導入 (#333)

### DIFF
--- a/backend/src/services/__tests__/session-metadata-lock.test.ts
+++ b/backend/src/services/__tests__/session-metadata-lock.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Force the data directory before the module loads so session-metadata.json
+// lands in our scratch dir. ensureDataDir reads CC_HUB_DATA_DIR. #333
+let tempDir: string;
+let originalDataDir: string | undefined;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'cchub-meta-'));
+  originalDataDir = process.env.CC_HUB_DATA_DIR;
+  process.env.CC_HUB_DATA_DIR = tempDir;
+});
+
+afterEach(async () => {
+  if (originalDataDir === undefined) delete process.env.CC_HUB_DATA_DIR;
+  else process.env.CC_HUB_DATA_DIR = originalDataDir;
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('session-metadata mutation lock', () => {
+  test('concurrent theme/title/order updates do not overwrite each other', async () => {
+    const meta = await import('../session-metadata');
+
+    // Interleave updates that all do load→mutate→save on the same file.
+    // Without the mutation lock, overlapping sequences drop each other's
+    // writes (lost update).
+    const ops: Array<Promise<unknown>> = [];
+    for (let i = 0; i < 20; i++) {
+      ops.push(meta.setSessionTheme('ses-a', 'blue'));
+      ops.push(meta.setSessionTitle('ses-b', `title ${i}`));
+      ops.push(meta.setSessionOrder([`ses-a`, `ses-b`, `ses-${i}`]));
+    }
+    await Promise.all(ops);
+
+    const sessions = await meta.getAllSessionMetadata();
+    expect(sessions['ses-a']?.theme).toBe('blue');
+    expect(sessions['ses-b']?.title).toBe('title 19');
+    expect(await meta.getSessionOrder()).toEqual(['ses-a', 'ses-b', 'ses-19']);
+
+    // The file on disk must always be complete JSON (atomic temp+rename).
+    const text = await readFile(join(tempDir, 'session-metadata.json'), 'utf-8');
+    const parsed = JSON.parse(text);
+    expect(parsed.sessions['ses-a'].theme).toBe('blue');
+  });
+
+  test('concurrent last-known-session updates are serialised', async () => {
+    const meta = await import('../session-metadata');
+
+    await meta.saveLastKnownSessions([
+      { id: 's1', name: 'one' },
+      { id: 's2', name: 'two' },
+      { id: 's3', name: 'three' },
+    ]);
+    await Promise.all([
+      meta.removeLastKnownSession('s1'),
+      meta.removeLastKnownSession('s3'),
+    ]);
+
+    const remaining = await meta.getLastKnownSessions();
+    expect(remaining.map(s => s.id)).toEqual(['s2']);
+  });
+});

--- a/backend/src/services/session-metadata.ts
+++ b/backend/src/services/session-metadata.ts
@@ -1,10 +1,15 @@
 import { join } from 'node:path';
-import { readFile, writeFile, unlink } from 'node:fs/promises';
-import { ensureDataDir } from '../utils/storage';
+import { readFile, unlink } from 'node:fs/promises';
+import { ensureDataDir, atomicWriteFile, createMutationLock } from '../utils/storage';
 import type { AgentProvider, SessionTheme } from '../../../shared/types';
 
 const METADATA_FILE = 'session-metadata.json';
 const LAST_KNOWN_FILE = 'last-known-sessions.json';
+
+// Serialise read-modify-write sequences per store file so concurrent theme /
+// title / order updates can't clobber each other (lost update). #333
+const withMetadataLock = createMutationLock();
+const withLastKnownLock = createMutationLock();
 
 interface SessionMeta {
   theme?: SessionTheme;
@@ -48,9 +53,9 @@ async function load(): Promise<MetadataStore> {
     // Migrate: if lastKnownSessions exists in metadata file, move to separate file
     if (parsed.lastKnownSessions) {
       const lkPath = await getLastKnownFilePath();
-      await writeFile(lkPath, JSON.stringify(parsed.lastKnownSessions, null, 2)).catch(() => {});
+      await atomicWriteFile(lkPath, JSON.stringify(parsed.lastKnownSessions, null, 2)).catch(() => {});
       delete parsed.lastKnownSessions;
-      await writeFile(filePath, JSON.stringify(parsed, null, 2)).catch(() => {});
+      await atomicWriteFile(filePath, JSON.stringify(parsed, null, 2)).catch(() => {});
     }
     return { sessions: parsed.sessions || {}, sessionOrder: parsed.sessionOrder };
   } catch {
@@ -102,7 +107,7 @@ async function save(data: MetadataStore): Promise<void> {
       delete data.sessions[id];
     }
   }
-  await writeFile(filePath, JSON.stringify(data, null, 2));
+  await atomicWriteFile(filePath, JSON.stringify(data, null, 2));
 }
 
 export async function getAllSessionMetadata(): Promise<Record<string, SessionMeta>> {
@@ -111,14 +116,16 @@ export async function getAllSessionMetadata(): Promise<Record<string, SessionMet
 }
 
 export async function setSessionTheme(sessionId: string, theme: SessionTheme | null): Promise<void> {
-  const data = await load();
-  if (!data.sessions[sessionId]) data.sessions[sessionId] = {};
-  if (theme === null) {
-    delete data.sessions[sessionId].theme;
-  } else {
-    data.sessions[sessionId].theme = theme;
-  }
-  await save(data);
+  await withMetadataLock(async () => {
+    const data = await load();
+    if (!data.sessions[sessionId]) data.sessions[sessionId] = {};
+    if (theme === null) {
+      delete data.sessions[sessionId].theme;
+    } else {
+      data.sessions[sessionId].theme = theme;
+    }
+    await save(data);
+  });
 }
 
 export async function getSessionOrder(): Promise<string[]> {
@@ -127,9 +134,11 @@ export async function getSessionOrder(): Promise<string[]> {
 }
 
 export async function setSessionOrder(order: string[]): Promise<void> {
-  const data = await load();
-  data.sessionOrder = order;
-  await save(data);
+  await withMetadataLock(async () => {
+    const data = await load();
+    data.sessionOrder = order;
+    await save(data);
+  });
 }
 
 // Last known sessions: separate file to avoid race conditions with metadata writes
@@ -144,25 +153,32 @@ export async function getLastKnownSessions(): Promise<LastKnownSession[]> {
 }
 
 export async function saveLastKnownSessions(sessions: LastKnownSession[]): Promise<void> {
-  const filePath = await getLastKnownFilePath();
-  await writeFile(filePath, JSON.stringify(sessions, null, 2));
+  await withLastKnownLock(async () => {
+    const filePath = await getLastKnownFilePath();
+    await atomicWriteFile(filePath, JSON.stringify(sessions, null, 2));
+  });
 }
 
 export async function removeLastKnownSession(sessionId: string): Promise<void> {
-  const sessions = await getLastKnownSessions();
-  const filtered = sessions.filter(s => s.id !== sessionId);
-  if (filtered.length !== sessions.length) {
-    await saveLastKnownSessions(filtered);
-  }
+  await withLastKnownLock(async () => {
+    const sessions = await getLastKnownSessions();
+    const filtered = sessions.filter(s => s.id !== sessionId);
+    if (filtered.length !== sessions.length) {
+      const filePath = await getLastKnownFilePath();
+      await atomicWriteFile(filePath, JSON.stringify(filtered, null, 2));
+    }
+  });
 }
 
 export async function setSessionTitle(sessionId: string, title: string | null): Promise<void> {
-  const data = await load();
-  if (!data.sessions[sessionId]) data.sessions[sessionId] = {};
-  if (title === null || title === '') {
-    delete data.sessions[sessionId].title;
-  } else {
-    data.sessions[sessionId].title = title;
-  }
-  await save(data);
+  await withMetadataLock(async () => {
+    const data = await load();
+    if (!data.sessions[sessionId]) data.sessions[sessionId] = {};
+    if (title === null || title === '') {
+      delete data.sessions[sessionId].title;
+    } else {
+      data.sessions[sessionId].title = title;
+    }
+    await save(data);
+  });
 }

--- a/backend/src/services/sessions.ts
+++ b/backend/src/services/sessions.ts
@@ -1,10 +1,15 @@
 import { join } from 'node:path';
-import { readdir, readFile, writeFile, rm, mkdir } from 'node:fs/promises';
+import { readdir, readFile, rm, mkdir } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
-import { ensureDataDir } from '../utils/storage';
+import { ensureDataDir, atomicWriteFile, createMutationLock } from '../utils/storage';
 import type { Session, SessionState, SessionResponse } from '../../../shared/types';
 
 const SESSIONS_DIR = 'sessions';
+
+// Serialise read-modify-write updates against the per-session JSON files so
+// concurrent updateSessionAccess / updateSessionState calls can't drop each
+// other's changes. #333
+const withSessionsLock = createMutationLock();
 
 async function getSessionsDir(): Promise<string> {
   const dataDir = await ensureDataDir();
@@ -41,7 +46,7 @@ export async function createSession(name?: string): Promise<SessionResponse> {
   };
 
   const filePath = join(sessionsDir, `${id}.json`);
-  await writeFile(filePath, JSON.stringify(session, null, 2));
+  await atomicWriteFile(filePath, JSON.stringify(session, null, 2));
 
   return sessionToResponse(session);
 }
@@ -105,32 +110,36 @@ export async function deleteSession(id: string): Promise<boolean> {
 }
 
 export async function updateSessionAccess(id: string): Promise<boolean> {
-  const sessionsDir = await getSessionsDir();
-  const filePath = join(sessionsDir, `${id}.json`);
+  return withSessionsLock(async () => {
+    const sessionsDir = await getSessionsDir();
+    const filePath = join(sessionsDir, `${id}.json`);
 
-  try {
-    const data = await readFile(filePath, 'utf-8');
-    const session = JSON.parse(data) as Session;
-    session.lastAccessedAt = new Date().toISOString();
-    await writeFile(filePath, JSON.stringify(session, null, 2));
-    return true;
-  } catch {
-    return false;
-  }
+    try {
+      const data = await readFile(filePath, 'utf-8');
+      const session = JSON.parse(data) as Session;
+      session.lastAccessedAt = new Date().toISOString();
+      await atomicWriteFile(filePath, JSON.stringify(session, null, 2));
+      return true;
+    } catch {
+      return false;
+    }
+  });
 }
 
 export async function updateSessionState(id: string, state: SessionState): Promise<boolean> {
-  const sessionsDir = await getSessionsDir();
-  const filePath = join(sessionsDir, `${id}.json`);
+  return withSessionsLock(async () => {
+    const sessionsDir = await getSessionsDir();
+    const filePath = join(sessionsDir, `${id}.json`);
 
-  try {
-    const data = await readFile(filePath, 'utf-8');
-    const session = JSON.parse(data) as Session;
-    session.state = state;
-    session.lastAccessedAt = new Date().toISOString();
-    await writeFile(filePath, JSON.stringify(session, null, 2));
-    return true;
-  } catch {
-    return false;
-  }
+    try {
+      const data = await readFile(filePath, 'utf-8');
+      const session = JSON.parse(data) as Session;
+      session.state = state;
+      session.lastAccessedAt = new Date().toISOString();
+      await atomicWriteFile(filePath, JSON.stringify(session, null, 2));
+      return true;
+    } catch {
+      return false;
+    }
+  });
 }

--- a/backend/src/utils/storage.ts
+++ b/backend/src/utils/storage.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, writeFile, rename, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
+import { randomBytes } from 'node:crypto';
 
 const DEFAULT_DATA_DIR = join(homedir(), '.cc-hub');
 
@@ -12,4 +13,40 @@ export async function ensureDataDir(): Promise<string> {
   const dataDir = getDataDir();
   await mkdir(dataDir, { recursive: true });
   return dataDir;
+}
+
+/**
+ * Write to a sibling temp file and rename atomically so a crash mid-write
+ * can't truncate the target (a truncated JSON store reads back as empty and
+ * silently loses everything it held). Same pattern as peer-registry. #251 #333
+ */
+export async function atomicWriteFile(filePath: string, content: string): Promise<void> {
+  const tempPath = `${filePath}.tmp.${process.pid}.${randomBytes(4).toString('hex')}`;
+  try {
+    await writeFile(tempPath, content);
+    await rename(tempPath, filePath);
+  } catch (err) {
+    try {
+      await unlink(tempPath);
+    } catch {
+      /* best-effort cleanup if rename never happened */
+    }
+    throw err;
+  }
+}
+
+/**
+ * Create a mutex that serialises load→mutate→save sequences against a single
+ * store file. Without it, overlapping read-modify-write calls clobber each
+ * other's changes (lost update). One lock per store file. #251 #333
+ */
+export function createMutationLock(): <T>(fn: () => Promise<T>) => Promise<T> {
+  let queue: Promise<unknown> = Promise.resolve();
+  return <T>(fn: () => Promise<T>): Promise<T> => {
+    const next = queue.then(fn, fn);
+    // Don't propagate failures into the queue's success chain — the next
+    // caller must still get to run even if this one rejected.
+    queue = next.catch(() => undefined);
+    return next;
+  };
 }


### PR DESCRIPTION
## 概要
`session-metadata.ts` / `sessions.ts` の永続化が `writeFile` 直接上書き + 非直列の load→modify→save だったため、並行更新での lost-update と書き込み中クラッシュによる JSON truncate（→全メタデータ消失）が起き得た問題を修正。

## 変更内容
- peer-registry (#251) で実証済みのパターンを `utils/storage.ts` に共通化:
  - `atomicWriteFile` — 一時ファイル + rename によるアトミック書き込み
  - `createMutationLock` — ストアファイル単位の FIFO mutex
- `session-metadata.ts`: `setSessionTheme` / `setSessionTitle` / `setSessionOrder`（metadata lock）、`saveLastKnownSessions` / `removeLastKnownSession`（last-known lock）に適用。マイグレーション時の書き込みもアトミック化
- `sessions.ts`: `createSession` をアトミック書き込み化、`updateSessionAccess` / `updateSessionState` を lock + アトミック書き込み化
- 回帰テスト追加: 並行 theme/title/order 更新で lost-update が起きないこと、並行 removeLastKnownSession が直列化されること

## 検証
- 新規テスト 2 件パス、`bun test` 263 pass、`tsc --noEmit` クリーン、`bun run lint` パス
- dev 環境で `PUT /api/sessions/linux/theme` / `title` → 200、`session-metadata.json` に正しく永続化、`.tmp` ファイル残骸なしを確認（確認後は null に戻して原状復帰）

Fixes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)