### PR TITLE
fix: cchub notify -p <port> を常に https で送信する

### DIFF
--- a/backend/src/commands/notify.ts
+++ b/backend/src/commands/notify.ts
@@ -1,7 +1,7 @@
 /**
  * cchub notify - Claude Code / Codex hookイベントをCC Hubサーバーに送信する。
  * stdinからhookのJSON入力を読み取り、CC Hubの /api/notify エンドポイントにPOSTする。
- * デフォルトで本番(5923)とdev(3000)の両方に送信する（失敗は無視）。
+ * デフォルトで本番(5923)とdev(3456)の両方に送信する（失敗は無視）。
  *
  * 使い方（hook設定）:
  *   "command": "cchub notify"
@@ -45,11 +45,14 @@ export async function sendNotify(port: number): Promise<void> {
     // Skip TLS verification since cert is for Tailscale hostname, not localhost
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-    // Determine target ports
+    // Determine target ports. The server always serves over HTTPS (Tailscale
+    // cert), including in dev, so every target uses https. TLS verification is
+    // disabled above because the cert is for the Tailscale hostname, not
+    // localhost.
     const ports = port !== PRODUCTION_PORT
-      // Explicit port specified via -p: send to that port only
-      ? [{ port, https: port !== DEV_PORT }]
-      // Default: try both production (HTTPS) and dev (HTTP), ignore failures
+      // Explicit port specified via -p: send to that port only.
+      ? [{ port, https: true }]
+      // Default: try both production and dev, ignore failures.
       : [
           { port: PRODUCTION_PORT, https: true },
           { port: DEV_PORT, https: true },


### PR DESCRIPTION
## 概要

Fixes #350

サーバは dev 含め全ポートで HTTPS（Tailscale 証明書）で待ち受ける。しかし明示ポート指定経路は `https: port !== DEV_PORT` としていたため、`cchub notify -p 3456` が平文 HTTP で送られ常にサイレント失敗していた（エラーは握りつぶされる）。デフォルト経路は既に両ポート https:true。

明示ポートも `https: true` に統一し、ヘッダコメントの dev ポート表記(3000→3456)も修正。

## 検証

- `bun run lint`
- dev環境E2E: 実 CLI `bun run backend/src/index.ts notify -p 3456` に hook JSON を pipe → WS で `hook-event` 受信を確認（修正前は届かなかった経路）

🤖 Generated with [Claude Code](https://claude.com/claude-code)