### PR TITLE
Release v0.1.192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.192] - 2026-07-14
+
+### Fixed
+- **`cchub tui`（バイナリ）が起動直後に終了する問題**: embed-tui の `main()` がセットアップ後すぐ return する設計だったため、CLI 経路（`await runTui()` → `process.exit`）ではプロセスごと即終了していた（v0.1.189 から）。`bun run dev:tui` ではイベントループが残るため露見しなかった。`main()` が終了（`q` / Ctrl-C → cleanup）まで待つよう修正（`tui/src/embed/embed-tui.ts`）
+
 ## [0.1.191] - 2026-07-13
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.1.191",
-  "generated": "2026-07-13",
+  "version": "0.1.192",
+  "generated": "2026-07-14",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.1.191",
-  "generated": "2026-07-13",
+  "version": "0.1.192",
+  "generated": "2026-07-14",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in tmux sessions and provides a web UI for remote access from tablets/mobile devices. Also ships a local TUI (cchub tui), an EVEN G2 smart-glasses app, and multi-server federation over Tailscale (peers).",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.1.191",
+  "version": "0.1.192",
   "private": true,
   "workspaces": [
     "backend",

--- a/tui/src/embed/embed-tui.ts
+++ b/tui/src/embed/embed-tui.ts
@@ -1450,6 +1450,11 @@ async function main() {
 
   let timer: ReturnType<typeof setInterval> | null = null;
   let sessionsTimer: ReturnType<typeof setInterval> | null = null;
+  // main() は終了（cleanup）まで解決しないための待ち合わせ。CLI（cchub tui）は
+  // `await runTui()` の後に process.exit するので、ここで待たないとセットアップ直後に
+  // プロセスごと終了してしまう（`bun run embed-tui.ts` 直起動ではイベントループが
+  // 生きたまま残るため気づけない）。
+  let resolveDone: (() => void) | null = null;
 
   function cleanup() {
     if (done) return;
@@ -1468,6 +1473,7 @@ async function main() {
     // リサイズしたセッションを自動サイズへ戻す。
     for (const name of resized) tmux(['set-option', '-u', '-t', name, 'window-size']);
     write(MOUSE_OFF + SHOW_CURSOR + ALT_OFF);
+    resolveDone?.();
   }
 
   // セットアップ
@@ -1515,6 +1521,12 @@ async function main() {
     ensureCtl(sessions[selected]?.name);
     renderSidebar();
   }, SESSIONS_REFRESH_MS);
+
+  // 終了（q / Ctrl-C → cleanup）までブロックする。
+  await new Promise<void>((resolve) => {
+    resolveDone = resolve;
+    if (done) resolve(); // ここに来る前に cleanup 済みならハングさせない
+  });
 }
 
 /** `cchub tui` / `bun run dev:tui` の入口。 */


### PR DESCRIPTION
## Changes
- fix(tui): `cchub tui`（バイナリ）が起動直後に exit 0 で終了する問題を修正。embed-tui の main() がセットアップ後すぐ return していたため、CLI 経路（await → process.exit）で即終了していた（v0.1.189 からのリグレッション）。main() が q / Ctrl-C の cleanup まで待つように変更

## Notes
検証: compile したバイナリを tmux 内で起動 → TUI 描画・操作 OK、q で exit 0 を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)