### PR TITLE
fix: remote logger auth + clear error for outdated herdr servers

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -384,7 +384,8 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
       controlSession.removeClient();
     }
     try {
-      ws.send(JSON.stringify({ type: 'error', message: 'Failed to subscribe', sessionId }));
+      const detail = error instanceof Error ? error.message : String(error);
+      ws.send(JSON.stringify({ type: 'error', message: `Failed to subscribe: ${detail}`, sessionId }));
     } catch { /* disconnected */ }
   }
 }

--- a/backend/src/services/__tests__/herdr-pane-scroll.test.ts
+++ b/backend/src/services/__tests__/herdr-pane-scroll.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+import { assertPanesHaveScroll } from '../herdr-control';
+
+/**
+ * herdr < protocol 16 (v0.7.1 and older) returns panes without `scroll`.
+ * Subscribing then used to die with a bare TypeError deep in
+ * HerdrControlSession.start(), reaching the client as an unexplained
+ * "Failed to subscribe". The guard must name the actual fix instead.
+ */
+describe('assertPanesHaveScroll', () => {
+  const scroll = { offset_from_bottom: 0, max_offset_from_bottom: 460, viewport_rows: 23 };
+
+  it('accepts protocol 16 panes (scroll present)', () => {
+    expect(() => assertPanesHaveScroll([{ scroll }, { scroll }])).not.toThrow();
+  });
+
+  it('accepts an empty pane list', () => {
+    expect(() => assertPanesHaveScroll([])).not.toThrow();
+  });
+
+  it('rejects protocol 14 panes with a message naming the fix', () => {
+    expect(() => assertPanesHaveScroll([{ scroll }, { scroll: undefined }])).toThrow(
+      /herdr server is too old.*protocol >= 16/,
+    );
+  });
+});

--- a/backend/src/services/herdr-client.ts
+++ b/backend/src/services/herdr-client.ts
@@ -87,7 +87,8 @@ export interface HerdrPane {
   focused: boolean;
   agent_status: HerdrAgentStatus;
   revision: number;
-  scroll: HerdrScroll;
+  /** Absent on herdr servers older than protocol 16 (< v0.7.3). */
+  scroll?: HerdrScroll;
 }
 
 export interface HerdrWorkspace {

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -22,6 +22,7 @@
 import type { PaneCursor, PaneModes, PaneViewport, TmuxLayoutNode } from '../../../shared/types';
 import {
   getPane,
+  type HerdrPane,
   herdrRpc,
   herdrSubscribe,
   listPanes,
@@ -90,7 +91,7 @@ async function guessInitialAltScreen(
     const leader = res.process_info?.foreground_processes?.[0]?.name ?? '';
     if (!leader || SHELL_NAMES.has(leader)) return;
     const pane = await getPane(herdrPaneId);
-    if (!pane) return;
+    if (!pane?.scroll) return;
     const offset = pane.scroll.max_offset_from_bottom;
     // Allow up to one screenful of host scrollback: panes created by the
     // resume/create flows carry a few shell lines (the `cd … && claude -r`
@@ -104,6 +105,19 @@ async function guessInitialAltScreen(
     }
   } catch {
     // keep the default (normal screen)
+  }
+}
+
+/**
+ * herdr servers older than protocol 16 return panes without scroll state,
+ * which every viewport computation depends on. Fail the subscribe with the
+ * actual fix instead of letting it surface as a TypeError deep in start().
+ */
+export function assertPanesHaveScroll(panes: Array<Pick<HerdrPane, 'scroll'>>): void {
+  if (panes.some((p) => !p.scroll)) {
+    throw new Error(
+      'herdr server is too old: pane.list returned no scroll state (protocol >= 16 / v0.7.3+ required). Update herdr and restart the server.',
+    );
   }
 }
 
@@ -228,6 +242,7 @@ export class HerdrControlSession {
     this.workspaceId = ws.workspace_id;
 
     const panes = await listPanes(ws.workspace_id);
+    assertPanesHaveScroll(panes);
     const tmuxIds = panes
       .map((p) => toTmuxPaneId(p.pane_id))
       .filter((id): id is string => id !== null);
@@ -245,7 +260,7 @@ export class HerdrControlSession {
       if (tmuxId) {
         this.paneSizes.set(tmuxId, {
           cols: this.clientSize.cols,
-          rows: pane.scroll.viewport_rows || this.clientSize.rows,
+          rows: pane.scroll?.viewport_rows || this.clientSize.rows,
         });
       }
     }
@@ -844,7 +859,7 @@ export async function captureViewportHerdr(
   const pane = await getPane(herdrId);
   if (!pane) return null;
 
-  const rows = size?.rows ?? pane.scroll.viewport_rows;
+  const rows = size?.rows ?? pane.scroll?.viewport_rows ?? 0;
   const cols = size?.cols ?? 80;
   if (rows <= 0 || cols <= 0) return null;
 
@@ -854,7 +869,7 @@ export async function captureViewportHerdr(
   const runtimeCheck = cs.getRuntimeState(paneId);
   if (
     runtimeCheck?.altGuessed &&
-    pane.scroll.max_offset_from_bottom > (runtimeCheck.altGuessBaseline ?? 0)
+    (pane.scroll?.max_offset_from_bottom ?? 0) > (runtimeCheck.altGuessBaseline ?? 0)
   ) {
     runtimeCheck.altScreen = false;
     runtimeCheck.altGuessed = false;
@@ -864,7 +879,7 @@ export async function captureViewportHerdr(
   // what pane.read can actually reach (1000-line cap minus the window).
   const historySize = Math.max(
     0,
-    Math.min(pane.scroll.max_offset_from_bottom, HERDR_READ_CAP - rows),
+    Math.min(pane.scroll?.max_offset_from_bottom ?? 0, HERDR_READ_CAP - rows),
   );
   const clampedOffset = Math.max(0, Math.min(offset, historySize));
 

--- a/frontend/src/utils/remoteLogger.ts
+++ b/frontend/src/utils/remoteLogger.ts
@@ -1,4 +1,6 @@
 const LOG_ENDPOINT = "/api/logs";
+// Same key as useAuth — imported by value to avoid pulling React hooks in here.
+const TOKEN_KEY = "cc-hub-token";
 
 type LogLevel = "log" | "warn" | "error" | "info";
 
@@ -16,14 +18,32 @@ const originalConsole = {
 	info: console.info.bind(console),
 };
 
+// Token value that last got a 401 (null = no token). While the stored token
+// still equals it, sending is pointless — stay quiet instead of emitting a
+// doomed request per console call.
+let unauthorizedToken: string | null | undefined;
+
 function sendLog(entry: LogEntry) {
+	const token = localStorage.getItem(TOKEN_KEY);
+	if (unauthorizedToken !== undefined && unauthorizedToken === token) return;
+
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+	if (token) {
+		headers.Authorization = `Bearer ${token}`;
+	}
 	fetch(LOG_ENDPOINT, {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
+		headers,
 		body: JSON.stringify(entry),
-	}).catch(() => {
-		// Ignore send errors
-	});
+	})
+		.then((res) => {
+			unauthorizedToken = res.status === 401 ? token : undefined;
+		})
+		.catch(() => {
+			// Ignore send errors
+		});
 }
 
 function formatArgs(args: unknown[]): string {


### PR DESCRIPTION
## Changes

- **fix: attach auth token to remote log submissions** — password-auth setups got a 401 for every `console.*` call because `remoteLogger.ts` sent bare fetches without the `cc-hub-token` bearer header. Also stops resending after a 401 until the token changes, so unauthenticated pages don't spam doomed requests.
- **fix: fail herdr subscribe with a clear error on pre-protocol-16 servers** — herdr < v0.7.3 (protocol 14) returns panes without `scroll` state, so subscribing died with a bare `TypeError: undefined is not an object (evaluating 'pane.scroll.viewport_rows')` and reached the browser as an unexplained `Failed to subscribe`. Now the subscribe path fails with a message naming the actual fix (update herdr + restart the server), error details are forwarded to the client, and the read-only viewport/peek paths are null-safe.

## Background

Hit in production: after `herdr update` swapped the binary but the running server stayed on 0.7.1/protocol 14, every terminal showed a blank pane with only `[control-mode] Error: Failed to subscribe` in the console, drowned in `/api/logs` 401 noise.

## Tests

- New `herdr-pane-scroll.test.ts` covering the guard (protocol 14/16 pane shapes)
- `bun run test`: backend 268 pass / frontend 37 pass, `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)