### PR TITLE
fix: %window-renamed [dead] のpane-dead通知を該当ウィンドウ・該当ペインに限定

### DIFF
--- a/backend/src/services/__tests__/tmux-control-pane-dead.test.ts
+++ b/backend/src/services/__tests__/tmux-control-pane-dead.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test';
+import { TmuxControlSession } from '../tmux-control';
+
+/**
+ * Tests for %window-renamed [dead] handling (#348).
+ *
+ * A pane process exiting under remain-on-exit makes tmux rename the window
+ * with a "[dead]" suffix. The old code flagged EVERY known pane as dead,
+ * so live sibling panes (and panes in other windows) were wrongly marked
+ * dead. These tests lock in window scoping and per-pane dead detection.
+ */
+
+interface FakeStdin {
+  writes: string[];
+  write(data: string): void;
+}
+
+function attachFakeProc(session: TmuxControlSession): FakeStdin {
+  const stdin: FakeStdin = {
+    writes: [],
+    write(data: string) {
+      this.writes.push(data);
+    },
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: test seam into private fields.
+  (session as any).proc = { stdin, killed: false, pid: 0 };
+  return stdin;
+}
+
+function feed(session: TmuxControlSession, line: string): void {
+  // biome-ignore lint/suspicious/noExplicitAny: test seam into private method.
+  (session as any).processRawLine(Buffer.from(line, 'utf-8'));
+}
+
+function respond(session: TmuxControlSession, num: number, output: string): void {
+  feed(session, `%begin 0 ${num} 0`);
+  if (output.length > 0) {
+    for (const out of output.split('\n')) feed(session, out);
+  }
+  feed(session, `%end 0 ${num} 0`);
+}
+
+function consumeReady(session: TmuxControlSession): void {
+  respond(session, 0, '');
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 4; i++) await Promise.resolve();
+}
+
+describe('%window-renamed [dead] handling', () => {
+  test('single-pane window: notifies that pane synchronously', () => {
+    const session = new TmuxControlSession('test');
+    attachFakeProc(session);
+    consumeReady(session);
+
+    const dead: string[] = [];
+    session.onPaneDead((paneId) => dead.push(paneId));
+
+    feed(session, '%layout-change @1 a1b2,80x24,0,0,0');
+    feed(session, '%window-renamed @1 zsh[dead]');
+
+    expect(dead).toEqual(['%0']);
+  });
+
+  test('multi-pane window: flags only the pane tmux reports as dead', async () => {
+    const session = new TmuxControlSession('test');
+    attachFakeProc(session);
+    consumeReady(session);
+
+    const dead: string[] = [];
+    session.onPaneDead((paneId) => dead.push(paneId));
+
+    // Window @1 has two panes: %0 and %1.
+    feed(session, '%layout-change @1 a1b2,80x24,0,0{40x24,0,0,0,39x24,41,0,1}');
+    feed(session, '%window-renamed @1 zsh[dead]');
+
+    // No synchronous notification — a list-panes query is in flight.
+    expect(dead).toEqual([]);
+
+    await flushMicrotasks();
+    // Reply: %0 alive, %1 dead.
+    respond(session, 1, '%0 0\n%1 1');
+    await flushMicrotasks();
+
+    expect(dead).toEqual(['%1']);
+  });
+
+  test('does not flag panes in unaffected windows', () => {
+    const session = new TmuxControlSession('test');
+    attachFakeProc(session);
+    consumeReady(session);
+
+    const dead: string[] = [];
+    session.onPaneDead((paneId) => dead.push(paneId));
+
+    // Window @1: panes %0,%1.  Window @2: single pane %2.
+    feed(session, '%layout-change @1 a1b2,80x24,0,0{40x24,0,0,0,39x24,41,0,1}');
+    feed(session, '%layout-change @2 c3d4,80x24,0,0,2');
+
+    // @2's pane dies — @1's panes must not be touched.
+    feed(session, '%window-renamed @2 zsh[dead]');
+
+    expect(dead).toEqual(['%2']);
+  });
+
+  test('ignores non-dead window renames', () => {
+    const session = new TmuxControlSession('test');
+    attachFakeProc(session);
+    consumeReady(session);
+
+    const dead: string[] = [];
+    session.onPaneDead((paneId) => dead.push(paneId));
+
+    feed(session, '%layout-change @1 a1b2,80x24,0,0,0');
+    feed(session, '%window-renamed @1 my-project');
+
+    expect(dead).toEqual([]);
+  });
+});

--- a/backend/src/services/tmux-control.ts
+++ b/backend/src/services/tmux-control.ts
@@ -112,7 +112,11 @@ export class TmuxControlSession {
 
   // Mobile pane separation
   private clientDeviceTypes = new Map<string, 'mobile' | 'tablet' | 'desktop'>();
-  private knownPaneIds = new Set<string>();
+  // Known pane IDs grouped by tmux window id (e.g. "@3" → {"%1","%2"}).
+  // %layout-change is per-window, so we key by window to avoid wiping
+  // other windows' panes and to scope %window-renamed [dead] notifications
+  // to the window whose pane actually died. #348
+  private knownPanesByWindow = new Map<string, Set<string>>();
 
   // Resize debounce
   private resizeTimer: Timer | null = null;
@@ -394,21 +398,19 @@ export class TmuxControlSession {
    */
   private handleLayoutChange(line: string): void {
     // Format: %layout-change @N <layout-string>
-    const match = line.match(/^%layout-change @\d+ (.+)$/);
+    const match = line.match(/^%layout-change @(\d+) (.+)$/);
     if (!match) return;
 
-    const layoutString = match[1];
+    const windowId = `@${match[1]}`;
+    const layoutString = match[2];
     try {
       const layout = parseTmuxLayout(layoutString);
       const frontendLayout = toFrontendLayout(layout);
       this.currentLayout = layout;
 
-      // Track known pane IDs (for future use)
-      const newPaneIds = this.collectPaneIds(layout);
-      this.knownPaneIds.clear();
-      for (const id of newPaneIds) {
-        this.knownPaneIds.add(id);
-      }
+      // Track known pane IDs per window so %window-renamed [dead] only
+      // touches the affected window (and not stale panes from others).
+      this.knownPanesByWindow.set(windowId, new Set(this.collectPaneIds(layout)));
 
       for (const listener of this.layoutListeners) {
         listener(layout, frontendLayout);
@@ -538,21 +540,48 @@ export class TmuxControlSession {
    * When remain-on-exit is on and a pane's process exits, tmux renames
    * the window with a [dead] suffix (e.g. "zsh[dead]").
    *
-   * IMPORTANT: This must notify listeners SYNCHRONOUSLY because tmux
-   * sends %client-detached immediately after, which triggers destroy()
-   * and clears all listeners. An async sendCommand would arrive too late.
+   * Scope the notification to the renamed window's panes (not every known
+   * pane). For a single-pane window we must notify SYNCHRONOUSLY: the dead
+   * pane tears down the session and tmux sends %client-detached immediately
+   * after, which destroys this session before any sendCommand could reply.
+   * For a multi-pane window the session survives (only one pane died), so we
+   * ask tmux which pane is actually dead instead of flagging live siblings.
    */
   private handleWindowRenamed(line: string): void {
-    if (!line.includes('[dead]')) return;
+    const match = line.match(/^%window-renamed @(\d+) (.+)$/);
+    if (!match) return;
+    if (!match[2].includes('[dead]')) return;
 
-    // Use known pane IDs from the last layout to notify immediately.
-    // We cannot use sendCommand here because %client-detached follows
-    // immediately and will destroy the session before the response arrives.
-    for (const paneId of this.knownPaneIds) {
-      console.log(`[tmux-control] Pane ${paneId} is dead (process exited, window renamed)`);
-      for (const listener of this.paneDeadListeners) {
-        listener(paneId);
+    const windowId = `@${match[1]}`;
+    const panes = this.knownPanesByWindow.get(windowId);
+    if (!panes || panes.size === 0) return;
+
+    if (panes.size === 1) {
+      for (const paneId of panes) this.emitPaneDead(paneId);
+      return;
+    }
+
+    // Multi-pane window: identify the dead pane(s) without blocking line
+    // processing. Safe because the session is not being torn down.
+    void this.notifyDeadPanesInWindow(windowId);
+  }
+
+  private emitPaneDead(paneId: string): void {
+    console.log(`[tmux-control] Pane ${paneId} is dead (process exited, window renamed)`);
+    for (const listener of this.paneDeadListeners) {
+      listener(paneId);
+    }
+  }
+
+  private async notifyDeadPanesInWindow(windowId: string): Promise<void> {
+    try {
+      const out = await this.sendCommand(`list-panes -t ${windowId} -F "#{pane_id} #{pane_dead}"`);
+      for (const row of out.trim().split('\n')) {
+        const [paneId, dead] = row.trim().split(' ');
+        if (dead === '1' && paneId) this.emitPaneDead(paneId);
       }
+    } catch (err) {
+      console.warn(`[tmux-control] dead-pane detection failed for ${windowId}:`, err);
     }
   }
 
@@ -1000,7 +1029,7 @@ export class TmuxControlSession {
     this.paneDeadListeners.clear();
     this.newSessionListeners.clear();
     this.clientDeviceTypes.clear();
-    this.knownPaneIds.clear();
+    this.knownPanesByWindow.clear();
 
     // Remove from global registry
     controlSessions.delete(this.sessionId);


### PR DESCRIPTION
## 概要

Fixes #348

remain-on-exit で1ペインのプロセスが終了すると tmux はウィンドウ名に `[dead]` を付けてリネームするが、従来は `knownPaneIds` の**全ペイン**に `pane-dead` を通知していた。複数ペイン構成では生きている兄弟ペインや別ウィンドウのペインまで dead 表示になっていた。

## 修正

ペインIDを tmux ウィンドウID単位（`knownPanesByWindow`）で管理し、`%window-renamed [dead]` 受信時:

- **単一ペインのウィンドウ**: そのペインを同期通知（セッションが破棄され `%client-detached` が直後に来るため、async クエリでは間に合わない）
- **複数ペインのウィンドウ**: セッションは生存するので `list-panes -F "#{pane_id} #{pane_dead}"` を投げ、tmux が dead と報告したペインのみ通知

`%layout-change` がウィンドウ単位イベントである点に合わせ、全ウィンドウのペインを毎回 wipe していた従来挙動（多ウィンドウで取りこぼし）も解消。

## 検証

- ユニットテスト追加（4件、実tmuxプロトコル文字列を `processRawLine` に流して検証）:
  - 単一ペイン → 同期通知
  - 複数ペイン → `list-panes` 応答で dead と報告されたペインのみ通知
  - 別ウィンドウのペインは触らない
  - dead を含まないリネームは無視
- `bun run lint` / `bun run test`（backend 267 pass, tui 66 pass）
- dev環境でbackend再起動・`/api/sessions` 正常応答（layout処理の回帰なし）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)