### PR TITLE
Release v0.1.181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.181] - 2026-06-21
+
+### Fixed
+- **Claude TUI のカーソルが入力行からズレる**: 最近の Claude Code がモードヒントのフッター下に空行を残すレイアウトになり、`padFill`（ペイン下部の void を scrollback で埋める処理）が prepend する行数が常時 1 以上になった。カーソル補正 `computeCursorPadShift` は prepend 量から 2 を引いていた（`prependCount - 2`）ため、カーソルが入力ボックス（`›` / `❯`）より最大2行上の空白行・枠線上に浮いて表示されていた。prepend した行数ぶんちょうど下げるよう修正（`Math.max(0, prependCount)`）（#371, `backend/src/services/viewport-cursor-policy.ts`）
+
 ## [0.1.180] - 2026-06-20
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.180",
-  "generated": "2026-06-20",
+  "version": "0.1.181",
+  "generated": "2026-06-21",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.180",
-  "generated": "2026-06-20",
+  "version": "0.1.181",
+  "generated": "2026-06-21",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.180",
+  "version": "0.1.181",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(viewport): Claude TUI のカーソルが入力行から最大2行ズレる問題を修正（#371）

## Notes
最近の Claude Code がフッター下に空行を残すレイアウトになり、`padFill` の prepend 量と `computeCursorPadShift` の補正値（`-2` の fudge）の不一致が顕在化したもの。prepend した行数ぶんちょうどカーソルを下げるよう修正。dev 環境で before/after を目視確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)