### PR TITLE
feat(dashboard): モデル別（Fable等）の使用量リミットをチャートに表示

### DIFF
--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -55,6 +55,7 @@ export async function buildDashboard(): Promise<DashboardResponse> {
     usageHistoryService.recordSnapshot(
       { utilization: usageLimits.fiveHour.utilization, resetsAt: usageLimits.fiveHour.resetsAt },
       { utilization: usageLimits.sevenDay.utilization, resetsAt: usageLimits.sevenDay.resetsAt },
+      usageLimits.scopedLimits,
     );
   }
 

--- a/backend/src/services/__tests__/anthropic-scoped-limits.test.ts
+++ b/backend/src/services/__tests__/anthropic-scoped-limits.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'bun:test';
+import { parseScopedLimits } from '../anthropic-usage';
+
+// Trimmed from a real GET /api/oauth/usage response (2026-07-16). The flat
+// five_hour / seven_day fields still carry the overall cycles; `limits[]` is
+// where per-model limits appear.
+const REAL_RESPONSE = {
+  five_hour: { utilization: 7.0, resets_at: '2026-07-16T01:59:59.799410+00:00' },
+  seven_day: { utilization: 68.0, resets_at: '2026-07-18T05:59:59.799432+00:00' },
+  seven_day_opus: null,
+  seven_day_sonnet: null,
+  limits: [
+    {
+      kind: 'session',
+      group: 'session',
+      percent: 7,
+      severity: 'normal',
+      resets_at: '2026-07-16T01:59:59.799410+00:00',
+      scope: null,
+      is_active: false,
+    },
+    {
+      kind: 'weekly_all',
+      group: 'weekly',
+      percent: 68,
+      severity: 'normal',
+      resets_at: '2026-07-18T05:59:59.799432+00:00',
+      scope: null,
+      is_active: false,
+    },
+    {
+      kind: 'weekly_scoped',
+      group: 'weekly',
+      percent: 100,
+      severity: 'critical',
+      resets_at: '2026-07-18T05:59:59.799770+00:00',
+      scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+      is_active: true,
+    },
+  ],
+};
+
+describe('parseScopedLimits', () => {
+  test('extracts the per-model limit from a real response', () => {
+    expect(parseScopedLimits(REAL_RESPONSE)).toEqual([
+      {
+        key: 'weekly:Fable',
+        name: 'Fable',
+        group: 'weekly',
+        utilization: 100,
+        resetsAt: '2026-07-18T05:59:59.799770+00:00',
+        isActive: true,
+        severity: 'critical',
+      },
+    ]);
+  });
+
+  test('ignores unscoped entries — those are the overall cycles already charted', () => {
+    const parsed = parseScopedLimits(REAL_RESPONSE);
+    expect(parsed).toHaveLength(1);
+    expect(parsed.every((l) => l.name === 'Fable')).toBe(true);
+  });
+
+  test('falls back to the surface name when a limit is not scoped to a model', () => {
+    const parsed = parseScopedLimits({
+      limits: [
+        {
+          group: 'session',
+          percent: 42,
+          resets_at: '2026-07-16T01:59:59Z',
+          scope: { model: null, surface: 'Claude Code' },
+          is_active: false,
+        },
+      ],
+    });
+    expect(parsed).toEqual([
+      {
+        key: 'session:Claude Code',
+        name: 'Claude Code',
+        group: 'session',
+        utilization: 42,
+        resetsAt: '2026-07-16T01:59:59Z',
+        isActive: false,
+        severity: undefined,
+      },
+    ]);
+  });
+
+  // The overlays ride the cycle charts, so a limit on a cycle cchub doesn't
+  // draw has no axis to sit on. Dropping it beats guessing a placement.
+  test('drops limits belonging to a cycle that has no chart', () => {
+    expect(
+      parseScopedLimits({
+        limits: [
+          {
+            group: 'monthly',
+            percent: 10,
+            resets_at: '2026-08-01T00:00:00Z',
+            scope: { model: { display_name: 'Fable' } },
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  test.each([
+    ['no limits array', { five_hour: { utilization: 7 } }],
+    ['limits is not an array', { limits: 'nope' }],
+    ['limits is null', { limits: null }],
+    ['null input', null],
+    ['undefined input', undefined],
+    ['empty array', { limits: [] }],
+  ])('degrades to no overlays: %s', (_label, input) => {
+    expect(parseScopedLimits(input)).toEqual([]);
+  });
+
+  test.each([
+    ['null entry', null],
+    ['missing percent', { group: 'weekly', resets_at: '2026-07-18T05:59:59Z', scope: { model: { display_name: 'Fable' } } }],
+    ['non-numeric percent', { group: 'weekly', percent: '100', resets_at: '2026-07-18T05:59:59Z', scope: { model: { display_name: 'Fable' } } }],
+    ['NaN percent', { group: 'weekly', percent: Number.NaN, resets_at: '2026-07-18T05:59:59Z', scope: { model: { display_name: 'Fable' } } }],
+    ['missing resets_at', { group: 'weekly', percent: 100, scope: { model: { display_name: 'Fable' } } }],
+    ['empty display_name', { group: 'weekly', percent: 100, resets_at: '2026-07-18T05:59:59Z', scope: { model: { display_name: '' } } }],
+    ['scope present but empty', { group: 'weekly', percent: 100, resets_at: '2026-07-18T05:59:59Z', scope: {} }],
+  ])('skips unusable entry: %s', (_label, entry) => {
+    expect(parseScopedLimits({ limits: [entry] })).toEqual([]);
+  });
+
+  test('keeps usable entries when a sibling entry is malformed', () => {
+    const parsed = parseScopedLimits({
+      limits: [
+        null,
+        { group: 'weekly', percent: 'bad', scope: { model: { display_name: 'Broken' } } },
+        {
+          group: 'weekly',
+          percent: 100,
+          severity: 'critical',
+          resets_at: '2026-07-18T05:59:59Z',
+          scope: { model: { display_name: 'Fable' } },
+          is_active: true,
+        },
+      ],
+    });
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].name).toBe('Fable');
+  });
+
+  test('keys distinguish the same model across cycles', () => {
+    const parsed = parseScopedLimits({
+      limits: [
+        { group: 'session', percent: 20, resets_at: '2026-07-16T01:00:00Z', scope: { model: { display_name: 'Fable' } } },
+        { group: 'weekly', percent: 100, resets_at: '2026-07-18T05:00:00Z', scope: { model: { display_name: 'Fable' } } },
+      ],
+    });
+    expect(parsed.map((l) => l.key)).toEqual(['session:Fable', 'weekly:Fable']);
+  });
+
+  test('treats a missing is_active as not active rather than truthy', () => {
+    const parsed = parseScopedLimits({
+      limits: [
+        { group: 'weekly', percent: 100, resets_at: '2026-07-18T05:59:59Z', scope: { model: { display_name: 'Fable' } } },
+      ],
+    });
+    expect(parsed[0].isActive).toBe(false);
+  });
+});

--- a/backend/src/services/__tests__/usage-history-legacy.test.ts
+++ b/backend/src/services/__tests__/usage-history-legacy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { rm, writeFile } from 'node:fs/promises';
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import type { UsageScopedLimit } from '../../../../shared/types';
 import { UsageHistoryService } from '../usage-history';
 
 // getHistory reads this fixed path; the service has no injection seam.
@@ -41,5 +42,59 @@ describe('UsageHistoryService.getHistory format handling', () => {
     await writeFile(HISTORY_FILE, JSON.stringify({ unexpected: 'value' }));
     const history = await new UsageHistoryService().getHistory();
     expect(history).toEqual([]);
+  });
+
+  test('keeps snapshots written before scoped limits were tracked', async () => {
+    await writeFile(HISTORY_FILE, JSON.stringify([snap('2026-01-01T00:00:00.000Z')]));
+    const history = await new UsageHistoryService().getHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].scoped).toBeUndefined();
+  });
+});
+
+describe('UsageHistoryService.recordSnapshot scoped limits', () => {
+  const cycle = { utilization: 50, resetsAt: '2026-07-18T05:59:59Z' };
+  const fable: UsageScopedLimit = {
+    key: 'weekly:Fable',
+    name: 'Fable',
+    group: 'weekly',
+    utilization: 100,
+    resetsAt: '2026-07-18T05:59:59Z',
+    isActive: true,
+    severity: 'critical',
+  };
+
+  afterEach(async () => {
+    await rm(HISTORY_FILE, { force: true });
+  });
+
+  const readSnapshots = async () => JSON.parse(await readFile(HISTORY_FILE, 'utf-8'));
+
+  test('records scoped utilization keyed by limit key', async () => {
+    await new UsageHistoryService().recordSnapshot(cycle, cycle, [fable]);
+    const [written] = await readSnapshots();
+    expect(written.scoped).toEqual({
+      'weekly:Fable': { utilization: 100, resetsAt: '2026-07-18T05:59:59Z' },
+    });
+  });
+
+  // A plan without scoped limits shouldn't pay for an empty object on every
+  // snapshot, and readers must be able to tell "not measured" from "0%".
+  test.each([
+    ['no argument', undefined],
+    ['empty array', [] as UsageScopedLimit[]],
+  ])('omits the scoped key entirely: %s', async (_label, scoped) => {
+    await new UsageHistoryService().recordSnapshot(cycle, cycle, scoped);
+    const [written] = await readSnapshots();
+    expect('scoped' in written).toBe(false);
+  });
+
+  test('appends to history that predates scoped tracking', async () => {
+    await writeFile(HISTORY_FILE, JSON.stringify([snap('2026-07-17T00:00:00.000Z')]));
+    await new UsageHistoryService().recordSnapshot(cycle, cycle, [fable]);
+    const written = await readSnapshots();
+    expect(written).toHaveLength(2);
+    expect(written[0].scoped).toBeUndefined();
+    expect(written[1].scoped['weekly:Fable'].utilization).toBe(100);
   });
 });

--- a/backend/src/services/anthropic-usage.ts
+++ b/backend/src/services/anthropic-usage.ts
@@ -1,7 +1,7 @@
 import { t } from '../i18n';
 import { VERSION } from '../cli';
 import { getClaudeAccessToken } from '../utils/claude-credentials';
-import type { UsageLimitsErrorReason, UsageLimitsStatus } from '../../../shared/types';
+import type { UsageLimitsErrorReason, UsageLimitsStatus, UsageScopedLimit } from '../../../shared/types';
 
 function parseRetryAfter(header: string | null): number | null {
   if (!header) return null;
@@ -21,6 +21,68 @@ interface UsageResponse {
     utilization: number;
     resets_at: string;
   };
+  limits?: unknown;
+}
+
+interface RawLimitEntry {
+  group?: unknown;
+  percent?: unknown;
+  severity?: unknown;
+  resets_at?: unknown;
+  is_active?: unknown;
+  scope?: {
+    model?: { display_name?: unknown } | null;
+    surface?: unknown;
+  } | null;
+}
+
+/**
+ * Extract per-model limits from the `limits[]` array of the OAuth usage
+ * response. Entries whose `scope` is null are the overall cycles, which
+ * `five_hour` / `seven_day` already carry — only scoped entries add anything.
+ *
+ * Every field is validated because `limits[]` is newer than the flat fields
+ * and cchub must never break the existing chart over an unexpected shape: an
+ * entry that doesn't parse (unknown `group`, missing `percent`) is dropped
+ * rather than guessed at, and an absent/malformed array yields no overlays.
+ */
+export function parseScopedLimits(raw: unknown): UsageScopedLimit[] {
+  const entries = (raw as { limits?: unknown } | null)?.limits;
+  if (!Array.isArray(entries)) return [];
+
+  const scoped: UsageScopedLimit[] = [];
+  for (const entry of entries as RawLimitEntry[]) {
+    if (!entry || typeof entry !== 'object') continue;
+
+    const modelName = entry.scope?.model?.display_name;
+    const surface = entry.scope?.surface;
+    const name =
+      typeof modelName === 'string' && modelName
+        ? modelName
+        : typeof surface === 'string' && surface
+          ? surface
+          : null;
+    if (!name) continue;
+
+    // Anything other than the two cycles cchub charts would have no axis to
+    // sit on, so drop it instead of misplacing it.
+    const group = entry.group === 'session' || entry.group === 'weekly' ? entry.group : null;
+    if (!group) continue;
+
+    if (typeof entry.percent !== 'number' || !Number.isFinite(entry.percent)) continue;
+    if (typeof entry.resets_at !== 'string' || !entry.resets_at) continue;
+
+    scoped.push({
+      key: `${group}:${name}`,
+      name,
+      group,
+      utilization: entry.percent,
+      resetsAt: entry.resets_at,
+      isActive: entry.is_active === true,
+      severity: typeof entry.severity === 'string' ? entry.severity : undefined,
+    });
+  }
+  return scoped;
 }
 
 export interface UsageLimits {
@@ -40,6 +102,7 @@ export interface UsageLimits {
     status: 'safe' | 'warning' | 'danger' | 'exceeded';
     statusMessage: string;
   };
+  scopedLimits?: UsageScopedLimit[];
 }
 
 export class AnthropicUsageService {
@@ -167,6 +230,7 @@ export class AnthropicUsageService {
           estimatedHitTime: sevenDayEstimate,
           ...this.calculateStatus(data.seven_day.utilization, sevenDayEstimate, this.formatTimeRemaining(data.seven_day.resets_at)),
         },
+        scopedLimits: parseScopedLimits(data),
       };
 
       this.lastSuccessfulResult = result;

--- a/backend/src/services/usage-history.ts
+++ b/backend/src/services/usage-history.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import type { UsageSnapshot } from '../../../shared/types';
+import type { UsageScopedLimit, UsageSnapshot } from '../../../shared/types';
 
 const HISTORY_FILE = '/tmp/cchub-usage-history.json';
 const THROTTLE_MS = 30 * 1000; // 30 seconds
@@ -33,7 +33,11 @@ export class UsageHistoryService {
     }
   }
 
-  async recordSnapshot(fiveHour: { utilization: number; resetsAt: string }, sevenDay: { utilization: number; resetsAt: string }): Promise<void> {
+  async recordSnapshot(
+    fiveHour: { utilization: number; resetsAt: string },
+    sevenDay: { utilization: number; resetsAt: string },
+    scopedLimits?: UsageScopedLimit[],
+  ): Promise<void> {
     const now = Date.now();
     if (now - this.lastRecordTime < THROTTLE_MS) {
       return;
@@ -47,6 +51,14 @@ export class UsageHistoryService {
       fiveHour: { utilization: fiveHour.utilization, resetsAt: fiveHour.resetsAt },
       sevenDay: { utilization: sevenDay.utilization, resetsAt: sevenDay.resetsAt },
     };
+
+    // Omit the key entirely when there are no scoped limits, so a plan without
+    // them doesn't grow every snapshot by an empty object.
+    if (scopedLimits?.length) {
+      snapshot.scoped = Object.fromEntries(
+        scopedLimits.map((l) => [l.key, { utilization: l.utilization, resetsAt: l.resetsAt }]),
+      );
+    }
 
     snapshots.push(snapshot);
 

--- a/frontend/src/components/dashboard/UsageChart.tsx
+++ b/frontend/src/components/dashboard/UsageChart.tsx
@@ -20,6 +20,16 @@ function useIsLightMode() {
 	return light;
 }
 
+/** A per-model limit drawn as an extra line over the cycle's own usage line. */
+export interface UsageChartOverlay {
+	key: string;
+	name: string;
+	utilization: number;
+	isActive: boolean;
+	severity?: string;
+	color: string;
+}
+
 interface UsageChartProps {
 	label: string;
 	field: "fiveHour" | "sevenDay";
@@ -28,6 +38,7 @@ interface UsageChartProps {
 	resetsAt: string;
 	status: "safe" | "warning" | "danger" | "exceeded";
 	statusMessage: string;
+	overlays?: UsageChartOverlay[];
 }
 
 const CHART_WIDTH = 300;
@@ -44,6 +55,16 @@ function utilToY(util: number): number {
 // Map time ratio (0–1) to X coordinate
 function ratioToX(ratio: number): number {
 	return PADDING.left + Math.min(Math.max(ratio, 0), 1) * INNER_W;
+}
+
+function toPath(points: { x: number; y: number }[]): string {
+	return points.length > 1
+		? points
+				.map(
+					(p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(1)},${p.y.toFixed(1)}`,
+				)
+				.join(" ")
+		: "";
 }
 
 function getStatusColor(status: string): string {
@@ -71,6 +92,23 @@ function getStatusTextColor(status: string): string {
 	}
 }
 
+// Anthropic sends its own verdict per limit, so trust it when present and only
+// fall back to thresholds for a severity string we don't recognize.
+function getOverlayTextColor(overlay: UsageChartOverlay): string {
+	switch (overlay.severity) {
+		case "critical":
+			return "text-red-400 font-medium";
+		case "warning":
+			return "text-yellow-400";
+		case "normal":
+			return "text-th-text-secondary";
+		default:
+			if (overlay.utilization >= 100) return "text-red-400 font-medium";
+			if (overlay.utilization >= 75) return "text-yellow-400";
+			return "text-th-text-secondary";
+	}
+}
+
 export function UsageChart({
 	label,
 	field,
@@ -79,6 +117,7 @@ export function UsageChart({
 	resetsAt,
 	status,
 	statusMessage,
+	overlays = [],
 }: UsageChartProps) {
 	const { t } = useTranslation();
 	const isLight = useIsLightMode();
@@ -134,6 +173,43 @@ export function UsageChart({
 		};
 		actualPoints.push(currentPoint);
 
+		// --- Per-model overlay lines ---
+		// Scoped limits reset with the cycle they belong to, so they share this
+		// chart's x-axis. Snapshots recorded before scoped tracking existed carry
+		// no `scoped` key at all; a missing sample means "not measured" and must
+		// be skipped rather than read as 0%.
+		const overlaySeries = overlays.map((overlay) => {
+			const samples = relevantSnapshots.flatMap((snap) => {
+				const sample = snap.scoped?.[overlay.key];
+				return sample
+					? [{ ts: new Date(snap.timestamp).getTime(), sample }]
+					: [];
+			});
+
+			const points: { x: number; y: number }[] = [];
+			const firstSampleRatio = samples[0]
+				? (samples[0].ts - cycleStart) / cycleDuration
+				: 1;
+			// Same 0% anchor as the primary line, for the same reason: utilization
+			// is cumulative, so a cycle missing early samples provably began at 0.
+			if (samples.length === 0 || firstSampleRatio > FIRST_GAP_THRESHOLD) {
+				points.push({ x: ratioToX(0), y: utilToY(0) });
+			}
+			for (const { ts, sample } of samples) {
+				points.push({
+					x: ratioToX((ts - cycleStart) / cycleDuration),
+					y: utilToY(sample.utilization),
+				});
+			}
+			const current = {
+				x: ratioToX(nowRatio),
+				y: utilToY(overlay.utilization),
+			};
+			points.push(current);
+
+			return { key: overlay.key, color: overlay.color, points, current };
+		});
+
 		// --- Projection line (from current point, extending at current pace) ---
 		let projectionEnd: { x: number; y: number } | null = null;
 		let hitLabel: string | null = null; // Date/time label at the hit point
@@ -183,8 +259,9 @@ export function UsageChart({
 			idealStart,
 			idealEnd,
 			markers,
+			overlaySeries,
 		};
-	}, [snapshots, field, currentUtilization, resetsAt]);
+	}, [snapshots, field, currentUtilization, resetsAt, overlays]);
 
 	const {
 		actualPoints,
@@ -195,21 +272,14 @@ export function UsageChart({
 		idealStart,
 		idealEnd,
 		markers,
+		overlaySeries,
 	} = chartData;
 
 	const lineColor = getStatusColor(status);
 	const gradientId = `grad-${field}`;
 
 	// Build actual usage path
-	const actualPath =
-		actualPoints.length > 1
-			? actualPoints
-					.map(
-						(p, i) =>
-							`${i === 0 ? "M" : "L"}${p.x.toFixed(1)},${p.y.toFixed(1)}`,
-					)
-					.join(" ")
-			: "";
+	const actualPath = toPath(actualPoints);
 
 	// Build area under actual usage
 	const areaPath =
@@ -374,6 +444,28 @@ export function UsageChart({
 					/>
 				)}
 
+				{/* 5) Per-model overlay lines — drawn above the cycle's own line so a
+				    maxed-out model stays visible when the overall usage looks fine */}
+				{overlaySeries.map((series) => (
+					<g key={series.key}>
+						<path
+							d={toPath(series.points)}
+							fill="none"
+							stroke={series.color}
+							strokeWidth="1.2"
+							strokeLinejoin="round"
+						/>
+						<circle
+							cx={series.current.x}
+							cy={series.current.y}
+							r="2"
+							fill={series.color}
+							stroke={isLight ? "#ffffff" : "#111827"}
+							strokeWidth="0.75"
+						/>
+					</g>
+				))}
+
 				{/* Current point dot */}
 				<circle
 					cx={currentPoint.x}
@@ -429,6 +521,30 @@ export function UsageChart({
 			<div className={`text-[10px] mt-0.5 ${getStatusTextColor(status)}`}>
 				{statusMessage}
 			</div>
+			{overlays.length > 0 && (
+				<div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5">
+					{overlays.map((overlay) => (
+						<div
+							key={overlay.key}
+							className="flex items-center gap-1 text-[10px]"
+						>
+							<span
+								className="w-2.5 h-[2px] rounded-full shrink-0"
+								style={{ backgroundColor: overlay.color }}
+							/>
+							<span className="text-th-text-muted">{overlay.name}</span>
+							<span className={getOverlayTextColor(overlay)}>
+								{overlay.utilization.toFixed(0)}%
+							</span>
+							{overlay.isActive && (
+								<span className="text-th-text-muted">
+									{t("dashboard.scopedLimitActive")}
+								</span>
+							)}
+						</div>
+					))}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/frontend/src/components/dashboard/UsageLimits.tsx
+++ b/frontend/src/components/dashboard/UsageLimits.tsx
@@ -2,13 +2,42 @@ import { useTranslation } from "react-i18next";
 import type {
 	UsageCycleInfo,
 	UsageLimitsStatus,
+	UsageScopedLimit,
 	UsageSnapshot,
 } from "../../../../shared/types";
-import { UsageChart } from "./UsageChart";
+import { type UsageChartOverlay, UsageChart } from "./UsageChart";
 
 interface UsageLimitsData {
 	fiveHour?: UsageCycleInfo;
 	sevenDay?: UsageCycleInfo;
+	scopedLimits?: UsageScopedLimit[];
+}
+
+// Hues chosen to stay distinct from the cycle line, which is already green /
+// yellow / red depending on status.
+const OVERLAY_COLORS = ["#a855f7", "#06b6d4", "#f472b6", "#facc15"];
+
+function toOverlays(
+	scopedLimits: UsageScopedLimit[] | undefined,
+	group: "session" | "weekly",
+): UsageChartOverlay[] {
+	if (!scopedLimits?.length) return [];
+	// Index the palette within the whole set rather than per group, so a model
+	// keeps one colour across both charts.
+	return scopedLimits.flatMap((limit, i) =>
+		limit.group === group
+			? [
+					{
+						key: limit.key,
+						name: limit.name,
+						utilization: limit.utilization,
+						isActive: limit.isActive,
+						severity: limit.severity,
+						color: OVERLAY_COLORS[i % OVERLAY_COLORS.length],
+					},
+				]
+			: [],
+	);
 }
 
 interface UsageLimitsProps {
@@ -198,6 +227,7 @@ export function UsageLimits({
 						data.fiveHour.timeRemaining,
 						data.fiveHour.estimatedHitTime,
 					)}
+					overlays={toOverlays(data.scopedLimits, "session")}
 				/>
 			) : (
 				showMissingCycles && (
@@ -222,6 +252,7 @@ export function UsageLimits({
 						data.sevenDay.timeRemaining,
 						data.sevenDay.estimatedHitTime,
 					)}
+					overlays={toOverlays(data.scopedLimits, "weekly")}
 				/>
 			) : (
 				showMissingCycles && (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -152,6 +152,7 @@
 		"latencyNA": "N/A",
 		"chartNow": "Now",
 		"chartReset": "Reset",
+		"scopedLimitActive": "(in effect)",
 		"clearCache": "Clear Cache & Reload",
 		"cpuUsage": "CPU Usage",
 		"memoryUsage": "Memory Usage",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -152,6 +152,7 @@
 		"latencyNA": "N/A",
 		"chartNow": "現在",
 		"chartReset": "リセット",
+		"scopedLimitActive": "（適用中）",
 		"clearCache": "キャッシュクリア & リロード",
 		"cpuUsage": "CPU使用率",
 		"memoryUsage": "メモリ使用率",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -409,9 +409,37 @@ export interface UsageCycleInfo {
   statusMessage?: string; // Human-readable prediction message
 }
 
+/**
+ * A usage limit that applies to a subset of usage rather than the whole plan —
+ * currently a single model (e.g. "Fable"). Read from the `limits[]` array of
+ * Anthropic's OAuth usage response, where entries with a non-null `scope` are
+ * the scoped ones; entries without a scope are the overall cycles already
+ * carried by `fiveHour` / `sevenDay`.
+ *
+ * These matter because the overall cycle can read as comfortable while a
+ * scoped limit is already exhausted, which is invisible on a chart that only
+ * plots the overall number.
+ */
+export interface UsageScopedLimit {
+  /** `${group}:${name}` — stable identity for history snapshots. */
+  key: string;
+  /** What the limit is scoped to, e.g. "Fable". */
+  name: string;
+  /** Which cycle this shares an axis with. */
+  group: 'session' | 'weekly';
+  utilization: number;
+  resetsAt: string;
+  /** True when this limit is the one currently constraining usage. */
+  isActive: boolean;
+  /** Anthropic's own severity verdict, e.g. 'normal' | 'critical'. */
+  severity?: string;
+}
+
 export interface UsageLimits {
   fiveHour: UsageCycleInfo;
   sevenDay: UsageCycleInfo;
+  /** Per-model limits; empty when the API reports none. */
+  scopedLimits?: UsageScopedLimit[];
 }
 
 // Usage limits derived from Codex rollouts (rate_limits in token_count events).
@@ -434,6 +462,12 @@ export interface UsageSnapshot {
   timestamp: string; // ISO 8601
   fiveHour: { utilization: number; resetsAt: string };
   sevenDay: { utilization: number; resetsAt: string };
+  /**
+   * Per-model utilization keyed by `UsageScopedLimit.key`. Absent on snapshots
+   * written before scoped limits were tracked, so readers must treat a missing
+   * key as "no sample" rather than 0%.
+   */
+  scoped?: Record<string, { utilization: number; resetsAt: string }>;
 }
 
 export interface UsageHistoryResponse {


### PR DESCRIPTION
## 背景

ダッシュボードの「使用量リミット」が **68%・余裕十分** と表示している裏で、Fable のリミットは既に **100% / critical / 適用中** だった。

Anthropic の `GET /api/oauth/usage` を実際に叩いて確認したところ、レスポンスに新しい `limits[]` 配列が増えており、モデル別のリミットはそこにしか現れない:

```json
{
  "five_hour": { "utilization": 9,  "resets_at": "..." },
  "seven_day": { "utilization": 68, "resets_at": "..." },
  "seven_day_opus": null, "seven_day_sonnet": null,
  "limits": [
    { "kind": "session",       "group": "session", "percent": 9,   "severity": "normal",   "scope": null, "is_active": false },
    { "kind": "weekly_all",    "group": "weekly",  "percent": 68,  "severity": "normal",   "scope": null, "is_active": false },
    { "kind": "weekly_scoped", "group": "weekly",  "percent": 100, "severity": "critical",
      "scope": { "model": { "id": null, "display_name": "Fable" } }, "is_active": true }
  ]
}
```

cchub は `five_hour` / `seven_day` しか読んでいなかったため、この行が丸ごと見えていなかった。

## 変更

`limits[]` のうち **`scope` が非 null のエントリ = モデル別リミット** を抽出し、`group` に対応するチャート（`session`→5時間 / `weekly`→7日間）に**追加のライン**として重ねる。凡例には Anthropic 自身の `severity` に沿った色でパーセントを出す。

- `"Fable"` という名前には一切依存していない。API が scope したものがそのまま線になるので、将来モデルが増えてもここは変更不要
- サイクル本体は従来どおり `five_hour` / `seven_day` 由来。`limits[]` は新しいので、想定外の形が来ても**既存チャートを壊さない**ことを優先した。全フィールドを検証し、解釈できないエントリは推測せず捨てる。cchub が描かないサイクル（例: 将来の `monthly`）は載せる軸が無いので同様に捨てる
- モデル別の値を使用量履歴にも記録し、線が直線補間ではなく実データになるようにした。これ以前のスナップショットに `scoped` キーは無く、読み手は「未計測」として扱う（0% ではない）

## 確認

dev 環境の実データで確認（`bun run dev` → `/api/dashboard`）:

```json
"scopedLimits": [
  { "key": "weekly:Fable", "name": "Fable", "group": "weekly",
    "utilization": 100, "isActive": true, "severity": "critical" }
]
```

履歴にも記録される:
```json
{"timestamp":"2026-07-15T22:24:25.065Z","fiveHour":{"utilization":9},"sevenDay":{"utilization":68},
 "scoped":{"weekly:Fable":{"utilization":100,"resetsAt":"2026-07-18T06:00:00Z"}}}
```

7日間チャートに紫の Fable ラインが 100% まで伸び、緑の 68% ラインと明確に分かれて描画されることを Playwright のスクリーンショットで確認。凡例は `Fable 100%（適用中）`。5時間チャートには session スコープのリミットが無いためオーバーレイ無し（正しい）。

- `bun run test` — backend 293 pass / frontend 37 pass
- `bun run typecheck` / `bun run lint` — clean

新規テスト 20件は実レスポンスを fixture にしたパーサのテストで、degrade 系（`limits` 不在 / 配列でない / null / 壊れた兄弟エントリ）を含む。

## 補足（このPRの範囲外）

overall が「余裕十分」と出ている**文言自体**は、scoped が振り切っていても変わらない。ラインと凡例で見えるようにはなったが、ステータス文の扱いは別途判断が要る。
