### PR TITLE
fix: usage-history の legacy {snapshots} 形式を実際に読み込む

### DIFF
--- a/backend/src/services/__tests__/usage-history-legacy.test.ts
+++ b/backend/src/services/__tests__/usage-history-legacy.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { rm, writeFile } from 'node:fs/promises';
+import { UsageHistoryService } from '../usage-history';
+
+// getHistory reads this fixed path; the service has no injection seam.
+const HISTORY_FILE = '/tmp/cchub-usage-history.json';
+
+const snap = (timestamp: string) => ({
+  timestamp,
+  fiveHour: { utilization: 1, resetsAt: timestamp },
+  sevenDay: { utilization: 2, resetsAt: timestamp },
+});
+
+describe('UsageHistoryService.getHistory format handling', () => {
+  afterEach(async () => {
+    await rm(HISTORY_FILE, { force: true });
+  });
+
+  test('reads the current array format', async () => {
+    await writeFile(HISTORY_FILE, JSON.stringify([snap('2026-01-01T00:00:00.000Z')]));
+    const history = await new UsageHistoryService().getHistory();
+    expect(history).toHaveLength(1);
+  });
+
+  test('reads the legacy { snapshots: [...] } format', async () => {
+    await writeFile(
+      HISTORY_FILE,
+      JSON.stringify({ snapshots: [snap('2026-01-01T00:00:00.000Z'), snap('2026-01-02T00:00:00.000Z')] }),
+    );
+    const history = await new UsageHistoryService().getHistory();
+    expect(history).toHaveLength(2);
+  });
+
+  test('drops entries without a timestamp', async () => {
+    await writeFile(HISTORY_FILE, JSON.stringify([snap('2026-01-01T00:00:00.000Z'), { bogus: true }]));
+    const history = await new UsageHistoryService().getHistory();
+    expect(history).toHaveLength(1);
+  });
+
+  test('returns [] for unrecognized shapes', async () => {
+    await writeFile(HISTORY_FILE, JSON.stringify({ unexpected: 'value' }));
+    const history = await new UsageHistoryService().getHistory();
+    expect(history).toEqual([]);
+  });
+});

--- a/backend/src/services/usage-history.ts
+++ b/backend/src/services/usage-history.ts
@@ -5,6 +5,13 @@ const HISTORY_FILE = '/tmp/cchub-usage-history.json';
 const THROTTLE_MS = 30 * 1000; // 30 seconds
 const MAX_AGE_MS = 8 * 24 * 60 * 60 * 1000; // 8 days
 
+function onlySnapshots(items: unknown[]): UsageSnapshot[] {
+  return items.filter(
+    (s): s is UsageSnapshot =>
+      !!s && typeof s === 'object' && 'timestamp' in (s as Record<string, unknown>),
+  );
+}
+
 export class UsageHistoryService {
   private lastRecordTime = 0;
 
@@ -12,9 +19,13 @@ export class UsageHistoryService {
     try {
       const content = await readFile(HISTORY_FILE, 'utf-8');
       const parsed = JSON.parse(content);
-      // Handle both array format and legacy {snapshots: [...]} format
+      // Handle both the current array format and the legacy
+      // { snapshots: [...] } format written by older versions.
       if (Array.isArray(parsed)) {
-        return parsed.filter((s: unknown) => s && typeof s === 'object' && 'timestamp' in (s as Record<string, unknown>));
+        return onlySnapshots(parsed);
+      }
+      if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { snapshots?: unknown }).snapshots)) {
+        return onlySnapshots((parsed as { snapshots: unknown[] }).snapshots);
       }
       return [];
     } catch {


### PR DESCRIPTION
## 概要

Fixes #355

`getHistory` のコメントは legacy `{ snapshots: [...] }` 形式に対応すると書いていたが、実装は配列以外を `[]` で捨てており、旧バージョンが書いた履歴ファイルを無音で破棄していた。`parsed.snapshots` が配列ならそれを読むよう修正し、フィルタ処理を `onlySnapshots` ヘルパに集約。

## 検証

- ユニットテスト追加（4件）: 現行配列形式 / legacy `{snapshots}` 形式 / timestamp 無しエントリ除外 / 未知形状で `[]`
- `bun run lint` / `bun run test`（backend 284 pass, tui 66 pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)