### PR TITLE
Release v0.1.184

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.184] - 2026-07-03
+
+### Fixed
+- **端末クライアントでマウスが一切効かなくなる**: Web UI（tmux -CC 制御モード）は接続時に copy-mode 誤爆防止のため `set-option -t <session> mouse off` を実行するが、Web 切断後もこの override がセッションに残り続けるため、同じ tmux セッションに繋いでいるローカル端末クライアントのマウス（クリック選択・境界ドラッグ・ホイール）まで死んでいた。`TmuxControlSession.destroy()` で mouse override を `set-option -u` で解除し、global の `mouse on` へフォールバックさせるよう修正（`backend/src/services/tmux-control.ts`）
+
 ## [0.1.183] - 2026-07-03
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.183",
+  "version": "0.1.184",
   "generated": "2026-07-03",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.1.183",
+  "version": "0.1.184",
   "generated": "2026-07-03",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {

--- a/backend/src/services/tmux-control.ts
+++ b/backend/src/services/tmux-control.ts
@@ -986,6 +986,20 @@ export class TmuxControlSession {
     if (this.destroyed) return;
     this.destroyed = true;
 
+    // Restore mouse mode we disabled on attach (see `mouse off` above). Otherwise
+    // a terminal client sharing this tmux session is left with mouse off after the
+    // browser disconnects ("mouse doesn't work at all"). Unsetting the session
+    // override falls the option back to the global default (`mouse on`). Runs via a
+    // fresh tmux process since our own control connection is being torn down here.
+    try {
+      spawn('tmux', ['set-option', '-u', '-t', this.sessionId, 'mouse'], { stdio: 'ignore' }).on(
+        'error',
+        () => {},
+      );
+    } catch {
+      // best-effort — the tmux session may already be gone
+    }
+
     if (this.graceTimer) {
       clearTimeout(this.graceTimer);
       this.graceTimer = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.183",
+  "version": "0.1.184",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(tmux): 端末クライアントでマウスが一切効かなくなる不具合を修正。Web UI(tmux -CC)が接続時に設定する `mouse off` が切断後もセッションに残り、同じ tmux セッションの端末クライアントのマウスまで死んでいた。`TmuxControlSession.destroy()` で override を解除して global の `mouse on` に戻す
- chore: bump version to 0.1.184

## Notes
全テスト green（frontend 37 / tui 68 / backend 284）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)