### PR TITLE
fix: searchSessions の limit を有効化し JSONL を逐次ストリーム読みに (#335)

### DIFF
--- a/backend/src/services/session-history.ts
+++ b/backend/src/services/session-history.ts
@@ -147,11 +147,12 @@ export class SessionHistoryService {
    * Returns the matching message snippet if found, otherwise null
    */
   private async searchInSessionFile(filePath: string, query: string): Promise<string | null> {
+    // Stream line-by-line instead of readFile: session JSONL files can be
+    // tens to hundreds of MB, and a search request touches many of them (#335)
+    const fileStream = createReadStream(filePath);
+    const rl = createInterface({ input: fileStream, crlfDelay: Infinity });
     try {
-      const fileContent = await readFile(filePath, 'utf-8');
-      const lines = fileContent.split('\n');
-
-      for (const line of lines) {
+      for await (const line of rl) {
         if (!line.trim()) continue;
         try {
           const entry = JSON.parse(line);
@@ -182,6 +183,9 @@ export class SessionHistoryService {
       return null;
     } catch {
       return null;
+    } finally {
+      rl.close();
+      fileStream.destroy();
     }
   }
 
@@ -821,64 +825,19 @@ export class SessionHistoryService {
    * Search sessions across all projects
    */
   async searchSessions(query: string, limit: number = 50): Promise<HistorySession[]> {
-    if (!query || query.trim().length === 0) {
-      return [];
-    }
-
-    const normalizedQuery = query.toLowerCase().trim();
+    // Delegate to the serial generator: the old Promise.all fan-out kicked off
+    // a scan of every project directory at once, so the `limit` early-exit
+    // never stopped work already in flight and a single request could saturate
+    // I/O across all JSONL files (#335). The generator walks newest-first and
+    // stops as soon as `limit` matches are found.
     const results: HistorySession[] = [];
-
-    try {
-      const projectDirs = await readdir(this.projectsDir);
-
-      await Promise.all(projectDirs.map(async (dir) => {
-        const projectDir = join(this.projectsDir, dir);
-
-        try {
-          const dirStat = await stat(projectDir);
-          if (!dirStat.isDirectory()) return;
-
-          const files = await readdir(projectDir);
-          const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
-
-          for (const file of jsonlFiles) {
-            if (results.length >= limit) break;
-
-            const jsonlPath = join(projectDir, file);
-            const basicInfo = await this.scanJsonlForBasicInfo(jsonlPath);
-
-            if (basicInfo?.lastPrompt) {
-              // Search in project name and first prompt
-              const projectName = basicInfo.projectPath.replace(/^\/home\/[^/]+\//, '~/');
-              const searchText = `${projectName} ${basicInfo.lastPrompt}`.toLowerCase();
-
-              if (searchText.includes(normalizedQuery)) {
-                // recap intentionally omitted on both search paths — avoid an
-                // extra tail-read per result. Search matches title/prompt only.
-                results.push({
-                  sessionId: basicInfo.sessionId,
-                  projectPath: basicInfo.projectPath,
-                  projectName,
-                  firstPrompt: basicInfo.lastPrompt,
-                  lastPrompt: basicInfo.lastPrompt,
-                  gitBranch: basicInfo.gitBranch,
-                  modified: basicInfo.modified,
-                });
-              }
-            }
-          }
-        } catch {
-          // Skip directories that can't be read
-        }
-      }));
-
-      // Sort by modified date (newest first)
-      results.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
-
-      return results.slice(0, limit);
-    } catch {
-      return [];
+    for await (const session of this.searchSessionsStream(query, limit)) {
+      results.push(session);
     }
+
+    // Sort by modified date (newest first) to keep the old response contract
+    results.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+    return results;
   }
 
   /**


### PR DESCRIPTION
## 概要
- `searchSessions` の早期打ち切りが `Promise.all` の内側にあり limit が機能せず、検索1回で全プロジェクト×全 JSONL の走査が同時起動していた問題を修正
- `searchInSessionFile` の `readFile` 全量メモリ読みを `createReadStream` + `readline` の逐次スキャンに置換（マッチ時点で即 close）

## 変更内容
- `searchSessions` を、シリアル走査 + limit 早期終了が正しく実装済みの `searchSessionsStream` への委譲に書き換え（収集後 modified 降順ソートで旧レスポンス契約を維持）
- 副次効果: 非ストリーム版 `GET /history/search` も SSE 版と同じ全文検索フォールバックを持つようになる（従来は projectName + lastPrompt のみ）

## 検証（dev 環境）
- `?q=cchub&limit=5` → 200, 5件, 60ms
- `?q=tailscale&limit=10` → 200, 10件（limit 遵守）
- `?q=zzz_no_match_zzz` → 200, 0件, 全走査でも 1.5s・逐次読みでメモリ膨張なし
- `bun test` 263 pass、`tsc --noEmit` クリーン、`bun run lint` パス

Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)