### PR TITLE
chore: remove dead code (ViewportRequest, pendingSessionId scaffolding)

### DIFF
--- a/backend/src/services/pane-viewport.ts
+++ b/backend/src/services/pane-viewport.ts
@@ -142,10 +142,6 @@ async function captureScrollback(
   }
 }
 
-export interface ViewportRequest {
-  offset: number;
-}
-
 /**
  * Capture a viewport from a pane. Returns null if the pane no longer exists.
  *

--- a/frontend/src/utils/hookNotification.ts
+++ b/frontend/src/utils/hookNotification.ts
@@ -19,16 +19,6 @@ const EVENT_MESSAGES: Record<string, string> = {
 let lastNotification = { key: "", time: 0 };
 const DEBOUNCE_MS = 500;
 
-// 最後に通知したセッションID（アプリ復帰時のセッション切り替え用）
-let pendingSessionId: string | null = null;
-
-/** 通知タップでアプリ復帰時に切り替えるべきセッションIDを取得・クリア */
-export function consumePendingSessionId(): string | null {
-	const id = pendingSessionId;
-	pendingSessionId = null;
-	return id;
-}
-
 async function showNotification(title: string, options: NotificationOptions) {
 	// 1. Try ServiceWorker (required for PWA / installed web apps)
 	if ("serviceWorker" in navigator) {
@@ -84,11 +74,6 @@ export function fireHookNotification(
 	const projectName = toHomeShortPath(cwd) || "CC Hub";
 	// Body: smart message from transcript, or fallback
 	const body = smartMessage || EVENT_MESSAGES[event] || `Hook: ${event}`;
-
-	// 通知発火時にセッションIDを記録（アプリ復帰時に切り替え用）
-	if (_sessionId) {
-		pendingSessionId = _sessionId;
-	}
 
 	showNotification(projectName, {
 		body,


### PR DESCRIPTION
alt-screen スクロール対応(#373)まわりのデッドコード整理。**今回の scroll 変更自体は追加のみで新規デッドは無し**（ts-prune 全体スキャン＋シンボル追跡で確認）。既存の真のデッドコードを2件除去。

## 削除

- **`ViewportRequest`**（`backend/src/services/pane-viewport.ts`）: export のみで参照ゼロの未使用 interface。server-side scrollback 改修以降デッド
- **`pendingSessionId` / `consumePendingSessionId`**（`frontend/src/utils/hookNotification.ts`）: 「通知タップ→セッション切替」用に sessionId を保存していたが `consume` を誰も呼ばず、機能が未配線のままの死んだ scaffolding。setter/getter/書き込みを除去（`_sessionId` は Notification の `data` payload で引き続き使用）

## 対象外（誤検出）
- `getPeer` はテストで使用中、`ResizeTerminalInput` 等 `*Input` 型・`files/index.ts` バレルは shared の公開面で意図的

lint / backend テスト(98 pass) クリーン。ユーザー影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)