### PR TITLE
fix: /api/notify の transcript_path を検証して任意ファイル読み取りを防ぐ

### DIFF
--- a/backend/src/routes/__tests__/notify-transcript-path.test.ts
+++ b/backend/src/routes/__tests__/notify-transcript-path.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { isAllowedTranscriptPath } from '../notify';
+
+const claudeDir = join(homedir(), '.claude');
+const realFile = join(claudeDir, '.cchub-test-transcript.jsonl');
+const linkFile = join(claudeDir, '.cchub-test-escape-link.jsonl');
+
+describe('isAllowedTranscriptPath', () => {
+  beforeAll(async () => {
+    await mkdir(claudeDir, { recursive: true });
+    await writeFile(realFile, '{}\n');
+    await rm(linkFile, { force: true });
+    await symlink('/etc/hosts', linkFile);
+  });
+
+  afterAll(async () => {
+    await rm(realFile, { force: true });
+    await rm(linkFile, { force: true });
+  });
+
+  test('allows a transcript under ~/.claude', async () => {
+    expect(await isAllowedTranscriptPath(realFile)).toBe(true);
+  });
+
+  test('rejects files outside the allowed dirs', async () => {
+    expect(await isAllowedTranscriptPath('/etc/passwd')).toBe(false);
+  });
+
+  test('rejects nonexistent paths', async () => {
+    expect(await isAllowedTranscriptPath(join(claudeDir, 'no-such-file.jsonl'))).toBe(false);
+  });
+
+  test('rejects traversal that resolves outside the allowed dirs', async () => {
+    expect(await isAllowedTranscriptPath(join(claudeDir, '..', '..', 'etc', 'passwd'))).toBe(false);
+  });
+
+  test('rejects symlinks escaping the allowed dirs', async () => {
+    expect(await isAllowedTranscriptPath(linkFile)).toBe(false);
+  });
+});

--- a/backend/src/routes/notify.ts
+++ b/backend/src/routes/notify.ts
@@ -1,3 +1,5 @@
+import { realpath } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { Hono } from 'hono';
 import { broadcastToMuxClients } from './terminal-mux';
 import type { IndicatorState } from '../../../shared/types';
@@ -23,6 +25,25 @@ async function readTrailingLines(path: string, lineCount: number): Promise<strin
   // drop it so JSON.parse below doesn't fail on a truncated entry.
   if (offset > 0) lines.shift();
   return lines.slice(-lineCount);
+}
+
+// /api/notify is unauthenticated (local hooks call into it), so the
+// transcript_path in the request body cannot be trusted: generateSmartMessage
+// reads the file and broadcasts text fragments of it to every connected
+// client. Only real transcript locations (the Claude Code / Codex state
+// dirs) may be read. Symlinks are resolved before the prefix check. #347
+export async function isAllowedTranscriptPath(path: string): Promise<boolean> {
+  let resolved: string;
+  try {
+    resolved = await realpath(path);
+  } catch {
+    return false;
+  }
+  for (const dir of ['.claude', '.codex']) {
+    const root = await realpath(`${homedir()}/${dir}`).catch(() => null);
+    if (root && resolved.startsWith(`${root}/`)) return true;
+  }
+  return false;
 }
 
 /** transcriptファイルからコンテキストに応じた通知メッセージを生成する */
@@ -174,7 +195,7 @@ notify.post('/', async (c) => {
 
     // transcriptからスマートなメッセージを生成
     let message: string | undefined;
-    if (transcriptPath) {
+    if (transcriptPath && (await isAllowedTranscriptPath(transcriptPath))) {
       message = await generateSmartMessage(transcriptPath, event);
     }
 


### PR DESCRIPTION
## 概要

Fixes #347

認証不要の `POST /api/notify` がリクエストボディの `transcript_path` を無検証で `generateSmartMessage`（ファイル末尾読み取り→内容断片をWSブロードキャスト）に渡していたため、任意ファイルの読み取り・内容流出に使えた。

## 修正

`isAllowedTranscriptPath()` を追加: `realpath` でシンボリックリンクを解決した上で、`~/.claude/` または `~/.codex/` 配下のみ許可。許可外は smart message 生成をスキップ（通知自体は従来どおり送る）。

## 検証

- ユニットテスト追加（5件）: 許可パス / 許可外 / 不存在 / `..` トラバーサル / 許可外へのsymlink
- `bun run lint` / `bun run test`（backend 268 pass, tui 66 pass）
- dev環境E2E: 正規transcriptでは `message` 生成、`/etc/passwd` では `message=undefined` をWS受信で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)