### PR TITLE
fix: usePeers のポーリングタイマーをモジュールレベルで1本に統合 (#336)

### DIFF
--- a/frontend/src/hooks/useHistoryActions.ts
+++ b/frontend/src/hooks/useHistoryActions.ts
@@ -5,7 +5,7 @@ import type {
 	HistorySession,
 	SessionResponse,
 } from "../../../shared/types";
-import { useSessionHistory } from "./useSessionHistory";
+import type { useSessionHistory } from "./useSessionHistory";
 import { authFetch } from "../services/api";
 
 const API_BASE = import.meta.env.VITE_API_URL || "";

--- a/frontend/src/hooks/usePeers.ts
+++ b/frontend/src/hooks/usePeers.ts
@@ -22,11 +22,17 @@ interface UsePeersReturn {
 
 // module-level cache: 全コンポーネントで共有
 let cachedPeers: PeerClientView[] | null = null;
-const listeners = new Set<(peers: PeerClientView[]) => void>();
+let lastError: string | null = null;
+const listeners = new Set<() => void>();
 
-function broadcast(peers: PeerClientView[]) {
-	cachedPeers = peers;
-	for (const l of listeners) l(peers);
+// usePeers は複数コンポーネントから同時に呼ばれるが、ポーリングタイマーは
+// モジュールレベルで1本だけ管理する（参照カウント方式）。インスタンスごとに
+// setInterval を張ると /api/peers への 5 秒ポーリングが N 倍に多重化する (#336)
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let refreshInFlight: Promise<void> | null = null;
+
+function notifyListeners() {
+	for (const l of listeners) l();
 }
 
 async function fetchPeers(): Promise<PeerClientView[]> {
@@ -36,48 +42,64 @@ async function fetchPeers(): Promise<PeerClientView[]> {
 	return data.peers;
 }
 
+// 同時要求は1本の fetch に合流させる
+function refreshShared(): Promise<void> {
+	if (refreshInFlight) return refreshInFlight;
+	refreshInFlight = (async () => {
+		try {
+			cachedPeers = await fetchPeers();
+			lastError = null;
+		} catch (err) {
+			lastError = err instanceof Error ? err.message : "Failed to load peers";
+		} finally {
+			refreshInFlight = null;
+			notifyListeners();
+		}
+	})();
+	return refreshInFlight;
+}
+
+function subscribePeers(listener: () => void): () => void {
+	listeners.add(listener);
+	if (!pollTimer) {
+		// 定期更新 (peer の status を最新化するため)。購読者がいる間だけ動かす
+		pollTimer = setInterval(() => {
+			void refreshShared();
+		}, 5000);
+	}
+	return () => {
+		listeners.delete(listener);
+		if (listeners.size === 0 && pollTimer) {
+			clearInterval(pollTimer);
+			pollTimer = null;
+		}
+	};
+}
+
 export function usePeers(): UsePeersReturn {
 	const [peers, setPeers] = useState<PeerClientView[]>(() => cachedPeers ?? []);
 	const [isLoading, setIsLoading] = useState(() => cachedPeers === null);
-	const [error, setError] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(() => lastError);
 
 	useEffect(() => {
-		const listener = (next: PeerClientView[]) => setPeers(next);
-		listeners.add(listener);
-		return () => {
-			listeners.delete(listener);
+		const listener = () => {
+			setPeers(cachedPeers ?? []);
+			setError(lastError);
+			setIsLoading(false);
 		};
+		const unsubscribe = subscribePeers(listener);
+		// 初回ロード。キャッシュ済みなら即確定し、裏のポーリングが最新化する
+		if (cachedPeers === null) {
+			void refreshShared();
+		} else {
+			listener();
+		}
+		return unsubscribe;
 	}, []);
 
 	const refresh = useCallback(async () => {
-		try {
-			const next = await fetchPeers();
-			broadcast(next);
-			setError(null);
-		} catch (err) {
-			setError(err instanceof Error ? err.message : "Failed to load peers");
-		} finally {
-			setIsLoading(false);
-		}
+		await refreshShared();
 	}, []);
-
-	// 初回ロード + 定期更新 (peer の status を最新化するため)
-	useEffect(() => {
-		let cancelled = false;
-		if (cachedPeers === null) {
-			void refresh();
-		} else {
-			setIsLoading(false);
-		}
-		const timer = setInterval(() => {
-			if (cancelled) return;
-			void refresh();
-		}, 5000);
-		return () => {
-			cancelled = true;
-			clearInterval(timer);
-		};
-	}, [refresh]);
 
 	const addPeer = useCallback(async (input: PeerCreateInput): Promise<PeerClientView> => {
 		const res = await authFetch(`${API_BASE}/api/peers`, {


### PR DESCRIPTION
## 概要
`usePeers()` がインスタンスごとに独立した `setInterval(5000)` を張っていたため、5〜6 箇所から呼ばれると `/api/peers` ポーリングと再レンダリング broadcast が N 倍化していた問題を修正。

## 変更内容
- `latency-store.ts` と同様の参照カウント方式: モジュールレベルの単一タイマーを、最初の購読者で開始・最後の購読解除で停止
- `refreshShared` で同時リクエストを単一の in-flight fetch に合流
- エラー状態もモジュールレベルで共有し、リスナー経由で各フックへ配信
- unmount 時にリスナーを外すため、triage #268 で指摘の unmount 後 setState も解消
- ついで: `useHistoryActions.ts` の既存 Biome warning（useImportType）を修正

## 検証（dev 環境 + agent-browser）
- 修正後の UI を 25 秒間観測し、`performance.getEntriesByType('resource')` で `/api/peers` リクエストが **6 件（= 初回 + 5秒間隔×5、タイマー1本）** であることを確認
- UI 正常レンダリング（ターミナル表示・オンボーディング表示）をスクリーンショットで確認
- `bun run test`（frontend 37 pass）、`tsc --noEmit`（新規エラーなし）、`bun run lint` パス

Fixes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)