### PR TITLE
fix: ファイルブラウザの展開済みディレクトリに新規ファイルが表示されない

### DIFF
--- a/frontend/src/components/files/FileBrowser.tsx
+++ b/frontend/src/components/files/FileBrowser.tsx
@@ -8,7 +8,7 @@ import {
 	FolderOpen,
 	Image,
 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { FileInfo } from "../../../../shared/types";
 import { authFetch } from "../../services/api";
@@ -25,6 +25,12 @@ interface FileBrowserProps {
 	showHidden?: boolean;
 	/** Path of the file currently shown in the viewer (highlighted in the tree). */
 	selectedPath?: string;
+	/**
+	 * Bumping this number forces a refetch of every currently-expanded directory
+	 * (the in-memory `dirContents` cache is otherwise never invalidated). Wired
+	 * to the toolbar reload button so newly created files/dirs appear.
+	 */
+	refreshSignal?: number;
 }
 
 // File type icons
@@ -196,6 +202,7 @@ export function FileBrowser({
 	onSelectFile,
 	showHidden = false,
 	selectedPath,
+	refreshSignal,
 }: FileBrowserProps) {
 	const { t } = useTranslation();
 	const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
@@ -207,10 +214,13 @@ export function FileBrowser({
 	// Filter hidden files if needed
 	const visibleFiles = showHidden ? files : files.filter((f) => !f.isHidden);
 
-	// Load directory contents
+	// Load directory contents. `silent` skips the spinner and keeps the existing
+	// cached children visible while refetching in the background — used when
+	// re-expanding or refreshing a directory that's already been loaded.
 	const loadDirContents = useCallback(
-		async (path: string) => {
-			setLoadingDirs((prev) => new Set(prev).add(path));
+		async (path: string, opts?: { silent?: boolean }) => {
+			const silent = opts?.silent ?? false;
+			if (!silent) setLoadingDirs((prev) => new Set(prev).add(path));
 
 			try {
 				const params = new URLSearchParams({
@@ -228,11 +238,12 @@ export function FileBrowser({
 			} catch (err) {
 				console.error("Failed to load directory:", err);
 			} finally {
-				setLoadingDirs((prev) => {
-					const next = new Set(prev);
-					next.delete(path);
-					return next;
-				});
+				if (!silent)
+					setLoadingDirs((prev) => {
+						const next = new Set(prev);
+						next.delete(path);
+						return next;
+					});
 			}
 		},
 		[sessionWorkingDir],
@@ -252,14 +263,31 @@ export function FileBrowser({
 				// Expand
 				setExpandedDirs((prev) => new Set(prev).add(path));
 
-				// Load contents if not already loaded
 				if (!dirContents.has(path)) {
 					await loadDirContents(path);
+				} else {
+					// Cache exists but may be stale (files created after the first
+					// expand). Show it immediately and refetch in the background.
+					void loadDirContents(path, { silent: true });
 				}
 			}
 		},
 		[expandedDirs, dirContents, loadDirContents],
 	);
+
+	// When the toolbar reload button bumps `refreshSignal`, refetch every
+	// currently-expanded directory so newly created entries become visible
+	// without collapsing/re-expanding each one by hand.
+	const expandedDirsRef = useRef(expandedDirs);
+	expandedDirsRef.current = expandedDirs;
+	const prevRefreshRef = useRef(refreshSignal);
+	useEffect(() => {
+		if (refreshSignal === prevRefreshRef.current) return;
+		prevRefreshRef.current = refreshSignal;
+		for (const path of expandedDirsRef.current) {
+			void loadDirContents(path, { silent: true });
+		}
+	}, [refreshSignal, loadDirContents]);
 
 	// Get short path for display
 	const shortPath = toHomeShortPath(currentPath);

--- a/frontend/src/components/files/FileViewer.tsx
+++ b/frontend/src/components/files/FileViewer.tsx
@@ -100,6 +100,9 @@ export function FileViewer({
 
 	const [viewMode, setViewMode] = useState<ViewMode>("browser");
 	const [listMode, setListMode] = useState<ListMode>("browser");
+	// Bumped by the reload button to force FileBrowser to refetch its
+	// already-expanded subtrees (whose contents are otherwise cached forever).
+	const [browserRefresh, setBrowserRefresh] = useState(0);
 	const [previewMode, setPreviewMode] = useState(false);
 	const [showHidden, setShowHidden] = useState(false);
 	const [selectedChange, setSelectedChange] = useState<FileChange | null>(null);
@@ -482,7 +485,10 @@ export function FileViewer({
 								)}
 								<button
 									type="button"
-									onClick={() => listDirectory(currentPath)}
+									onClick={() => {
+										listDirectory(currentPath);
+										setBrowserRefresh((n) => n + 1);
+									}}
 									className="p-2 text-zinc-500 hover:text-zinc-300 active:text-zinc-200 transition-colors"
 									title={t("files.reload")}
 								>
@@ -610,6 +616,7 @@ export function FileViewer({
 									onSelectFile={handleSelectFile}
 									showHidden={showHidden}
 									selectedPath={selectedFile?.path}
+									refreshSignal={browserRefresh}
 								/>
 							) : (
 								<ChangesView


### PR DESCRIPTION
## 概要

ファイルブラウザで、作成したばかりのファイル/ディレクトリが表示されない（リロードしても変化なし）バグを修正します。kakei セッションでの報告（`data/2026-06-20/` や ルート直下の新規 `.md` が出ない）に対応。

## 原因（フロントエンドのキャッシュ）

バックエンド（`FileService.listDirectory`）は毎回ディスクを読むため新鮮なデータを返しており、実 API でも新規ファイルが返ることを確認済み。原因は完全にフロントエンド側でした。

1. **`FileBrowser` の展開済みディレクトリキャッシュ（`dirContents` Map）が一度も無効化されない** — 一度展開したディレクトリの中身は永久にキャッシュされ、折りたたんで再展開しても再取得しない。→ 展開中の `data/` 配下に作った `2026-06-20/` が出ない。
2. **リロードボタンはルート階層しか更新しない** — `listDirectory(currentPath)` はトップレベルの `files` のみ再取得し、`FileBrowser` 内部の展開済みサブツリーには伝播しない。

## 修正内容

- **`FileBrowser.tsx`**: `refreshSignal` prop を追加。bump されると展開中の全ディレクトリを背景で再取得。再展開時もキャッシュを表示しつつ背景で再取得（`silent` フラグでスピナーのちらつきを抑制）。
- **`FileViewer.tsx`**: リロードボタンが `listDirectory`（ルート）に加えて `browserRefresh` を bump し、ルート＋展開済みサブツリーを一括リフレッシュ。

## 検証（dev 環境・実ブラウザ）

使い捨てセッション `/tmp/cchub-fbtest`（`sub/` 展開済み）で実機確認：

| 検証項目 | 結果 |
|---|---|
| リロード → 展開中 `sub/` 内の新規ファイル | ✅ `new-after-expand.md` 表示 |
| リロード → ルートの新規ファイル | ✅ `root-new.md` 表示 |
| 折りたたみ→再展開で再取得 | ✅ `reexpand-test.md` 表示 |

- `biome lint`（対象2ファイル）: exit 0
- `tsgo typecheck`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)