### PR TITLE
Release v0.1.180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.180] - 2026-06-20
+
+### Fixed
+- **ファイルブラウザの展開済みディレクトリに新規ファイルが表示されない**: ファイルブラウザは展開した各ディレクトリの中身を `dirContents` Map にキャッシュしたまま一度も無効化せず、リロードボタンも `listDirectory` でルート階層しか再取得しなかったため、展開中フォルダ内（や初回ロード後のルート直下）に作成したファイル/ディレクトリが表示されなかった。`FileBrowser` に `refreshSignal` prop を追加し、bump で展開中の全ディレクトリを背景で再取得・再展開時もキャッシュ表示しつつ背景再取得するよう変更。リロードボタンはルート再取得に加えて `refreshSignal` を bump し、ツリー全体を一括更新する（#369, `frontend/src/components/files/FileBrowser.tsx`, `frontend/src/components/files/FileViewer.tsx`）
+
 ## [0.1.179] - 2026-06-11
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.179",
-  "generated": "2026-06-11",
+  "version": "0.1.180",
+  "generated": "2026-06-20",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.179",
-  "generated": "2026-06-11",
+  "version": "0.1.180",
+  "generated": "2026-06-20",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.179",
+  "version": "0.1.180",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: ファイルブラウザの展開済みディレクトリ（や初回ロード後のルート）に新規作成したファイル/ディレクトリが表示されない問題を修正（#369）

## Notes
- フロントエンドのみの修正。`FileBrowser` のキャッシュ無効化機構（`refreshSignal`）を追加し、リロードでツリー全体を再取得する
- dev 環境・実ブラウザで検証済み（リロード/再展開ともに新規ファイルが反映されることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)