### PR TITLE
fix: ConversationWatcher.start() 再入時に旧 fs.watch を close (#334)

### DIFF
--- a/backend/src/services/conversation-watcher.ts
+++ b/backend/src/services/conversation-watcher.ts
@@ -34,6 +34,12 @@ export class ConversationWatcher {
    * Returns the initial set of conversation messages (may be empty if no session exists yet).
    */
   async start(workingDir: string): Promise<ConversationMessage[]> {
+    // Re-entrant start: close any previous fs.watch before re-initialising.
+    // Otherwise the old watcher leaks and its change events trigger reparse
+    // against the overwritten filePath, delivering the wrong file's
+    // conversation (#334). Listeners are kept — they belong to the subscriber.
+    this.closeWatcher();
+
     const session = await claudeCodeService.getSessionForPath(workingDir);
     if (!session?.sessionId) {
       return [];
@@ -130,7 +136,7 @@ export class ConversationWatcher {
     }
   }
 
-  stop(): void {
+  private closeWatcher(): void {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
@@ -143,6 +149,10 @@ export class ConversationWatcher {
       }
       this.watcher = null;
     }
+  }
+
+  stop(): void {
+    this.closeWatcher();
     this.listeners.clear();
     this.filePath = null;
     this.projectDirName = null;


### PR DESCRIPTION
## 概要
`ConversationWatcher.start()` が既存の `this.watcher` を close せずに上書きしていたため、同一インスタンスへの再 `start()` で旧 fs.watch がリークし、旧ファイルの変更イベントが上書き後の `filePath` に対して `reparseAndNotify` を呼ぶ（誤ファイルの会話配信）問題を修正。

## 変更内容
- watcher + debounce timer の close を `closeWatcher()` に切り出し、`start()` 冒頭で呼ぶ
- `stop()` は `closeWatcher()` + listener クリア + 状態リセットに整理
- listener は購読者に属するため `start()` 再入では保持（クリアしない）

## 検証（dev 環境）
- WebSocket で同一セッションに `subscribe-conversation` を2回送信 → 両方とも `conversation-subscribed`（ccSessionId 解決済み）+ `initial-conversation` を受信、`unsubscribe-conversation` も正常
- `bun test` 263 pass、`tsc --noEmit` クリーン、`bun run lint` パス

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)