### PR TITLE
Release v0.1.186

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.186] - 2026-07-06
+
+### Fixed
+- **react/react-dom のバージョン不整合でアプリが起動不能になる問題**: lockfile が react@19.2.6 / react-dom@19.2.4 と不整合なまま（v0.1.166 直後の tui scaffold 以降）で、依存の再インストールや vite の deps 再最適化を踏むと "Incompatible React versions" で White Screen になっていた。両方を 19.2.7 に整合させた（`frontend/package.json`, `bun.lock`）
+- **frontend の `bun:test` 型解決が backend への import 連鎖に偶然依存していた**: `@types/bun` を frontend に明示追加し、tsconfig に `types: ["bun"]` を設定（backend/tui と同じパターン）
+
+### Changed
+- **デッドコード除去（knip 走査）**: 未使用の export・関数・型・ファイル・依存を全ワークスペースから削除（31ファイル、−525行）。`session-history.ts` に重複していた `ConversationMessage` / `ToolUseInfo` / `ToolResultInfo` / `ToolResultImage` を `shared/types.ts` に一元化。未使用依存 `hono`・`sharp` を frontend から削除。ファイル内でのみ使用される約20シンボルを un-export（#379）
+
 ## [0.1.185] - 2026-07-04
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.185",
-  "generated": "2026-07-04",
+  "version": "0.1.186",
+  "generated": "2026-07-06",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.185",
-  "generated": "2026-07-04",
+  "version": "0.1.186",
+  "generated": "2026-07-06",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.185",
+  "version": "0.1.186",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Release v0.1.186

### Fixed
- react/react-dom のバージョン不整合（lockfile: react@19.2.6 / react-dom@19.2.4）でアプリが起動不能になる問題を修正 — 両方を 19.2.7 に整合
- frontend の `bun:test` 型解決を `@types/bun` + tsconfig `types` で自立化

### Changed
- デッドコード除去（knip 走査、31ファイル・−525行）: 重複型の `shared/types.ts` への一元化、未使用依存 `hono`/`sharp` の削除、約20シンボルの un-export（#379）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZqjfWd3hDVFqn2WRK2YVw