### PR TITLE
fix(ci): tui typecheck failure (stale react types)

### DIFF
--- a/tui/tsconfig.json
+++ b/tui/tsconfig.json
@@ -6,8 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "jsx": "react-jsx",
-    "types": ["bun", "react"],
+    "types": ["bun"],
     "resolveJsonModule": true,
     "paths": {
       "shared": ["../shared/types.ts"]


### PR DESCRIPTION
## Changes
- fix(ci): tui/tsconfig.json から Ink 時代の `react` types と `jsx` を除去。v0.1.189 以降 CI の Test (typecheck) が TS2688 で常に失敗していたのを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)