### PR TITLE
docs: bring the docs back in line with the herdr backend

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -21,8 +21,8 @@ Claude Codeセッションをリモート管理するWebベースのターミナ
 ## 機能
 
 - **マルチセッション管理** - 複数のClaude Codeセッションを同時に実行・切り替え
-- **マルチペインターミナル** - tmux制御モードによるペイン分割・リアルタイムレイアウト同期（全クライアント共有）
-- **ペイン操作** - ズーム、リサイズ、フォーカス、クローズ、リスポーンをキーボードショートカットまたはセッションモーダルUIから操作
+- **マルチペインターミナル** - herdrバックエンドによるペイン分割・リアルタイムレイアウト同期（全クライアント共有）
+- **ペイン操作** - ズーム、リサイズ、フォーカス、クローズをキーボードショートカットまたはセッションモーダルUIから操作
 - **チームエージェント表示** - ペイン一覧やモバイルタブバーにエージェント名と色を表示
 - **セッション色テーマ** - セッションごとに色を設定して視覚的に区別
 - **デスクトップ対応** - テキスト選択＆自動コピー、フォントサイズ調整（Ctrl+=/-)
@@ -39,11 +39,11 @@ Claude Codeセッションをリモート管理するWebベースのターミナ
 - **セッション履歴** - 過去のClaude Codeセッション閲覧・再開・全文検索
 - **会話ビューア** - Markdownレンダリング、画像表示、システムサマリー区別表示
 - **プロンプト検索** - 全セッションにまたがるプロンプト履歴の検索
+- **セッションインジケータ** - 処理中・入力待ち・完了を一覧で把握（ペイン自体から検出するのでhook不要）
 - **Hook通知** - Claude Codeイベント（応答完了、入力待ち等）のブラウザプッシュ通知
 - **Codex対応** - Claude Codeと並行してCodex CLIセッションを実行（会話ビュー、使用量トラッキング）
 - **チャットビュー** - ターミナルの代わりに現在のセッションを会話形式で表示
 - **Peerサーバー** - 複数のCC HubサーバーをTailscale経由で連携（自動検出、セッション/履歴/ダッシュボードの集約）
-- **ローカルTUI** - `cchub tui` によるターミナルUI（セッション一覧・履歴検索）
 - **リモートペイン制御** - `cchub send` / `cchub peek` でローカル・peerサーバーのペインをCLIから操作
 - **多言語対応** - 英語・日本語UIの自動言語検出
 - **オンボーディング** - 初回ユーザー向けスポットライト式操作ガイド
@@ -81,7 +81,7 @@ source ~/.bashrc
 | 依存関係 | 必須 | インストール方法 |
 |---------|-----|----------------|
 | [Tailscale](https://tailscale.com/) | ○ | Linux: https://tailscale.com/download / macOS: `brew install tailscale` |
-| [tmux](https://github.com/tmux/tmux) 3.0+ | ○ | `apt install tmux` / `brew install tmux` |
+| [herdr](https://herdr.dev/) | ○ | `curl -fsSL https://herdr.dev/install.sh \| sh` / `brew install herdr` |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ○ | `npm install -g @anthropic-ai/claude-code` |
 
 ## クイックスタート
@@ -137,10 +137,6 @@ cchub status
 cchub send <target> [text]   # ローカル/peerサーバーのペインに入力を送信
 cchub peek <target>          # ペインの現在のビューポートを取得
 
-# ローカルターミナルUI
-cchub tui                    # セッション一覧・履歴検索のTUI
-cchub tui --popup            # tmux display-popup 用ワンショットモード（F11にバインド）
-
 # デバッグ
 cchub debug <sub>            # 稼働中サービスのBunインスペクタ操作
                              # sub: enable | disable | profile | status
@@ -180,15 +176,15 @@ sudo tailscale set --operator=$USER
 
 > **macOSの場合**: App Store版ではなく、`brew install tailscale`でインストールしてください。App Store版はCLIコマンドが使えないため、証明書生成が動作しません。
 
-### tmux設定（オプション）
+### herdrバックエンド
 
-CC Hubはデフォルトのtmux設定で動作しますが、以下の設定を推奨します：
+CC Hubは全セッションを [herdr](https://herdr.dev/) のワークスペースとして実行します。`cchub setup` が必要な設定を一通り行います：常駐する `herdr server`（Linux: systemd / macOS: launchd）、`~/.config/herdr/config.toml` の `resume_agents_on_restore = true`（サーバー再起動をまたいでエージェントの会話が復元される）、Claude Code integration hook（ネイティブなセッションID連携）。
 
-```bash
-# ~/.tmux.conf
-set -g mouse on              # マウス操作を有効化
-set -g history-limit 10000   # スクロールバック履歴を増やす
-```
+セッションはherdrサーバーのプロセス内にあるため、**cchubの再起動・更新ではセッションは落ちません**。
+
+herdrを後から更新する場合は `herdr update` → `systemctl --user restart herdr`。`herdr update` はバイナリを置き換えるだけで稼働中のサーバーは旧版のまま動き続けるため、反映には再起動が必要です。CC Hubはこのズレを検知してダッシュボードに警告を出し、ボタンから両方を代行できます（再起動すると全ペインが張り直され、エージェントの会話は自動復元されますが実行中のコマンドは失われるため、実行はユーザーが押したときだけです）。
+
+> systemd/launchd配下では `herdr update --handoff` を使わないでください。ハンドオフ先のサーバーが監視外に出てしまいます。
 
 ## 使い方
 
@@ -199,7 +195,7 @@ set -g history-limit 10000   # スクロールバック履歴を増やす
 
 ### キーボードショートカット
 
-CC Hubはtmux制御モード（`tmux -CC`）によりリアルタイムでペインレイアウトを同期します。接続中の全クライアントが同じペインレイアウトを共有します。
+CC Hubはペインレイアウトをリアルタイムで同期します。接続中の全クライアントが同じペインレイアウトを共有します。
 
 **ペイン・セッション操作**:
 | ショートカット | 操作 |
@@ -289,8 +285,6 @@ Claude Codeが応答完了・入力待ち状態になった時にブラウザプ
 {
   "hooks": {
     "Stop": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
-    "PreToolUse": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
-    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "cchub notify" }] }],
     "PostToolUse": [{
       "matcher": "AskUserQuestion",
       "hooks": [{ "type": "command", "command": "cchub notify" }]
@@ -300,6 +294,10 @@ Claude Codeが応答完了・入力待ち状態になった時にブラウザプ
 ```
 
 CC Hubサーバーが起動している必要があります。初回アクセス時にブラウザの通知権限を許可してください。
+
+セッションのインジケータ（処理中・入力待ち・完了）にhookは不要です — herdrがエージェントの状態を自身で検出します。上記2つのhookは、herdrからは見えない情報だけを運びます：通知の本文（`Stop`）と、質問を出したツール名（`PostToolUse`/`AskUserQuestion`）。
+
+> v0.2.2より前は `PreToolUse` / `UserPromptSubmit` も必要でしたが、今は不要です。設定済みのまま残しても害はありませんが、`PreToolUse` はツール呼び出しのたびに `cchub notify` プロセスを起動するので、外すと無駄が減ります。
 
 ## 開発環境セットアップ
 
@@ -337,7 +335,7 @@ bun run lint            # リント
 
 - **Backend**: Bun, Hono, WebSocket
 - **Frontend**: React 19, Vite, Tailwind CSS v4, xterm.js, react-i18next
-- **Terminal**: tmux制御モード（`tmux -CC`）
+- **Terminal**: herdr（NDJSONソケットAPI + ペインごとの制御ストリーム）
 
 ## アーキテクチャ
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Left: session list adapts to a single-column layout on smartphones. Right: termi
 - **Session History** - Browse and resume past Claude Code sessions with full-text search
 - **Conversation Viewer** - Markdown rendering, image display, system summary distinction
 - **Prompt Search** - Search across prompt history from all sessions
+- **Session Indicators** - See at a glance which sessions are working, waiting on you, or done — detected from the pane itself, no hooks required
 - **Hook Notifications** - Browser push notifications for Claude Code events (response complete, user input needed)
 - **Codex Support** - Run Codex CLI sessions alongside Claude Code (conversation view, usage tracking)
 - **Chat View** - Conversation-style view of the current session as an alternative to the terminal
 - **Peer Servers** - Connect multiple CC Hub servers over Tailscale (auto-discovery, aggregated sessions/history/dashboard)
-- **Local TUI** - `cchub tui` terminal UI with session list and history search
 - **Remote Pane Control** - `cchub send` / `cchub peek` to drive panes on local or peer servers from the CLI
 - **i18n** - English and Japanese UI with automatic language detection
 - **Onboarding Walkthrough** - Spotlight-style guide for first-time users
@@ -180,7 +180,9 @@ sudo tailscale set --operator=$USER
 
 CC Hub runs every session as a [herdr](https://herdr.dev/) workspace. `cchub setup` provisions everything: a supervised `herdr server` (systemd on Linux, launchd on macOS), `~/.config/herdr/config.toml` with `resume_agents_on_restore = true` (agent conversations survive server restarts), and the Claude Code integration hook (native session identity).
 
-To update herdr later: `herdr update`, then restart the supervised server (`systemctl --user restart herdr`). Do **not** use `herdr update --handoff` under systemd/launchd — the handed-off server escapes supervision.
+To update herdr later: `herdr update`, then restart the supervised server (`systemctl --user restart herdr`). The update replaces the binary but leaves the running server on the old version, so the restart is what actually applies it — CC Hub notices that gap and shows a warning on the dashboard, with a button that does both steps for you. Restarting re-creates every pane: agent conversations come back automatically, but commands running in a pane do not, so it waits for you to press it.
+
+Do **not** use `herdr update --handoff` under systemd/launchd — the handed-off server escapes supervision.
 
 ## Usage
 

--- a/architecture.html
+++ b/architecture.html
@@ -147,7 +147,6 @@
   "diagram": [
     " Clients",
     "   |- Browser (React SPA) ------ tablet / mobile / desktop",
-    "   |- cchub tui (Ink) ---------- local TTY",
     "   |- G2 Glasses (EvenHub) ----- REST + /ws/mux",
     "   '- cchub send / peek -------- CLI (REST)",
     "            |",
@@ -182,6 +181,14 @@
         ]
       },
       {
+        "name": "HerdrAgentStatusWatcher",
+        "file": "backend/src/services/herdr-agent-status.ts",
+        "summary": "herdr の pane.agent_status_changed (pane_id 必須の per-pane 購読) と pane ライフサイクルを購読し、エージェントの状態変化を即座に sessions push へ反映。値は pane.list から取るため、イベント取りこぼしは遅延止まりで不整合にならない (#390)",
+        "deps": [
+          "HerdrClient"
+        ]
+      },
+      {
         "name": "HerdrLayout",
         "file": "backend/src/services/herdr-layout.ts",
         "summary": "CC Hub 自前の split 木 (headless では herdr グリッドがリサイズ不能)。split/close/zoom/ratio調整/絶対サイズ指定を tmux 慣習の TmuxLayoutNode 矩形にレンダリング",
@@ -190,7 +197,15 @@
       {
         "name": "HerdrService",
         "file": "backend/src/services/herdr.ts",
-        "summary": "セッションレベル操作を herdr workspace にマッピング。一覧 (pane.process_info でエージェント検出、agent.list で native session id、blocked 状態)、作成/削除、プレビュー",
+        "summary": "セッションレベル操作を herdr workspace にマッピング。一覧 (pane.process_info でエージェント検出、agent.list で native session id、agent_status: idle/working/blocked/done)、作成/削除、プレビュー",
+        "deps": [
+          "HerdrClient"
+        ]
+      },
+      {
+        "name": "HerdrUpdateService",
+        "file": "backend/src/services/herdr-update.ts",
+        "summary": "herdr のバイナリと稼働サーバの版ズレを検知 (herdr update はバイナリ置換のみで稼働サーバは旧版のまま)。herdr status --json を 30s キャッシュで読み、ダッシュボードに警告。適用 (update + 監視下再起動) は POST /api/herdr/apply-update のユーザー操作のみで、auto 更新経路からは呼ばない。判定不能な出力は警告せず degrade (#393)",
         "deps": [
           "HerdrClient"
         ]
@@ -199,12 +214,6 @@
         "name": "PaneState",
         "file": "backend/src/services/pane-state.ts",
         "summary": "stripAnsi / detectPaneState ヒューリスティック (cchub send --wait / peek 用のペイン状態判定)",
-        "deps": []
-      },
-      {
-        "name": "ViewportCursorPolicy",
-        "file": "backend/src/services/viewport-cursor-policy.ts",
-        "summary": "agent 種別ごとの cursor 描画ポリシー (default / codex-footer) を解決。padFill の prepend 量に応じた cursor シフト量を計算",
         "deps": []
       },
       {
@@ -222,7 +231,7 @@
       {
         "name": "SessionMetadataService",
         "file": "backend/src/services/session-metadata.ts",
-        "summary": "セッションのテーマ・タイトル・表示順を session-metadata.json に、再起動復旧用の last-known-sessions.json を分離して永続化。旧形式 (session-themes.json 等) からのマイグレーションも処理",
+        "summary": "セッションのテーマ・タイトル・表示順を herdr-session-metadata.json に、再起動復旧用の herdr-last-known-sessions.json を分離して永続化 (tmux 版の store とはファイル名で分離)",
         "deps": []
       },
       {
@@ -325,7 +334,7 @@
       {
         "name": "HookStatusService",
         "file": "backend/src/services/hook-status.ts",
-        "summary": "Claude (~/.claude/settings.json) / Codex (config.toml, hooks.json) の hook 設定を解析し、cchub notify が Stop / PreToolUse / UserPromptSubmit / PostToolUse に登録済みかを判定。missing イベント一覧を返す",
+        "summary": "CC Hub がまだ必要とする hook (Stop = 通知本文、PostToolUse/AskUserQuestion = 質問のツール名) の設定有無を報告。インジケータの状態遷移は herdr 由来なので PreToolUse/UserPromptSubmit は不要 (#390)",
         "deps": []
       },
       {
@@ -1467,7 +1476,7 @@
   },
   "websocket": {
     "endpoint": "/ws/mux",
-    "description": "単一の多重化 WebSocket。クライアントは subscribe でセッション毎に購読し、ターミナル表示は PaneViewport フレーム (offset ベースのサーバーサイドスクロールバック) で配信。request-viewport への応答に加え、live (offset=0) 購読者には tmux 出力時に未要求 push もされる。全クライアント入力フレームは zod で検証 (#231)",
+    "description": "単一の多重化 WebSocket。クライアントは subscribe でセッション毎に購読し、ターミナル表示は PaneViewport フレーム (offset ベースのサーバーサイドスクロールバック) で配信。request-viewport への応答に加え、live (offset=0) 購読者には herdr のフレーム到着時に未要求 push もされる。全クライアント入力フレームは zod で検証 (#231)",
     "client_messages": {
       "mux_level": [
         "subscribe",

--- a/architecture.json
+++ b/architecture.json
@@ -26,7 +26,6 @@
   "diagram": [
     " Clients",
     "   |- Browser (React SPA) ------ tablet / mobile / desktop",
-    "   |- cchub tui (Ink) ---------- local TTY",
     "   |- G2 Glasses (EvenHub) ----- REST + /ws/mux",
     "   '- cchub send / peek -------- CLI (REST)",
     "            |",
@@ -61,6 +60,14 @@
         ]
       },
       {
+        "name": "HerdrAgentStatusWatcher",
+        "file": "backend/src/services/herdr-agent-status.ts",
+        "summary": "herdr の pane.agent_status_changed (pane_id 必須の per-pane 購読) と pane ライフサイクルを購読し、エージェントの状態変化を即座に sessions push へ反映。値は pane.list から取るため、イベント取りこぼしは遅延止まりで不整合にならない (#390)",
+        "deps": [
+          "HerdrClient"
+        ]
+      },
+      {
         "name": "HerdrLayout",
         "file": "backend/src/services/herdr-layout.ts",
         "summary": "CC Hub 自前の split 木 (headless では herdr グリッドがリサイズ不能)。split/close/zoom/ratio調整/絶対サイズ指定を tmux 慣習の TmuxLayoutNode 矩形にレンダリング",
@@ -69,7 +76,15 @@
       {
         "name": "HerdrService",
         "file": "backend/src/services/herdr.ts",
-        "summary": "セッションレベル操作を herdr workspace にマッピング。一覧 (pane.process_info でエージェント検出、agent.list で native session id、blocked 状態)、作成/削除、プレビュー",
+        "summary": "セッションレベル操作を herdr workspace にマッピング。一覧 (pane.process_info でエージェント検出、agent.list で native session id、agent_status: idle/working/blocked/done)、作成/削除、プレビュー",
+        "deps": [
+          "HerdrClient"
+        ]
+      },
+      {
+        "name": "HerdrUpdateService",
+        "file": "backend/src/services/herdr-update.ts",
+        "summary": "herdr のバイナリと稼働サーバの版ズレを検知 (herdr update はバイナリ置換のみで稼働サーバは旧版のまま)。herdr status --json を 30s キャッシュで読み、ダッシュボードに警告。適用 (update + 監視下再起動) は POST /api/herdr/apply-update のユーザー操作のみで、auto 更新経路からは呼ばない。判定不能な出力は警告せず degrade (#393)",
         "deps": [
           "HerdrClient"
         ]
@@ -78,12 +93,6 @@
         "name": "PaneState",
         "file": "backend/src/services/pane-state.ts",
         "summary": "stripAnsi / detectPaneState ヒューリスティック (cchub send --wait / peek 用のペイン状態判定)",
-        "deps": []
-      },
-      {
-        "name": "ViewportCursorPolicy",
-        "file": "backend/src/services/viewport-cursor-policy.ts",
-        "summary": "agent 種別ごとの cursor 描画ポリシー (default / codex-footer) を解決。padFill の prepend 量に応じた cursor シフト量を計算",
         "deps": []
       },
       {
@@ -101,7 +110,7 @@
       {
         "name": "SessionMetadataService",
         "file": "backend/src/services/session-metadata.ts",
-        "summary": "セッションのテーマ・タイトル・表示順を session-metadata.json に、再起動復旧用の last-known-sessions.json を分離して永続化。旧形式 (session-themes.json 等) からのマイグレーションも処理",
+        "summary": "セッションのテーマ・タイトル・表示順を herdr-session-metadata.json に、再起動復旧用の herdr-last-known-sessions.json を分離して永続化 (tmux 版の store とはファイル名で分離)",
         "deps": []
       },
       {
@@ -204,7 +213,7 @@
       {
         "name": "HookStatusService",
         "file": "backend/src/services/hook-status.ts",
-        "summary": "Claude (~/.claude/settings.json) / Codex (config.toml, hooks.json) の hook 設定を解析し、cchub notify が Stop / PreToolUse / UserPromptSubmit / PostToolUse に登録済みかを判定。missing イベント一覧を返す",
+        "summary": "CC Hub がまだ必要とする hook (Stop = 通知本文、PostToolUse/AskUserQuestion = 質問のツール名) の設定有無を報告。インジケータの状態遷移は herdr 由来なので PreToolUse/UserPromptSubmit は不要 (#390)",
         "deps": []
       },
       {
@@ -1346,7 +1355,7 @@
   },
   "websocket": {
     "endpoint": "/ws/mux",
-    "description": "単一の多重化 WebSocket。クライアントは subscribe でセッション毎に購読し、ターミナル表示は PaneViewport フレーム (offset ベースのサーバーサイドスクロールバック) で配信。request-viewport への応答に加え、live (offset=0) 購読者には tmux 出力時に未要求 push もされる。全クライアント入力フレームは zod で検証 (#231)",
+    "description": "単一の多重化 WebSocket。クライアントは subscribe でセッション毎に購読し、ターミナル表示は PaneViewport フレーム (offset ベースのサーバーサイドスクロールバック) で配信。request-viewport への応答に加え、live (offset=0) 購読者には herdr のフレーム到着時に未要求 push もされる。全クライアント入力フレームは zod で検証 (#231)",
     "client_messages": {
       "mux_level": [
         "subscribe",


### PR DESCRIPTION
v0.2.2 リリース後のドキュメント一斉更新。

## 見つかった取り残し

- **README.ja.md が丸ごと tmux 時代のまま**だった（英語版だけ移行時に更新していた）
  - 必要環境の表に **tmux 3.0+ が必須** として載っていた → herdr に差し替え
  - 「tmux制御モードによるペイン分割」「Terminal: tmux制御モード (`tmux -CC`)」→ herdr の記述に
  - **削除済みの `cchub tui`** のコマンド例が残っていた → 削除
  - hook 設定例に PreToolUse / UserPromptSubmit が残っていた → 削除 + v0.2.2 の注記
- **README.md** にも機能一覧に `cchub tui` が残っていた → 削除
- **architecture.json**: 移行で削除した `viewport-cursor-policy.ts` が載ったまま、クライアント図に `cchub tui (Ink)`、viewport の説明が「tmux 出力時に push」のまま

## 追加した記述

- セッションインジケータ（hook 不要、ペインから検出）を両 README の機能一覧に
- herdr の更新手順に、版ズレ警告とダッシュボードの適用ボタン（#393）を反映
- architecture.json に v0.2.2 の新サービス2件（HerdrUpdateService / HerdrAgentStatusWatcher）を追加し、HerdrService・SessionMetadataService・HookStatusService の説明を現状に更新

## 検証

`architecture.json` の services を実ファイルと突き合わせて、記載と実体のズレが 0 になったことを確認（削除済み1件を除去、未記載2件を追加）。`cchub tui` / `tmux` の残存も dist と CHANGELOG を除いて 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185QThpJTL5RmMWUgCYWFQK