### PR TITLE
fix(viewport): land Claude TUI cursor on the input row after padFill

### DIFF
--- a/backend/src/services/__tests__/viewport-cursor-policy.test.ts
+++ b/backend/src/services/__tests__/viewport-cursor-policy.test.ts
@@ -13,7 +13,12 @@ describe('viewport cursor policy', () => {
   });
 
   test('computes cursor pad shift per policy', () => {
-    expect(computeCursorPadShift('default', 5)).toBe(3);
+    // The default policy shifts the cursor down by exactly the number of
+    // prepended scrollback rows so it tracks the input row that padFill
+    // pushed down. Codex keeps its own footer-relative cursor (no shift).
+    expect(computeCursorPadShift('default', 5)).toBe(5);
+    expect(computeCursorPadShift('default', 1)).toBe(1);
+    expect(computeCursorPadShift('default', 0)).toBe(0);
     expect(computeCursorPadShift('codex-footer', 5)).toBe(0);
   });
 

--- a/backend/src/services/viewport-cursor-policy.ts
+++ b/backend/src/services/viewport-cursor-policy.ts
@@ -19,7 +19,12 @@ export function resolveViewportCursorPolicy(agent?: string): ViewportCursorPolic
 
 export function computeCursorPadShift(policy: ViewportCursorPolicy, prependCount: number): number {
   if (policy === 'codex-footer') return 0;
-  return Math.max(0, prependCount - 2);
+  // padFill prepends exactly `prependCount` scrollback rows to the top of the
+  // viewport, so every row below — including the cursor row — shifts down by
+  // that same amount. The shift must match the prepend 1:1; any fudge factor
+  // (we previously subtracted 2) leaves the cursor floating above the real
+  // input row whenever the pane has trailing blanks below the footer.
+  return Math.max(0, prependCount);
 }
 
 export function resolveViewportCursor(policy: ViewportCursorPolicy, input: ViewportCursorInput): PaneCursor {


### PR DESCRIPTION
## 問題

Claude Code ターミナルで、カーソルが入力ボックス(`›`/`❯`)の中ではなく、その**上の空白行/枠線上に浮く**ようになっていた（最大2行ズレ）。

## 原因

`padFill` はペイン下部の void を埋めるため scrollback を `prependCount` 行ぶん viewport 先頭に prepend する。これでカーソル行を含む全行がちょうど `prependCount` 行ぶん下にずれる。ところが `computeCursorPadShift` が `prependCount - 2` と2行引いていたため、フッター下に末尾空行があるペインでカーソルが入力行より最大2行上に取り残されていた。

最近の Claude Code はモードヒントのフッター下に空行を残すレイアウトになり、`prependCount >= 1` が常態化したことで、これまで潜在していた off-by-N が顕在化した。

## 修正

prepend した行数ぶんちょうどカーソルを下げる（`Math.max(0, prependCount)`）。

## 検証

- 実機 Claude ペインで `captureViewport` を実行 → cursor.y が枠線(35)→入力行(36)へ補正されることを確認
- dev 環境のブラウザで before/after を比較: 修正前はカーソルが入力行の2行上に浮き、修正後は `›` 直後に正しく表示
- ユニットテスト更新・全パス、lint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)