### PR TITLE
Release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.4] - 2026-07-16
+
+### Added
+- **モデル別（Fable 等）の使用量リミットをチャートに表示**: Anthropic の `GET /api/oauth/usage` に `limits[]` 配列が増え、**特定モデルにスコープされたリミットはそこにしか現れない**ようになっていた。cchub は `five_hour` / `seven_day` しか読んでいなかったため、ダッシュボードが「余裕十分（68%）」と表示している裏で Fable の週次リミットが既に 100% / critical / 適用中、という状態がまったく見えなかった。`scope` が非 null のエントリ（= モデル別）を抽出し、`group` に対応するチャート（`session`→5時間 / `weekly`→7日間）に追加のラインとして重ね、凡例に Anthropic 自身の `severity` に沿った色でパーセントを出す。`"Fable"` という名前には依存しておらず、API が scope したものがそのまま線になるので将来モデルが増えても変更は要らない。サイクル本体は従来どおり `five_hour` / `seven_day` 由来で、`limits[]` が想定外の形でも既存チャートは壊れない（全フィールドを検証し、解釈できないエントリは推測せず捨てる）。モデル別の値は使用量履歴にも記録され、線は直線補間ではなく実データになる（これ以前のスナップショットに `scoped` キーは無く、「未計測」として扱われる。0% ではない）（`backend/src/services/anthropic-usage.ts`, `usage-history.ts`, `frontend/src/components/dashboard/UsageChart.tsx`, `UsageLimits.tsx`）
+  - 現時点で API がモデル別に分けているのは週次のみ（5時間は全モデル共通の1本）。`group: "session"` の scoped リミットが返り始めたら、コード変更なしで5時間チャートにも線が出る
+
 ## [0.2.3] - 2026-07-16
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "generated": "2026-07-16",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
@@ -261,7 +261,7 @@
       {
         "name": "AnthropicUsageService",
         "file": "backend/src/services/anthropic-usage.ts",
-        "summary": "Anthropic API から使用量リミット (5時間 / 7日サイクル) を取得。60s cache、429 時は 5min backoff、in-flight リクエストの合流 (coalescing)。現在ペースからのリミット到達予測も算出",
+        "summary": "Anthropic API から使用量リミット (5時間 / 7日サイクル) を取得。60s cache、429 時は 5min backoff、in-flight リクエストの合流 (coalescing)。現在ペースからのリミット到達予測も算出。`limits[]` の scope 付きエントリからモデル別リミット (Fable 等) も抽出 — 全体サイクルが余裕でもモデル別が振り切っていることがあるため。解釈できないエントリは推測せず捨てる",
         "deps": []
       },
       {
@@ -279,7 +279,7 @@
       {
         "name": "UsageHistoryService",
         "file": "backend/src/services/usage-history.ts",
-        "summary": "使用量スナップショットを /tmp/cchub-usage-history.json に 30s スロットルで記録。最大 8 日分保持し、利用率トレンドのチャートに使用",
+        "summary": "使用量スナップショットを /tmp/cchub-usage-history.json に 30s スロットルで記録。最大 8 日分保持し、利用率トレンドのチャートに使用。モデル別リミットの値も `scoped` に記録 (このキーを持たない旧スナップショットは 0% ではなく「未計測」扱い)",
         "deps": []
       },
       {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "generated": "2026-07-16",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
@@ -140,7 +140,7 @@
       {
         "name": "AnthropicUsageService",
         "file": "backend/src/services/anthropic-usage.ts",
-        "summary": "Anthropic API から使用量リミット (5時間 / 7日サイクル) を取得。60s cache、429 時は 5min backoff、in-flight リクエストの合流 (coalescing)。現在ペースからのリミット到達予測も算出",
+        "summary": "Anthropic API から使用量リミット (5時間 / 7日サイクル) を取得。60s cache、429 時は 5min backoff、in-flight リクエストの合流 (coalescing)。現在ペースからのリミット到達予測も算出。`limits[]` の scope 付きエントリからモデル別リミット (Fable 等) も抽出 — 全体サイクルが余裕でもモデル別が振り切っていることがあるため。解釈できないエントリは推測せず捨てる",
         "deps": []
       },
       {
@@ -158,7 +158,7 @@
       {
         "name": "UsageHistoryService",
         "file": "backend/src/services/usage-history.ts",
-        "summary": "使用量スナップショットを /tmp/cchub-usage-history.json に 30s スロットルで記録。最大 8 日分保持し、利用率トレンドのチャートに使用",
+        "summary": "使用量スナップショットを /tmp/cchub-usage-history.json に 30s スロットルで記録。最大 8 日分保持し、利用率トレンドのチャートに使用。モデル別リミットの値も `scoped` に記録 (このキーを持たない旧スナップショットは 0% ではなく「未計測」扱い)",
         "deps": []
       },
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- feat(dashboard): モデル別（Fable 等）の使用量リミットをチャートに表示（#401）

## Notes

Anthropic の `GET /api/oauth/usage` に `limits[]` 配列が増え、特定モデルにスコープされたリミットはそこにしか現れないようになっていた。cchub は `five_hour` / `seven_day` しか読んでいなかったため、**ダッシュボードが「余裕十分（68%）」と表示している裏で Fable の週次リミットが既に 100% / critical / 適用中**、という状態が見えていなかった。

7日間チャートに Fable のラインと凡例（`Fable 100%（適用中）`）が出るようになる。

現時点で API がモデル別に分けているのは週次のみで、5時間は全モデル共通の1本。`group: "session"` の scoped リミットが返り始めたらコード変更なしで5時間チャートにも線が出る。

既存の 5時間 / 7日サイクルの表示・計算は変更なし。
