### PR TITLE
fix: cchub send の --base64 と --submit/--newline 併用を拒否

### DIFF
--- a/backend/src/commands/__tests__/send-base64-exclusive.test.ts
+++ b/backend/src/commands/__tests__/send-base64-exclusive.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { runSend, type SendOptions } from '../send';
+
+/**
+ * #351: --base64 must not be combined with --submit / --newline. Those flags
+ * wrap the payload in VT escapes, which would corrupt a literal base64 string
+ * before the server decodes it. runSend should reject the combination before
+ * touching the network.
+ */
+
+function opts(over: Partial<SendOptions>): SendOptions {
+  return {
+    target: 'local:dev:%1',
+    text: 'aGVsbG8=',
+    stdin: false,
+    newline: false,
+    submit: false,
+    base64: false,
+    localPort: 3456,
+    wait: false,
+    waitMs: 800,
+    lines: 20,
+    ...over,
+  };
+}
+
+describe('runSend --base64 exclusivity', () => {
+  test('rejects --base64 with --submit', async () => {
+    await expect(runSend(opts({ base64: true, submit: true }))).rejects.toThrow(
+      '--base64 は --submit / --newline と併用できません',
+    );
+  });
+
+  test('rejects --base64 with --newline', async () => {
+    await expect(runSend(opts({ base64: true, newline: true }))).rejects.toThrow(
+      '--base64 は --submit / --newline と併用できません',
+    );
+  });
+});

--- a/backend/src/commands/send.ts
+++ b/backend/src/commands/send.ts
@@ -100,6 +100,15 @@ async function resolvePeer(name: string, localPort: number): Promise<{ url: stri
 export async function runSend(options: SendOptions): Promise<void> {
   const target = parseTarget(options.target);
 
+  // --submit / --newline wrap the payload in VT escapes (bracketed-paste
+  // markers, trailing CR). With --base64 the payload is meant to be a literal
+  // base64 string the server decodes verbatim, so wrapping it would inject
+  // non-base64 bytes and break decoding. Reject the combination up front
+  // rather than send a corrupt payload (#351).
+  if (options.base64 && (options.submit || options.newline)) {
+    throw new Error('--base64 は --submit / --newline と併用できません');
+  }
+
   let payload: string;
   if (options.stdin) {
     payload = await readStdin();


### PR DESCRIPTION
## 概要

Fixes #351

`--submit` / `--newline` はペイロードを VT エスケープ（bracketed-paste マーカー、末尾 CR）で包む。`--base64` 指定時のペイロードはサーバがそのままデコードする base64 文字列なので、包むと非 base64 バイトが混入しデコードがサイレント失敗する。`runSend` 冒頭でこの組み合わせを拒否する。

## 検証

- ユニットテスト追加（2件）: `--base64 --submit` / `--base64 --newline` が throw
- `bun run lint` / `bun run test`
- 実 CLI: 両組み合わせが `❌ --base64 は --submit / --newline と併用できません` + exit 1。`--base64` 単独はガードを通過（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)