### PR TITLE
fix: GET /files/changes に isAllowedSessionDir 検証を追加

### DIFF
--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -136,6 +136,10 @@ files.get('/changes/:sessionWorkingDir', async (c) => {
     return c.json({ error: 'Missing sessionWorkingDir parameter' }, 400);
   }
 
+  if (!(await isAllowedSessionDir(sessionWorkingDir))) {
+    return c.json({ error: 'Access denied' }, 403);
+  }
+
   try {
     const changes = await changeTracker.getChangesForWorkingDir(sessionWorkingDir);
 


### PR DESCRIPTION
## 概要

Fixes #349

`/list`, `/read`, `/raw`, `/download`, `/upload`, `/git-changes`, `/git-diff` は全て `isAllowedSessionDir` で working dir を検証しているが、`GET /files/changes/:sessionWorkingDir` だけ検証が抜けていた。他と同じ 403 ガードを追加。

## 検証

- `bun run lint`
- dev環境:
  - `/api/files/changes/%2Fetc` → **403**（許可外）
  - 稼働セッションの working dir → **200**（許可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)