### PR TITLE
Release v0.1.182

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.182] - 2026-07-02
+
+### Added
+- **代替スクリーンの TUI にスクロールを明け渡す**: Claude Code (v2.1.172+) / Codex は TUI を端末の代替スクリーン(alternate screen)に描画するようになり、代替スクリーンは tmux scrollback を持たないため、cchub の「上スクロールで tmux 履歴を辿る」方式では過去が一切出なくなっていた。alt スクリーンのペイン（各 viewport frame の `modes.altScreen` で判定）では、スクロールを横取りして tmux scrollback を辿る代わりに、**SGR マウスホイールイベント（button 64=上/65=下）をペインへ送信**してアプリ自身に transcript をスクロールさせるよう変更。wheel/touch/momentum は `flushPendingScroll` に集約されているのでそこで一括分岐し、touch momentum の flood は1フラッシュあたり上限でガード。タップでの live 復帰は tmux offset が無いため Ctrl+End を送ってアプリの transcript を最下部へジャンプさせる。normal スクリーンのペインは既存の tmux-scrollback 挙動のまま（#373, `frontend/src/components/Terminal.tsx`）
+
 ## [0.1.181] - 2026-06-21
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.181",
-  "generated": "2026-06-21",
+  "version": "0.1.182",
+  "generated": "2026-07-02",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.181",
-  "generated": "2026-06-21",
+  "version": "0.1.182",
+  "generated": "2026-07-02",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.181",
+  "version": "0.1.182",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- feat(terminal): 代替スクリーン(alt screen)の fullscreen TUI にスクロールを明け渡す（#373）

## Notes
Claude Code (v2.1.172+) / Codex が TUI を代替スクリーンに描画するようになり、tmux scrollback が無効化されて cchub で上スクロールしても過去が出なくなっていた問題への対応。alt スクリーンのペインでは SGR マウスホイールをアプリへ送り、アプリ自身に transcript をスクロールさせる。dev 実機（fullscreen Claude）で wheel/touch/タップ復帰・ゴミ入力なしを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)