### PR TITLE
Release v0.1.183

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.183] - 2026-07-03
+
+### Added
+- **herdr 風のエージェント状態ドットを tmux status-bar に表示**: cchub 経由で入室中のセッションで、エージェント状態を色ドット（🟡 作業中 / 🔴 入力待ち / 🔵 完了 / 🟢 アイドル）として status-bar に表示する。セッション一覧処理が hook ベースの状態を tmux ユーザオプション `@cchub_state` へ変更時のみ push（dedupe / fire-and-forget）し、`attachStatusRight` の `#{@cchub_state}` が描画する（`backend/src/services/tmux.ts`, `backend/src/routes/sessions.ts`, `tui/src/tmux/attach.ts`）
+- **常時表示のセッションサイドバー（`cchub tui --sidebar` / no-prefix F10）**: 左端に幅48桁のライブなセッション一覧をペインとして常駐させる。Enter で `switch-client` してもサイドバーは閉じず、切替え先セッションにもサイドバーを自動で生やすため「どこへ行っても左に一覧が居る」herdr 風の体験になる。サイドバーは自ペインを `@cchub_sidebar=1` でマークして重複作成を防ぎ、`q` で自ペインを閉じる（`tui/src/index.ts`, `tui/src/tmux/attach.ts`, `backend/src/cli.ts`）
+
+### Changed
+- **`cchub tui` の Help をカテゴリ分け + 状態ドット凡例を追加**: フラットなキー一覧を「移動 / セッション操作 / 入室中 / 履歴・その他」にグループ化し、状態ドットの凡例を併記。App のフッタヒントも状況（通常 / 終了確認 / ヘルプ）で出し分けるようにした（`tui/src/components/Help.tsx`, `tui/src/components/App.tsx`）
+
 ## [0.1.182] - 2026-07-02
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.182",
-  "generated": "2026-07-02",
+  "version": "0.1.183",
+  "generated": "2026-07-03",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.182",
-  "generated": "2026-07-02",
+  "version": "0.1.183",
+  "generated": "2026-07-03",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -29,6 +29,7 @@ interface CliOptions {
   sendLines?: number;
   peekTarget?: string;
   tuiPopup?: boolean;
+  tuiSidebar?: boolean;
 }
 
 function printHelp(): void {
@@ -86,6 +87,10 @@ tui options:
                          the current client to the selected session and exits
                          (the popup closes automatically). Bound to F11 by
                          CC Hub's tmux config.
+  --sidebar              Persistent left-edge session sidebar: runs inside a
+                         tmux pane, Enter switches sessions without exiting
+                         (provisioning a sidebar in the target too), q closes
+                         the pane. Toggle with F10 (CC Hub's tmux config).
 
 ${t('cli.examples')}
   ${t('cli.exampleStart')}
@@ -154,6 +159,9 @@ export function parseArgs(args: string[]): CliOptions {
         break;
       case '--popup':
         options.tuiPopup = true;
+        break;
+      case '--sidebar':
+        options.tuiSidebar = true;
         break;
       case '--stdin':
         options.sendStdin = true;
@@ -385,6 +393,7 @@ async function runTuiCommand(options: CliOptions): Promise<void> {
     port: options.port,
     host: options.host,
     popup: options.tuiPopup ?? false,
+    sidebar: options.tuiSidebar ?? false,
   });
 }
 

--- a/backend/src/commands/tui.ts
+++ b/backend/src/commands/tui.ts
@@ -11,11 +11,13 @@ export interface RunTuiOptions {
   host: string;
   /** tmux の display-popup から呼ばれた場合の単発モード（switch-client → 終了）。 */
   popup?: boolean;
+  /** 常時表示サイドバーペイン内で動くモード（F10 で split-window 起動）。 */
+  sidebar?: boolean;
 }
 
 export async function runTui(options: RunTuiOptions): Promise<void> {
   // `-H` の既定はサーバの bind 用 `0.0.0.0`。TUI は接続側なので localhost へ正規化する
   // （明示指定された host はそのまま尊重）。
   const host = options.host === '0.0.0.0' ? '127.0.0.1' : options.host;
-  await startTui({ port: options.port, host, popup: options.popup ?? false });
+  await startTui({ port: options.port, host, popup: options.popup ?? false, sidebar: options.sidebar ?? false });
 }

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -225,6 +225,10 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         ? (hookState ?? undefined)
         : undefined;
 
+    // Push the herdr-style state dot into tmux so it shows in the status bar
+    // (rendered by attachStatusRight's #{@cchub_state}). Deduped/fire-and-forget.
+    tmuxService.setSessionState(s.name, sessionIndicatorState);
+
     const panePids: (number | undefined)[] = s.panes ? s.panes.map((p: { pid?: number }) => p.pid) : [];
     const metrics = await computeSessionMetrics({
       ccSessionId: includeClaudeInfo ? ccSession?.sessionId : undefined,

--- a/backend/src/services/tmux.ts
+++ b/backend/src/services/tmux.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { detectAgentProviderFromArgs, type AgentProvider } from '../../../shared/types';
+import { detectAgentProviderFromArgs, type AgentProvider, type IndicatorState } from '../../../shared/types';
 
 interface TmuxPaneInfo {
   paneId: string;          // "%0", "%1"
@@ -63,12 +63,42 @@ bind-key -n F11 display-popup -E -B -w 50 -h "100%" -x 0 -y 0 "cchub tui --popup
 # (Also re-applied per-attach by tui/src/tmux/attach.ts as a safety net.)
 bind-key -n F12 detach-client
 
+# F10 (no-prefix): open a persistent left-edge session sidebar in the current
+# window (herdr-style always-on list). The sidebar process marks its own pane
+# with @cchub_sidebar=1 so we skip if one already exists; it kills its pane on
+# quit. Enter in the sidebar switches sessions without closing it.
+bind-key -n F10 if-shell "tmux list-panes -F '#{@cchub_sidebar}' | grep -q 1" 'display-message "cchub sidebar is already open (q to close)"' 'split-window -h -b -l 48 "cchub tui --sidebar"'
+
 # Mouse click on status-bar "≡ cchub" button → open session popup.
 # The button itself (with #[range=user|sessions]) is set per-attach by
 # tui/src/tmux/attach.ts so we don't clobber the user's global status-right.
 # MouseDown1Status fires for any status click; if-shell filters by range name.
 bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},sessions}" "display-popup -E -B -w 50 -h 100% -x 0 -y 0 'cchub tui --popup'"
 `;
+
+/**
+ * Map an agent's indicator state to a herdr-style "state at a glance" dot,
+ * rendered in the tmux status bar via the `@cchub_state` user option.
+ *   🟡 processing (working) / 🔴 waiting_input (needs you) /
+ *   🔵 completed (done) / 🟢 idle-or-unknown.
+ */
+export function indicatorStateToDot(state?: IndicatorState): string {
+  switch (state) {
+    case 'processing':
+      return '🟡';
+    case 'waiting_input':
+      return '🔴';
+    case 'completed':
+      return '🔵';
+    default:
+      return '🟢';
+  }
+}
+
+// Dedupe cache so we only spawn `tmux set-option` when a session's dot actually
+// changes. The sessions list recomputes state every ~5s; without this we'd
+// fork one tmux process per session per poll for no visible change.
+const lastSessionDot = new Map<string, string>();
 
 /** Parsed process info from a single `ps` call, shared across consumers */
 export interface ParsedProcessInfo {
@@ -105,6 +135,28 @@ export class TmuxService {
   constructor() {
     const configDir = path.join(process.env.HOME || '/tmp', '.config', 'cchub');
     this.configPath = path.join(configDir, 'tmux.conf');
+  }
+
+  /**
+   * Push a herdr-style agent-state dot into the tmux session's `@cchub_state`
+   * user option so `attachStatusRight()` can render it in the status bar.
+   * Fire-and-forget and deduped: only spawns when the dot changes.
+   */
+  setSessionState(sessionName: string, state?: IndicatorState): void {
+    const dot = indicatorStateToDot(state);
+    if (lastSessionDot.get(sessionName) === dot) return;
+    lastSessionDot.set(sessionName, dot);
+    try {
+      Bun.spawn(['tmux', 'set-option', '-t', sessionName, '@cchub_state', dot], {
+        stdout: 'ignore',
+        stderr: 'ignore',
+        env: TMUX_ENV,
+      });
+    } catch {
+      // Best-effort: the status dot is cosmetic; drop the cache entry so the
+      // next poll retries rather than sticking on a stale value.
+      lastSessionDot.delete(sessionName);
+    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.182",
+  "version": "0.1.183",
   "private": true,
   "workspaces": [
     "backend",

--- a/tui/src/components/App.tsx
+++ b/tui/src/components/App.tsx
@@ -9,7 +9,10 @@ import type { ListAction, TuiSession } from '../types';
 import { Help } from './Help';
 import { SessionList } from './SessionList';
 
-const SHORTCUTS = `↑↓ 選択 · Enter 入室(${RETURN_KEY}で戻る) · n 新規 · x 終了 · r 再開 · c compact · / 履歴 · ? ヘルプ · q 終了`;
+// フッタのヒントは状況で出し分ける（herdr 風のコンテキスト対応）。
+const SHORTCUTS_LIST = `↑↓ 選択 · Enter 入室(${RETURN_KEY}で戻る) · n 新規 · x 終了 · r 再開 · c compact · / 履歴 · ? ヘルプ · q 終了`;
+const SHORTCUTS_CONFIRM = 'y 終了する · n キャンセル';
+const SHORTCUTS_HELP = '何かキーで閉じる · ? でも閉じる';
 
 export function App({
   client,
@@ -123,7 +126,7 @@ export function App({
         borderLeft={false}
         borderRight={false}
       >
-        <Text dimColor>{SHORTCUTS}</Text>
+        <Text dimColor>{showHelp ? SHORTCUTS_HELP : confirmKill ? SHORTCUTS_CONFIRM : SHORTCUTS_LIST}</Text>
       </Box>
     </Box>
   );

--- a/tui/src/components/Help.tsx
+++ b/tui/src/components/Help.tsx
@@ -1,16 +1,41 @@
 import { Box, Text } from 'ink';
 
-const BINDINGS: Array<[string, string]> = [
-  ['↑↓ / j k', '選択を移動'],
-  ['Enter', '選択セッションに入室（tmux attach）'],
-  ['F12（入室中）', '一覧へ戻る（prefix 不要）'],
-  ['n', '新規セッションを作成'],
-  ['x / d', '選択セッションを終了（y / n で確認）'],
-  ['r', '選択セッションを再開（claude -r 等）'],
-  ['c', '選択セッションに /compact を送信'],
-  ['/', '履歴検索'],
-  ['q / Ctrl-C', '終了'],
-  ['?', 'このヘルプの開閉'],
+/** カテゴリ見出し → [キー, 説明] の並び。herdr 風にグループ分けして見通しを良くする。 */
+const GROUPS: Array<[string, Array<[string, string]>]> = [
+  ['移動', [['↑↓ / j k', '選択を移動']]],
+  [
+    'セッション操作',
+    [
+      ['Enter', '入室（tmux attach）'],
+      ['n', '新規セッションを作成'],
+      ['r', '再開（claude -r 等）'],
+      ['c', '選択セッションに /compact を送信'],
+      ['x / d', '終了（y / n で確認）'],
+    ],
+  ],
+  [
+    '入室中（prefix 不要）',
+    [
+      ['F11', 'popup サイドバーでセッション切替'],
+      ['F12', '一覧へ戻る'],
+    ],
+  ],
+  [
+    '履歴・その他',
+    [
+      ['/', '履歴検索'],
+      ['?', 'このヘルプの開閉'],
+      ['q / Ctrl-C', '終了'],
+    ],
+  ],
+];
+
+/** status-bar のエージェント状態ドット凡例（`@cchub_state` と対応）。 */
+const STATE_LEGEND: Array<[string, string]> = [
+  ['🟡', '作業中'],
+  ['🔴', '入力待ち'],
+  ['🔵', '完了'],
+  ['🟢', 'アイドル'],
 ];
 
 export function Help() {
@@ -19,14 +44,34 @@ export function Help() {
       <Text bold color="cyan">
         キーバインド
       </Text>
-      {BINDINGS.map(([key, desc]) => (
-        <Box key={key}>
-          <Box width={14}>
-            <Text color="yellow">{key}</Text>
-          </Box>
-          <Text>{desc}</Text>
+      {GROUPS.map(([title, bindings]) => (
+        <Box key={title} flexDirection="column" marginTop={1}>
+          <Text bold dimColor>
+            {title}
+          </Text>
+          {bindings.map(([key, desc]) => (
+            <Box key={key}>
+              <Box width={14}>
+                <Text color="yellow">{key}</Text>
+              </Box>
+              <Text>{desc}</Text>
+            </Box>
+          ))}
         </Box>
       ))}
+      <Box marginTop={1} flexDirection="column">
+        <Text bold dimColor>
+          状態ドット
+        </Text>
+        <Box>
+          {STATE_LEGEND.map(([dot, desc]) => (
+            <Text key={desc}>
+              {dot} <Text dimColor>{desc}</Text>
+              {'   '}
+            </Text>
+          ))}
+        </Box>
+      </Box>
       <Box marginTop={1}>
         <Text dimColor>何かキーを押して閉じる</Text>
       </Box>

--- a/tui/src/index.ts
+++ b/tui/src/index.ts
@@ -8,7 +8,7 @@ import { resolveToken } from './api/auth';
 import { type ApiClient, createClient } from './api/client';
 import { getSessions } from './api/sessions';
 import { Root } from './components/Root';
-import { attachSession, switchClient } from './tmux/attach';
+import { attachSession, closeSidebarPane, markSidebarPane, switchClient, switchClientWithSidebar } from './tmux/attach';
 import type { ListAction } from './types';
 
 const ALT_ON = '\x1b[?1049h';
@@ -23,6 +23,12 @@ export interface StartTuiOptions {
    * detach ループはしない。
    */
   popup?: boolean;
+  /**
+   * sidebar モード: 常時表示のサイドバーペイン内で動く前提（F10 で split-window 起動）。
+   * alt-screen はスキップし、Enter で `switch-client`（切替え先にもサイドバーを生やす）
+   * してもプロセスは終了せずループ継続＝ペインが残り続ける。q で自ペインを閉じる。
+   */
+  sidebar?: boolean;
 }
 
 function isLocalHost(host: string): boolean {
@@ -117,6 +123,20 @@ export async function startTui(opts: StartTuiOptions): Promise<void> {
     return;
   }
 
+  // sidebar モード: 自ペインとして常駐する。alt-screen は使わない（ペインの一部なので）。
+  // Enter(attach) → 切替え先にもサイドバーを生やして switch-client、プロセスは終了せず
+  // 次のループで再描画（= ペインが残る）。q(quit) → 自ペインを閉じて終了。
+  if (opts.sidebar) {
+    markSidebarPane();
+    for (;;) {
+      const action = await renderRootOnce(client, baseUrl, token);
+      if (action.type === 'quit') break;
+      if (action.type === 'attach') switchClientWithSidebar(action.sessionName);
+    }
+    closeSidebarPane();
+    return;
+  }
+
   // 通常モード: alt-screen ループ。一覧 → Enter で入室（alt 退出 → tmux attach → alt 復帰）→ q で終了。
   process.on('exit', () => {
     try {
@@ -147,11 +167,13 @@ if (import.meta.main) {
   let port = 5923;
   let host = '127.0.0.1';
   let popup = false;
+  let sidebar = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if ((a === '-p' || a === '--port') && argv[i + 1]) port = Number.parseInt(argv[++i], 10);
     else if ((a === '-H' || a === '--host') && argv[i + 1]) host = argv[++i];
     else if (a === '--popup') popup = true;
+    else if (a === '--sidebar') sidebar = true;
   }
-  await startTui({ port, host, popup });
+  await startTui({ port, host, popup, sidebar });
 }

--- a/tui/src/tmux/__tests__/attach.test.ts
+++ b/tui/src/tmux/__tests__/attach.test.ts
@@ -5,6 +5,8 @@ import {
   planSwitchClient,
   preAttachCommands,
   RETURN_KEY,
+  SIDEBAR_WIDTH,
+  sidebarSplitArgs,
 } from '../attach';
 
 describe('planAttach', () => {
@@ -54,6 +56,21 @@ describe('attachStatusRight', () => {
 
   test('戻りキーは差し替え可能', () => {
     expect(attachStatusRight('F8')).toContain('F8 で一覧へ戻る');
+  });
+});
+
+describe('sidebarSplitArgs', () => {
+  test('左に幅固定の横分割 + フォーカス据え置き(-d) で sidebar を生やす', () => {
+    const args = sidebarSplitArgs('proj-2');
+    expect(args).toEqual([
+      'split-window', '-h', '-b', '-l', String(SIDEBAR_WIDTH), '-d', '-t', 'proj-2', 'cchub tui --sidebar',
+    ]);
+  });
+
+  test('幅・コマンドは差し替え可能', () => {
+    const args = sidebarSplitArgs('s', 30, 'cchub tui --sidebar -p 3456');
+    expect(args).toContain('30');
+    expect(args[args.length - 1]).toBe('cchub tui --sidebar -p 3456');
   });
 });
 

--- a/tui/src/tmux/attach.ts
+++ b/tui/src/tmux/attach.ts
@@ -43,9 +43,14 @@ export function preAttachCommands(sessionName: string, returnKey: string = RETUR
  * `#[range=user|sessions]` でクリック可能領域を定義する。CCHUB_TMUX_CONFIG 側の
  * `MouseDown1Status` バインドが mouse_status_range='sessions' を検知して popup を開く。
  * 反転表示でボタンであることを明示し、F12 ヒントも併記する。
+ *
+ * 先頭に `#{@cchub_state}` を出す。これは cc-hub のセッション一覧処理が
+ * `tmux set-option -t <session> @cchub_state <dot>` で流し込むエージェント状態ドット
+ * （🟡=作業中 / 🔴=入力待ち / 🔵=完了 / 🟢=アイドル）で、herdr 風に「状態が一目でわかる」。
+ * 未設定なら何も出さない（`#{?...}` で条件付き）。
  */
 export function attachStatusRight(returnKey: string = RETURN_KEY): string {
-  return `#[range=user|sessions,reverse] ≡ cchub #[norange,default]  ${returnKey} で一覧へ戻る `;
+  return `#{?#{@cchub_state},#{@cchub_state} ,}#[range=user|sessions,reverse] ≡ cchub #[norange,default]  ${returnKey} で一覧へ戻る `;
 }
 
 function runTmux(args: string[]): void {
@@ -99,6 +104,65 @@ export function switchClient(sessionName: string): number {
     }
   }
   return lastCode;
+}
+
+/** 常時表示サイドバーの既定幅（桁）。F10 バインドと provision で共有する。 */
+export const SIDEBAR_WIDTH = 48;
+
+/** サイドバーとして開くペインを起動するコマンド文字列（tmux split-window に渡す）。 */
+export const SIDEBAR_SPAWN_CMD = 'cchub tui --sidebar';
+
+/**
+ * `switchClientWithSidebar` が発行する split-window 引数（純粋関数）。
+ * `-h -b`（左に横分割）+ `-l <width>`（幅固定）+ `-d`（フォーカスは切替え先の作業ペインに残す）。
+ */
+export function sidebarSplitArgs(
+  targetSession: string,
+  width: number = SIDEBAR_WIDTH,
+  cmd: string = SIDEBAR_SPAWN_CMD,
+): string[] {
+  return ['split-window', '-h', '-b', '-l', String(width), '-d', '-t', targetSession, cmd];
+}
+
+/** 対象セッションに既にサイドバーペイン（@cchub_sidebar=1）があるか。 */
+export function sessionHasSidebar(targetSession: string): boolean {
+  try {
+    const proc = Bun.spawnSync(['tmux', 'list-panes', '-t', targetSession, '-F', '#{@cchub_sidebar}'], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+    });
+    const text = proc.stdout ? new TextDecoder().decode(proc.stdout) : '';
+    return text.split('\n').some((line) => line.trim() === '1');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * サイドバーモードの起動時に自ペインを整える（$TMUX_PANE 経由で現在ペインに適用）:
+ * - `@cchub_sidebar 1`: 重複作成防止・provision 検出用のマーカー
+ * - `remain-on-exit off`: グローバルは on だが、サイドバーは終了時にペインを消したい
+ */
+export function markSidebarPane(): void {
+  runTmux(['set-option', '-p', '@cchub_sidebar', '1']);
+  runTmux(['set-option', '-p', 'remain-on-exit', 'off']);
+}
+
+/** サイドバーの終了時に自ペインを閉じる（remain-on-exit を自ペインで off 済み）。 */
+export function closeSidebarPane(): void {
+  runTmux(['kill-pane']);
+}
+
+/**
+ * サイドバーからのセッション切替え。切替え先にサイドバーが無ければ先に生やしてから
+ * `switch-client` する（= どのセッションへ行っても左に一覧が居る＝常駐に見える）。
+ * 自分のペインは残るので呼出元プロセスは終了しない（index.ts 側でループ継続）。
+ */
+export function switchClientWithSidebar(targetSession: string, width: number = SIDEBAR_WIDTH): void {
+  if (!sessionHasSidebar(targetSession)) {
+    runTmux(sidebarSplitArgs(targetSession, width));
+  }
+  runTmux(['switch-client', '-t', targetSession]);
 }
 
 /** 子プロセスを stdio 継承で起動し、detach（= RETURN_KEY 等）まで同期的に待つ。 */


### PR DESCRIPTION
## Changes
- feat(tui): herdr 風のエージェント状態ドット（🟡🔴🔵🟢）を tmux status-bar に表示（`@cchub_state` 経由の dedupe push）
- feat(tui): 常時表示のセッションサイドバー（`cchub tui --sidebar` / no-prefix F10）— Enter で switch-client しても閉じず、切替え先にもサイドバーを生やして常駐に見せる
- chore(tui): Help をカテゴリ分け + 状態ドット凡例、App フッタをコンテキスト別ヒントに
- chore: bump version to 0.1.183

## Notes
tmux の「セッション切替え = client が別セッションへ移る」制約のため、単一ペインでの全セッション横断常駐は不可。各セッションにサイドバーペインを持たせる方式で herdr の体験を再現している。
全テスト green（frontend 37 / tui 68 / backend 284）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)