### PR TITLE
fix: JWT署名とサーバーパスワードの照合を定数時間比較にする

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -4,6 +4,7 @@ import { LoginSchema } from 'shared';
 import { AuthService } from '../services/auth';
 import { getDataDir } from '../utils/storage';
 import { getJwtSecret, authMiddleware, isAuthRequired, getServerPassword } from '../middleware/auth';
+import { timingSafeStringEqual } from '../utils/timing-safe-equal';
 
 const auth = new Hono();
 
@@ -25,8 +26,8 @@ auth.post(
       return c.json({ error: 'Authentication not enabled' }, 400);
     }
 
-    // Check against server password
-    if (password !== serverPassword) {
+    // Check against server password (constant-time, #353)
+    if (!timingSafeStringEqual(password, serverPassword)) {
       return c.json({ error: 'Invalid password' }, 401);
     }
 

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import type { User, AuthResponse } from 'shared';
+import { timingSafeStringEqual } from '../utils/timing-safe-equal';
 
 export interface JwtPayload {
   userId: string;
@@ -129,7 +130,7 @@ export class AuthService {
     const [headerB64, payloadB64, signature] = parts;
     const expectedSig = await this.sign(`${headerB64}.${payloadB64}`);
 
-    if (signature !== expectedSig) {
+    if (!timingSafeStringEqual(signature, expectedSig)) {
       throw new Error('Invalid token signature');
     }
 

--- a/backend/src/utils/__tests__/timing-safe-equal.test.ts
+++ b/backend/src/utils/__tests__/timing-safe-equal.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { timingSafeStringEqual } from '../timing-safe-equal';
+
+describe('timingSafeStringEqual', () => {
+  test('returns true for identical strings', () => {
+    expect(timingSafeStringEqual('s3cret-token', 's3cret-token')).toBe(true);
+  });
+
+  test('returns false for different strings of equal length', () => {
+    expect(timingSafeStringEqual('aaaaaa', 'aaaaab')).toBe(false);
+  });
+
+  test('returns false for different-length strings (no throw)', () => {
+    expect(timingSafeStringEqual('short', 'a-much-longer-secret')).toBe(false);
+  });
+
+  test('handles empty strings', () => {
+    expect(timingSafeStringEqual('', '')).toBe(true);
+    expect(timingSafeStringEqual('', 'x')).toBe(false);
+  });
+
+  test('handles non-ASCII content', () => {
+    expect(timingSafeStringEqual('パスワード', 'パスワード')).toBe(true);
+    expect(timingSafeStringEqual('パスワード', 'ぱすわーど')).toBe(false);
+  });
+});

--- a/backend/src/utils/timing-safe-equal.ts
+++ b/backend/src/utils/timing-safe-equal.ts
@@ -1,0 +1,17 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Constant-time string comparison for secrets (HMAC signatures, server
+ * password). A plain `a === b` short-circuits on the first differing byte,
+ * leaking how many leading bytes matched via timing.
+ *
+ * Both inputs are SHA-256 hashed first so the comparison runs over
+ * fixed-length (32-byte) digests: timingSafeEqual requires equal-length
+ * buffers, and hashing also avoids leaking the secret's length when the
+ * inputs differ in size. #353
+ */
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  const ha = createHash('sha256').update(a, 'utf8').digest();
+  const hb = createHash('sha256').update(b, 'utf8').digest();
+  return timingSafeEqual(ha, hb);
+}


### PR DESCRIPTION
## 概要

Fixes #353

`verifyToken` の `signature !== expectedSig` と login の `password !== serverPassword` は通常の文字列比較で、最初に異なるバイトで短絡するためタイミングで一致進捗が漏れる。

`timingSafeStringEqual` ヘルパ（両入力を SHA-256 ダイジェスト化してから `crypto.timingSafeEqual`）を追加。ダイジェスト化により長さの相違でもリーク・例外が起きず、秘密の長さも漏らさない。両箇所で使用。

## 検証

- ユニットテスト追加（5件）: 一致 / 同長不一致 / 異長 / 空文字 / 非ASCII
- JWT ラウンドトリップ: 正常 verify=OK、署名改ざん=拒否、別 secret 署名=拒否
- パスワード認証（実HTTP, 一時ポート + `-P`）: 正解=200、不正解=401
- `bun run lint` / `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)