### PR TITLE
feat(herdr): drive session indicators from herdr agent status, not hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - **CodexUsageService** (`services/codex-usage.ts`) - Tracks Codex token usage and rate-limit state
 - **CodexHistoryService** (`services/codex-history.ts`) - Reads Codex rollout transcripts (`~/.codex/sessions`) and merges them into project history alongside Claude Code sessions
 - **ConversationWatcher** (`services/conversation-watcher.ts`) - Watches Claude Code / Codex `.jsonl` files and emits conversation updates to subscribed WebSocket clients
-- **HookStatusService** (`services/hook-status.ts`) - Tracks per-session indicator state driven by Claude Code / Codex hook events (`Stop`, `PreToolUse`, `UserPromptSubmit`, etc.)
+- **HookStatusService** (`services/hook-status.ts`) - Reports whether the hooks CC Hub still needs are installed (`Stop` for notification text, `PostToolUse`/`AskUserQuestion` for the question's tool name). Indicator transitions come from herdr, not hooks
+- **HerdrAgentStatusWatcher** (`services/herdr-agent-status.ts`) - Subscribes to herdr's per-pane `pane.agent_status_changed` (plus pane lifecycle events, which re-subscribe the pane set) and triggers an immediate sessions push. Decides *when* to rebuild the list, never what's in it — a dropped event costs latency, not correctness
 - **AuthService** (`services/auth.ts`) - Password-based authentication with session tokens
 - **PeerRegistry** (`services/peer-registry.ts`) - Persists peer server metadata to `peers.json` (with mutation locking), records per-peer success/failure state
 - **PeerAuth** (`services/peer-auth.ts`) - Proxy login to peer servers (`POST /api/auth/login`), stores JWT tokens for subsequent API/WS calls, marks peers `unauthorized` on 401
@@ -356,8 +357,6 @@ Hook → cchub notify (stdin JSON) → POST /api/notify → WebSocket broadcast 
 {
   "hooks": {
     "Stop": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
-    "PreToolUse": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
-    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
     "PostToolUse": [{
       "matcher": "AskUserQuestion",
       "hooks": [{ "type": "command", "command": "cchub notify" }]
@@ -365,6 +364,8 @@ Hook → cchub notify (stdin JSON) → POST /api/notify → WebSocket broadcast 
   }
 }
 ```
+
+`PreToolUse` / `UserPromptSubmit` はもう不要（v0.2.2〜）。インジケータの状態遷移は herdr の `pane.agent_status_changed` から取るようになったため、hook は herdr が持たない情報（通知本文・質問のツール名）だけを運ぶ。既に登録済みでも害はない。
 
 2. `cchub` バイナリにPATHが通っていることを確認（hookはClaude Code / Codex のプロセスから実行される）
 

--- a/README.md
+++ b/README.md
@@ -281,8 +281,6 @@ Receive browser push notifications when Claude Code completes a response or need
 {
   "hooks": {
     "Stop": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
-    "PreToolUse": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
-    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
     "PostToolUse": [{
       "matcher": "AskUserQuestion",
       "hooks": [{ "type": "command", "command": "cchub notify" }]
@@ -292,6 +290,8 @@ Receive browser push notifications when Claude Code completes a response or need
 ```
 
 Add this to `~/.claude/settings.json`. The CC Hub server must be running. Allow browser notification permissions on first access.
+
+Session indicators (working / waiting / done) need no hooks at all — herdr reports agent status itself. These two hooks only carry what herdr can't see: the notification text and the name of the tool that asked a question.
 
 ## Development Setup
 

--- a/backend/src/routes/notify.ts
+++ b/backend/src/routes/notify.ts
@@ -189,7 +189,11 @@ notify.post('/', async (c) => {
       if (newState) {
         const ttl = OVERRIDE_TTL;
         evictStateOverrides();
-        stateOverrides.set(sessionId, { state: newState, expiresAt: Date.now() + ttl, toolName: event === 'PreToolUse' ? toolName : undefined });
+        // Keep the tool name from either side of the tool call: PreToolUse is
+        // optional now that herdr reports `blocked` on its own (#390), so
+        // PostToolUse/AskUserQuestion has to be able to name the question.
+        const carriesToolName = event === 'PreToolUse' || event === 'PostToolUse';
+        stateOverrides.set(sessionId, { state: newState, expiresAt: Date.now() + ttl, toolName: carriesToolName ? toolName : undefined });
       }
     }
 
@@ -227,8 +231,8 @@ notify.get('/hook-status', async (c) => {
     // settings / config files don't exist or are invalid
     return c.json({
       configured: false,
-      events: { stop: false, preToolUse: false, userPromptSubmit: false, askUserQuestion: false },
-      missing: ['stop', 'preToolUse', 'userPromptSubmit', 'askUserQuestion'],
+      events: { stop: false, askUserQuestion: false },
+      missing: ['stop', 'askUserQuestion'],
     });
   }
 });

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -139,6 +139,29 @@ async function sendTextToSession(
   });
 }
 
+/**
+ * herdr's agent status → CC Hub indicator.
+ *
+ * Verified against Claude 2.x on herdr 0.7.3: `working` while responding,
+ * `blocked` while a TUI prompt waits on the user (AskUserQuestion and
+ * permission prompts both), `idle` before the first turn, `done` after one.
+ * Anything else — `unknown`, or a state a future herdr adds — returns null so
+ * the caller falls back instead of showing a confidently wrong indicator.
+ */
+export function herdrStatusToIndicator(status?: string): IndicatorState | null {
+  switch (status) {
+    case 'working':
+      return 'processing';
+    case 'blocked':
+      return 'waiting_input';
+    case 'idle':
+    case 'done':
+      return 'completed';
+    default:
+      return null;
+  }
+}
+
 export const sessions = new Hono();
 
 /** Build the full sessions list (shared by HTTP handler and WS push) */
@@ -183,16 +206,16 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         ? codexThread?.sessionId
         : undefined;
 
-    // Indicator state: hook events are the source of truth.
-    // Claude defaults to completed (idle/waiting for user input); Codex keeps
-    // tmux/process state unless a hook event has been received.
+    // Indicator state: herdr's own agent detection is the source of truth —
+    // it tracks the pane itself, so it can't go stale when a hook is missing,
+    // fails to fire, or the agent is killed mid-turn. Hooks only fill in what
+    // herdr can't see (an agent it hasn't detected) and carry the notification
+    // text / tool name.
     const hookResult = conversationSessionId ? getIndicatorOverride(conversationSessionId) : null;
     const hookState = hookResult?.state ?? null;
     const hookToolName = hookResult?.toolName;
-    // When hooks say "processing" but herdr's agent detection says the agent
-    // is blocked, Claude is waiting for permission (not actually processing).
-    // (Replaces the tmux-era ✳-pane-title heuristic.)
-    const indicatorState: IndicatorState = (hookState === 'processing' && s.agentBlocked) ? 'waiting_input' : (hookState ?? 'completed');
+    const herdrState = herdrStatusToIndicator(s.agentStatus);
+    const indicatorState: IndicatorState = herdrState ?? hookState ?? 'completed';
     // Use hook tool name for waiting state when jsonl doesn't have it yet
     const effectiveWaitingToolName = (indicatorState === 'waiting_input' && hookToolName && !ccSession?.waitingToolName)
       ? hookToolName : ccSession?.waitingToolName;
@@ -210,10 +233,12 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     // ccSession.projectPath === s.currentPath.
     const isExactPathMatch = !!ccSession && !!s.currentPath && ccSession.projectPath === s.currentPath;
 
+    // Codex keeps hooks first: herdr detects Codex panes too, but its status
+    // accuracy there hasn't been verified the way it has for Claude (#390).
     const sessionIndicatorState = includeClaudeInfo
       ? indicatorState
       : includeCodexInfo
-        ? (hookState ?? undefined)
+        ? (hookState ?? herdrState ?? undefined)
         : undefined;
 
     const panePids: (number | undefined)[] = s.panes ? s.panes.map((p: { pid?: number }) => p.pid) : [];

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -5,6 +5,7 @@ import {
   getOrCreateHerdrControlSession,
   type HerdrControlSession,
 } from '../services/herdr-control';
+import { startAgentStatusWatcher, stopAgentStatusWatcher } from '../services/herdr-agent-status';
 import { ConversationWatcher } from '../services/conversation-watcher';
 import type {
   ControlClientMessage,
@@ -88,6 +89,11 @@ let lastSessionsJson = '';
 
 function startSessionsPush() {
   if (sessionsPushTimer) return;
+  // herdr tells us the instant an agent changes state; the interval below is
+  // the floor (metrics, recap, anything herdr doesn't emit), not the ceiling.
+  startAgentStatusWatcher(() => {
+    if (activeMuxConnections.size > 0) pushSessionsNow();
+  });
   sessionsPushTimer = setInterval(async () => {
     if (activeMuxConnections.size === 0) {
       stopSessionsPush();
@@ -115,6 +121,7 @@ function stopSessionsPush() {
     clearInterval(sessionsPushTimer);
     sessionsPushTimer = null;
   }
+  stopAgentStatusWatcher();
   lastSessionsJson = '';
 }
 

--- a/backend/src/services/__tests__/herdr-agent-indicator.test.ts
+++ b/backend/src/services/__tests__/herdr-agent-indicator.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+import { herdrStatusToIndicator } from '../../routes/sessions';
+import { parseHookJson, parseHookToml } from '../hook-status';
+
+/**
+ * #390: herdr's own agent detection drives the indicator, so the
+ * status-transition hooks (PreToolUse / UserPromptSubmit) are gone. These lock
+ * in the mapping and the "don't ask for hooks we no longer need" contract.
+ */
+describe('herdrStatusToIndicator', () => {
+  it('maps herdr agent states to indicator states', () => {
+    // Verified against Claude 2.x on herdr 0.7.3 (probe: idle -> working ->
+    // blocked at an AskUserQuestion prompt -> done).
+    expect(herdrStatusToIndicator('working')).toBe('processing');
+    expect(herdrStatusToIndicator('blocked')).toBe('waiting_input');
+    expect(herdrStatusToIndicator('idle')).toBe('completed');
+    expect(herdrStatusToIndicator('done')).toBe('completed');
+  });
+
+  it('falls through on states it cannot interpret', () => {
+    // `unknown` = no agent on the pane. A future herdr may add states; guessing
+    // would show a confidently wrong indicator, so the caller must fall back.
+    expect(herdrStatusToIndicator('unknown')).toBeNull();
+    expect(herdrStatusToIndicator(undefined)).toBeNull();
+    expect(herdrStatusToIndicator('thinking_very_hard')).toBeNull();
+  });
+});
+
+describe('hook status expectations', () => {
+  it('only requires the hooks herdr cannot replace', () => {
+    const settings = JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ command: 'cchub notify' }] }],
+        PostToolUse: [{ matcher: 'AskUserQuestion', hooks: [{ command: 'cchub notify' }] }],
+      },
+    });
+    const parsed = parseHookJson(settings);
+    // No PreToolUse / UserPromptSubmit here — this must still be "complete".
+    expect(parsed).toEqual({ stop: true, askUserQuestion: true });
+  });
+
+  it('does not credit an untracked TOML section to the hook parsed before it', () => {
+    // Regression: dropping PreToolUse from the section regex left currentEvent
+    // pointing at Stop, so PreToolUse's `cchub notify` marked stop configured.
+    const toml = `
+[[hooks.PreToolUse]]
+command = "cchub notify"
+`;
+    expect(parseHookToml(toml)).toEqual({ stop: false, askUserQuestion: false });
+  });
+
+  it('still detects the hooks it does track in TOML', () => {
+    const toml = `
+[[hooks.Stop]]
+command = "cchub notify"
+
+[[hooks.PostToolUse]]
+matcher = "AskUserQuestion"
+command = "cchub notify"
+`;
+    expect(parseHookToml(toml)).toEqual({ stop: true, askUserQuestion: true });
+  });
+});

--- a/backend/src/services/herdr-agent-status.ts
+++ b/backend/src/services/herdr-agent-status.ts
@@ -1,0 +1,123 @@
+/**
+ * Live agent-status watcher.
+ *
+ * herdr knows the moment an agent starts working, finishes, or gets stuck on a
+ * prompt. Without this, the UI only learns about it on the next 5s sessions
+ * push. Subscribing turns that into an immediate push.
+ *
+ * The watcher owns no state: it decides *when* to rebuild the session list, not
+ * what's in it. Status values still come from `pane.list` at build time, so a
+ * dropped event costs latency (until the next 5s tick), never correctness.
+ *
+ * `pane.agent_status_changed` is a per-pane subscription (`pane_id` required,
+ * verified against `herdr api schema`, protocol 16), so the pane set has to be
+ * re-subscribed as panes come and go — hence the lifecycle subscriptions.
+ */
+
+import { herdrSubscribe, listPanes } from './herdr-client';
+
+/** Events that change which panes exist — each one re-subscribes the pane set. */
+const LIFECYCLE_EVENTS = ['pane.created', 'pane.closed', 'pane.exited', 'pane.agent_detected'];
+
+const CHANGE_DEBOUNCE_MS = 150;
+const RESUBSCRIBE_DEBOUNCE_MS = 400;
+/** Backoff after a dropped/rejected subscription. herdr restarts land here. */
+const RETRY_DELAY_MS = 5_000;
+
+let unsubscribe: (() => void) | null = null;
+let running = false;
+let changeTimer: ReturnType<typeof setTimeout> | null = null;
+let resubscribeTimer: ReturnType<typeof setTimeout> | null = null;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+let onStatusChange: (() => void) | null = null;
+
+function clearTimer(t: ReturnType<typeof setTimeout> | null): null {
+  if (t) clearTimeout(t);
+  return null;
+}
+
+/** Coalesce bursts: a turn ending fires status + output events together. */
+function scheduleChangePush(): void {
+  if (changeTimer) return;
+  changeTimer = setTimeout(() => {
+    changeTimer = null;
+    onStatusChange?.();
+  }, CHANGE_DEBOUNCE_MS);
+}
+
+function scheduleResubscribe(): void {
+  if (resubscribeTimer) return;
+  resubscribeTimer = setTimeout(() => {
+    resubscribeTimer = null;
+    void subscribeToPanes();
+  }, RESUBSCRIBE_DEBOUNCE_MS);
+}
+
+function scheduleRetry(): void {
+  if (retryTimer || !running) return;
+  retryTimer = setTimeout(() => {
+    retryTimer = null;
+    void subscribeToPanes();
+  }, RETRY_DELAY_MS);
+}
+
+async function subscribeToPanes(): Promise<void> {
+  if (!running) return;
+
+  let panes: Awaited<ReturnType<typeof listPanes>>;
+  try {
+    panes = await listPanes();
+  } catch {
+    scheduleRetry(); // herdr down / restarting — the 5s poll covers us meanwhile
+    return;
+  }
+  if (!running) return;
+
+  unsubscribe?.();
+  unsubscribe = null;
+
+  const subscriptions: Array<Record<string, unknown>> = [
+    ...LIFECYCLE_EVENTS.map((type) => ({ type })),
+    ...panes.map((p) => ({ type: 'pane.agent_status_changed', pane_id: p.pane_id })),
+  ];
+
+  unsubscribe = herdrSubscribe(
+    subscriptions,
+    (ev) => {
+      const kind = typeof ev.event === 'string' ? ev.event : '';
+      if (kind === 'pane.agent_status_changed') {
+        scheduleChangePush();
+      } else if (LIFECYCLE_EVENTS.includes(kind)) {
+        // A new pane needs its own status subscription; a closed one should
+        // stop holding one. Push too — pane sets are user-visible.
+        scheduleResubscribe();
+        scheduleChangePush();
+      }
+    },
+    () => {
+      unsubscribe = null;
+      scheduleRetry();
+    },
+  );
+}
+
+/**
+ * Start watching. `onChange` fires (debounced) whenever herdr reports an agent
+ * status change or a pane appears/disappears. Idempotent.
+ */
+export function startAgentStatusWatcher(onChange: () => void): void {
+  if (running) return;
+  running = true;
+  onStatusChange = onChange;
+  void subscribeToPanes();
+}
+
+export function stopAgentStatusWatcher(): void {
+  running = false;
+  onStatusChange = null;
+  unsubscribe?.();
+  unsubscribe = null;
+  changeTimer = clearTimer(changeTimer);
+  resubscribeTimer = clearTimer(resubscribeTimer);
+  retryTimer = clearTimer(retryTimer);
+}

--- a/backend/src/services/herdr-client.ts
+++ b/backend/src/services/herdr-client.ts
@@ -70,6 +70,13 @@ export interface HerdrScroll {
   viewport_rows: number;
 }
 
+/**
+ * herdr's AgentStatus enum (protocol 16, `herdr api schema`). Kept as a union
+ * of known values plus `string`: herdr may add states, and an unknown one must
+ * fall through to the caller's default rather than be mapped to a wrong state.
+ */
+export type HerdrAgentStatus = 'idle' | 'working' | 'blocked' | 'done' | 'unknown' | (string & {});
+
 export interface HerdrPane {
   pane_id: string;
   workspace_id: string;
@@ -78,7 +85,7 @@ export interface HerdrPane {
   cwd: string;
   foreground_cwd?: string;
   focused: boolean;
-  agent_status: string;
+  agent_status: HerdrAgentStatus;
   revision: number;
   scroll: HerdrScroll;
 }

--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -14,6 +14,7 @@ import {
   listWorkspaces,
   readPaneText,
   toTmuxPaneId,
+  type HerdrAgentStatus,
   type HerdrWorkspace,
 } from './herdr-client';
 import { herdrControlSessions } from './herdr-control';
@@ -45,9 +46,12 @@ interface HerdrSessionInfo {
    *  herdr agent integration hook. Authoritative for .jsonl matching — two
    *  sessions in the same workingDir stay distinguishable. */
   agentSessionId?: string;
-  /** herdr's own detection says the agent is blocked waiting for input
-   *  (permission prompt etc.). */
-  agentBlocked?: boolean;
+  /** herdr's own agent detection, verified against Claude 2.x on herdr 0.7.3:
+   *  `working` while it responds, `blocked` while a TUI prompt waits on the
+   *  user (AskUserQuestion / permission), `idle` before a turn, `done` after
+   *  one, `unknown` when no agent is on the pane. Drives the indicator, so
+   *  hooks no longer have to report every state transition. */
+  agentStatus?: HerdrAgentStatus;
 }
 
 /** Session id for a workspace: label when present, else the workspace id. */
@@ -193,12 +197,14 @@ export class HerdrService {
           // agent).
           let agent: AgentProvider | undefined;
           let agentPanePath: string | undefined;
+          let agentPaneStatus: HerdrAgentStatus | undefined;
           for (const p of wsPanes) {
             const { cmdlines } = await this.paneProcesses(p.pane_id);
             const detected = HerdrService.detectAgent(cmdlines);
             if (detected) {
               agent = detected;
               agentPanePath = p.foreground_cwd || p.cwd;
+              agentPaneStatus = p.agent_status;
               break;
             }
           }
@@ -224,7 +230,14 @@ export class HerdrService {
           const agentSessionId = wsPanes
             .map((p) => agentSessions.get(p.pane_id))
             .find((id) => id !== undefined);
-          const agentBlocked = wsPanes.some((p) => p.agent_status === 'blocked');
+          // `blocked` anywhere in the workspace wins: an agent waiting on a
+          // prompt is the state the user has to act on, even if the split it
+          // sits in isn't the one we matched an agent process to.
+          const agentStatus: HerdrAgentStatus | undefined = wsPanes.some(
+            (p) => p.agent_status === 'blocked',
+          )
+            ? 'blocked'
+            : agentPaneStatus;
           return {
             id: workspaceSessionId(ws),
             name: workspaceSessionId(ws),
@@ -238,7 +251,7 @@ export class HerdrService {
             preview,
             panes,
             agentSessionId,
-            agentBlocked,
+            agentStatus,
           };
         }),
       );

--- a/backend/src/services/hook-status.ts
+++ b/backend/src/services/hook-status.ts
@@ -2,10 +2,15 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
+/**
+ * Hooks CC Hub still needs. Indicator transitions used to need PreToolUse and
+ * UserPromptSubmit too; herdr reports agent status itself now (#390), so those
+ * are no longer expected — flagging their absence would be a false alarm.
+ * What's left is what herdr can't give us: the notification text (Stop) and the
+ * name of the tool a question came from (PostToolUse/AskUserQuestion).
+ */
 type HookEventStatus = {
   stop: boolean;
-  preToolUse: boolean;
-  userPromptSubmit: boolean;
   askUserQuestion: boolean;
 };
 
@@ -26,8 +31,6 @@ type HookStatus = HookProviderStatus & {
 
 const DEFAULT_EVENTS: HookEventStatus = {
   stop: false,
-  preToolUse: false,
-  userPromptSubmit: false,
   askUserQuestion: false,
 };
 
@@ -69,8 +72,6 @@ export function parseHookJson(content: string): HookEventStatus | null {
 
     return {
       stop: hasCchubNotify(hooks.Stop),
-      preToolUse: hasCchubNotify(hooks.PreToolUse),
-      userPromptSubmit: hasCchubNotify(hooks.UserPromptSubmit),
       askUserQuestion: hasCchubNotify(hooks.PostToolUse, 'AskUserQuestion'),
     };
   } catch {
@@ -99,16 +100,17 @@ export function parseHookToml(content: string): HookEventStatus | null {
     const line = rawLine.trim();
     if (!line || line.startsWith('#')) continue;
 
-    const sectionMatch = line.match(/^\[\[hooks\.(Stop|PreToolUse|UserPromptSubmit|PostToolUse)(?:\.hooks)?\]\]$/);
-    if (sectionMatch) {
-      currentEvent = sectionMatch[1] === 'Stop'
-        ? 'stop'
-        : sectionMatch[1] === 'PreToolUse'
-          ? 'preToolUse'
-          : sectionMatch[1] === 'UserPromptSubmit'
-            ? 'userPromptSubmit'
-            : 'askUserQuestion';
-      inHookItems = line.includes('.hooks]]');
+    // Any section header ends the previous one. Sections we don't track
+    // (PreToolUse etc.) must clear currentEvent, or their `cchub notify` line
+    // would be credited to whichever hook was parsed before them.
+    if (line.startsWith('[')) {
+      const sectionMatch = line.match(/^\[\[hooks\.(Stop|PostToolUse)(?:\.hooks)?\]\]$/);
+      currentEvent = sectionMatch
+        ? sectionMatch[1] === 'Stop'
+          ? 'stop'
+          : 'askUserQuestion'
+        : null;
+      inHookItems = !!sectionMatch && line.includes('.hooks]]');
       if (!inHookItems) {
         currentMatcher = null;
       }
@@ -161,8 +163,6 @@ async function getProviderStatus(paths: string[]): Promise<HookProviderStatus> {
     const events = await readHookFile(path);
     if (!events) continue;
     aggregated.stop ||= events.stop;
-    aggregated.preToolUse ||= events.preToolUse;
-    aggregated.userPromptSubmit ||= events.userPromptSubmit;
     aggregated.askUserQuestion ||= events.askUserQuestion;
   }
 
@@ -186,8 +186,6 @@ export async function getHookStatus(): Promise<HookStatus> {
 
   const events = {
     stop: claude.events.stop || codex.events.stop,
-    preToolUse: claude.events.preToolUse || codex.events.preToolUse,
-    userPromptSubmit: claude.events.userPromptSubmit || codex.events.userPromptSubmit,
     askUserQuestion: claude.events.askUserQuestion || codex.events.askUserQuestion,
   };
 

--- a/backend/tests/unit/hook-status.test.ts
+++ b/backend/tests/unit/hook-status.test.ts
@@ -4,14 +4,15 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { getHookStatus, parseHookJson, parseHookToml } from '../../src/services/hook-status';
 
+// Only Stop and PostToolUse/AskUserQuestion are tracked: herdr reports agent
+// status itself, so the transition hooks (PreToolUse / UserPromptSubmit) are no
+// longer installed and their absence must not be reported as missing (#390).
 describe('hook status parsing', () => {
   test('detects cchub notify in Claude-style JSON hooks', () => {
     const parsed = parseHookJson(
       JSON.stringify({
         hooks: {
           Stop: [{ hooks: [{ type: 'command', command: 'cchub notify' }] }],
-          PreToolUse: [{ hooks: [{ type: 'command', command: 'cchub notify' }] }],
-          UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'cchub notify' }] }],
           PostToolUse: [{ matcher: 'AskUserQuestion', hooks: [{ type: 'command', command: 'cchub notify' }] }],
         },
       }),
@@ -19,9 +20,23 @@ describe('hook status parsing', () => {
 
     expect(parsed).toEqual({
       stop: true,
-      preToolUse: true,
-      userPromptSubmit: true,
       askUserQuestion: true,
+    });
+  });
+
+  test('ignores hooks that are no longer required', () => {
+    const parsed = parseHookJson(
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: 'command', command: 'cchub notify' }] }],
+          UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'cchub notify' }] }],
+        },
+      }),
+    );
+
+    expect(parsed).toEqual({
+      stop: false,
+      askUserQuestion: false,
     });
   });
 
@@ -29,16 +44,6 @@ describe('hook status parsing', () => {
     const parsed = parseHookToml(`
 [[hooks.Stop]]
 [[hooks.Stop.hooks]]
-type = "command"
-command = "cchub notify"
-
-[[hooks.PreToolUse]]
-[[hooks.PreToolUse.hooks]]
-type = "command"
-command = "cchub notify"
-
-[[hooks.UserPromptSubmit]]
-[[hooks.UserPromptSubmit.hooks]]
 type = "command"
 command = "cchub notify"
 
@@ -51,9 +56,26 @@ command = "cchub notify"
 
     expect(parsed).toEqual({
       stop: true,
-      preToolUse: true,
-      userPromptSubmit: true,
       askUserQuestion: true,
+    });
+  });
+
+  test('does not credit an untracked TOML section to the hook before it', () => {
+    const parsed = parseHookToml(`
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = "smart-notify.py"
+
+[[hooks.PreToolUse]]
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "cchub notify"
+`);
+
+    expect(parsed).toEqual({
+      stop: false,
+      askUserQuestion: false,
     });
   });
 
@@ -68,8 +90,6 @@ command = "cchub notify"
 
     expect(parsed).toEqual({
       stop: false,
-      preToolUse: false,
-      userPromptSubmit: false,
       askUserQuestion: false,
     });
   });
@@ -85,8 +105,6 @@ command = "cchub notify"
 
     expect(parsed).toEqual({
       stop: false,
-      preToolUse: false,
-      userPromptSubmit: false,
       askUserQuestion: true,
     });
   });
@@ -103,8 +121,6 @@ command = "cchub notify"
         JSON.stringify({
           hooks: {
             Stop: [{ hooks: [{ type: 'command', command: 'cchub notify' }] }],
-            PreToolUse: [{ hooks: [{ type: 'command', command: 'cchub notify' }] }],
-            UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'cchub notify' }] }],
             PostToolUse: [{ matcher: 'AskUserQuestion', hooks: [{ type: 'command', command: 'cchub notify' }] }],
           },
         }),
@@ -116,15 +132,11 @@ command = "cchub notify"
       expect(status.providers.codex.configured).toBe(true);
       expect(status.providers.codex.events).toEqual({
         stop: true,
-        preToolUse: true,
-        userPromptSubmit: true,
         askUserQuestion: true,
       });
       expect(status.configured).toBe(true);
       expect(status.events).toEqual({
         stop: true,
-        preToolUse: true,
-        userPromptSubmit: true,
         askUserQuestion: true,
       });
     } finally {


### PR DESCRIPTION
Closes #390

## 背景

インジケータは hook (PreToolUse/UserPromptSubmit → processing, Stop → completed) で状態遷移を作り、その上に herdr の `agent_status === 'blocked'` の補正を乗せる二重構造だった。hook のインストール状態にインジケータの正しさが依存するため、hook 未設定・発火漏れ・エージェントが途中で kill された場合に「自信を持って間違った」表示になる。

## 実測（herdr 0.7.3 / Claude 2.x）

`pane.list` の `agent_status` を実ペインで観測:

| 状況 | agent_status |
|---|---|
| エージェントなし（シェル） | `unknown` |
| claude 起動直後・入力待ち | `idle` |
| 応答中 | `working` |
| **AskUserQuestion の選択待ち** | `blocked` |
| 応答完了後 | `done` |

権限プロンプトの `blocked` は移行時に検証済み（現行 `agentBlocked` の根拠）。

## 変更

- **herdr を source of truth に**: `working`→processing / `blocked`→waiting_input / `idle`,`done`→completed。`unknown` と将来 herdr が追加する未知の値は `null` を返して hook 状態にフォールバック（推測して誤表示しない）
- **hook は herdr が持てない情報だけ**: 通知本文 (Stop) と質問のツール名 (PostToolUse/AskUserQuestion)。PreToolUse / UserPromptSubmit は不要になり、hook-status の「未設定」報告対象からも外した（誤警告になるため）。PostToolUse でも toolName を保持するようにして、PreToolUse を外しても質問名が残るようにした
- **即時化**: `pane.agent_status_changed` を購読して状態変化の瞬間にセッション一覧を push（従来は最大5秒待ち）。**この購読は pane_id 必須の per-pane 購読**（`herdr api schema` protocol 16 で確認）なので、pane のライフサイクルイベントで購読を張り替える。ウォッチャーは「いつ再構築するか」だけを決め、値は従来通り `pane.list` から取るため、イベント取りこぼしは遅延にはなっても不整合にはならない
- **Codex は hook 優先のまま**: herdr は Codex ペインも検出するが精度未検証のため、herdr はフォールバックに留めた

## 検証

- dev 環境の実セッションで確認: 稼働中のペイン → `processing`、`done`/`idle` のペイン → `completed` が herdr の生値と一致
- `bun run test` 243 pass / 0 fail（新規5件）、`bun run lint` clean
- TOML パーサの回帰テストを追加: 追跡しないセクション (`[[hooks.PreToolUse]]`) の `cchub notify` が直前の hook (Stop) に誤って計上されるバグを作り込みかけたため

## ドキュメント

CLAUDE.md / README.md の hook 設定例から PreToolUse / UserPromptSubmit を削除（既に登録済みでも害はない旨を明記）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185QThpJTL5RmMWUgCYWFQK