### PR TITLE
Release v0.1.179

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.179] - 2026-06-11
+
+### Changed
+- **Model Usage パネルを過去30日に限定**: 従来は `stats-cache.json` の日付なし累計を表示していたため全期間累計しか出せなかった。`~/.claude/projects/*/*.jsonl` トランスクリプトを直接集計し、`timestamp` で過去30日にフィルタしてモデル別トークンを表示するよう変更。mtime が cutoff より古いファイルはスキップ、結果は5分 TTL でキャッシュ。見出しを「モデル使用量（過去30日）」/ "Model Usage (last 30 days)" に変更（#367, `backend/src/services/stats-service.ts`, `frontend/src/components/dashboard/ModelUsageChart.tsx`）
+  - 注: jsonl 直集計の数値は Claude Code 本体の累計値と完全一致しない（本体側の重複排除を再現しないため）が、期間内の相対内訳は正確
+
 ## [0.1.178] - 2026-06-11
 
 全体レビューで検出した問題の一括修正リリース（issue #346〜#355）。

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.178",
+  "version": "0.1.179",
   "generated": "2026-06-11",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.178",
+  "version": "0.1.179",
   "generated": "2026-06-11",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.178",
+  "version": "0.1.179",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- feat: Model Usage パネルを過去30日に限定（#367）。`~/.claude/projects/*/*.jsonl` を直接集計し、過去30日のモデル別トークンを表示。mtime スキップ + 5分 TTL キャッシュ。見出しを「モデル使用量（過去30日）」に変更

## Notes
- jsonl 直集計の数値は Claude Code 本体の累計値と完全一致しない（本体側の重複排除を再現しないため）が、期間内の相対内訳は正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)