### PR TITLE
Release v0.2.1 — fix herdr binary resolution under systemd/launchd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] - 2026-07-15
+
+### Fixed
+- **systemd / launchd 配下で `herdr command not found` になり起動できない問題（v0.2.0 のリグレッション）**: サービスの `ExecStart` は `zsh -lc`（非対話ログインシェル = `.zshrc` を読まない）のため、herdr の公式インストール先である `~/.local/bin` が PATH に入らず、herdr がインストール済み・稼働中でも起動に失敗して再起動ループに入っていた。herdr バイナリを `$HERDR_BIN` → PATH → 既知のインストール先（`~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`）の順に一度だけ解決し、以降のすべての herdr 起動（起動時チェック、サーバ自動起動、ペインの制御ストリーム、`cchub setup` のプロビジョニング）を絶対パスで行うようにした（`backend/src/services/herdr-client.ts`）
+
 ## [0.2.0] - 2026-07-15
 
 ターミナルバックエンドを tmux から **herdr** へ全面移行しました。**herdr のインストールが必須** になり、tmux 上の既存セッションは引き継がれません（移行手順は後述）。

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "generated": "2026-07-15",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "generated": "2026-07-15",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/backend/src/commands/setup.ts
+++ b/backend/src/commands/setup.ts
@@ -4,6 +4,7 @@ import { mkdir, writeFile, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { t } from '../i18n';
+import { herdrBinaryPath } from '../services/herdr-client';
 import { storePassword as storePasswordInKeychain } from '../utils/keychain';
 
 /** Escape special characters for safe inclusion in XML/plist content. */
@@ -190,14 +191,13 @@ pane_history = true
 async function provisionHerdr(): Promise<void> {
   console.log('🐑 herdr バックエンドのセットアップ');
 
-  const which = Bun.spawnSync(['which', 'herdr']);
-  if (which.exitCode !== 0) {
+  const herdrPath = herdrBinaryPath();
+  if (!herdrPath) {
     console.error('⚠️  herdr が見つかりません。先にインストールしてください:');
     console.error('   curl -fsSL https://herdr.dev/install.sh | sh  (または brew install herdr)');
     console.log('');
     return;
   }
-  const herdrPath = which.stdout.toString().trim();
 
   // config.toml: create with our defaults; never clobber an existing file.
   const herdrConfigDir = join(homedir(), '.config', 'herdr');
@@ -215,7 +215,7 @@ async function provisionHerdr(): Promise<void> {
   }
 
   // Supervised server.
-  const wasRunning = Bun.spawnSync(['herdr', 'status', 'server'])
+  const wasRunning = Bun.spawnSync([herdrPath, 'status', 'server'])
     .stdout.toString()
     .includes('status: running');
   if (platform() === 'darwin') {
@@ -257,7 +257,7 @@ async function provisionHerdr(): Promise<void> {
   // Claude Code integration: reports native session ids to herdr so agent
   // conversations survive server restarts. Adds a SessionStart hook to
   // ~/.claude/settings.json (coexists with cchub notify hooks).
-  const integ = Bun.spawnSync(['herdr', 'integration', 'install', 'claude']);
+  const integ = Bun.spawnSync([herdrPath, 'integration', 'install', 'claude']);
   if (integ.exitCode === 0) {
     console.log('✅ herdr Claude integration を設定しました (~/.claude/settings.json に SessionStart hook)');
   } else {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,7 +15,7 @@ import { parseArgs, runCli, VERSION } from './cli';
 import { conditionalAuthMiddleware, isAuthRequired, getJwtSecret, initJwtSecret } from './middleware/auth';
 import { AuthService } from './services/auth';
 import { getDataDir } from './utils/storage';
-import { herdrRpc, herdrSocketPath } from './services/herdr-client';
+import { herdrBinaryPath, herdrRpc, herdrSocketPath } from './services/herdr-client';
 import { t } from './i18n';
 
 // Global error handlers to prevent silent crashes
@@ -215,8 +215,8 @@ if (whichResult.exitCode !== 0) {
 // herdr backend: verify the binary exists, then make sure the headless
 // server is reachable — auto-start it if not (it daemon-izes per user and
 // owns all pane PTYs, so cchub restarts don't kill running agents).
-const herdrWhichResult = Bun.spawnSync(['which', 'herdr']);
-if (herdrWhichResult.exitCode !== 0) {
+const herdrPath = herdrBinaryPath();
+if (!herdrPath) {
   console.error(`❌ ${t('server.herdrNotFound')}`);
   console.error(`   ${t('server.herdrInstallHint')}`);
   process.exit(1);
@@ -244,7 +244,7 @@ async function herdrPing(): Promise<HerdrPong | null> {
 let herdrPong = await herdrPing();
 if (!herdrPong) {
   console.log('⏳ herdr server not running; starting it...');
-  Bun.spawn(['herdr', 'server'], {
+  Bun.spawn([herdrPath, 'server'], {
     stdin: 'ignore',
     stdout: 'ignore',
     stderr: 'ignore',

--- a/backend/src/services/__tests__/herdr-binary-path.test.ts
+++ b/backend/src/services/__tests__/herdr-binary-path.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { herdrBin, herdrBinaryPath } from '../herdr-client';
+
+/**
+ * Regression: cchub v0.2.0 failed to start under systemd because it resolved
+ * herdr through PATH only. `zsh -lc` (the unit's ExecStart) never sources
+ * .zshrc, so ~/.local/bin — where herdr's install.sh puts the binary — is
+ * absent from PATH at boot, and the service exit-looped with
+ * "herdr command not found" even though herdr was installed and running.
+ */
+describe('herdrBinaryPath', () => {
+  it('resolves to an existing absolute path when herdr is installed', () => {
+    const resolved = herdrBinaryPath();
+    if (resolved === null) return; // herdr not installed on this machine
+    expect(resolved.startsWith('/')).toBe(true);
+    expect(existsSync(resolved)).toBe(true);
+  });
+
+  it('finds the install.sh location even when PATH omits it', () => {
+    const installShPath = join(homedir(), '.local', 'bin', 'herdr');
+    if (!existsSync(installShPath)) return; // not installed via install.sh here
+
+    const prevPath = process.env.PATH;
+    process.env.PATH = '/usr/bin:/bin'; // systemd-like PATH, no ~/.local/bin
+    try {
+      // Re-resolve in a fresh module registry so the cached value doesn't hide
+      // the PATH-independent fallback we're asserting on.
+      delete require.cache?.[require.resolve('../herdr-client')];
+      expect(existsSync(herdrBinaryPath() ?? '')).toBe(true);
+    } finally {
+      process.env.PATH = prevPath;
+    }
+  });
+
+  it('herdrBin falls back to the bare name so spawns still report a usable error', () => {
+    expect(herdrBin().length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/services/herdr-client.ts
+++ b/backend/src/services/herdr-client.ts
@@ -12,11 +12,56 @@
  * long as one CC Hub session maps to one herdr workspace.
  */
 
+import { existsSync } from 'node:fs';
 import { connect } from 'node:net';
 import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 export function herdrSocketPath(): string {
   return process.env.HERDR_SOCKET_PATH || `${homedir()}/.config/herdr/herdr.sock`;
+}
+
+let cachedHerdrBinary: string | null | undefined;
+
+/**
+ * Absolute path to the herdr binary, or null when it isn't installed.
+ *
+ * PATH alone isn't enough: herdr's install script drops the binary in
+ * `~/.local/bin`, which systemd (`zsh -lc` never sources .zshrc) and launchd
+ * leave out of PATH — so a service that works interactively fails at boot.
+ * Spawns must use the resolved absolute path, not the bare name.
+ */
+export function herdrBinaryPath(): string | null {
+  if (cachedHerdrBinary !== undefined) return cachedHerdrBinary;
+
+  const override = process.env.HERDR_BIN;
+  if (override && existsSync(override)) {
+    cachedHerdrBinary = override;
+    return cachedHerdrBinary;
+  }
+
+  const which = Bun.spawnSync(['which', 'herdr']);
+  if (which.exitCode === 0) {
+    const resolved = which.stdout.toString().trim();
+    if (resolved) {
+      cachedHerdrBinary = resolved;
+      return cachedHerdrBinary;
+    }
+  }
+
+  const candidates = [
+    join(homedir(), '.local', 'bin', 'herdr'), // install.sh
+    '/opt/homebrew/bin/herdr', // brew (Apple Silicon)
+    '/usr/local/bin/herdr', // brew (Intel) / manual
+    '/usr/bin/herdr', // distro package
+  ];
+  cachedHerdrBinary = candidates.find((p) => existsSync(p)) ?? null;
+  return cachedHerdrBinary;
+}
+
+/** Resolved herdr path, falling back to the bare name so spawns still error usefully. */
+export function herdrBin(): string {
+  return herdrBinaryPath() ?? 'herdr';
 }
 
 export interface HerdrScroll {
@@ -306,7 +351,7 @@ export class PaneController {
     // geometry is known.
     const sizeArgs = size ? ['--cols', String(size.cols), '--rows', String(size.rows)] : [];
     this.proc = Bun.spawn(
-      ['herdr', 'terminal', 'session', 'control', herdrPaneId, '--takeover', ...sizeArgs],
+      [herdrBin(), 'terminal', 'session', 'control', herdrPaneId, '--takeover', ...sizeArgs],
       { stdin: 'pipe', stdout: 'pipe', stderr: 'ignore' },
     );
     this.stdinWriter = this.proc.stdin as unknown as { write(s: string): unknown };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(herdr): PATH に依存せず herdr バイナリを解決する（v0.2.0 のリグレッション修正）
- chore: bump version to 0.2.1

## 背景

v0.2.0 に更新した本番機（systemd）が `❌ Error: herdr command not found` で起動失敗し、再起動ループに入った。herdr はインストール済み（`~/.local/bin/herdr`）で `herdr.service` も稼働中だったにもかかわらず。

原因は cchub の unit の `ExecStart=/usr/bin/zsh -lc '...'`。zsh は **非対話ログインシェルでは .zshrc を読まない** ため、`~/.local/bin`（herdr の公式 install.sh の配置先）が PATH に入らず、`which herdr` が失敗する。launchd はさらに PATH が最小限なので macOS でも同様に踏む。

## 修正

herdr バイナリを `$HERDR_BIN` → PATH → 既知のインストール先（`~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`）の順に一度だけ解決してキャッシュし、すべての herdr 起動（起動時チェック / サーバ自動起動 / ペイン制御ストリーム / `cchub setup`）を絶対パスで行う。

## 検証

- systemd 相当の PATH で再現確認: `env -i PATH=/usr/bin:/bin` では `which herdr` が exit 1 になるが、修正後は `/home/m0a/.local/bin/herdr` を解決する
- 回帰テスト追加 (`herdr-binary-path.test.ts`)
- backend 236 / frontend 37 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185QThpJTL5RmMWUgCYWFQK