### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.3] - 2026-07-16
+
+### Fixed
+- **リモートログ送信が 401 で全滅していた問題**: `remoteLogger.ts` が認証ヘッダなしの素の fetch で `/api/logs` へ送っていたため、パスワード認証を有効にした環境ではブラウザログが一切サーバに届かず、コンソールが 401 エラーで埋まっていた。保存済みトークン（`cc-hub-token`）を `Authorization: Bearer` として付与し、401 を受けたらトークンが変わるまで送信を止める（未ログインのページが console 呼び出しごとに失敗確定のリクエストを撃ち続けない）（`frontend/src/utils/remoteLogger.ts`）
+- **古い herdr サーバで subscribe が原因不明のまま失敗する問題**: protocol 16（herdr v0.7.3）未満のサーバは `pane.list` に `scroll` を返さないため、`pane.scroll.viewport_rows` の参照が TypeError になり、ブラウザには説明のない `Failed to subscribe` だけが届いてターミナルが真っ白になっていた（`herdr update` / `brew upgrade` 後にサーバが旧版のまま動き続ける版ズレで実際に発生）。subscribe の入口で検出して「herdr を更新してサーバを再起動せよ」という対処法つきのエラーを投げ、エラー詳細をクライアントへ転送し、read-only の viewport / peek 経路も `scroll` 欠損で落ちないようにした（`backend/src/services/herdr-control.ts`, `herdr-client.ts`, `backend/src/routes/terminal-mux.ts`）
+
 ## [0.2.2] - 2026-07-15
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.2",
-  "generated": "2026-07-15",
+  "version": "0.2.3",
+  "generated": "2026-07-16",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.2.2",
-  "generated": "2026-07-15",
+  "version": "0.2.3",
+  "generated": "2026-07-16",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes

- fix: remote logger auth — attach the bearer token to `/api/logs` submissions and stop resending after a 401 (#398)
- fix: fail herdr subscribe with a clear, actionable error on pre-protocol-16 (< v0.7.3) herdr servers instead of a silent TypeError (#398)

🤖 Generated with [Claude Code](https://claude.com/claude-code)