### PR TITLE
Release v0.1.185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.185] - 2026-07-04
+
+### Added
+- **herdr 風の既定レイアウト（入室時に左サイドバーを自動表示）**: `cchub tui` でセッションに入室すると、左端に幅34桁のセッション一覧サイドバーを自動で開くようにした（「左に一覧・右に作業」の herdr 風レイアウト）。狭幅向けの専用コンポーネント（1セッション=1行: `▸ ドット セッション名`）で描画し、既にサイドバーがあれば二重に開かず、フォーカスは作業ペインに残す。popup 経由の切替でも切替え先にサイドバーを生やす。`CCHUB_TUI_SIDEBAR=0`（または `off` / `false`）で無効化できる（`tui/src/components/Sidebar.tsx`, `tui/src/tmux/attach.ts`, `tui/src/index.ts`）
+
+### Changed
+- **常時表示サイドバーの幅を 48→34 桁に縮小**: herdr のスリムなサイドバーに寄せ、専用のコンパクト表示（カードではなく1行表示）に変更（`tui/src/tmux/attach.ts`, `backend/src/services/tmux.ts` の F10 バインド）
+
 ## [0.1.184] - 2026-07-03
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.184",
-  "generated": "2026-07-03",
+  "version": "0.1.185",
+  "generated": "2026-07-04",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.184",
-  "generated": "2026-07-03",
+  "version": "0.1.185",
+  "generated": "2026-07-04",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -92,6 +92,10 @@ tui options:
                          (provisioning a sidebar in the target too), q closes
                          the pane. Toggle with F10 (CC Hub's tmux config).
 
+  On entering a session, cchub tui auto-opens this sidebar (herdr-style
+  "list on the left, work on the right" layout). Disable with the env var
+  CCHUB_TUI_SIDEBAR=0 (or off/false).
+
 ${t('cli.examples')}
   ${t('cli.exampleStart')}
   ${t('cli.exampleWithPort')}

--- a/backend/src/services/tmux.ts
+++ b/backend/src/services/tmux.ts
@@ -67,7 +67,7 @@ bind-key -n F12 detach-client
 # window (herdr-style always-on list). The sidebar process marks its own pane
 # with @cchub_sidebar=1 so we skip if one already exists; it kills its pane on
 # quit. Enter in the sidebar switches sessions without closing it.
-bind-key -n F10 if-shell "tmux list-panes -F '#{@cchub_sidebar}' | grep -q 1" 'display-message "cchub sidebar is already open (q to close)"' 'split-window -h -b -l 48 "cchub tui --sidebar"'
+bind-key -n F10 if-shell "tmux list-panes -F '#{@cchub_sidebar}' | grep -q 1" 'display-message "cchub sidebar is already open (q to close)"' 'split-window -h -b -l 34 "cchub tui --sidebar"'
 
 # Mouse click on status-bar "≡ cchub" button → open session popup.
 # The button itself (with #[range=user|sessions]) is set per-attach by

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.184",
+  "version": "0.1.185",
   "private": true,
   "workspaces": [
     "backend",

--- a/tui/src/components/Sidebar.tsx
+++ b/tui/src/components/Sidebar.tsx
@@ -1,0 +1,82 @@
+// 常時表示サイドバー（`cchub tui --sidebar`）用のコンパクト表示。
+// 狭幅（~34桁）で崩れないよう、1 セッション = 1 行（ドット + タイトル）に畳む。
+// カード表示の App とは別物で、目的は「一覧を眺めて選んで switch」に絞る。
+import { Box, Text, useInput } from 'ink';
+import { useState } from 'react';
+import type { ApiClient } from '../api/client';
+import { useSessions } from '../hooks/useSessions';
+import type { ListAction, TuiSession } from '../types';
+import { deriveRow, indicatorGlyph } from './session-row';
+
+/** 1 セッション = 1 行（選択中は ▸ + cyan bold）。純粋な presentational でテスト対象。 */
+export function SidebarRow({ session, selected }: { session: TuiSession; selected: boolean }) {
+  const row = deriveRow(session);
+  const ind = indicatorGlyph(row.indicator);
+  return (
+    <Box>
+      <Text color={selected ? 'cyan' : undefined}>{selected ? '▸' : ' '}</Text>
+      <Text color={ind.color}>{`${ind.glyph} `}</Text>
+      <Text bold={selected} color={selected ? 'cyan' : undefined} wrap="truncate-end">
+        {row.title}
+      </Text>
+    </Box>
+  );
+}
+
+/** サイドバー本体（presentational）。選択位置を props で受けるのでテストしやすい。 */
+export function SidebarList({
+  sessions,
+  selectedIndex,
+}: {
+  sessions: TuiSession[];
+  selectedIndex: number;
+}) {
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold color="cyan">
+        ≡ sessions
+      </Text>
+      <Box flexDirection="column" marginTop={1}>
+        {sessions.length === 0 ? (
+          <Text dimColor>セッションがありません</Text>
+        ) : (
+          sessions.map((s, i) => <SidebarRow key={s.id} session={s} selected={i === selectedIndex} />)
+        )}
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>↑↓ 選択 · Enter 切替 · q 閉じる</Text>
+      </Box>
+    </Box>
+  );
+}
+
+/** サイドバーの状態＋入力を担うコンテナ。Enter で attach、q で quit を bubble する。 */
+export function SidebarApp({
+  client,
+  onAction,
+}: {
+  client: ApiClient;
+  onAction: (action: ListAction) => void;
+}) {
+  const { sessions } = useSessions(client);
+  const [selected, setSelected] = useState(0);
+  const count = sessions.length;
+  const clamped = count === 0 ? 0 : Math.min(selected, count - 1);
+
+  useInput((input, key) => {
+    if (input === 'q' || (key.ctrl && input === 'c')) {
+      onAction({ type: 'quit' });
+      return;
+    }
+    if (key.upArrow || input === 'k') {
+      setSelected(Math.max(0, clamped - 1));
+    } else if (key.downArrow || input === 'j') {
+      setSelected(Math.min(Math.max(0, count - 1), clamped + 1));
+    } else if (key.return && count > 0) {
+      const target = sessions[clamped];
+      if (target) onAction({ type: 'attach', sessionName: target.name });
+    }
+  });
+
+  return <SidebarList sessions={sessions} selectedIndex={clamped} />;
+}

--- a/tui/src/components/__tests__/Sidebar.test.tsx
+++ b/tui/src/components/__tests__/Sidebar.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { render } from 'ink-testing-library';
+import type { TuiSession } from '../../types';
+import { SidebarList } from '../Sidebar';
+
+const sessions: TuiSession[] = [
+  { id: '1', name: 'alpha', agent: 'claude', indicatorState: 'processing' },
+  { id: '2', name: 'beta', customTitle: 'Refactor', agent: 'codex', indicatorState: 'idle' },
+];
+
+describe('SidebarList', () => {
+  test('1 行 1 セッションで名前 / customTitle を表示', () => {
+    const { lastFrame } = render(<SidebarList sessions={sessions} selectedIndex={0} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('alpha');
+    expect(frame).toContain('Refactor');
+    expect(frame).toContain('≡ sessions');
+  });
+
+  test('選択行に ▸ マーカーが付く', () => {
+    const { lastFrame } = render(<SidebarList sessions={sessions} selectedIndex={1} />);
+    expect(lastFrame() ?? '').toContain('▸');
+  });
+
+  test('空配列は空状態メッセージ', () => {
+    const { lastFrame } = render(<SidebarList sessions={[]} selectedIndex={0} />);
+    expect(lastFrame() ?? '').toContain('セッションがありません');
+  });
+});

--- a/tui/src/index.ts
+++ b/tui/src/index.ts
@@ -8,6 +8,7 @@ import { resolveToken } from './api/auth';
 import { type ApiClient, createClient } from './api/client';
 import { getSessions } from './api/sessions';
 import { Root } from './components/Root';
+import { SidebarApp } from './components/Sidebar';
 import { attachSession, closeSidebarPane, markSidebarPane, switchClient, switchClientWithSidebar } from './tmux/attach';
 import type { ListAction } from './types';
 
@@ -59,6 +60,21 @@ function renderRootOnce(client: ApiClient, baseUrl: string, token: string | null
         client,
         baseUrl,
         token,
+        onAction: (action: ListAction) => {
+          instance.unmount();
+          resolve(action);
+        },
+      }),
+    );
+  });
+}
+
+/** サイドバー用に SidebarApp を 1 回描画し、ユーザ操作（attach / quit）で解決して unmount する。 */
+function renderSidebarOnce(client: ApiClient, _baseUrl: string, _token: string | null): Promise<ListAction> {
+  return new Promise((resolve) => {
+    const instance = render(
+      React.createElement(SidebarApp, {
+        client,
         onAction: (action: ListAction) => {
           instance.unmount();
           resolve(action);
@@ -129,7 +145,7 @@ export async function startTui(opts: StartTuiOptions): Promise<void> {
   if (opts.sidebar) {
     markSidebarPane();
     for (;;) {
-      const action = await renderRootOnce(client, baseUrl, token);
+      const action = await renderSidebarOnce(client, baseUrl, token);
       if (action.type === 'quit') break;
       if (action.type === 'attach') switchClientWithSidebar(action.sessionName);
     }

--- a/tui/src/tmux/__tests__/attach.test.ts
+++ b/tui/src/tmux/__tests__/attach.test.ts
@@ -6,6 +6,7 @@ import {
   preAttachCommands,
   RETURN_KEY,
   SIDEBAR_WIDTH,
+  sidebarAutoEnabled,
   sidebarSplitArgs,
 } from '../attach';
 
@@ -71,6 +72,23 @@ describe('sidebarSplitArgs', () => {
     const args = sidebarSplitArgs('s', 30, 'cchub tui --sidebar -p 3456');
     expect(args).toContain('30');
     expect(args[args.length - 1]).toBe('cchub tui --sidebar -p 3456');
+  });
+});
+
+describe('sidebarAutoEnabled', () => {
+  test('未設定は既定で有効', () => {
+    expect(sidebarAutoEnabled({})).toBe(true);
+  });
+
+  test('0 / off / false（大文字小文字問わず）で無効', () => {
+    expect(sidebarAutoEnabled({ CCHUB_TUI_SIDEBAR: '0' })).toBe(false);
+    expect(sidebarAutoEnabled({ CCHUB_TUI_SIDEBAR: 'off' })).toBe(false);
+    expect(sidebarAutoEnabled({ CCHUB_TUI_SIDEBAR: 'FALSE' })).toBe(false);
+  });
+
+  test('その他の値（1 / on 等）は有効', () => {
+    expect(sidebarAutoEnabled({ CCHUB_TUI_SIDEBAR: '1' })).toBe(true);
+    expect(sidebarAutoEnabled({ CCHUB_TUI_SIDEBAR: 'on' })).toBe(true);
   });
 });
 

--- a/tui/src/tmux/attach.ts
+++ b/tui/src/tmux/attach.ts
@@ -93,6 +93,8 @@ export function planSwitchClient(sessionName: string): string[][] {
  * 戻り値は最後の tmux コマンド（switch-client）の exit code（成功=0）。
  */
 export function switchClient(sessionName: string): number {
+  // 既定レイアウト一貫性: popup 経由の切替でも切替え先にサイドバーを生やす。
+  if (sidebarAutoEnabled()) ensureSidebar(sessionName);
   const plan = planSwitchClient(sessionName);
   let lastCode = 0;
   for (const args of plan) {
@@ -107,7 +109,7 @@ export function switchClient(sessionName: string): number {
 }
 
 /** 常時表示サイドバーの既定幅（桁）。F10 バインドと provision で共有する。 */
-export const SIDEBAR_WIDTH = 48;
+export const SIDEBAR_WIDTH = 34;
 
 /** サイドバーとして開くペインを起動するコマンド文字列（tmux split-window に渡す）。 */
 export const SIDEBAR_SPAWN_CMD = 'cchub tui --sidebar';
@@ -165,6 +167,21 @@ export function switchClientWithSidebar(targetSession: string, width: number = S
   runTmux(['switch-client', '-t', targetSession]);
 }
 
+/**
+ * 入室時のサイドバー自動表示の有効/無効。既定は有効（herdr 風の「常に左に一覧」レイアウト）。
+ * `CCHUB_TUI_SIDEBAR=0|off|false` で無効化できる。
+ */
+export function sidebarAutoEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env.CCHUB_TUI_SIDEBAR ?? '').trim().toLowerCase();
+  return v !== '0' && v !== 'off' && v !== 'false';
+}
+
+/** 対象セッションにサイドバーが無ければ生やす（`-d` でフォーカスは作業ペインに残す）。 */
+export function ensureSidebar(sessionName: string, width: number = SIDEBAR_WIDTH): void {
+  if (sessionHasSidebar(sessionName)) return;
+  runTmux(sidebarSplitArgs(sessionName, width));
+}
+
 /** 子プロセスを stdio 継承で起動し、detach（= RETURN_KEY 等）まで同期的に待つ。 */
 export function attachSession(sessionName: string, tmuxEnv: string | undefined = process.env.TMUX): void {
   const plan = planAttach(sessionName, tmuxEnv);
@@ -189,6 +206,10 @@ export function attachSession(sessionName: string, tmuxEnv: string | undefined =
   // ここでの設定は web 側に影響しない（detach 後は元の値へ復元する）。
   const originalMouse = captureOption(sessionName, 'mouse');
   runTmux(['set-option', '-t', sessionName, 'mouse', 'on']);
+
+  // herdr 風の既定レイアウト: 入室時に左サイドバー（セッション一覧）を自動で開く。
+  // 既にあれば二重に開かない。フォーカスは作業ペインに残る（-d）。CCHUB_TUI_SIDEBAR=0 で無効。
+  if (sidebarAutoEnabled()) ensureSidebar(sessionName);
 
   Bun.spawnSync([plan.command, ...plan.args], {
     stdio: ['inherit', 'inherit', 'inherit'],


### PR DESCRIPTION
## Changes
- feat(tui): herdr 風の既定レイアウト — 入室時に左サイドバー（セッション一覧）を自動表示。狭幅向けの専用コンパクト表示（1セッション=1行）を新設、幅48→34桁。`CCHUB_TUI_SIDEBAR=0` で無効化可
- chore: bump version to 0.1.185

## Notes
全テスト green（frontend 37 / tui 74 / backend 284）。サイドバーの中身は Ink 製のため行のクリック選択は非対応（開くのはマウス、選ぶのは ↑↓/Enter）。完全マウス化（choose-tree 化）は別途検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)