### PR TITLE
feat: Model Usage パネルを過去30日に限定

### DIFF
--- a/backend/src/services/stats-service.ts
+++ b/backend/src/services/stats-service.ts
@@ -1,7 +1,24 @@
-import { readFile } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { readFile, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { createInterface } from 'node:readline';
 import type { DailyActivity, ModelUsage } from '../../../shared/types';
+
+// Model Usage panel covers a rolling recent window. stats-cache.json only
+// holds a date-less cumulative total, so the per-model breakdown for a window
+// is aggregated directly from the Claude Code transcripts (#: model-usage-30d).
+export const MODEL_USAGE_WINDOW_DAYS = 30;
+// Full jsonl scans are not free; the dashboard polls every 60s. Cache the
+// aggregate so repeated polls within this window reuse one scan.
+const MODEL_USAGE_CACHE_TTL_MS = 5 * 60_000;
+
+interface ModelTokenTotals {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+}
 
 interface StatsCache {
   version: number;
@@ -25,6 +42,8 @@ interface StatsCache {
 
 export class StatsService {
   private claudeDir: string;
+  // Cached result of the last jsonl scan, shared across requests.
+  private modelUsageCache: { computedAt: number; data: ModelUsage[] } | null = null;
 
   constructor() {
     this.claudeDir = join(homedir(), '.claude');
@@ -58,18 +77,98 @@ export class StatsService {
   }
 
   async getModelUsage(): Promise<ModelUsage[]> {
-    const stats = await this.readStatsCache();
-    if (!stats?.modelUsage) {
-      return [];
+    const now = Date.now();
+    if (this.modelUsageCache && now - this.modelUsageCache.computedAt < MODEL_USAGE_CACHE_TTL_MS) {
+      return this.modelUsageCache.data;
     }
 
-    return Object.entries(stats.modelUsage).map(([model, usage]) => ({
+    const cutoff = now - MODEL_USAGE_WINDOW_DAYS * 24 * 60 * 60_000;
+    const totals = await this.aggregateModelUsageSince(cutoff);
+
+    const data: ModelUsage[] = Array.from(totals.entries()).map(([model, t]) => ({
       model: this.getModelDisplayName(model),
-      totalTokensIn: usage.inputTokens,
-      totalTokensOut: usage.outputTokens,
-      totalCacheRead: usage.cacheReadInputTokens,
-      totalCacheWrite: usage.cacheCreationInputTokens,
+      totalTokensIn: t.inputTokens,
+      totalTokensOut: t.outputTokens,
+      totalCacheRead: t.cacheReadInputTokens,
+      totalCacheWrite: t.cacheCreationInputTokens,
     }));
+
+    this.modelUsageCache = { computedAt: now, data };
+    return data;
+  }
+
+  /**
+   * Aggregate per-model token usage from Claude Code transcripts for entries
+   * whose timestamp is >= cutoff. Files last modified before the cutoff are
+   * skipped wholesale (they cannot contain in-window entries), bounding the
+   * scan to recently-active sessions.
+   */
+  private async aggregateModelUsageSince(cutoffMs: number): Promise<Map<string, ModelTokenTotals>> {
+    const totals = new Map<string, ModelTokenTotals>();
+    const files = await this.listTranscriptFiles();
+
+    for (const filePath of files) {
+      let mtimeMs: number;
+      try {
+        mtimeMs = (await stat(filePath)).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (mtimeMs < cutoffMs) continue;
+
+      try {
+        const rl = createInterface({
+          input: createReadStream(filePath, { encoding: 'utf-8' }),
+          crlfDelay: Number.POSITIVE_INFINITY,
+        });
+        for await (const line of rl) {
+          if (!line) continue;
+          let obj: Record<string, unknown>;
+          try {
+            obj = JSON.parse(line);
+          } catch {
+            continue;
+          }
+          const ts = Date.parse(obj.timestamp as string);
+          if (!Number.isFinite(ts) || ts < cutoffMs) continue;
+
+          const message = obj.message as { model?: unknown; usage?: Record<string, unknown> } | undefined;
+          const usage = message?.usage;
+          const model = message?.model;
+          if (!usage || typeof usage !== 'object') continue;
+          if (typeof model !== 'string' || !model || model === '<synthetic>') continue;
+
+          const entry = totals.get(model) ?? {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+          };
+          entry.inputTokens += Number(usage.input_tokens) || 0;
+          entry.outputTokens += Number(usage.output_tokens) || 0;
+          entry.cacheReadInputTokens += Number(usage.cache_read_input_tokens) || 0;
+          entry.cacheCreationInputTokens += Number(usage.cache_creation_input_tokens) || 0;
+          totals.set(model, entry);
+        }
+      } catch {
+        // Unreadable file — skip.
+      }
+    }
+
+    return totals;
+  }
+
+  /** Collect all transcript .jsonl paths under ~/.claude/projects. */
+  private async listTranscriptFiles(): Promise<string[]> {
+    const projectsDir = join(this.claudeDir, 'projects');
+    try {
+      const entries = await readdir(projectsDir, { withFileTypes: true, recursive: true });
+      return entries
+        .filter((e) => e.isFile() && e.name.endsWith('.jsonl'))
+        .map((e) => join(e.parentPath ?? projectsDir, e.name));
+    } catch {
+      return [];
+    }
   }
 
   private getModelDisplayName(modelId: string): string {

--- a/frontend/src/components/dashboard/ModelUsageChart.tsx
+++ b/frontend/src/components/dashboard/ModelUsageChart.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import type { ModelUsage } from "../../../../shared/types";
 
 interface ModelUsageChartProps {
@@ -43,9 +44,14 @@ function buildColorMap(models: string[]): Map<string, string> {
 }
 
 export function ModelUsageChart({ data }: ModelUsageChartProps) {
+	const { t } = useTranslation();
+
 	if (data.length === 0) {
 		return (
 			<div className="p-3 bg-th-surface rounded-md">
+				<div className="text-sm font-medium text-th-text mb-1">
+					{t("dashboard.modelUsageWindow")}
+				</div>
 				<div className="text-th-text-muted text-xs">No model usage data</div>
 			</div>
 		);
@@ -60,7 +66,9 @@ export function ModelUsageChart({ data }: ModelUsageChartProps) {
 
 	return (
 		<div className="p-3 bg-th-surface rounded-md">
-			<div className="text-sm font-medium text-th-text mb-2">Model Usage</div>
+			<div className="text-sm font-medium text-th-text mb-2">
+				{t("dashboard.modelUsageWindow")}
+			</div>
 
 			{/* Bar chart */}
 			<div className="h-4 bg-th-surface-hover rounded-full overflow-hidden flex">

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -117,6 +117,7 @@
 		"limitPrediction": "Limit Prediction",
 		"dailyStats": "Daily Activity",
 		"modelUsage": "Model Usage",
+		"modelUsageWindow": "Model Usage (last 30 days)",
 		"messages": "Messages",
 		"sessions": "Sessions",
 		"tokens": "Tokens",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -117,6 +117,7 @@
 		"limitPrediction": "リミット到達予測",
 		"dailyStats": "日別アクティビティ",
 		"modelUsage": "モデル使用量",
+		"modelUsageWindow": "モデル使用量（過去30日）",
 		"messages": "メッセージ",
 		"sessions": "セッション",
 		"tokens": "トークン",


### PR DESCRIPTION
## 概要

ダッシュボードの Model Usage パネルを「全期間累計」から「過去30日」に変更する。

### 背景
別セッションの調査で、パネルの数値が `~/.claude/stats-cache.json` の `modelUsage`（日付なし・累計のみ）に由来し、期間で絞る仕組みが構造上存在しないと判明。元データに期間情報がないため、期間別表示には Claude Code のトランスクリプト(`~/.claude/projects/*/*.jsonl`)を直接集計する必要がある。

### 変更
- `StatsService.getModelUsage` をトランスクリプト集計に書き換え。各 assistant エントリの `timestamp` で過去30日にフィルタし、`message.model` 別に `usage`（in/out/cache）を加算。
  - mtime が cutoff より古いファイルは丸ごとスキップ（in-window エントリを含み得ないため）→ 走査対象を直近アクティブなセッションに限定
  - 結果を5分 TTL でキャッシュ（ダッシュボードは60s間隔ポーリング。cold scan は約0.9s、cache hit は約7ms）
- パネル見出しを「モデル使用量（過去30日）」/ "Model Usage (last 30 days)" に変更（i18n キー `dashboard.modelUsageWindow` 追加）

### 注意
- jsonl 直集計の数値は Claude Code 本体の累計値と完全一致しない（本体側の重複排除を再現しないため）。ただし期間内の相対内訳は正確。

## 検証
- `bun run lint` / frontend `build` / backend `test`（284 pass）
- dev: `/api/dashboard` の modelUsage が過去30日集計に。uuid 重複チェックで二重カウントなしを確認（32468件すべてユニーク、合計6.81B＝API値一致）。Opus 4.6（全期間3.33B）が30日窓から正しく消え、6/10-11 の作業分が反映されることを確認
- cold/cached タイミング（0.88s → 0.007s）でキャッシュ動作確認
- ブラウザ実機: ダッシュボードに「モデル使用量（過去30日）」表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)