### PR TITLE
feat(herdr): detect and surface herdr version skew after `herdr update`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - **HerdrControlSession** (`services/herdr-control.ts`) - One instance per CC Hub session (= one herdr workspace). Owns the pane split tree, tracks the focused pane, spawns lazy per-pane controllers (WS subscribe / first input only — read-only REST never takes over a pane), scans frames for cursor position and alt-screen state, client lifecycle with 30s grace period. Also `captureViewportHerdr`: viewport composition from `pane.read` (visible at offset 0, `recent` slice for scrollback, capped at herdr's 1000-line read limit)
 - **HerdrLayout** (`services/herdr-layout.ts`) - CC Hub-owned split tree (herdr's own grid can't be resized headlessly): split/close/zoom/ratio adjust/absolute pane sizing, rendered to tmux-convention `TmuxLayoutNode` rects for the frontend
 - **HerdrService** (`services/herdr.ts`) - Session-level operations mapping CC Hub sessions onto herdr workspaces: list (with agent detection from `pane.process_info`, native agent session ids from `agent.list`, `blocked` status), create/kill, previews
+- **HerdrUpdateService** (`services/herdr-update.ts`) - Detects herdr binary-vs-server version skew (`herdr update` swaps the binary but leaves the running server old) by parsing `herdr status --json`, cached 30s and refreshed off the dashboard poll. Reports only — applying (`herdr update` + supervised restart) is an explicit user action via `POST /api/herdr/apply-update`; never the `cchub update --auto` timer, never `--handoff`. Unreadable status degrades to no warning
 - **PaneState** (`services/pane-state.ts`) - Backend-agnostic `stripAnsi` / `detectPaneState` heuristics for peer-dialog tooling (`cchub send --wait`, `cchub peek`)
 - **ClaudeCodeService** (`services/claude-code.ts`) - Monitors Claude Code state from `.jsonl` files; session matching via herdr's native agent session id, falling back to working-dir path matching
 - **SessionHistoryService** (`services/session-history.ts`) - Reads past Claude Code session history and conversations
@@ -142,7 +143,8 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - Server periodically pushes `sessions-updated` (5s interval) with full session list
 
 **Other**:
-- `GET /api/dashboard` - Dashboard data (usage limits, statistics, cost estimates, system metrics, usage history)
+- `GET /api/dashboard` - Dashboard data (usage limits, statistics, cost estimates, system metrics, usage history, herdr version skew)
+- `POST /api/herdr/apply-update` - Apply a pending herdr update (`herdr update` + supervised restart). User-initiated only; restarts every pane PTY
 - `POST /api/upload/image` - Upload image file
 - `POST /api/notify` - Receive hook events from Claude Code / Codex
 - `GET /api/notify/hook-status` - Per-session hook indicator state (lists sessions with missing hook setup)

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,7 @@ import { files } from './routes/files';
 import { dashboard } from './routes/dashboard';
 import { notify } from './routes/notify';
 import { peers } from './routes/peers';
+import { herdr } from './routes/herdr';
 import { muxOpen, muxMessage, muxClose, type MuxData } from './routes/terminal-mux';
 import { parseArgs, runCli, VERSION } from './cli';
 import { conditionalAuthMiddleware, isAuthRequired, getJwtSecret, initJwtSecret } from './middleware/auth';
@@ -153,6 +154,7 @@ app.use('/api/files/*', conditionalAuthMiddleware);
 app.use('/api/dashboard', conditionalAuthMiddleware);
 app.use('/api/peers', conditionalAuthMiddleware);
 app.use('/api/peers/*', conditionalAuthMiddleware);
+app.use('/api/herdr/*', conditionalAuthMiddleware);
 
 app.route('/api/logs', logs);
 app.route('/api/sessions', sessions);
@@ -161,6 +163,7 @@ app.route('/api/files', files);
 app.route('/api/dashboard', dashboard);
 app.route('/api/notify', notify);
 app.route('/api/peers', peers);
+app.route('/api/herdr', herdr);
 
 // Static files handling
 const staticRoot = process.env.STATIC_ROOT || '../frontend/dist';

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -4,6 +4,7 @@ import { AnthropicUsageService } from '../services/anthropic-usage';
 import { CodexUsageService } from '../services/codex-usage';
 import { UsageHistoryService } from '../services/usage-history';
 import { SystemMetricsService } from '../services/system-metrics';
+import { HerdrUpdateService } from '../services/herdr-update';
 import { getConnectedClientCount } from './terminal-mux';
 import { VERSION } from '../cli';
 import type { DashboardResponse } from '../../../shared/types';
@@ -13,6 +14,8 @@ const anthropicUsageService = new AnthropicUsageService();
 const codexUsageService = new CodexUsageService();
 const usageHistoryService = new UsageHistoryService();
 const systemMetricsService = new SystemMetricsService();
+// Shared with the /api/herdr apply route so an apply invalidates this cache.
+export const herdrUpdateService = new HerdrUpdateService();
 
 async function getDiskUsage(): Promise<{ total: number; used: number; available: number; mountpoint: string } | null> {
   try {
@@ -33,7 +36,9 @@ async function getDiskUsage(): Promise<{ total: number; used: number; available:
 }
 
 export async function buildDashboard(): Promise<DashboardResponse> {
-  const [usageLimits, codexUsageLimits, dailyActivity, modelUsage, hourlyActivity, usageHistory, systemMetrics, diskUsage] = await Promise.all([
+  // The herdr skew check rides on this poll instead of its own timer (#393);
+  // it is cached, so the extra spawn is far rarer than the request rate.
+  const [usageLimits, codexUsageLimits, dailyActivity, modelUsage, hourlyActivity, usageHistory, systemMetrics, diskUsage, herdrUpdate] = await Promise.all([
     anthropicUsageService.getUsageLimits(),
     codexUsageService.getUsageLimits(),
     statsService.getDailyActivity(14),
@@ -42,6 +47,7 @@ export async function buildDashboard(): Promise<DashboardResponse> {
     usageHistoryService.getHistory(),
     Promise.resolve(systemMetricsService.getMetrics()),
     getDiskUsage(),
+    herdrUpdateService.getStatus(),
   ]);
 
   // Record snapshot for history
@@ -65,6 +71,7 @@ export async function buildDashboard(): Promise<DashboardResponse> {
     systemMetrics,
     diskUsage: diskUsage || undefined,
     connectedClients: getConnectedClientCount(),
+    herdrUpdate,
   };
 }
 

--- a/backend/src/routes/herdr.ts
+++ b/backend/src/routes/herdr.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono';
+import { herdrUpdateService } from './dashboard';
+
+export const herdr = new Hono();
+
+/**
+ * Apply a pending herdr update: `herdr update` + a supervised server restart.
+ *
+ * Deliberately POST-only and driven by an explicit dashboard click (#393).
+ * Restarting herdr re-creates every pane PTY — agent conversations come back
+ * via `resume_agents_on_restore`, but running commands do not — so cchub never
+ * triggers this on its own, and never from the `cchub update --auto` timer.
+ */
+herdr.post('/apply-update', async (c) => {
+  const result = await herdrUpdateService.apply();
+  if (!result.ok) {
+    return c.json({ error: result.error ?? 'herdr update failed', output: result.output }, 500);
+  }
+  return c.json({ success: true, output: result.output });
+});

--- a/backend/src/services/__tests__/herdr-update.test.ts
+++ b/backend/src/services/__tests__/herdr-update.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildHerdrApplyCommands, parseHerdrStatus } from '../herdr-update';
+
+/**
+ * #393: `herdr update` swaps the binary but leaves the running server on the
+ * old version, and cchub spawns the binary to drive panes. The parser has to
+ * catch that skew, but a herdr release that changes the status format must
+ * degrade to silence — a false "restart your server" nag costs the user every
+ * running command in every pane.
+ */
+describe('parseHerdrStatus', () => {
+  // Real `herdr status --json` output (herdr 0.7.3, protocol 16).
+  const healthy = JSON.stringify({
+    client: { version: '0.7.3', channel: 'stable', protocol: 16, binary: '/home/u/.local/bin/herdr', session: null },
+    server: {
+      status: 'running',
+      running: true,
+      version: '0.7.3',
+      protocol: 16,
+      capabilities: { live_handoff: true, detached_server_daemon: true },
+      compatible: true,
+      socket: '/home/u/.config/herdr/herdr.sock',
+      session: null,
+      restart_needed: false,
+    },
+    update: { restart_needed: false },
+  });
+
+  it('reports no skew when binary and server match', () => {
+    expect(parseHerdrStatus(healthy)).toEqual({
+      binaryVersion: '0.7.3',
+      serverVersion: '0.7.3',
+      restartNeeded: false,
+    });
+  });
+
+  it('detects skew from differing versions', () => {
+    const raw = JSON.stringify({
+      client: { version: '0.7.4' },
+      server: { running: true, version: '0.7.3' },
+    });
+    expect(parseHerdrStatus(raw)?.restartNeeded).toBe(true);
+  });
+
+  it('honors herdr update.restart_needed even when versions read equal', () => {
+    const raw = JSON.stringify({
+      client: { version: '0.7.3' },
+      server: { running: true, version: '0.7.3' },
+      update: { restart_needed: true },
+    });
+    expect(parseHerdrStatus(raw)?.restartNeeded).toBe(true);
+  });
+
+  it('treats an incompatible server as needing a restart', () => {
+    const raw = JSON.stringify({
+      client: { version: '0.8.0' },
+      server: { running: true, version: '0.8.0', compatible: false },
+    });
+    expect(parseHerdrStatus(raw)?.restartNeeded).toBe(true);
+  });
+
+  it('exposes both versions so the UI can name them', () => {
+    const raw = JSON.stringify({
+      client: { version: '0.7.4' },
+      server: { running: true, version: '0.7.3' },
+    });
+    const reading = parseHerdrStatus(raw);
+    expect(reading?.binaryVersion).toBe('0.7.4');
+    expect(reading?.serverVersion).toBe('0.7.3');
+  });
+
+  it('ignores unknown fields a newer herdr may add', () => {
+    const raw = JSON.stringify({
+      client: { version: '0.7.3', someNewField: 'x' },
+      server: { running: true, version: '0.7.3', futureFlag: 42 },
+      update: { restart_needed: false },
+      brandNewSection: { anything: true },
+    });
+    expect(parseHerdrStatus(raw)?.restartNeeded).toBe(false);
+  });
+
+  // Everything below must not warn: unreadable input means "don't know".
+  it.each([
+    ['empty output', ''],
+    ['non-JSON text output', 'status: running\nversion: 0.7.3\ncompatible: yes'],
+    ['a JSON array', '[]'],
+    ['a JSON scalar', '"running"'],
+    ['truncated JSON', '{"client":{"version":"0.7.3"'],
+    ['a usage error from an older herdr', 'error: unknown flag --json'],
+  ])('returns null for %s', (_label, raw) => {
+    expect(parseHerdrStatus(raw)).toBeNull();
+  });
+
+  it('stays silent when the server is not running', () => {
+    const raw = JSON.stringify({
+      client: { version: '0.7.4' },
+      server: { status: 'stopped', running: false },
+    });
+    expect(parseHerdrStatus(raw)).toBeNull();
+  });
+
+  it('stays silent when the running flag is missing or renamed', () => {
+    const raw = JSON.stringify({
+      client: { version: '0.7.4' },
+      server: { state: 'up', version: '0.7.3' },
+    });
+    expect(parseHerdrStatus(raw)).toBeNull();
+  });
+
+  it('does not infer skew from a missing or blank version', () => {
+    for (const server of [{ running: true }, { running: true, version: '' }, { running: true, version: null }]) {
+      const raw = JSON.stringify({ client: { version: '0.7.4' }, server });
+      expect(parseHerdrStatus(raw)?.restartNeeded).toBe(false);
+    }
+    const noClient = JSON.stringify({ client: {}, server: { running: true, version: '0.7.3' } });
+    expect(parseHerdrStatus(noClient)?.restartNeeded).toBe(false);
+  });
+
+  it('does not treat non-boolean restart_needed as a signal', () => {
+    const raw = JSON.stringify({
+      client: { version: '0.7.3' },
+      server: { running: true, version: '0.7.3' },
+      update: { restart_needed: 'maybe' },
+    });
+    expect(parseHerdrStatus(raw)?.restartNeeded).toBe(false);
+  });
+});
+
+/**
+ * `--handoff` is banned: the handed-off server escapes systemd/launchd and
+ * fights `Restart=always`. Unsupervised herdr gets no button at all, since
+ * `systemctl restart` would be a silent no-op there.
+ */
+describe('buildHerdrApplyCommands', () => {
+  it('updates then restarts the systemd user unit', () => {
+    expect(buildHerdrApplyCommands('systemd', '/home/u/.local/bin/herdr', 1000)).toEqual([
+      ['/home/u/.local/bin/herdr', 'update'],
+      ['systemctl', '--user', 'restart', 'herdr'],
+    ]);
+  });
+
+  it('updates then kickstarts the launchd job on macOS', () => {
+    expect(buildHerdrApplyCommands('launchd', '/opt/homebrew/bin/herdr', 501)).toEqual([
+      ['/opt/homebrew/bin/herdr', 'update'],
+      ['launchctl', 'kickstart', '-k', 'gui/501/com.herdr.server'],
+    ]);
+  });
+
+  it('refuses to act when nothing supervises herdr', () => {
+    expect(buildHerdrApplyCommands('unmanaged', '/usr/bin/herdr', 1000)).toBeNull();
+  });
+
+  it('never passes --handoff', () => {
+    for (const supervisor of ['systemd', 'launchd'] as const) {
+      const flat = (buildHerdrApplyCommands(supervisor, 'herdr', 1000) ?? []).flat();
+      expect(flat).not.toContain('--handoff');
+    }
+  });
+
+  it('updates before restarting so a failed download never bounces the server', () => {
+    const commands = buildHerdrApplyCommands('systemd', 'herdr', 1000) ?? [];
+    expect(commands[0]).toContain('update');
+    expect(commands[1]).toContain('restart');
+  });
+});
+
+/**
+ * `cchub update --auto` runs unattended from a timer. Restarting herdr there
+ * would silently kill whatever builds/tests/long jobs were running in every
+ * pane overnight, so the auto path must never reach herdr — hence this guard
+ * on the source itself rather than on behavior.
+ */
+describe('cchub update timer', () => {
+  it('never touches herdr', () => {
+    const source = readFileSync(join(import.meta.dir, '../../commands/update.ts'), 'utf-8');
+    expect(source).not.toMatch(/herdr/i);
+  });
+});

--- a/backend/src/services/herdr-update.ts
+++ b/backend/src/services/herdr-update.ts
@@ -1,0 +1,226 @@
+/**
+ * herdr version-skew detection (#393).
+ *
+ * `herdr update` only replaces the binary on disk — the running server keeps
+ * serving the old version until it is restarted. cchub spawns the *binary*
+ * (`herdr terminal session control`, see PaneController) to drive panes, so
+ * between `herdr update` and a server restart we run new CLI against an old
+ * server: control streams can fail to attach and the symptom reads as
+ * "the terminal won't connect", long after the user forgot they ran an update.
+ *
+ * We only *report* the skew. Restarting herdr re-creates every pane PTY and
+ * kills whatever is running in them, so applying is strictly a user action
+ * (never the `cchub update --auto` timer, never `--handoff`: a handed-off
+ * server escapes systemd/launchd supervision and fights `Restart=always`).
+ */
+
+import type { HerdrUpdateStatus } from '../../../shared/types';
+import { herdrBin, herdrBinaryPath } from './herdr-client';
+
+/** Matches the dashboard's own refresh cadence; a spawn per poll is plenty. */
+const CACHE_TTL_MS = 30_000;
+const SPAWN_TIMEOUT_MS = 5_000;
+
+export type HerdrSupervisor = 'systemd' | 'launchd' | 'unmanaged';
+
+export interface HerdrSkewReading {
+  binaryVersion?: string;
+  serverVersion?: string;
+  restartNeeded: boolean;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Read `herdr status --json`, which reports the on-disk binary (`client`) and
+ * the live server side by side plus herdr's own `restart_needed` verdict.
+ *
+ * Every field is treated as optional and unknown values are ignored: herdr's
+ * output format is versioned independently of cchub, and a format change must
+ * degrade to "no skew detected" rather than nag the user with a false alarm.
+ * Returns null when the output is unusable.
+ */
+export function parseHerdrStatus(raw: string): HerdrSkewReading | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+
+  const root = parsed as Record<string, unknown>;
+  const client = (root.client ?? {}) as Record<string, unknown>;
+  const server = (root.server ?? {}) as Record<string, unknown>;
+  const update = (root.update ?? {}) as Record<string, unknown>;
+  if (typeof server !== 'object' || server === null) return null;
+
+  // Only a *running* server can be stale. A stopped one is cchub's startup
+  // problem, not a version skew, and a missing/renamed field lands here too.
+  if (server.running !== true) return null;
+
+  const binaryVersion = asString(client.version);
+  const serverVersion = asString(server.version);
+
+  // herdr's explicit verdicts win; the version compare is the fallback for
+  // builds that don't emit them. Any difference counts as skew — cchub can't
+  // tell a compatible bump from a breaking one, and the fix is identical.
+  const restartNeeded =
+    update.restart_needed === true ||
+    server.restart_needed === true ||
+    server.compatible === false ||
+    (binaryVersion !== undefined && serverVersion !== undefined && binaryVersion !== serverVersion);
+
+  return { binaryVersion, serverVersion, restartNeeded };
+}
+
+/**
+ * Commands cchub runs on the user's behalf, in order. `herdr update` must
+ * succeed before the restart, so callers stop at the first non-zero exit.
+ * Returns null when nothing supervises herdr: `systemctl restart` is a no-op
+ * for a server cchub itself spawned, so we show manual steps instead of a
+ * button that silently does nothing.
+ */
+export function buildHerdrApplyCommands(
+  supervisor: HerdrSupervisor,
+  herdrPath: string,
+  uid: number,
+): string[][] | null {
+  switch (supervisor) {
+    case 'systemd':
+      return [
+        [herdrPath, 'update'],
+        ['systemctl', '--user', 'restart', 'herdr'],
+      ];
+    case 'launchd':
+      return [
+        [herdrPath, 'update'],
+        ['launchctl', 'kickstart', '-k', `gui/${uid}/com.herdr.server`],
+      ];
+    default:
+      return null;
+  }
+}
+
+async function runCapture(cmd: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' });
+  const timer = setTimeout(() => proc.kill(), SPAWN_TIMEOUT_MS);
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export class HerdrUpdateService {
+  private cached: HerdrUpdateStatus | undefined;
+  private cachedAt = 0;
+  private inFlight: Promise<HerdrUpdateStatus | undefined> | null = null;
+
+  /**
+   * Undefined means "nothing to say" — herdr missing, unreadable status, or no
+   * skew worth surfacing. Callers should render a warning only for
+   * `restartNeeded`.
+   */
+  async getStatus(): Promise<HerdrUpdateStatus | undefined> {
+    if (Date.now() - this.cachedAt < CACHE_TTL_MS) return this.cached;
+    // Several dashboard pollers (local card + peers) can land together; one
+    // spawn serves them all.
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = this.probe().finally(() => {
+      this.inFlight = null;
+    });
+    return this.inFlight;
+  }
+
+  /** Force the next getStatus() to re-probe (used right after applying). */
+  invalidate(): void {
+    this.cachedAt = 0;
+  }
+
+  private async probe(): Promise<HerdrUpdateStatus | undefined> {
+    const status = await this.readStatus();
+    this.cached = status;
+    this.cachedAt = Date.now();
+    return status;
+  }
+
+  private async readStatus(): Promise<HerdrUpdateStatus | undefined> {
+    if (!herdrBinaryPath()) return undefined; // herdr not installed
+
+    let reading: HerdrSkewReading | null = null;
+    try {
+      const { exitCode, stdout } = await runCapture([herdrBin(), 'status', '--json']);
+      if (exitCode !== 0) return undefined;
+      reading = parseHerdrStatus(stdout);
+    } catch {
+      return undefined;
+    }
+    if (!reading) return undefined;
+
+    const supervisor = reading.restartNeeded ? await this.detectSupervisor() : 'unmanaged';
+    return {
+      binaryVersion: reading.binaryVersion,
+      serverVersion: reading.serverVersion,
+      restartNeeded: reading.restartNeeded,
+      canApply: reading.restartNeeded && supervisor !== 'unmanaged',
+    };
+  }
+
+  async detectSupervisor(): Promise<HerdrSupervisor> {
+    try {
+      if (process.platform === 'darwin') {
+        const { exitCode } = await runCapture([
+          'launchctl',
+          'print',
+          `gui/${process.getuid?.() ?? 0}/com.herdr.server`,
+        ]);
+        return exitCode === 0 ? 'launchd' : 'unmanaged';
+      }
+      const { stdout } = await runCapture(['systemctl', '--user', 'is-active', 'herdr']);
+      return stdout.trim() === 'active' ? 'systemd' : 'unmanaged';
+    } catch {
+      return 'unmanaged';
+    }
+  }
+
+  /**
+   * Run `herdr update` and restart the supervised server. Only ever called
+   * from the authenticated endpoint behind an explicit user click.
+   */
+  async apply(): Promise<{ ok: boolean; error?: string; output: string }> {
+    const supervisor = await this.detectSupervisor();
+    const commands = buildHerdrApplyCommands(supervisor, herdrBin(), process.getuid?.() ?? 0);
+    if (!commands) {
+      return {
+        ok: false,
+        error: 'herdr is not managed by systemd/launchd; restart it manually',
+        output: '',
+      };
+    }
+
+    let output = '';
+    for (const cmd of commands) {
+      const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      output += stdout + stderr;
+      if (exitCode !== 0) {
+        return { ok: false, error: `${cmd.join(' ')} failed (exit ${exitCode})`, output };
+      }
+    }
+
+    this.invalidate();
+    return { ok: true, output };
+  }
+}

--- a/frontend/src/components/dashboard/PeerServerCard.tsx
+++ b/frontend/src/components/dashboard/PeerServerCard.tsx
@@ -14,7 +14,7 @@ interface PeerServerCardProps {
  */
 export function PeerServerCard({ peer }: PeerServerCardProps) {
 	const isLocal = peer.id === LOCAL_PEER_ID;
-	const { systemMetrics, diskUsage, connectedClients, error } =
+	const { systemMetrics, diskUsage, connectedClients, herdrUpdate, error, refetch } =
 		usePeerServerMetrics(peer.id);
 
 	return (
@@ -43,6 +43,9 @@ export function PeerServerCard({ peer }: PeerServerCardProps) {
 				connectedClients={connectedClients}
 				label={peer.nickname}
 				hideThroughput={!isLocal}
+				herdrUpdate={herdrUpdate}
+				allowHerdrApply={isLocal}
+				onHerdrApplied={refetch}
 			/>
 		</div>
 	);

--- a/frontend/src/components/dashboard/ServerInfo.tsx
+++ b/frontend/src/components/dashboard/ServerInfo.tsx
@@ -1,9 +1,14 @@
-import { Users } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle, Users } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import type {
+	HerdrUpdateStatus,
 	SystemMetrics,
 	SystemMetricsSnapshot,
 } from "../../../../shared/types";
+import { authFetch } from "../../services/api";
+
+const API_BASE = import.meta.env.VITE_API_URL || "";
 
 function useIsLightMode() {
 	const [light, setLight] = useState(
@@ -197,6 +202,97 @@ function formatSpeed(bps: number): string {
 	return `${bps.toFixed(0)} B/s`;
 }
 
+// ─── herdr version skew notice (#393) ───
+/**
+ * `herdr update` swaps the binary but leaves the running server on the old
+ * version, and cchub spawns that binary to drive panes — so the skew shows up
+ * as "the terminal won't connect". Applying costs every running command, so
+ * the restart happens only when the user presses this button.
+ */
+function HerdrUpdateNotice({
+	status,
+	allowApply,
+	onApplied,
+}: {
+	status: HerdrUpdateStatus;
+	allowApply: boolean;
+	onApplied?: () => void;
+}) {
+	const { t } = useTranslation();
+	const [applying, setApplying] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const apply = useCallback(async () => {
+		setApplying(true);
+		setError(null);
+		try {
+			const res = await authFetch(`${API_BASE}/api/herdr/apply-update`, {
+				method: "POST",
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({}));
+				throw new Error(body.error || `HTTP ${res.status}`);
+			}
+			onApplied?.();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Unknown error");
+		} finally {
+			setApplying(false);
+		}
+	}, [onApplied]);
+
+	// The button is offered only for the local server: it restarts *this*
+	// host's herdr, and an unsupervised server can't be restarted at all.
+	const canApply = allowApply && status.canApply;
+
+	return (
+		<div className="rounded-md border border-amber-500/30 bg-amber-500/[0.08] p-2 space-y-1.5">
+			<div className="flex items-start gap-1.5">
+				<AlertTriangle className="w-3 h-3 text-amber-400 mt-0.5 shrink-0" />
+				<div className="min-w-0 space-y-0.5">
+					<p className="text-[11px] font-medium text-amber-300">
+						{t("dashboard.herdrUpdateTitle")}
+					</p>
+					{status.serverVersion && status.binaryVersion && (
+						<p className="text-[10px] text-amber-200/60 font-mono tabular-nums">
+							{t("dashboard.herdrUpdateVersions", {
+								server: status.serverVersion,
+								binary: status.binaryVersion,
+							})}
+						</p>
+					)}
+					<p className="text-[10px] text-amber-200/70 leading-snug">
+						{t("dashboard.herdrUpdateCost")}
+					</p>
+				</div>
+			</div>
+			{canApply ? (
+				<button
+					type="button"
+					onClick={apply}
+					disabled={applying}
+					className="w-full text-[11px] font-medium px-2 py-1 rounded bg-amber-500/20 text-amber-200 border border-amber-500/30 hover:bg-amber-500/30 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+				>
+					{applying
+						? t("dashboard.herdrUpdateApplying")
+						: t("dashboard.herdrUpdateApply")}
+				</button>
+			) : (
+				allowApply && (
+					<p className="text-[10px] text-amber-200/50 leading-snug">
+						{t("dashboard.herdrUpdateManualHint")}
+					</p>
+				)
+			)}
+			{error && (
+				<p className="text-[10px] text-red-400 leading-snug break-words">
+					{t("dashboard.herdrUpdateFailed", { error })}
+				</p>
+			)}
+		</div>
+	);
+}
+
 // ─── Main component ───
 interface ServerInfoProps {
 	systemMetrics?: SystemMetrics;
@@ -211,6 +307,12 @@ interface ServerInfoProps {
 	label?: string;
 	/** Hide the throughput chart (it tracks this browser's WS bytes, not the peer's). */
 	hideThroughput?: boolean;
+	/** herdr binary-vs-server skew for this server (#393). */
+	herdrUpdate?: HerdrUpdateStatus;
+	/** Offer the apply button — local server only; the endpoint restarts this host's herdr. */
+	allowHerdrApply?: boolean;
+	/** Re-poll after an apply so the warning clears once the server is current. */
+	onHerdrApplied?: () => void;
 }
 
 // Throughput history (kept in module scope so it persists across re-renders)
@@ -244,6 +346,9 @@ export function ServerInfo({
 	connectedClients,
 	label,
 	hideThroughput = false,
+	herdrUpdate,
+	allowHerdrApply = false,
+	onHerdrApplied,
 }: ServerInfoProps) {
 	const isLight = useIsLightMode();
 
@@ -293,6 +398,14 @@ export function ServerInfo({
 					</span>
 				</div>
 			</div>
+
+			{herdrUpdate?.restartNeeded && (
+				<HerdrUpdateNotice
+					status={herdrUpdate}
+					allowApply={allowHerdrApply}
+					onApplied={onHerdrApplied}
+				/>
+			)}
 
 			{/* Charts: CPU, Memory, Throughput */}
 			{cur && (

--- a/frontend/src/hooks/usePeerServerMetrics.ts
+++ b/frontend/src/hooks/usePeerServerMetrics.ts
@@ -8,6 +8,7 @@ interface PeerServerMetrics {
 	systemMetrics?: DashboardResponse["systemMetrics"];
 	diskUsage?: DashboardResponse["diskUsage"];
 	connectedClients?: number;
+	herdrUpdate?: DashboardResponse["herdrUpdate"];
 }
 
 interface UsePeerServerMetricsReturn extends PeerServerMetrics {
@@ -42,6 +43,7 @@ export function usePeerServerMetrics(
 				systemMetrics: data.systemMetrics,
 				diskUsage: data.diskUsage,
 				connectedClients: data.connectedClients,
+				herdrUpdate: data.herdrUpdate,
 			});
 			setError(null);
 		} catch (err) {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -156,7 +156,14 @@
 		"cpuUsage": "CPU Usage",
 		"memoryUsage": "Memory Usage",
 		"loadAverage": "Load avg",
-		"cores": "cores"
+		"cores": "cores",
+		"herdrUpdateTitle": "herdr has been updated",
+		"herdrUpdateCost": "Applying it requires restarting the herdr server. All panes are re-created — agent conversations are restored automatically, but running commands are lost.",
+		"herdrUpdateVersions": "server {{server}} → binary {{binary}}",
+		"herdrUpdateApply": "Update & restart herdr",
+		"herdrUpdateApplying": "Updating…",
+		"herdrUpdateManualHint": "herdr isn't managed by systemd/launchd here, so restart the herdr server manually to apply.",
+		"herdrUpdateFailed": "Update failed: {{error}}"
 	},
 	"files": {
 		"title": "File Browser",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -156,7 +156,14 @@
 		"cpuUsage": "CPU使用率",
 		"memoryUsage": "メモリ使用率",
 		"loadAverage": "負荷平均",
-		"cores": "コア"
+		"cores": "コア",
+		"herdrUpdateTitle": "herdr が更新されています",
+		"herdrUpdateCost": "反映には herdr サーバの再起動が必要です。再起動すると全ペインが張り直され、エージェントの会話は自動復元されますが、実行中のコマンドは失われます。",
+		"herdrUpdateVersions": "サーバ {{server}} → バイナリ {{binary}}",
+		"herdrUpdateApply": "更新して herdr を再起動",
+		"herdrUpdateApplying": "更新中…",
+		"herdrUpdateManualHint": "herdr が systemd/launchd の管理下にないため、herdr サーバを手動で再起動してください。",
+		"herdrUpdateFailed": "更新に失敗しました: {{error}}"
 	},
 	"files": {
 		"title": "ファイルブラウザ",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -471,6 +471,22 @@ export interface UsageLimitsStatus {
   isStale?: boolean; // true when serving cached data while backing off
 }
 
+/**
+ * herdr binary-vs-server version skew (#393). Present only when cchub could
+ * read herdr's status; absent means "don't say anything" (herdr missing or an
+ * unreadable status) so a format change never turns into a false warning.
+ */
+export interface HerdrUpdateStatus {
+  /** Version of the herdr binary on disk. */
+  binaryVersion?: string;
+  /** Version of the herdr server process currently holding the panes. */
+  serverVersion?: string;
+  /** True when the running server is older than the binary cchub spawns. */
+  restartNeeded: boolean;
+  /** True when herdr runs under systemd/launchd, so cchub can restart it. */
+  canApply: boolean;
+}
+
 export interface DashboardResponse {
   limits: LimitsInfo | null; // Deprecated, kept for compatibility
   usageLimits: UsageLimits | null; // New: from Anthropic API
@@ -484,6 +500,7 @@ export interface DashboardResponse {
   systemMetrics?: SystemMetrics; // System CPU/memory metrics
   diskUsage?: { total: number; used: number; available: number; mountpoint: string };
   connectedClients?: number;
+  herdrUpdate?: HerdrUpdateStatus;
 }
 
 export interface ExtendedSessionResponse extends SessionResponse {


### PR DESCRIPTION
## 背景

`herdr update` はバイナリを置き換えるだけで、稼働中のサーバは旧版のまま動き続ける。cchub はペイン制御に CLI バイナリを spawn する (`PaneController`) ため、update 後・再起動前は「新しい CLI → 古い稼働サーバ」の版ズレになり、症状は「ターミナルが繋がらない」として出る。既存の検査は起動時に一度だけで、`herdr update` は必ずその後に走るので捕まえられなかった。

Closes #393

## 実装

**検知** (`backend/src/services/herdr-update.ts`)
`herdr status --json` は on-disk バイナリ (`client`) と稼働サーバ (`server`) を並べて返し、herdr 自身の `restart_needed` / `compatible` 判定も含む。これを1回の spawn で読み、30秒キャッシュしてダッシュボードのポーリングに相乗りする（専用タイマーなし）。

**通告** (`ServerInfo.tsx`)
ローカルのサーバカードに警告。文言に再起動のコストを明示（全ペイン張り直し / 会話は自動復元 / 実行中のコマンドは失われる）。i18n は en / ja 両方。

**適用** (`POST /api/herdr/apply-update`, 認証必須)
ユーザーがボタンを押した時だけ `herdr update` → 監視下のサーバを再起動。update が失敗したら再起動に進まない。

## 「やらないこと」の担保

- `cchub update --auto` の経路は herdr に一切触れない → `update.ts` のソースを検査するガードテストで固定
- `--handoff` は使わない（handoff 先が systemd/launchd の管理外に出て `Restart=always` と衝突）→ テストで固定
- cchub は自発的に再起動しない（適用は明示操作のみ）
- herdr 未インストール / 出力形式変更 / パース不能 → 警告を出さずに degrade。誤警告は全ペインの実行中コマンドを失わせるコストがあるため「読めなければ検知しない」に倒す
- systemd/launchd 管理外では適用ボタンを出さず手順提示のみ（`systemctl restart` が無音の no-op になるため）

## テスト

`bun run test` 295 pass / 0 fail（新規 22 件）、`bun run lint` / `bun run typecheck` clean。パースは実際の herdr 0.7.3 出力に加え、空文字・非JSON・配列・スカラー・切断JSON・旧版の usage エラー・server 停止中・フィールド改名・非boolean値で **警告を出さない** ことを網羅。

## dev 確認済み (backend 3496-3499, 本番 5923 とは別ポート)

- 実機（版一致）→ `restartNeeded: false` で警告なし
- `$HERDR_BIN` にスタブを噛ませて版ズレを再現 → `{"binaryVersion":"0.7.4","serverVersion":"0.7.3","restartNeeded":true,"canApply":true}`、UI に警告 + ボタンが ja/en 両方で描画
- 出力を壊したスタブ → `herdrUpdate` フィールドごと消えて警告なし、他のダッシュボードは無傷
- 認証: 未認証 POST → 401
- 適用経路: `update` が失敗するスタブで認証済み POST → 500 で停止し、`systemctl restart` に到達しないことを確認（herdr の `ActiveEnterTimestamp` 不変）

**未確認**: 実際の `systemctl --user restart herdr` は実行していない（稼働中の他セッションを巻き込むため）。再起動後に警告が消えること・workspace とエージェント会話が復元されることの実機確認は残っている。コマンド組み立てと「update 失敗時に再起動へ進まない」順序はユニットテストで担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185QThpJTL5RmMWUgCYWFQK
