### PR TITLE
Release v0.1.191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.191] - 2026-07-13
+
+### Added
+- **`cchub tui` に複数 pane 分割表示**: 選択セッションの全 pane を tmux レイアウト通りに 1 画面へ合成描画（区切り線 │/─）。クリックで pane フォーカス切替、ホイールはマウス直下の pane へルーティング、**端末領域の右クリックメニューで split │（左右）/ split ─（上下）/ close pane**（split は元 pane の cwd を引き継ぎ、最後の 1 枚は close 不可）（`tui/src/embed/embed-tui.ts`）
+- **`cchub tui` にダッシュボードパネル**: サイドバーの `dash` ボタンまたは `D` キーで、Claude/Codex の使用率バー（5h/7d、状態色付き）・today のアクティビティ・システムメトリクス・disk をオーバーレイ表示。データはサーバの `/api/dashboard` から statusline.sh と同じ経路（HTTPS 自己署名許容＋Keychain の `cchub` パスワードで login → Bearer）で取得し、表示中は 5 秒ごとに自動更新。サーバ未起動時はエラーメッセージに degrade（`tui/src/embed/dashboard.ts`）
+
+### Changed
+- **`cchub tui` の描画エンジンを tmux 制御モード常駐クライアント化**: 毎フレームの `tmux` fork（macOS で 1 回 5〜20ms）をやめ、常駐 `tmux -C attach` へコマンドをパイプ（サブ ms）。`%output` をダーティ信号としたイベント駆動再描画＋行差分キャッシュ＋約 30fps レート制限＋Synchronized Output (DEC 2026) で、スクロール/ストリーミング時の遅さと点滅を解消（`tui/src/embed/tmux-ctl.ts`, `tui/src/embed/embed-tui.ts`）
+- **normal-screen の void 埋め（padFill）**: Claude Code 等の非 alt-screen TUI でカーソル行より下の空白を刈り、スクロールバックを上に継ぎ足して画面を埋める（web UI の PaneViewport と同じ方式）
+
+### Fixed
+- **トラックパッドの横スクロールで pane メニューが誤って開く問題**: SGR ホイールイベント（button 64〜67）をクリック判定から除外（`66 & 3 === 2` が右クリックに誤マッチしていた）。メニュー表示中のホイールがクリック扱いになる穴も修正
+- **描画中のカーソルちらつき**: カーソル可視性（DECTCEM）の切替を状態遷移時のみに限定し、サイドバー定期更新後にカーソル位置を pane へ復元
+- **罫線・ブロック文字（│ ─ █ ░）の幅計算**: 全角扱い（幅 2）していたのを幅 1 に修正し、メニューやバーの右罫線ズレを解消
+
 ## [0.1.190] - 2026-07-10
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.190",
-  "generated": "2026-07-10",
+  "version": "0.1.191",
+  "generated": "2026-07-13",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.190",
-  "generated": "2026-07-10",
+  "version": "0.1.191",
+  "generated": "2026-07-13",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.190",
+  "version": "0.1.191",
   "private": true,
   "workspaces": [
     "backend",

--- a/tui/src/embed/dashboard.ts
+++ b/tui/src/embed/dashboard.ts
@@ -1,0 +1,255 @@
+import type { DashboardResponse, UsageCycleInfo } from '../../../shared/types';
+
+/** 1 行ぶんの表示データ。text は ANSI を含まないプレーンテキスト、color は SGR パラメータ（例 '1;36', '32', '2'）。 */
+export interface DashRow {
+  text: string;
+  color?: string;
+}
+
+const BAR_WIDTH = 12;
+const FETCH_TIMEOUT_MS = 2000;
+
+/**
+ * 使用率(0-100)からブロック文字のバーを描画する（幅 BAR_WIDTH）。
+ */
+function renderBar(utilization: number): string {
+  const clamped = Math.max(0, Math.min(100, utilization));
+  const filled = Math.round((clamped / 100) * BAR_WIDTH);
+  const empty = BAR_WIDTH - filled;
+  return '█'.repeat(filled) + '░'.repeat(empty);
+}
+
+/**
+ * UsageCycleInfo.status を SGR カラーコードにマッピングする。
+ */
+function statusColor(status: UsageCycleInfo['status']): string {
+  if (status === 'warning') return '33';
+  if (status === 'danger' || status === 'exceeded') return '31';
+  return '32';
+}
+
+/**
+ * resetsAt (ISO 8601) をローカル時刻表記に変換する。
+ * includeDate=true の場合は `M/D HH:MM`、false の場合は `HH:MM`。
+ */
+function fmtResetTime(resetsAt: string, includeDate: boolean): string {
+  const date = new Date(resetsAt);
+  if (Number.isNaN(date.getTime())) return resetsAt;
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  if (!includeDate) return `${hh}:${mm}`;
+  return `${date.getMonth() + 1}/${date.getDate()} ${hh}:${mm}`;
+}
+
+/**
+ * 使用サイクル（5h / 7d）を 1 行に整形する。
+ */
+function fmtCycleRow(label: string, cycle: UsageCycleInfo, includeDate: boolean): DashRow {
+  const bar = renderBar(cycle.utilization);
+  const pct = Math.round(cycle.utilization);
+  const resets = fmtResetTime(cycle.resetsAt, includeDate);
+  return {
+    text: `${label}  [${bar}] ${pct}%  resets ${resets}`,
+    color: statusColor(cycle.status),
+  };
+}
+
+/**
+ * トークン数を k / M 単位に丸めて表示する（1000 未満はそのまま）。
+ */
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1000) return `${Math.round(n / 1000)}k`;
+  return `${n}`;
+}
+
+/**
+ * MB を GB に変換して小数 1 桁で表示する。
+ */
+function fmtGB(mb: number): string {
+  return (mb / 1024).toFixed(1);
+}
+
+/**
+ * text を width 以内に切り詰める（ASCII 前提、全角幅は考慮しない）。
+ */
+function truncate(text: string, width: number): string {
+  if (width <= 0) return '';
+  if (text.length <= width) return text;
+  return text.slice(0, width);
+}
+
+// CC Hub サーバは Tailscale 証明書の HTTPS で立つ（証明書の CN は ts.net 名なので
+// localhost アクセスでは検証を外す。statusline.sh の `curl -sk` と同じ）。
+// 証明書が無い環境向けに http へのフォールバックも試す。到達できた base URL と
+// 認証トークンはモジュール内にキャッシュする（パネルは 5 秒ごとに再取得するため）。
+let cachedBase: string | null = null;
+let cachedToken: string | null = null;
+
+/** タイムアウト付き fetch。ネットワーク到達不可は null。 */
+async function tryFetch(url: string, token: string | null, init?: RequestInit): Promise<Response | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = { ...(init?.headers as Record<string, string>) };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return await fetch(url, {
+      ...init,
+      headers,
+      signal: controller.signal,
+      // Bun 拡張: 自己署名/ホスト名不一致の証明書を許容（localhost への HTTPS 用）。
+      tls: { rejectUnauthorized: false },
+    } as RequestInit);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** サービスパスワード。env 優先、次に macOS Keychain（`cchub setup` が保存する）。 */
+function servicePassword(): string | null {
+  if (process.env.CCHUB_PASSWORD) return process.env.CCHUB_PASSWORD;
+  try {
+    const p = Bun.spawnSync(['security', 'find-generic-password', '-s', 'cchub', '-w'], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+    });
+    const s = p.stdout ? new TextDecoder().decode(p.stdout).trim() : '';
+    return s || null;
+  } catch {
+    return null;
+  }
+}
+
+/** /api/auth/login で JWT トークンを取得。失敗は null。 */
+async function login(base: string): Promise<string | null> {
+  const pw = servicePassword();
+  if (!pw) return null;
+  const res = await tryFetch(`${base}/api/auth/login`, null, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password: pw }),
+  });
+  if (!res?.ok) return null;
+  try {
+    const data = (await res.json()) as { token?: string };
+    return data.token || null;
+  } catch {
+    return null;
+  }
+}
+
+/** /api/dashboard を取得（base URL 解決・401 時の再ログイン込み）。 */
+async function fetchDashboard(): Promise<{ ok: true; data: DashboardResponse } | { ok: false; error: string }> {
+  const port = Number(process.env.CCHUB_PORT) || 5923;
+  const bases = cachedBase ? [cachedBase] : [`https://127.0.0.1:${port}`, `http://127.0.0.1:${port}`];
+  for (const base of bases) {
+    let res = await tryFetch(`${base}/api/dashboard`, cachedToken);
+    if (!res) continue;
+    cachedBase = base;
+    if (res.status === 401) {
+      const token = await login(base);
+      if (!token) return { ok: false, error: 'auth failed (password not found in Keychain)' };
+      cachedToken = token;
+      res = await tryFetch(`${base}/api/dashboard`, token);
+      if (!res) return { ok: false, error: 'server not reachable (start cchub server)' };
+      if (res.status === 401) return { ok: false, error: 'auth failed (invalid credentials)' };
+    }
+    if (!res.ok) return { ok: false, error: `server error (HTTP ${res.status})` };
+    try {
+      return { ok: true, data: (await res.json()) as DashboardResponse };
+    } catch {
+      return { ok: false, error: 'server error (invalid response body)' };
+    }
+  }
+  cachedBase = null;
+  return { ok: false, error: 'server not reachable (start cchub server)' };
+}
+
+/**
+ * CC Hub サーバから /api/dashboard を取得し、TUI 表示用の行データに整形する。
+ * @param width - 本文の表示幅。各行はこの幅に収まるよう切り詰められる。
+ */
+export async function fetchDashboardRows(
+  width: number
+): Promise<{ ok: true; rows: DashRow[] } | { ok: false; error: string }> {
+  const fetched = await fetchDashboard();
+  if (!fetched.ok) return fetched;
+  const data = fetched.data;
+
+  const rows: DashRow[] = [];
+  const push = (text: string, color?: string) => {
+    rows.push({ text: truncate(text, width), color });
+  };
+
+  // 1. claude セクション
+  const claudeRows: DashRow[] = [];
+  if (data.usageLimits) {
+    claudeRows.push(fmtCycleRow('5h ', data.usageLimits.fiveHour, false));
+    claudeRows.push(fmtCycleRow('7d ', data.usageLimits.sevenDay, true));
+  } else if (data.usageLimitsStatus?.errorReason) {
+    claudeRows.push({ text: `(usage unavailable: ${data.usageLimitsStatus.errorReason})`, color: '2' });
+  }
+  if (claudeRows.length > 0) {
+    push('claude', '1;36');
+    for (const row of claudeRows) push(row.text, row.color);
+  }
+
+  // 2. codex セクション
+  const codex = data.codexUsageLimits;
+  if (codex && (codex.fiveHour || codex.sevenDay)) {
+    push('codex', '1;36');
+    if (codex.fiveHour) {
+      const row = fmtCycleRow('5h ', codex.fiveHour, false);
+      push(row.text, row.color);
+    }
+    if (codex.sevenDay) {
+      const row = fmtCycleRow('7d ', codex.sevenDay, true);
+      push(row.text, row.color);
+    }
+    if (codex.rateLimitExceeded) {
+      push('(rate limit exceeded)', '31');
+    }
+  }
+
+  // 3. 空行
+  push('');
+
+  // 4. today セクション
+  const today = data.dailyActivity.length > 0 ? data.dailyActivity[data.dailyActivity.length - 1] : undefined;
+  if (today) {
+    push('today', '1;36');
+    push(
+      `${today.messageCount} msgs · ${today.sessionCount} sessions · in ${fmtTokens(today.tokensIn)} / out ${fmtTokens(today.tokensOut)} tokens`
+    );
+  }
+
+  // 5. system セクション
+  if (data.systemMetrics) {
+    push('system', '1;36');
+    const { current, loadAvg } = data.systemMetrics;
+    push(
+      `cpu ${Math.round(current.cpuPercent)}% · mem ${Math.round(current.memUsedPercent)}% (${fmtGB(current.memUsedMB)}/${fmtGB(current.memTotalMB)}GB) · load ${loadAvg[0].toFixed(2)}`
+    );
+    if (data.diskUsage) {
+      const usedPct = data.diskUsage.total > 0 ? Math.round((data.diskUsage.used / data.diskUsage.total) * 100) : 0;
+      const usedGB = Math.round(data.diskUsage.used / 1024 ** 3);
+      const totalGB = Math.round(data.diskUsage.total / 1024 ** 3);
+      push(`disk ${usedPct}% used (${usedGB}/${totalGB}GB)`);
+    }
+  }
+
+  // 6. 空行
+  push('');
+
+  // 7. フッタ
+  const footerParts: string[] = [];
+  if (data.version) footerParts.push(`cchub v${data.version}`);
+  if (data.connectedClients !== undefined) footerParts.push(`${data.connectedClients} client(s)`);
+  if (footerParts.length > 0) {
+    push(footerParts.join(' · '), '2');
+  }
+
+  return { ok: true, rows };
+}

--- a/tui/src/embed/embed-tui.ts
+++ b/tui/src/embed/embed-tui.ts
@@ -11,7 +11,9 @@
 // 実行: bun run tui/src/embed/embed-tui.ts   (= bun run dev:tui-embed)
 
 import { readdirSync, readFileSync } from 'node:fs';
+import { fetchDashboardRows, type DashRow } from './dashboard';
 import { listHistory, resumeCommand, type HistoryEntry } from './history';
+import { TmuxCtl } from './tmux-ctl';
 
 const ESC = '\x1b';
 const HIDE_CURSOR = `${ESC}[?25l`;
@@ -26,11 +28,19 @@ const CLEAR = `${ESC}[2J${ESC}[H`;
 const CLEAR_EOL = `${ESC}[K`;
 const MOUSE_PREFIX = `${ESC}[<`; // SGR マウス列の接頭辞
 
-const FRAME_MS = 33; // ~30fps
+// 再描画は tmux 制御モードの %output イベント駆動が基本。以下は保険と低頻度更新の間隔。
+const MIN_PAINT_MS = 33; // 再描画の最小間隔（~30fps 上限。%output ストームの間引き）
+const FALLBACK_REPAINT_MS = 250; // %output 取り逃し用のフォールバック再描画
+const SESSIONS_REFRESH_MS = 2000; // セッション一覧（ドット/詳細メタ）の更新間隔
+// Synchronized Output (DEC 2026): 対応端末（ghostty/iTerm2/kitty 等）は BSU..ESU の間の
+// 書き込みを 1 フレームでアトミックに反映する（未対応端末は単に無視）。
+const SYNC_ON = `${ESC}[?2026h`;
+const SYNC_OFF = `${ESC}[?2026l`;
 const LIST_TOP = 3; // セッション一覧の開始スクリーン行（1=タイトル, 2=アクションボタン, 3〜=一覧）
 const WHEEL_MIN_MS = 40; // alt-screen へのホイール転送の最小間隔（慣性フラッド抑制）
 const SIDEBAR_MIN = 20;
 const SIDEBAR_MAX = 32;
+const DASH_REFRESH_MS = 5000; // ダッシュボードパネル表示中の自動更新間隔
 
 const dec = new TextDecoder();
 function tmux(args: string[]): string {
@@ -128,6 +138,35 @@ function isAltScreen(pane: string): boolean {
   return tmux(['display-message', '-p', '-t', pane, '#{alternate_on}']).trim() === '1';
 }
 
+// ANSI エスケープを除いた「見た目が空行」判定（制御文字リテラルは biome が禁止するので構築）。
+const ANSI_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;:]*[A-Za-z]`, 'g');
+function isBlankLine(l: string): boolean {
+  return l.replace(ANSI_RE, '').trim() === '';
+}
+
+/**
+ * padFill（web UI の PaneViewport と同じ考え方）: normal-screen の Claude Code は
+ * カーソル周辺しか描かないため、pane の大半が未描画の空白（void）になる。
+ * カーソル行より下の空白を刈り、足りない分をスクロールバックで上に継ぎ足して
+ * 画面を埋める。カーソル y は継ぎ足した行数ぶん下へシフトする。
+ */
+async function padFill(
+  live: string[],
+  cursorY: number,
+  rows: number,
+  fetchHist: (n: number) => Promise<string[]>,
+): Promise<{ lines: string[]; cursorY: number }> {
+  let kept = Math.min(live.length, rows);
+  while (kept > 0 && kept - 1 > cursorY && isBlankLine(live[kept - 1])) kept--;
+  const prepend = Math.max(0, rows - kept);
+  if (prepend === 0) return { lines: live, cursorY };
+  const hist = await fetchHist(prepend);
+  const tail = hist.slice(-prepend);
+  const padTop = prepend - tail.length;
+  const blanks: string[] = new Array(Math.max(0, padTop)).fill('');
+  return { lines: [...blanks, ...tail, ...live.slice(0, kept)], cursorY: cursorY + prepend };
+}
+
 /** 生の入力バイトを hex 化して pane へ送る（エスケープ列・制御文字も忠実に転送できる）。 */
 function sendKeysHex(pane: string, data: string): void {
   const bytes = Array.from(Buffer.from(data, 'utf8')).map((b) => b.toString(16).padStart(2, '0'));
@@ -207,10 +246,79 @@ function moveTo(row: number, col: number): string {
   return `${ESC}[${row};${col}H`;
 }
 
+/** 表示幅ベースで width 桁ごとに折り返す（日本語=空白なしでも文字単位で改行）。maxLines で打ち切り。 */
+function wrapByWidth(text: string, width: number, maxLines: number): string[] {
+  if (width < 2) return [];
+  const lines: string[] = [];
+  let cur = '';
+  let curW = 0;
+  for (const ch of text) {
+    const w = (ch.codePointAt(0) ?? 0) > 0x2000 ? 2 : 1;
+    if (curW + w > width) {
+      lines.push(cur);
+      if (lines.length >= maxLines) return lines;
+      cur = ch;
+      curW = w;
+    } else {
+      cur += ch;
+      curW += w;
+    }
+  }
+  if (cur && lines.length < maxLines) lines.push(cur);
+  return lines;
+}
+
 function displayWidth(text: string): number {
   let w = 0;
-  for (const ch of text) w += (ch.codePointAt(0) ?? 0) > 0x2000 ? 2 : 1;
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0;
+    // 罫線・ブロック要素（U+2500–259F: │ ─ █ ░ 等）は曖昧幅だが端末では 1 桁描画が普通。
+    w += cp > 0x2000 && !(cp >= 0x2500 && cp <= 0x259f) ? 2 : 1;
+  }
   return w;
+}
+
+/** tmux pane のジオメトリ（ウィンドウ座標、0-based）。 */
+interface PaneRect {
+  id: string;
+  active: boolean;
+  left: number;
+  top: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * 複数 pane の 1 スクリーン行を、絶対位置指定の書き込み列として合成する。
+ * capture 行は行末の空白が刈られていて見た目幅が pane 幅に満たないことがあるため、
+ * 幅計算（wcwidth の曖昧幅問題）に頼らず「pane 幅ぶん空白で消してから内容を重ね書き」する。
+ * どの pane にも属さないセルは区切り線（幅 1 の隙間は │、それ以外は ─）。
+ */
+function composePaneRow(
+  views: Array<{ p: PaneRect; lines: string[] }>,
+  r: number,
+  termLeft: number,
+  termW: number,
+): string {
+  const segs = views.filter((v) => r >= v.p.top && r < v.p.top + v.p.h).sort((a, b) => a.p.left - b.p.left);
+  const sep = (col: number, n: number) =>
+    moveTo(r + 1, termLeft + col) + `${ESC}[90m${n === 1 ? '│' : '─'.repeat(n)}${RESET}`;
+  let out = '';
+  let col = 0;
+  for (const v of segs) {
+    if (v.p.left > col) out += sep(col, v.p.left - col);
+    const line = v.lines[r - v.p.top] ?? '';
+    out +=
+      moveTo(r + 1, termLeft + v.p.left) +
+      ' '.repeat(v.p.w) +
+      moveTo(r + 1, termLeft + v.p.left) +
+      RESET +
+      line +
+      RESET;
+    col = v.p.left + v.p.w;
+  }
+  if (col < termW) out += sep(col, termW - col);
+  return out;
 }
 
 function truncateDisplay(text: string, max: number): string {
@@ -250,6 +358,9 @@ async function main() {
   } | null = null;
   // 履歴から復帰パネル（開いている間は右領域にオーバーレイ表示）。
   let history: { entries: HistoryEntry[]; sel: number } | null = null;
+  // ダッシュボードパネル（開いている間は右領域にオーバーレイ表示。データはサーバ API から）。
+  let dash: { rows: DashRow[] | null; error: string | null } | null = null;
+  let dashFetchedAt = 0;
   // サイドバー幅の手動上書き（null=自動）。[ / ] で調整。
   let sidebarWidth: number | null = null;
   // 通常スクリーンの履歴スクロール量（0=ライブ）。alt-screen ではアプリ側に任せる。
@@ -259,17 +370,78 @@ async function main() {
   // alt-screen へホイールを最後に転送した時刻（レート制限用）。
   let lastWheelForward = 0;
   // サイドバーのクリック可能ボタンの x 範囲（renderSidebar で更新、クリック判定で参照）。
-  const actionBtns = { newBtn: [0, -1] as [number, number], histBtn: [0, -1] as [number, number] };
+  const actionBtns = {
+    newBtn: [0, -1] as [number, number],
+    histBtn: [0, -1] as [number, number],
+    dashBtn: [0, -1] as [number, number],
+  };
   // 一覧の最終スクリーン行（詳細パネルぶん減る）。クリック判定で「詳細/フッタ領域は選択しない」ために参照。
   let listBottomRow = 0;
   // 右クリックのコンテキストメニュー（開いている間は最前面に描画）。
-  let menu: { session: string; items: string[]; sel: number; mx: number; my: number; w: number } | null = null;
+  // kind: session=サイドバー行（セッション操作）/ pane=端末領域（pane 分割・クローズ）。
+  let menu: {
+    kind: 'session' | 'pane';
+    target: string;
+    title: string;
+    items: string[];
+    sel: number;
+    mx: number;
+    my: number;
+    w: number;
+  } | null = null;
   const resized = new Set<string>();
   let done = false;
 
+  // --- 常駐 tmux 制御クライアント（高速化の核）---
+  // 毎フレーム tmux を fork する（macOS で 1 回 5〜20ms）代わりに、1 本の `tmux -C attach`
+  // にコマンドをパイプで流し（サブ ms）、%output をダーティ通知として受けて必要な時だけ
+  // 再描画する。選択セッションの変更は switch-client で追従。切断時は spawn 経路へ fallback。
+  let ctl: TmuxCtl | null = null;
+  let ctlSession = '';
+
+  // 選択セッションの pane ジオメトリ（直近の paint で取得）。クリック→pane 解決と
+  // %output → 再描画判定に使う。セッション切替時にリセット。
+  let paneRects: PaneRect[] = [];
+  let paneIds = new Set<string>();
+
+  function ensureCtl(name: string | undefined) {
+    if (!name) return;
+    if (ctl && !ctl.closed) {
+      if (ctlSession !== name) {
+        ctlSession = name;
+        void ctl.exec(`switch-client -t ${name}`);
+      }
+      return;
+    }
+    ctlSession = name;
+    const c = new TmuxCtl(name);
+    c.onOutput = (paneId) => {
+      if (paneIds.has(paneId) || sessions[selected]?.activePane === paneId) renderTerminal();
+    };
+    c.onExit = () => {
+      if (ctl === c) ctl = null; // 以後は spawn fallback（次の選択/ティックで再接続）
+    };
+    ctl = c;
+    // 制御クライアントの申告サイズで window が縮まないよう、右領域サイズを申告しておく。
+    const { rows, termW } = layout();
+    void c.exec(`refresh-client -C ${Math.max(20, termW)}x${Math.max(5, rows)}`);
+  }
+
+  /** 入力転送（可能なら制御クライアント経由 = fork なし）。 */
+  function sendInput(pane: string, data: string) {
+    if (ctl && !ctl.closed) {
+      const bytes = Array.from(Buffer.from(data, 'utf8')).map((b) => b.toString(16).padStart(2, '0'));
+      if (bytes.length) void ctl.exec(`send-keys -H -t ${pane} ${bytes.join(' ')}`);
+    } else {
+      sendKeysHex(pane, data);
+    }
+  }
+
   const write = (s: string) => {
     try {
-      stdout.write(s);
+      // Synchronized Output で包む: 対応端末は途中状態を描かず 1 フレームで反映（ティアリング防止）。
+      if (process.env.CCHUB_TUI_NOSYNC) stdout.write(s);
+      else stdout.write(SYNC_ON + s + SYNC_OFF);
     } catch {
       // best-effort
     }
@@ -291,8 +463,15 @@ async function main() {
     const s = sessions[selected];
     if (!s) return;
     const { rows, termW } = layout();
-    tmux(['set-option', '-t', s.name, 'window-size', 'manual']);
-    tmux(['resize-window', '-t', s.name, '-x', String(Math.max(20, termW)), '-y', String(Math.max(5, rows))]);
+    const w = String(Math.max(20, termW));
+    const h = String(Math.max(5, rows));
+    if (ctl && !ctl.closed) {
+      void ctl.exec(`set-option -t ${s.name} window-size manual`);
+      void ctl.exec(`resize-window -t ${s.name} -x ${w} -y ${h}`);
+    } else {
+      tmux(['set-option', '-t', s.name, 'window-size', 'manual']);
+      tmux(['resize-window', '-t', s.name, '-x', w, '-y', h]);
+    }
     resized.add(s.name);
   }
 
@@ -300,26 +479,48 @@ async function main() {
     const { rows, sidebarW } = layout();
     const sidebarActive = focus === 'sidebar';
     let out = '';
+    // 重要: サイドバーの行は CLEAR_EOL（行末まで消去）を使わない。行末まで消すと右の
+    // 端末領域まで白紙化し、差分描画キャッシュは「変化なし」と思って再描画しないため
+    // 画面が消えたままになる。かわりにサイドバー幅ちょうどまで空白でパディングする。
+    const pad = (plainWidth: number) => ' '.repeat(Math.max(0, sidebarW - plainWidth));
     // タイトル: フォーカス中は明るい cyan＋◀ 印、非フォーカスは暗く。
-    const title = sidebarActive ? '≡ sessions ◀' : '≡ sessions';
+    const title = truncateDisplay(sidebarActive ? '≡ sessions ◀' : '≡ sessions', sidebarW);
     const titleStyle = sidebarActive ? '1;36' : '2';
-    out += moveTo(1, 1) + `${ESC}[${titleStyle}m${truncateDisplay(title, sidebarW)}${RESET}${CLEAR_EOL}`;
-    // アクションボタン行（クリック可能）: [ + 新規 ] [ 履歴 ]。x 範囲を記録して当たり判定に使う。
-    const newLabel = ' + 新規 ';
-    const histLabel = ' 履歴 ';
+    out += moveTo(1, 1) + `${ESC}[${titleStyle}m${title}${RESET}` + pad(displayWidth(title));
+    // アクションボタン行（クリック可能）: [ +new ] [ hist ] [ dash ]。x 範囲を記録して当たり判定に使う。
+    const newLabel = ' +new ';
+    const histLabel = ' hist ';
+    const dashLabel = ' dash ';
     const wNew = displayWidth(newLabel);
     const wHist = displayWidth(histLabel);
+    const wDash = displayWidth(dashLabel);
     actionBtns.newBtn = [1, wNew];
     actionBtns.histBtn = [wNew + 2, wNew + 1 + wHist];
-    out += `${moveTo(2, 1)}${ESC}[7;36m${newLabel}${RESET} ${ESC}[7;35m${histLabel}${RESET}${CLEAR_EOL}`;
+    actionBtns.dashBtn = [wNew + wHist + 3, wNew + wHist + 2 + wDash];
+    out +=
+      `${moveTo(2, 1)}${ESC}[7;36m${newLabel}${RESET} ${ESC}[7;35m${histLabel}${RESET} ${ESC}[7;34m${dashLabel}${RESET}` +
+      pad(wNew + wHist + wDash + 2);
 
-    // 詳細パネル: 選択セッションの recap/branch/tokens/ctx を下部3行に表示（画面が十分高い時のみ）。
-    // 一覧はそのぶん短くする。footer=rows, detail=rows-3..rows-1, list=LIST_TOP..rows-4。
+    // 詳細パネル: 選択セッションの recap（複数行折り返し）/ branch·tokens·ctx を
+    // 一覧の「直下」に表示する（最下部固定だと間に空白が空いて遠すぎるため）。
+    // 一覧に最低2行を残しつつ、区切り + recap 最大4行 + meta を割り当てる。
     const sel = sessions[selected];
-    const hasDetail = rows >= 9 && !!sel && !!(sel.recap || sel.branch || sel.tokens || sel.ctx);
-    const detailTop = hasDetail ? rows - 3 : rows; // 詳細が無ければ list はフッタ直前まで
-    const lastListRow = detailTop - 1; // これ以下が一覧領域（フッタは常に rows）
-    listBottomRow = lastListRow; // クリック判定用
+    const hasData = !!sel && !!(sel.recap || sel.branch || sel.tokens || sel.ctx);
+    const region = rows - LIST_TOP; // 一覧+詳細に使える行数（screen rows LIST_TOP..rows-1）
+    let recapLines = 0;
+    let detailHeight = 0;
+    if (hasData && region - Math.min(sessions.length, 2) >= 3) {
+      // 一覧が長い場合は一覧側を削る（最低2行は残す）。
+      const maxDetail = region - Math.min(sessions.length, Math.max(2, region - 3));
+      const budget = Math.max(3, Math.min(6, region - Math.min(sessions.length, region - 3)));
+      recapLines = Math.max(1, Math.min(4, budget - 2)); // 区切り + meta = 2
+      detailHeight = recapLines + 2;
+      void maxDetail;
+    }
+    // 一覧の表示可能行数（詳細とフッタを差し引く）。
+    const visibleSessions = Math.min(sessions.length, region - detailHeight);
+    const lastListRow = LIST_TOP + visibleSessions - 1;
+    listBottomRow = lastListRow; // クリック判定用（実在する行まで）
 
     sessions.forEach((s, i) => {
       const row = i + LIST_TOP;
@@ -331,62 +532,263 @@ async function main() {
       // 選択行: サイドバーフォーカス中は cyan 反転、そうでなければ通常反転（暗め）。
       if (i === selected) out += `${ESC}[7${sidebarActive ? ';36' : ''}m${label}${RESET}`;
       else out += label;
-      out += CLEAR_EOL;
+      out += pad(displayWidth(label));
     });
-    // 一覧の余白行をクリア（詳細パネルの上まで）。
-    for (let r = LIST_TOP + sessions.length; r <= lastListRow; r++) out += moveTo(r, 1) + CLEAR_EOL;
 
-    // 詳細パネル。
-    if (hasDetail && sel) {
-      const rule = `─ 詳細 ${'─'.repeat(Math.max(0, sidebarW - 5))}`;
-      out += `${moveTo(rows - 3, 1)}${ESC}[90m${truncateDisplay(rule, sidebarW)}${RESET}${CLEAR_EOL}`;
-      const recapLine = sel.recap ? sel.recap : '—';
-      out += `${moveTo(rows - 2, 1)}${ESC}[2m${truncateDisplay(recapLine, sidebarW)}${RESET}${CLEAR_EOL}`;
+    // 詳細パネル（一覧の直下）。
+    let cursorRow = lastListRow + 1;
+    if (detailHeight > 0 && sel) {
+      const rule = truncateDisplay(`─ detail ${'─'.repeat(Math.max(0, sidebarW - 5))}`, sidebarW);
+      out += `${moveTo(cursorRow++, 1)}${ESC}[90m${rule}${RESET}` + pad(displayWidth(rule));
+      const recapWrapped = sel.recap ? wrapByWidth(sel.recap, sidebarW, recapLines) : ['—'];
+      for (let i = 0; i < recapLines; i++) {
+        const t = recapWrapped[i] ?? '';
+        out += `${moveTo(cursorRow++, 1)}${ESC}[37m${t}${RESET}` + pad(displayWidth(t));
+      }
       const metaParts: string[] = [];
       if (sel.branch) metaParts.push(`⎇ ${sel.branch}`);
       if (sel.tokens) metaParts.push(sel.tokens);
       if (sel.ctx) metaParts.push(`ctx ${sel.ctx}%`);
-      out += `${moveTo(rows - 1, 1)}${ESC}[36m${truncateDisplay(metaParts.join('  '), sidebarW)}${RESET}${CLEAR_EOL}`;
+      const metaText = truncateDisplay(metaParts.join('  '), sidebarW);
+      out += `${moveTo(cursorRow++, 1)}${ESC}[36m${metaText}${RESET}` + pad(displayWidth(metaText));
     }
+    // 残りの余白行をフッタ手前まで空白で塗る（CLEAR_EOL は右領域を消すので使わない）。
+    for (let r = cursorRow; r <= rows - 1; r++) out += moveTo(r, 1) + pad(0);
     // 区切り線: フォーカスのある側を cyan、無い側は暗いグレー。
     const sepColor = sidebarActive ? '90' : '36';
     for (let r = 1; r <= rows; r++) out += moveTo(r, sidebarW + 1) + `${ESC}[${sepColor}m│${RESET}`;
     // フッタ: モードバッジ（反転）＋ヒント。
-    const badge = sidebarActive ? `${ESC}[7;36m 一覧 ${RESET}` : `${ESC}[7;33m 端末 ${RESET}`;
-    const hint = sidebarActive ? ' ↑↓ Enter n H:履歴 [] q' : ' Ctrl-B で一覧へ';
-    out += moveTo(rows, 1) + badge + `${ESC}[2m${truncateDisplay(hint, Math.max(0, sidebarW - 6))}${RESET}${CLEAR_EOL}`;
+    const badge = sidebarActive ? `${ESC}[7;36m LIST ${RESET}` : `${ESC}[7;33m TERM ${RESET}`;
+    const hint = truncateDisplay(sidebarActive ? ' ↑↓ Enter n H D [] q' : ' Ctrl-B: back to list', Math.max(0, sidebarW - 6));
+    out += moveTo(rows, 1) + badge + `${ESC}[2m${hint}${RESET}` + pad(6 + displayWidth(hint));
+    // 端末フォーカス中は、サイドバー描画で動いたカーソルを pane の位置へ戻す
+    // （戻さないと 2 秒ごとの一覧更新のたびにカーソルが左へ飛んでちらつく）。
+    if (focus === 'terminal' && lastCurKey && lastCurKey !== 'hidden') {
+      const [cx, cy] = lastCurKey.split(',').map((n) => Number.parseInt(n, 10));
+      if (Number.isFinite(cx) && Number.isFinite(cy)) out += moveTo(cy + 1, sidebarW + 2 + cx);
+    }
     write(out);
   }
 
+  // --- 端末領域の再描画（イベント駆動・非同期・差分・レート制限）---
+  // renderTerminal() はトリガ。実描画は paintTerminal()（ctl 経由なら fork なし）。
+  // 点滅防止:
+  //   1. 前回描画した行をキャッシュし、変わった行だけ書く（無変化なら 0 バイト）
+  //   2. 描画は最大 ~30fps に間引く（%output はストリーミング中に毎秒何十回も飛ぶ）
+  //   3. write() を Synchronized Output (DEC 2026) で包み、対応端末では描画をアトミックに
+  let paintCache: string[] | null = null;
+  let paintGeom = '';
+  let lastCurKey = '';
+  let painting = false;
+  let pendingPaint = false;
+  let paintTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastPaintAt = 0;
+
+  /** 端末領域のキャッシュを無効化（オーバーレイ表示や画面クリアで内容が壊れた時に呼ぶ）。 */
+  function invalidatePaint() {
+    paintCache = null;
+    lastCurKey = '';
+  }
+
   function renderTerminal() {
+    if (painting) {
+      pendingPaint = true;
+      return;
+    }
+    if (paintTimer) return; // 既にスケジュール済み
+    const since = Date.now() - lastPaintAt;
+    const delay = since >= MIN_PAINT_MS ? 0 : MIN_PAINT_MS - since;
+    paintTimer = setTimeout(() => {
+      paintTimer = null;
+      painting = true;
+      lastPaintAt = Date.now();
+      void paintTerminal().finally(() => {
+        painting = false;
+        if (pendingPaint) {
+          pendingPaint = false;
+          renderTerminal(); // レート制限を通して次を予約
+        }
+      });
+    }, delay);
+  }
+
+  /** セッションの pane 一覧（ジオメトリ付き）。可能なら制御クライアント経由。 */
+  async function fetchPanes(name: string): Promise<PaneRect[]> {
+    const FMT = '#{pane_id},#{pane_active},#{pane_left},#{pane_top},#{pane_width},#{pane_height}';
+    let raw: string[];
+    if (ctl && !ctl.closed) {
+      raw = await ctl.exec(`list-panes -t ${name} -F '${FMT}'`);
+      // 空応答 = 切断中（fetchPaneView と同じ理由）。spawn へフォールバック。
+      if (raw.length === 0) raw = tmux(['list-panes', '-t', name, '-F', FMT]).split('\n');
+    } else {
+      raw = tmux(['list-panes', '-t', name, '-F', FMT]).split('\n');
+    }
+    const out: PaneRect[] = [];
+    for (const line of raw) {
+      const [id, active, left, top, w, h] = line.trim().split(',');
+      if (!id?.startsWith('%')) continue;
+      out.push({
+        id,
+        active: active === '1',
+        left: Number.parseInt(left, 10) || 0,
+        top: Number.parseInt(top, 10) || 0,
+        w: Number.parseInt(w, 10) || 1,
+        h: Number.parseInt(h, 10) || 1,
+      });
+    }
+    return out;
+  }
+
+  /** スクリーン座標 (x,y) が乗っている pane（直近 paint のジオメトリで解決）。 */
+  function paneAt(x: number, y: number): PaneRect | null {
+    const { termLeft } = layout();
+    const wx = x - termLeft;
+    const wy = y - 1;
+    for (const p of paneRects) {
+      if (wx >= p.left && wx < p.left + p.w && wy >= p.top && wy < p.top + p.h) return p;
+    }
+    return null;
+  }
+
+  /** pane をアクティブにする（クリックフォーカス）。 */
+  function focusPane(p: PaneRect) {
+    const s = sessions[selected];
+    if (!s || s.activePane === p.id) return;
+    if (ctl && !ctl.closed) void ctl.exec(`select-pane -t ${p.id}`);
+    else tmux(['select-pane', '-t', p.id]);
+    s.activePane = p.id;
+    scrollOffset = 0;
+    renderTerminal();
+  }
+
+  /** pane の alt/カーソル/画面内容を取得（可能なら常駐制御クライアント経由 = fork なし）。 */
+  async function fetchPaneView(
+    pane: string,
+    rows: number,
+    offset: number,
+  ): Promise<{ cur: { x: number; y: number } | null; lines: string[] }> {
+    if (ctl && !ctl.closed) {
+      // 注意: 制御モードのコマンド行では未クオートの `#` がコメント扱いになるため、
+      // フォーマットは必ずシングルクオートで包む。
+      const c = ctl;
+      const meta = await c.exec(`display-message -p -t ${pane} '#{alternate_on},#{cursor_x},#{cursor_y}'`);
+      const [altS = '', xS = '', yS = ''] = (meta[0] ?? '').split(',');
+      const x = Number.parseInt(xS, 10);
+      const y = Number.parseInt(yS, 10);
+      const alt = altS === '1';
+      const off = alt ? 0 : offset;
+      const cmd =
+        off <= 0
+          ? `capture-pane -e -p -t ${pane}`
+          : `capture-pane -e -p -t ${pane} -S -${off} -E ${rows - 1 - off}`;
+      const lines = await c.exec(cmd);
+      // 空応答 = 切断（markClosed が未応答を [] で解決する）や失敗。実在 pane の capture が
+      // 0 行になることはない（空画面でも空文字の行が返る）ので、ここでブランクを描かず
+      // 下の spawn 経路へフォールバックする（切断中の「画面が消える」を防ぐ）。
+      if (lines.length > 0) {
+        const okCur = Number.isFinite(x) && Number.isFinite(y);
+        if (!alt && off === 0 && okCur) {
+          // normal-screen（Claude Code 等）は void をスクロールバックで埋める。
+          const filled = await padFill(lines, y, rows, (n) =>
+            c.exec(`capture-pane -e -p -t ${pane} -S -${n} -E -1`),
+          );
+          return { cur: { x, y: filled.cursorY }, lines: filled.lines };
+        }
+        return { cur: okCur ? { x, y } : null, lines };
+      }
+    }
+    // fallback: 使い捨て spawn（制御クライアント切断時）。
+    const alt = isAltScreen(pane);
+    const off = alt ? 0 : offset;
+    const lines = capture(pane, off, rows);
+    const cur = paneCursor(pane);
+    if (!alt && off === 0 && cur) {
+      const filled = await padFill(lines, cur.y, rows, (n) =>
+        Promise.resolve(tmux(['capture-pane', '-e', '-p', '-t', pane, '-S', `-${n}`, '-E', '-1']).split('\n')),
+      );
+      return { cur: { x: cur.x, y: filled.cursorY }, lines: filled.lines };
+    }
+    return { cur, lines };
+  }
+
+  async function paintTerminal(): Promise<void> {
+    if (done || creating || history || dash) return; // オーバーレイ表示中は上書きしない
     const { rows, termLeft, termW } = layout();
     const s = sessions[selected];
-    let out = '';
-    // alt-screen（Claude Code 等）は履歴 offset を使わず常にライブ画面を映す
-    // （スクロールはアプリ自身が代替スクリーン内でやる）。通常スクリーンは offset で遡る。
-    const alt = s?.activePane ? isAltScreen(s.activePane) : false;
-    const off = alt ? 0 : scrollOffset;
-    const lines = s?.activePane
-      ? capture(s.activePane, off, rows)
-      : sessions.length === 0
-        ? ['', '  他のセッションがありません。', '  （このセッション自身は自己参照防止のため除外しています）']
-        : [];
+    let lines: string[] = [];
+    let cur: { x: number; y: number } | null = null;
+    let multi = false; // 複数 pane 合成モード（行内に絶対位置指定を含むので CLEAR_EOL を付けない）
+    if (s) {
+      const panes = await fetchPanes(s.name);
+      if (panes.length > 0) {
+        paneRects = panes;
+        paneIds = new Set(panes.map((p) => p.id));
+        const act = panes.find((p) => p.active) ?? panes[0];
+        s.activePane = act.id;
+        if (panes.length === 1) {
+          ({ cur, lines } = await fetchPaneView(act.id, rows, scrollOffset));
+        } else {
+          // 複数 pane: 各 pane を個別に取得し、ジオメトリ通りに 1 画面へ合成する。
+          // 履歴スクロールはアクティブ pane のみ。
+          multi = true;
+          const views = await Promise.all(
+            panes.map(async (p) => ({
+              p,
+              v: await fetchPaneView(p.id, p.h, p.active ? scrollOffset : 0),
+            })),
+          );
+          const flat = views.map((x) => ({ p: x.p, lines: x.v.lines }));
+          lines = [];
+          for (let r = 0; r < rows; r++) lines.push(composePaneRow(flat, r, termLeft, termW));
+          const av = views.find((x) => x.p.active);
+          if (av?.v.cur) cur = { x: av.v.cur.x + av.p.left, y: av.v.cur.y + av.p.top };
+        }
+      }
+    } else if (sessions.length === 0) {
+      lines = ['', '  no other sessions', '  (this session is hidden to avoid recursion)'];
+    }
+    if (done || creating || history || dash) return; // await 中にオーバーレイが開いたら破棄
+
+    // 差分描画: 変わった行だけ書く（全行書き直しは点滅の原因）。
+    const clipped: string[] = [];
     for (let r = 0; r < rows; r++) {
       const line = lines[r] ?? '';
-      out += moveTo(r + 1, termLeft) + RESET;
-      // 領域幅にクリップ（表示幅で切る）。エスケープ込みなのでざっくり文字数で。
-      out += line.length > termW * 2 ? line.slice(0, termW * 2) : line;
-      out += `${RESET}${CLEAR_EOL}`;
+      // 領域幅にクリップ（エスケープ込みなのでざっくり文字数で）。合成行は位置指定込みで
+      // 幅が構造上保証されているのでクリップしない（途中で切るとエスケープが壊れる）。
+      clipped.push(!multi && line.length > termW * 2 ? line.slice(0, termW * 2) : line);
     }
-    // 端末フォーカス中は pane のカーソル位置に自前カーソルを合わせて表示。
-    if (focus === 'terminal' && s?.activePane) {
-      const cur = paneCursor(s.activePane);
-      if (cur && cur.y < rows) out += moveTo(cur.y + 1, termLeft + cur.x) + SHOW_CURSOR;
-      else out += HIDE_CURSOR;
-    } else {
-      out += HIDE_CURSOR;
+    const geom = `${termLeft}:${termW}:${rows}:${multi ? 'm' : 's'}`;
+    const full = paintCache === null || paintGeom !== geom;
+    let out = '';
+    for (let r = 0; r < rows; r++) {
+      if (full || paintCache?.[r] !== clipped[r]) {
+        // 合成行は絶対位置指定＋pane 幅ぶんの空白消去を内包するので、そのまま書く。
+        if (multi) out += clipped[r];
+        else out += moveTo(r + 1, termLeft) + RESET + clipped[r] + RESET + CLEAR_EOL;
+      }
     }
-    write(out);
+    paintCache = clipped;
+    paintGeom = geom;
+
+    // カーソル: 端末フォーカス中は pane の位置に表示。
+    // 重要: 毎フレーム HIDE→SHOW を繰り返すとカーソルがちらつくので、
+    // 可視性(DECTCEM)の切替は「状態が変わる時だけ」発行し、位置移動は毎回最後に行う。
+    // 書き込み途中のカーソル移動は Synchronized Output が隠す。
+    const showCur = focus === 'terminal' && !!s?.activePane && !!cur && cur.y < rows;
+    const curKey = showCur && cur ? `${cur.x},${cur.y}` : 'hidden';
+    if (out || curKey !== lastCurKey) {
+      const wasHidden = lastCurKey === 'hidden';
+      const unknown = lastCurKey === ''; // invalidate 直後は状態不明 → 必ず適用
+      if (showCur && cur) {
+        out += moveTo(cur.y + 1, termLeft + cur.x);
+        if (wasHidden || unknown) out += SHOW_CURSOR;
+      } else if (!wasHidden || unknown) {
+        out += HIDE_CURSOR;
+      }
+      write(out);
+      lastCurKey = curKey;
+    }
+    if (menu) renderMenu(); // メニューは最前面に重ねる
   }
 
   function openCreate() {
@@ -400,8 +802,67 @@ async function main() {
     renderHistory();
   }
 
+  function openDashboard() {
+    dash = { rows: null, error: null };
+    renderDash();
+    void refreshDash();
+  }
+
+  /** サーバ (/api/dashboard) からダッシュボードを取得して再描画。開いている間は定期更新。 */
+  async function refreshDash() {
+    if (!dash) return;
+    const { termW } = layout();
+    const res = await fetchDashboardRows(Math.max(20, termW - 4));
+    if (!dash || done) return; // await 中に閉じられたら破棄
+    dashFetchedAt = Date.now();
+    dash = res.ok ? { rows: res.rows, error: null } : { rows: null, error: res.error };
+    renderDash();
+  }
+
+  function renderDash() {
+    if (!dash) return;
+    invalidatePaint(); // 右領域を上書きするので閉じた後は全再描画
+    const d = dash;
+    const { rows, termLeft, termW } = layout();
+    const W = Math.max(24, termW);
+    const inner = W - 2; // 枠の内側幅
+    const B = (s: string) => `${ESC}[36m${s}${RESET}`; // 枠は cyan
+    let out = HIDE_CURSOR;
+    for (let r = 1; r <= rows; r++) out += moveTo(r, termLeft) + RESET + CLEAR_EOL;
+
+    const put = (r: number, s: string) => {
+      out += moveTo(r, termLeft) + s;
+    };
+    const bodyRow = (text: string, color?: string) => {
+      const t = truncateDisplay(text, inner - 1);
+      const padded = ` ${t}${' '.repeat(Math.max(0, inner - 1 - displayWidth(t)))}`;
+      const body = color ? `${ESC}[${color}m${padded}${RESET}` : padded;
+      return B('│') + body + B('│');
+    };
+    const sep = (l: string, r: string) => B(l + '─'.repeat(inner) + r);
+
+    const title = ' dashboard ';
+    put(1, B(`┌─${title}${'─'.repeat(Math.max(0, inner - displayWidth(title) - 1))}┐`));
+    put(2, sep('├', '┤'));
+
+    const bodyTop = 3;
+    const bodyRows = Math.max(1, rows - 5);
+    const content: DashRow[] =
+      d.rows ?? [{ text: d.error ? `⚠ ${d.error}` : 'loading…', color: d.error ? '31' : '2' }];
+    for (let i = 0; i < bodyRows; i++) {
+      const row = content[i];
+      put(bodyTop + i, row ? bodyRow(row.text, row.color) : bodyRow(''));
+    }
+
+    put(rows - 2, sep('├', '┤'));
+    put(rows - 1, bodyRow('r: refresh · Esc: close', '2'));
+    put(rows, sep('└', '┘'));
+    write(out);
+  }
+
   function renderCreate() {
     if (!creating) return;
+    invalidatePaint(); // 右領域を上書きするので閉じた後は全再描画
     const c = creating;
     const { rows, termLeft, termW } = layout();
     const W = Math.max(24, termW);
@@ -425,7 +886,7 @@ async function main() {
     const sep = (l: string, r: string) => B(l + '─'.repeat(inner) + r);
 
     // 上枠＋タイトル、パスバー、区切り。
-    const title = ' 新規セッション ';
+    const title = ' new session ';
     put(1, B(`┌─${title}${'─'.repeat(Math.max(0, inner - displayWidth(title) - 1))}┐`));
     put(2, bodyRow(`📂 ${c.dir}`, { color: '1;36' }));
     put(3, sep('├', '┤'));
@@ -455,7 +916,7 @@ async function main() {
     // 区切り＋フッタ（agent 選択はブラケットで表示）＋下枠。
     put(rows - 2, sep('├', '┤'));
     const agent = (a: string) => (c.agent === a ? `[${a}]` : ` ${a} `);
-    put(rows - 1, bodyRow(`agent ${agent('claude')} ${agent('codex')}  ·  クリック:開く 📂:作成 c:作成 Esc`, { color: '2' }));
+    put(rows - 1, bodyRow(`agent ${agent('claude')} ${agent('codex')}  ·  click:open 📂:create-here c:create Esc`, { color: '2' }));
     put(rows, sep('└', '┘'));
     write(out);
   }
@@ -469,6 +930,7 @@ async function main() {
     if (idx >= 0) {
       selected = idx;
       sessions[selected].activePane = activePaneOf(name);
+      ensureCtl(name);
       fitSelected();
     }
     focus = 'terminal';
@@ -478,6 +940,7 @@ async function main() {
 
   function renderHistory() {
     if (!history) return;
+    invalidatePaint(); // 右領域を上書きするので閉じた後は全再描画
     const h = history;
     const { rows, termLeft, termW } = layout();
     const W = Math.max(24, termW);
@@ -500,7 +963,7 @@ async function main() {
     const sep = (l: string, r: string) => B(l + '─'.repeat(inner) + r);
 
     // 上枠＋タイトル、区切り。
-    const title = ' 履歴から復帰 ';
+    const title = ' resume from history ';
     put(1, B(`┌─${title}${'─'.repeat(Math.max(0, inner - displayWidth(title) - 1))}┐`));
     put(2, sep('├', '┤'));
 
@@ -512,7 +975,7 @@ async function main() {
       const idx = start + i;
       const r = listTop + i;
       if (idx >= h.entries.length) {
-        if (h.entries.length === 0 && i === 0) put(r, bodyRow('(履歴なし)', { color: '2' }));
+        if (h.entries.length === 0 && i === 0) put(r, bodyRow('(no history)', { color: '2' }));
         else put(r, bodyRow(''));
         continue;
       }
@@ -544,7 +1007,7 @@ async function main() {
 
     // 区切り＋フッタ＋下枠。
     put(rows - 2, sep('├', '┤'));
-    put(rows - 1, bodyRow('↑↓ 移動 · Enter/クリック 復帰 · Esc 中止', { color: '2' }));
+    put(rows - 1, bodyRow('↑↓ move · Enter/click: resume · Esc', { color: '2' }));
     put(rows, sep('└', '┘'));
     write(out);
   }
@@ -560,6 +1023,7 @@ async function main() {
     if (idx >= 0) {
       selected = idx;
       sessions[selected].activePane = activePaneOf(name);
+      ensureCtl(name);
       fitSelected();
     }
     focus = 'terminal';
@@ -567,14 +1031,13 @@ async function main() {
     renderTerminal();
   }
 
-  function openMenu(session: string, clickX: number, clickY: number) {
+  function openMenu(kind: 'session' | 'pane', target: string, rawTitle: string, items: string[], clickX: number, clickY: number) {
     const { rows, cols } = layout();
-    const items = ['閉じる', 'キャンセル'];
-    const title = truncateDisplay(session, 20);
+    const title = truncateDisplay(rawTitle, 20);
     const w = Math.max(displayWidth(title) + 2, ...items.map((l) => displayWidth(l) + 2), 10);
     const mx = Math.max(1, Math.min(clickX, cols - w - 2));
     const my = Math.max(1, Math.min(clickY, rows - items.length - 2));
-    menu = { session, items, sel: 0, mx, my, w };
+    menu = { kind, target, title, items, sel: 0, mx, my, w };
     renderMenu();
   }
 
@@ -586,7 +1049,7 @@ async function main() {
     const at = (r: number, s: string) => {
       out += moveTo(r, m.mx) + s;
     };
-    const title = truncateDisplay(m.session, m.w - 2);
+    const title = truncateDisplay(m.title, m.w - 2);
     at(m.my, bd(`┌─${title}${'─'.repeat(Math.max(0, m.w - displayWidth(title) - 1))}┐`));
     m.items.forEach((label, i) => {
       const t = ` ${label}${' '.repeat(Math.max(0, m.w - 1 - displayWidth(label)))}`;
@@ -598,6 +1061,7 @@ async function main() {
 
   function closeMenu() {
     menu = null;
+    invalidatePaint();
     write(CLEAR);
     renderSidebar();
     renderTerminal();
@@ -607,16 +1071,30 @@ async function main() {
     const m = menu;
     if (!m) return;
     menu = null;
-    if (idx === 0) {
-      // 閉じる
-      killSessionByName(m.session);
+    const label = m.items[idx] ?? 'cancel';
+    if (m.kind === 'session' && label === 'close') {
+      killSessionByName(m.target);
       refreshSessions();
       if (selected >= sessions.length) selected = Math.max(0, sessions.length - 1);
       scrollOffset = 0;
       const cur = sessions[selected];
       if (cur) cur.activePane = activePaneOf(cur.name);
       focus = 'sidebar';
+    } else if (m.kind === 'pane' && label !== 'cancel') {
+      // split は分割先 pane のカレントディレクトリを引き継ぐ（-c はフォーマット展開される）。
+      // 反映は次 paint の fetchPanes が拾う（fallback 再描画 250ms が保険）。
+      if (label.startsWith('split')) {
+        const dir = label.includes('│') ? '-h' : '-v';
+        if (ctl && !ctl.closed) void ctl.exec(`split-window ${dir} -t ${m.target} -c '#{pane_current_path}'`);
+        else tmux(['split-window', dir, '-t', m.target, '-c', '#{pane_current_path}']);
+      } else if (label === 'close pane' && paneRects.length > 1) {
+        // 最後の 1 枚は kill しない（セッションごと消えるため。メニューにも出さない）。
+        if (ctl && !ctl.closed) void ctl.exec(`kill-pane -t ${m.target}`);
+        else tmux(['kill-pane', '-t', m.target]);
+      }
+      focus = 'terminal';
     }
+    invalidatePaint();
     write(CLEAR);
     renderSidebar();
     renderTerminal();
@@ -629,9 +1107,13 @@ async function main() {
     }
     selected = i;
     scrollOffset = 0;
+    paneRects = []; // 前セッションのジオメトリでクリック解決しないように
+    paneIds = new Set();
     sessions[selected].activePane = activePaneOf(sessions[selected].name);
+    ensureCtl(sessions[selected].name); // %output の追従先を切替え
     fitSelected();
     renderSidebar();
+    renderTerminal();
   }
 
   function refreshSessions() {
@@ -677,7 +1159,8 @@ async function main() {
           const button = Number.parseInt(p[0] ?? '', 10);
           const x = Number.parseInt(p[1] ?? '', 10);
           const y = Number.parseInt(p[2] ?? '', 10);
-          if ((button & 3) === 0) {
+          // ホイール（bit6）は無視: 64 & 3 === 0 なので左クリックと誤判定される。
+          if ((button & 64) === 0 && (button & 3) === 0) {
             const insideX = x >= menu.mx && x <= menu.mx + menu.w + 1;
             const itemRow = y - (menu.my + 1);
             if (insideX && itemRow >= 0 && itemRow < menu.items.length) menuSelect(itemRow);
@@ -811,6 +1294,18 @@ async function main() {
       return;
     }
 
+    // ダッシュボードパネルが開いている間は最優先で処理（マウスは握りつぶす）。
+    if (dash) {
+      if (data.indexOf(MOUSE_PREFIX) !== -1) return;
+      if (data === '\x1b' || data === 'q') {
+        dash = null;
+        renderTerminal();
+      } else if (data === 'r') {
+        void refreshDash();
+      }
+      return;
+    }
+
     // マウス処理。全フォーカス共通。区切り線ドラッグで幅調整・クリックで選択/フォーカス・ホイールでスクロール。
     // パースできたマウスイベントは常に握りつぶす（端末へ生シーケンスが漏れないように）。
     let handledMouse = false;
@@ -834,7 +1329,8 @@ async function main() {
         else if (motion) {
           sidebarWidth = x - 1; // 区切り線がマウス位置に来るように
           fitSelected();
-          write(CLEAR);
+          invalidatePaint();
+    write(CLEAR);
           renderSidebar();
           renderTerminal();
         }
@@ -845,20 +1341,40 @@ async function main() {
         if (now - lastWheelForward >= WHEEL_MIN_MS) {
           lastWheelForward = now;
           const s = sessions[selected];
-          if (s?.activePane) {
-            if (isAltScreen(s.activePane)) {
-              const px = Math.max(1, x - sidebarW - 1);
-              sendKeysHex(s.activePane, `${ESC}[<${button};${px};${y}M`);
-            } else {
+          // 複数 pane ではマウス直下の pane を対象にする（座標も pane ローカルへ変換）。
+          const p = paneAt(x, y);
+          const target = p?.id ?? s?.activePane;
+          if (target) {
+            if (isAltScreen(target)) {
+              const px = Math.max(1, x - sidebarW - 1 - (p?.left ?? 0));
+              const py = Math.max(1, y - (p?.top ?? 0));
+              sendInput(target, `${ESC}[<${button};${px};${py}M`);
+            } else if (!p || p.active) {
+              // 履歴スクロールはアクティブ pane のみ（scrollOffset は 1 本しか持たない）。
               scrollOffset = Math.max(0, scrollOffset + (button === 64 ? 3 : -3));
               renderTerminal();
             }
           }
         }
-      } else if (isPress && (button & 3) === 2 && !motion && x < sidebarW) {
-        // 右クリック（サイドバー行）→ コンテキストメニュー。
-        const idx = y - LIST_TOP;
-        if (y >= LIST_TOP && y <= listBottomRow && idx < sessions.length) openMenu(sessions[idx].name, x, y);
+      } else if ((button & 64) !== 0) {
+        // その他のホイールは握りつぶす: 横スクロール（66/67。トラックパッドで斜めに
+        // 滑ると飛んでくる）とサイドバー上の縦ホイール。66 & 3 === 2 なので、ここで
+        // 除外しないと下の右クリック判定に誤マッチして pane メニューが開いてしまう。
+      } else if (isPress && (button & 3) === 2 && !motion) {
+        if (x < sidebarW) {
+          // 右クリック（サイドバー行）→ セッションメニュー。
+          const idx = y - LIST_TOP;
+          if (y >= LIST_TOP && y <= listBottomRow && idx < sessions.length)
+            openMenu('session', sessions[idx].name, sessions[idx].name, ['close', 'cancel'], x, y);
+        } else if (x > sidebarW + 1) {
+          // 右クリック（端末領域）→ pane メニュー（分割・クローズ）。
+          const p = paneAt(x, y);
+          if (p) {
+            const items =
+              paneRects.length > 1 ? ['split │', 'split ─', 'close pane', 'cancel'] : ['split │', 'split ─', 'cancel'];
+            openMenu('pane', p.id, `pane ${p.id}`, items, x, y);
+          }
+        }
       } else if (isPress && (button & 3) === 0 && !motion) {
         if (x === sidebarW || x === sidebarW + 1) {
           // 区切り線（＋その左1桁）を掴んだらドラッグ開始。
@@ -866,7 +1382,9 @@ async function main() {
         } else if (y === 2 && x >= actionBtns.newBtn[0] && x <= actionBtns.newBtn[1]) {
           openCreate(); // [ + 新規 ] ボタン
         } else if (y === 2 && x >= actionBtns.histBtn[0] && x <= actionBtns.histBtn[1]) {
-          openHistory(); // [ 履歴 ] ボタン
+          openHistory(); // [ hist ] ボタン
+        } else if (y === 2 && x >= actionBtns.dashBtn[0] && x <= actionBtns.dashBtn[1]) {
+          openDashboard(); // [ dash ] ボタン
         } else if (x < sidebarW) {
           // サイドバー領域はどこをクリックしてもフォーカスを移す（空白でも）。
           // セッション行（一覧領域内）の上ならその行を選択も行う。
@@ -874,6 +1392,9 @@ async function main() {
           if (y >= LIST_TOP && y <= listBottomRow && idx < sessions.length) selectIndex(idx);
           enterSidebar();
         } else if (x > sidebarW) {
+          // 端末領域クリック: 複数 pane ならクリック位置の pane をアクティブに。
+          const p = paneAt(x, y);
+          if (p) focusPane(p);
           enterTerminal();
         }
       }
@@ -890,7 +1411,7 @@ async function main() {
       const s = sessions[selected];
       if (s?.activePane) {
         scrollOffset = 0; // 打鍵したらライブへ戻す
-        sendKeysHex(s.activePane, data);
+        sendInput(s.activePane, data);
       }
       return;
     }
@@ -908,11 +1429,16 @@ async function main() {
       openHistory();
       return;
     }
+    if (data === 'D') {
+      openDashboard();
+      return;
+    }
     if (data === '[' || data === ']') {
       const cur = layout().sidebarW;
       sidebarWidth = cur + (data === ']' ? 2 : -2);
       fitSelected(); // 端末領域の幅が変わったので再フィット
-      write(CLEAR);
+      invalidatePaint();
+    write(CLEAR);
       renderSidebar();
       renderTerminal();
       return;
@@ -923,11 +1449,15 @@ async function main() {
   }
 
   let timer: ReturnType<typeof setInterval> | null = null;
+  let sessionsTimer: ReturnType<typeof setInterval> | null = null;
 
   function cleanup() {
     if (done) return;
     done = true;
     if (timer) clearInterval(timer);
+    if (sessionsTimer) clearInterval(sessionsTimer);
+    if (paintTimer) clearTimeout(paintTimer);
+    ctl?.dispose();
     try {
       stdin.off('data', onData);
       stdin.setRawMode(false);
@@ -946,24 +1476,45 @@ async function main() {
   stdin.on('data', onData);
   stdout.on('resize', () => {
     fitSelected();
+    if (ctl && !ctl.closed) {
+      const { rows, termW } = layout();
+      void ctl.exec(`refresh-client -C ${Math.max(20, termW)}x${Math.max(5, rows)}`);
+    }
+    invalidatePaint();
     write(CLEAR);
     renderSidebar();
+    renderTerminal();
   });
   process.on('exit', cleanup);
 
   write(ALT_ON + HIDE_CURSOR + MOUSE_ON + CLEAR);
   if (sessions[selected]) {
     sessions[selected].activePane = activePaneOf(sessions[selected].name);
+    ensureCtl(sessions[selected].name);
     fitSelected();
   }
   renderSidebar();
+  renderTerminal();
 
+  // 再描画は %output イベント駆動が基本。これは取り逃し用のフォールバック（低頻度）。
   timer = setInterval(() => {
-    if (done || creating || history) return; // 作成フォーム/履歴パネル表示中は上書きしない
-    refreshSessions();
+    if (done) return;
     renderTerminal();
-    if (menu) renderMenu(); // メニューは最前面に再描画
-  }, FRAME_MS);
+  }, FALLBACK_REPAINT_MS);
+
+  // セッション一覧（ドット・詳細メタ含む）の定期更新。制御クライアントの再接続もここで拾う。
+  sessionsTimer = setInterval(() => {
+    if (done) return;
+    if (dash) {
+      // ダッシュボード表示中は一覧更新を止め、パネルの自動更新だけ行う。
+      if (Date.now() - dashFetchedAt >= DASH_REFRESH_MS) void refreshDash();
+      return;
+    }
+    if (creating || history || menu) return;
+    refreshSessions();
+    ensureCtl(sessions[selected]?.name);
+    renderSidebar();
+  }, SESSIONS_REFRESH_MS);
 }
 
 /** `cchub tui` / `bun run dev:tui` の入口。 */

--- a/tui/src/embed/tmux-ctl.ts
+++ b/tui/src/embed/tmux-ctl.ts
@@ -1,0 +1,135 @@
+// tmux 制御モード(-C)の常駐クライアント。
+//
+// 目的はホットパスの高速化: 毎フレーム `tmux ...` を fork する（macOS で 1 回 5〜20ms）
+// 代わりに、常駐した 1 本の `tmux -C attach` にコマンドをパイプで流す（サブ ms）。
+// さらに %output 通知を「ダーティ信号」として受け取り、出力があった時だけ再描画できる
+// （ブラインド 30fps ポーリングの廃止）。ペイロード自体は使わない（描画は capture-pane）。
+//
+// プロトコル: コマンドは stdin に 1 行ずつ。応答は %begin ... %end（%error）で囲まれ、
+// 発行順に返る（FIFO）。それ以外の % 行は非同期通知（%output %<pane> <data> など）。
+import type { FileSink, Subprocess } from 'bun';
+
+const dec = new TextDecoder();
+
+export class TmuxCtl {
+  private proc: Subprocess<'pipe', 'pipe', 'ignore'>;
+  private stdin: FileSink;
+  private pending: Array<(lines: string[]) => void> = [];
+  private collecting: string[] | null = null;
+  private buf = '';
+  private _closed = false;
+  /** 選択セッションの pane に出力があった時に呼ばれる（ダーティ通知）。 */
+  onOutput: ((paneId: string) => void) | null = null;
+  onExit: (() => void) | null = null;
+
+  constructor(target: string) {
+    // ネスト検出（$TMUX）を外して制御クライアントとして attach する。ただし $TMUX には
+    // ソケットパスが入っている（tmux 内で動いている場合）ので、外す前に -S で引き継ぐ。
+    // これを忘れると別ソケットの tmux サーバに繋いでしまう。
+    const sock = (process.env.TMUX ?? '').split(',')[0];
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && k !== 'TMUX') env[k] = v;
+    }
+    const args = sock ? ['-S', sock] : [];
+    this.proc = Bun.spawn(['tmux', ...args, '-C', 'attach-session', '-t', target], {
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'ignore',
+      env,
+    });
+    this.stdin = this.proc.stdin;
+    // 接続直後に tmux が出す最初の %begin/%end ブロック（attach 自体の応答）を吸収する。
+    this.pending.push(() => {});
+    void this.readLoop();
+  }
+
+  get closed(): boolean {
+    return this._closed;
+  }
+
+  private async readLoop(): Promise<void> {
+    try {
+      for await (const chunk of this.proc.stdout) {
+        this.buf += dec.decode(chunk);
+        let nl = this.buf.indexOf('\n');
+        while (nl !== -1) {
+          const line = this.buf.slice(0, nl).replace(/\r$/, '');
+          this.buf = this.buf.slice(nl + 1);
+          this.handleLine(line);
+          nl = this.buf.indexOf('\n');
+        }
+      }
+    } catch {
+      // 読み取り失敗 = 切断扱い
+    }
+    this.markClosed();
+  }
+
+  private handleLine(line: string): void {
+    if (this.collecting !== null) {
+      if (line.startsWith('%end') || line.startsWith('%error')) {
+        const resolve = this.pending.shift();
+        const lines = this.collecting;
+        this.collecting = null;
+        resolve?.(lines);
+      } else {
+        this.collecting.push(line);
+      }
+      return;
+    }
+    if (line.startsWith('%begin')) {
+      this.collecting = [];
+      return;
+    }
+    if (line.startsWith('%output ')) {
+      const rest = line.slice('%output '.length);
+      const sp = rest.indexOf(' ');
+      const pane = sp === -1 ? rest : rest.slice(0, sp);
+      this.onOutput?.(pane);
+      return;
+    }
+    if (line.startsWith('%exit')) {
+      this.markClosed();
+    }
+    // その他の通知（%session-changed 等）は無視。
+  }
+
+  private markClosed(): void {
+    if (this._closed) return;
+    this._closed = true;
+    // 未応答のコマンドは空で解決（呼び出し側は fallback へ）。
+    for (const resolve of this.pending.splice(0)) resolve([]);
+    this.onExit?.();
+  }
+
+  /** コマンドを 1 つ実行し、%begin/%end 間の出力行を返す。切断時は []。 */
+  exec(cmd: string): Promise<string[]> {
+    if (this._closed) return Promise.resolve([]);
+    return new Promise((resolve) => {
+      this.pending.push(resolve);
+      try {
+        this.stdin.write(`${cmd}\n`);
+        this.stdin.flush();
+      } catch {
+        this.pending.pop();
+        this.markClosed();
+        resolve([]);
+      }
+    });
+  }
+
+  dispose(): void {
+    this._closed = true;
+    try {
+      this.stdin.end();
+    } catch {
+      // best-effort
+    }
+    try {
+      this.proc.kill();
+    } catch {
+      // best-effort
+    }
+  }
+}


### PR DESCRIPTION
## Changes
- feat(tui): 複数 pane 分割表示 — 全 pane をレイアウト通りに合成描画、クリックで pane フォーカス、右クリックメニューで split / close pane
- feat(tui): ダッシュボードパネル（`D` / dash ボタン）— usage limits・today・system metrics を `/api/dashboard` から表示（HTTPS + Keychain 認証、5s 自動更新）
- perf(tui): 描画エンジンを tmux 制御モード常駐クライアント化（fork レス・%output イベント駆動・行差分・~30fps・Synchronized Output）
- feat(tui): padFill — normal-screen（Claude Code）の void をスクロールバックで埋める
- fix(tui): 横スクロール（SGR button 66/67）が右クリック誤判定で pane メニューを開く問題
- fix(tui): 描画中のカーソルちらつき / 罫線・ブロック文字の幅計算

## Notes
`cchub tui`（embed-tui）のみの変更。backend/frontend への影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)