### PR TITLE
fix: WS切断とsubscribe処理の競合によるTmuxControlSession/ConversationWatcherリークを修正

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -324,6 +324,19 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
       })
     );
 
+    // The client can disconnect while the awaits above are in flight. muxClose
+    // has already run at that point and didn't see this subscription, so the
+    // listeners and addClient() would leak (the grace period would never
+    // start and the tmux -CC subprocess would live forever). #346
+    if (!activeMuxConnections.has(ws)) {
+      console.log(`[mux] client disconnected during subscribe to ${sessionId}; rolling back`);
+      for (const fn of cleanupFns) {
+        try { fn(); } catch { /* ignore */ }
+      }
+      controlSession.removeClient();
+      return;
+    }
+
     ws.data.subscriptions.set(sessionId, sub);
 
     try {
@@ -490,6 +503,15 @@ async function handleSubscribeConversation(ws: ServerWebSocket<MuxData>, session
     initialMessages = await watcher.start(workingDir);
   } catch (err) {
     console.warn(`[mux] subscribe-conversation start failed for ${sessionId}:`, err);
+  }
+
+  // The client can disconnect while watcher.start() is in flight. muxClose
+  // has already run at that point and didn't see this watcher, so its
+  // FSWatcher would keep running forever. #346
+  if (!activeMuxConnections.has(ws)) {
+    console.log(`[mux] client disconnected during subscribe-conversation to ${sessionId}; stopping watcher`);
+    try { watcher.stop(); } catch { /* ignore */ }
+    return;
   }
 
   watcher.onUpdate((newMessages) => {


### PR DESCRIPTION
## 概要

Fixes #346

`handleSubscribe` / `handleSubscribeConversation` は、リソース取得（`addClient()` / `watcher.start()`）と `ws.data` への登録の間に await を挟む。この間に WebSocket が切断されると `muxClose` が先に走り、未登録のリソースをクリーンアップできずリークしていた:

- TmuxControlSession のクライアントカウントが過剰になり grace period が始まらず、`tmux -CC` サブプロセスが永続化
- ConversationWatcher の FSWatcher が永続化

## 修正

await 完了後の同期ブロック内（登録直前）で `activeMuxConnections.has(ws)` を確認し、切断済みならリスナー解除 + `removeClient()` / `watcher.stop()` でロールバックする。

## 検証

- `bun run lint` / `bun run test`（backend 263 pass, tui 66 pass）
- dev環境で再現スクリプト実行: subscribe / subscribe-conversation 送信直後に close
  - `[mux] client disconnected during subscribe to linux; rolling back`
  - `[mux] client disconnected during subscribe-conversation to linux; stopping watcher`
  の両方を確認
- 通常の subscribe フロー（subscribed + viewport 受信）が正常動作することも確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)