### PR TITLE
fix: frontend のリスナー/タイマー cleanup 漏れと会話購読の重複送信を修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -207,6 +207,33 @@ function getSavedOpenSessionIds(): string[] {
 	}
 }
 
+// Device type detection
+// - desktop: PC (非タッチデバイス) → ソフトキーボード不要
+// - tablet: タッチデバイスで width >= 640px && height >= 500px
+// - mobile: タッチデバイスでそれ以外
+type DeviceType = "mobile" | "tablet" | "desktop";
+
+function checkIsTouchDevice(): boolean {
+	const hasTouch = "ontouchstart" in window || navigator.maxTouchPoints > 0;
+	const hasCoarsePointer = window.matchMedia("(pointer: coarse)").matches;
+	return hasTouch && hasCoarsePointer;
+}
+
+function checkDeviceType(): DeviceType {
+	// 実タッチデバイス: 物理解像度の短辺で判定（向きに依存しない）
+	if (checkIsTouchDevice()) {
+		const shortSide = Math.min(screen.width, screen.height);
+		const longSide = Math.max(screen.width, screen.height);
+		if (shortSide >= 500 && longSide >= 640) return "tablet";
+		return "mobile";
+	}
+	// 非タッチデバイス（PC + DevToolsエミュレーション含む）: ビューポート幅で判定
+	const w = window.innerWidth;
+	if (w < 640) return "mobile";
+	if (w < 1024) return "tablet";
+	return "desktop";
+}
+
 export function App() {
 	const { t } = useTranslation();
 	const tRef = useRef(t);
@@ -378,33 +405,6 @@ export function App() {
 	// Session API state (for theme updates in mobile view)
 	const { sessions: apiSessions, createSession } = useSessions();
 
-	// Device type detection
-	// - desktop: PC (非タッチデバイス) → ソフトキーボード不要
-	// - tablet: タッチデバイスで width >= 640px && height >= 500px
-	// - mobile: タッチデバイスでそれ以外
-	type DeviceType = "mobile" | "tablet" | "desktop";
-
-	const checkIsTouchDevice = (): boolean => {
-		const hasTouch = "ontouchstart" in window || navigator.maxTouchPoints > 0;
-		const hasCoarsePointer = window.matchMedia("(pointer: coarse)").matches;
-		return hasTouch && hasCoarsePointer;
-	};
-
-	const checkDeviceType = (): DeviceType => {
-		// 実タッチデバイス: 物理解像度の短辺で判定（向きに依存しない）
-		if (checkIsTouchDevice()) {
-			const shortSide = Math.min(screen.width, screen.height);
-			const longSide = Math.max(screen.width, screen.height);
-			if (shortSide >= 500 && longSide >= 640) return "tablet";
-			return "mobile";
-		}
-		// 非タッチデバイス（PC + DevToolsエミュレーション含む）: ビューポート幅で判定
-		const w = window.innerWidth;
-		if (w < 640) return "mobile";
-		if (w < 1024) return "tablet";
-		return "desktop";
-	};
-
 	const [deviceType, setDeviceType] = useState<DeviceType>(checkDeviceType);
 
 	// Both tablet and mobile need keyboard control during onboarding
@@ -415,12 +415,13 @@ export function App() {
 				? handleMobileStepAction
 				: undefined;
 
-	// Update device type on resize
+	// Update device type on resize. checkDeviceType is a stable module-level
+	// function, so the listener is registered once for the component's life.
 	useEffect(() => {
 		const handleResize = () => setDeviceType(checkDeviceType());
 		window.addEventListener("resize", handleResize);
 		return () => window.removeEventListener("resize", handleResize);
-	}, [checkDeviceType]);
+	}, []);
 
 	// Sessions are now delivered via WS push (no HTTP polling needed)
 

--- a/frontend/src/components/InputBar.tsx
+++ b/frontend/src/components/InputBar.tsx
@@ -11,6 +11,7 @@ import {
 	forwardRef,
 	memo,
 	useCallback,
+	useEffect,
 	useImperativeHandle,
 	useRef,
 	useState,
@@ -97,6 +98,16 @@ export const InputBar = memo(
 		const inputBarSwipeRef = useRef<{ startX: number; startY: number } | null>(
 			null,
 		);
+
+		// Clear the auto-hide timers on unmount so they don't fire after the
+		// component is gone (it returns null in "hidden" mode).
+		useEffect(() => {
+			return () => {
+				if (hintTimeoutRef.current) clearTimeout(hintTimeoutRef.current);
+				if (positionToggleTimeoutRef.current)
+					clearTimeout(positionToggleTimeoutRef.current);
+			};
+		}, []);
 
 		// Auto-hide position toggle
 		const resetPositionToggleTimer = useCallback(() => {

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1064,6 +1064,10 @@ export const TerminalComponent = memo(
 			return () => {
 				if (longPressTimer) clearTimeout(longPressTimer);
 				if (mouseLongPressTimer) clearTimeout(mouseLongPressTimer);
+				// Clear the scroll-indicator auto-hide timer so a session switch
+				// doesn't let an old timer null out the new session's indicator.
+				if (scrollIndicatorTimerRef.current)
+					clearTimeout(scrollIndicatorTimerRef.current);
 				// Cancel rAF loops and the WebGL reload timer so they don't keep
 				// running against the disposed terminal — momentum scroll, touch
 				// coalesce, wheel flush, and the queued WebGL re-init all post

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -474,16 +474,14 @@ export function subscribeConversation(
 ) {
 	pendingConversationUnsubs.delete(sessionId);
 	if (sharedWs?.readyState === WebSocket.OPEN && wsReady) {
-		if (!subscribedConversations.has(sessionId)) {
-			sharedWs.send(
-				JSON.stringify({ type: "subscribe-conversation", sessionId }),
-			);
-			subscribedConversations.add(sessionId);
-		} else {
-			sharedWs.send(
-				JSON.stringify({ type: "subscribe-conversation", sessionId }),
-			);
-		}
+		// Already subscribed: nothing to do. The backend recreates the watcher
+		// on every subscribe-conversation, so re-sending would needlessly tear
+		// down and rebuild it (and re-send initial-conversation).
+		if (subscribedConversations.has(sessionId)) return;
+		sharedWs.send(
+			JSON.stringify({ type: "subscribe-conversation", sessionId }),
+		);
+		subscribedConversations.add(sessionId);
 	} else {
 		pendingConversationSubs.add(sessionId);
 		ensureConnection(token);


### PR DESCRIPTION
## 概要

Fixes #354

フロントエンドの小さなリソース管理漏れ・無駄処理をまとめて修正。

- **App.tsx**: `checkDeviceType` / `checkIsTouchDevice` をモジュールスコープへ巻き上げ、resize effect の依存配列から外した。これまで毎レンダーで `removeEventListener`→`addEventListener` が走っていた。
- **useMultiplexedTerminal.ts**: 既購読セッションへの `subscribe-conversation` 重複送信を停止（else ブランチが同じメッセージを再送し、バックエンドの watcher 再生成 + `initial-conversation` 再送を誘発していた）。
- **InputBar.tsx**: `hintTimeoutRef` / `positionToggleTimeoutRef` をアンマウント時にクリア（`hidden` モードで `return null` する）。
- **Terminal.tsx**: `scrollIndicatorTimerRef` を teardown でクリア（セッション切替時に旧タイマーが新セッションのインジケータを消すのを防止）。

## 検証

- `bun run lint` / frontend `build`（tsc 型チェック含む）pass
- ブラウザ実機（agent-browser, 非タッチ）:
  - 1440px → デスクトップ（InputBar + terminal）、390px → モバイル、戻して復帰。resize 駆動のデバイス判定が正常動作
  - 転送された browser ログにエラー/例外なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)