### PR TITLE
fix: credentials不在時のusage取得をバックオフしてディスクI/Oを抑制

### DIFF
--- a/backend/src/services/__tests__/anthropic-usage-no-credentials.test.ts
+++ b/backend/src/services/__tests__/anthropic-usage-no-credentials.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { AnthropicUsageService } from '../anthropic-usage';
+
+/**
+ * #352: with no credentials there is nothing to fetch, but the dashboard
+ * polls getUsageLimits every few seconds. Without a cooldown each call
+ * re-reads the credentials file. Verify the token lookup is not repeated
+ * within the cache TTL window.
+ */
+describe('AnthropicUsageService no-credentials backoff', () => {
+  test('does not re-read credentials on every poll', async () => {
+    const svc = new AnthropicUsageService();
+    let lookups = 0;
+    // biome-ignore lint/suspicious/noExplicitAny: test seam into private method.
+    (svc as any).getAccessToken = async () => {
+      lookups++;
+      return null;
+    };
+
+    expect(await svc.getUsageLimits()).toBeNull();
+    expect(await svc.getUsageLimits()).toBeNull();
+    expect(await svc.getUsageLimits()).toBeNull();
+
+    expect(lookups).toBe(1);
+    expect(svc.getStatus().errorReason).toBe('no-credentials');
+  });
+});

--- a/backend/src/services/anthropic-usage.ts
+++ b/backend/src/services/anthropic-usage.ts
@@ -50,6 +50,11 @@ export class AnthropicUsageService {
   private readonly CACHE_TTL_MS = 60_000;
   // On 429, back off for 5 minutes before retrying.
   private rateLimitedUntil = 0;
+  // When no credentials are present there is nothing to fetch, but the
+  // dashboard still polls every few seconds. Without a cooldown each poll
+  // re-reads the credentials file (disk I/O). Skip refetching until this
+  // timestamp. #352
+  private noCredentialsUntil = 0;
   private lastErrorReason: UsageLimitsErrorReason | undefined;
 
   private async getAccessToken(): Promise<string | null> {
@@ -85,6 +90,12 @@ export class AnthropicUsageService {
       return this.lastSuccessfulResult;
     }
 
+    // Respect the no-credentials cooldown so polling doesn't re-read the
+    // credentials file on every request.
+    if (now < this.noCredentialsUntil) {
+      return this.lastSuccessfulResult;
+    }
+
     // Coalesce concurrent requests
     if (this.inflight) {
       return this.inflight;
@@ -102,6 +113,8 @@ export class AnthropicUsageService {
     const token = await this.getAccessToken();
     if (!token) {
       this.lastErrorReason = 'no-credentials';
+      this.lastFetchAt = Date.now();
+      this.noCredentialsUntil = Date.now() + this.CACHE_TTL_MS;
       return this.lastSuccessfulResult;
     }
 


### PR DESCRIPTION
## 概要

Fixes #352

`getUsageLimits` のキャッシュ短絡は `lastSuccessfulResult` の存在が前提のため、credentials が無い環境では一切短絡せず、ダッシュボードの数秒ごとのポーリングが毎回 credentials ファイルをディスクから読み直していた。

429 用のバックオフに倣い、no-credentials 判定後は `CACHE_TTL_MS`（60s）の間 refetch しない `noCredentialsUntil` クールダウンを追加。credentials がその後現れた場合も最大60sで反映される（通常のキャッシュTTLと同等）。

## 検証

- ユニットテスト追加: `getAccessToken` をスタブし、3回連続で `getUsageLimits()` を呼んでも token 読み取りは1回のみ、`errorReason` は `no-credentials`
- `bun run lint` / `bun run test`（backend 275 pass, tui 66 pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)