### PR TITLE
feat(terminal): hand scroll to fullscreen TUIs on the alternate screen

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -188,6 +188,11 @@ export const TerminalComponent = memo(
 		const controlCleanupRef = useRef<(() => void) | null>(null);
 		const controlModeRef = useRef(controlMode);
 		controlModeRef.current = controlMode;
+		// Whether the active pane is on the alternate screen (fullscreen TUIs like
+		// Claude/Codex/vim). Updated from each viewport frame. When true we hand
+		// scrolling to the app (SGR mouse wheel) instead of paging tmux scrollback,
+		// because the alt screen has no tmux scrollback and the app scrolls itself.
+		const altScreenRef = useRef(false);
 		const hideKeyboardRef = useRef(hideKeyboard);
 		hideKeyboardRef.current = hideKeyboard;
 
@@ -584,11 +589,31 @@ export const TerminalComponent = memo(
 			// we issue one viewport refetch per frame instead of many tiny ones.
 			let pendingScrollDelta = 0;
 			let pendingScrollRafId: number | null = null;
+			// Alt-screen panes (fullscreen Claude/Codex/vim) have no tmux scrollback:
+			// the app scrolls its own transcript in response to mouse-wheel input.
+			// Forward the accumulated scroll as SGR mouse-wheel events aimed at the
+			// middle of the screen so the app pages itself. delta<0 = up (button 64),
+			// delta>0 = down (button 65). Capped per flush so touch momentum can't
+			// flood the pane with a burst of events.
+			const MAX_WHEEL_PER_FLUSH = 4;
+			const sendWheelToPane = (delta: number) => {
+				const button = delta < 0 ? 64 : 65;
+				const col = Math.max(1, Math.min(term.cols, Math.round(term.cols / 2)));
+				const row = Math.max(1, Math.min(term.rows, Math.round(term.rows / 2)));
+				const seq = `\x1b[<${button};${col};${row}M`;
+				const count = Math.min(Math.abs(delta), MAX_WHEEL_PER_FLUSH);
+				for (let i = 0; i < count; i++) controlModeRef.current?.sendInput(seq);
+			};
 			const flushPendingScroll = () => {
 				pendingScrollRafId = null;
 				const delta = pendingScrollDelta;
 				pendingScrollDelta = 0;
-				if (delta !== 0) controlModeRef.current?.scrollBy?.(delta);
+				if (delta === 0) return;
+				if (altScreenRef.current) {
+					sendWheelToPane(delta);
+				} else {
+					controlModeRef.current?.scrollBy?.(delta);
+				}
 			};
 			const scrollTerminal = (lines: number) => {
 				// Server-side scrollback: tmux holds the authoritative history; the
@@ -1149,6 +1174,7 @@ export const TerminalComponent = memo(
 			const cleanup = cm.registerOnViewport((viewport, isPseudo) => {
 				const term = terminalRef.current;
 				if (!term) return;
+				altScreenRef.current = viewport.modes.altScreen;
 				if (term.cols !== viewport.cols || term.rows !== viewport.rows) {
 					applyResize(viewport.cols, viewport.rows);
 				}
@@ -1345,7 +1371,14 @@ export const TerminalComponent = memo(
 			// the pre-server-side-scrollback behavior. `term.scrollToBottom()` is
 			// a no-op now (xterm scrollback is 0); the actual reset goes through
 			// the control mode's offset.
-			controlModeRef.current?.scrollToLive?.();
+			if (altScreenRef.current) {
+				// Fullscreen TUIs (Claude/Codex) own their own transcript scroll, so
+				// there is no tmux offset to reset — send Ctrl+End so the app jumps
+				// its transcript to the bottom. No-op when already at the live edge.
+				controlModeRef.current?.sendInput("\x1b[1;5F");
+			} else {
+				controlModeRef.current?.scrollToLive?.();
+			}
 			fitTerminal();
 		}, [fitTerminal]);
 		showKeyboardRef.current = handleShowKeyboard;


### PR DESCRIPTION
## 背景

Claude Code (v2.1.172+) と Codex は TUI を**代替スクリーン(alternate screen)**に描画するようになった。代替スクリーンは vim/htop/less 同様 **tmux scrollback を持たない**ため、cchub の「上スクロールで tmux 履歴を辿る」方式では何も出なくなっていた。

普通のターミナルではこれらのアプリは wheel 入力に応じて**自前の transcript をスクロール**する。しかし cchub は wheel をキャプチャ段階で横取りして tmux scrollback に流す設計（normal 画面では必要）なので、wheel が Claude に届かず、alt 画面では「遡れない」状態だった。

## 変更

**alt スクリーンのペイン**（各 viewport frame の `modes.altScreen` で判定）では、スクロールを**アプリに明け渡す**:

- wheel / touch / momentum はすべて `flushPendingScroll` に集約されるので、そこで分岐。alt 時は `scrollBy`(tmux scrollback) ではなく **SGR マウスホイールイベント**（button 64=up / 65=down、画面中央宛て）を `sendInput` で送る。アプリが自前の transcript をスクロールし、tmux の live viewport push で再描画される。touch momentum が flood しないよう1フラッシュあたりの件数を上限化
- tap→live 復帰（`handleShowKeyboard`）は、リセットすべき tmux offset が無いので **Ctrl+End** を送ってアプリの transcript を最下部へジャンプさせる

**normal スクリーンのペインは既存の tmux-scrollback 挙動のまま**（変更なし）。

## 検証（dev 実機・fullscreen Claude）

- wheel 上下 / touch スワイプで transcript が遡る（Claude 自身の "Jump to bottom" UI が出る＝アプリがスクロールを処理している証拠）
- タップで live 復帰（Ctrl+End）
- 入力欄にゴミバイトが混入しない（fullscreen Claude はマウス tracking ON を実機確認済み）
- lint / 型チェック クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)