### PR TITLE
fix: navigate to the notified session

### DIFF
--- a/frontend/public/sw-notification.js
+++ b/frontend/public/sw-notification.js
@@ -1,27 +1,29 @@
 // Custom notification click handler for CC Hub PWA
-// Version: 0.0.61-1
+// Version: 0.2.4-1
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
 
   const sessionId = event.notification.data?.sessionId;
+  const peerId = event.notification.data?.peerId;
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
       // Send log to all clients so it appears in frontend.log
       for (const c of clientList) {
-        c.postMessage({ type: 'sw-log', message: `[SW v0.0.61-1] notificationclick sessionId=${sessionId} clients=${clientList.length}` });
+        c.postMessage({ type: 'sw-log', message: `[SW v0.2.4-1] notificationclick sessionId=${sessionId} peerId=${peerId} clients=${clientList.length}` });
       }
-      for (const client of clientList) {
-        if ('navigate' in client) {
-          const url = sessionId ? `/?notify-session=${sessionId}` : '/';
-          return client.navigate(url).then((c) => c?.focus());
+      const client = clientList.find((candidate) => 'focus' in candidate);
+      if (client) {
+        if (sessionId) {
+          client.postMessage({ type: 'notification-click', sessionId, peerId });
         }
-        if ('focus' in client) {
-          return client.focus();
-        }
+        return client.focus();
       }
       if (self.clients.openWindow) {
-        const url = sessionId ? `/?notify-session=${sessionId}` : '/';
+        const params = new URLSearchParams();
+        if (sessionId) params.set('notify-session', sessionId);
+        if (peerId) params.set('notify-peer', peerId);
+        const url = params.size > 0 ? `/?${params.toString()}` : '/';
         return self.clients.openWindow(url);
       }
     })
@@ -32,7 +34,7 @@ self.addEventListener('notificationclick', (event) => {
 self.addEventListener('activate', () => {
   self.clients.matchAll({ type: 'window' }).then((clients) => {
     for (const c of clients) {
-      c.postMessage({ type: 'sw-log', message: '[SW v0.0.61-1] activated' });
+      c.postMessage({ type: 'sw-log', message: '[SW v0.2.4-1] activated' });
     }
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,13 @@ import { useAuth } from "./hooks/useAuth";
 import { useSessions } from "./hooks/useSessions";
 import { TerminalPage } from "./pages/TerminalPage";
 import { authFetch, isTransientNetworkError } from "./services/api";
+import {
+	findNotificationSession,
+	isSameNotificationPeer,
+	NOTIFICATION_NAVIGATION_EVENT,
+	parseNotificationTarget,
+	type NotificationTarget,
+} from "./utils/notificationNavigation";
 
 // Loading screen with phase display and timeout detection
 function LoadingScreen({
@@ -292,6 +299,14 @@ export function App() {
 
 	const [openSessions, setOpenSessions] = useState<OpenSession[]>([]);
 	const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+	const [pendingNotificationTarget, setPendingNotificationTarget] =
+		useState<NotificationTarget | null>(null);
+	const notificationRequestIdRef = useRef(0);
+	const notificationNavigationHandledRef = useRef(false);
+	const [desktopSessionSwitchRequest, setDesktopSessionSwitchRequest] = useState<{
+		sessionId: string;
+		requestId: number;
+	} | null>(null);
 
 	const [isLoading, setIsLoading] = useState(true);
 	const [loadError, setLoadError] = useState<string | null>(null);
@@ -565,22 +580,31 @@ export function App() {
 					.map(apiToOpenSession);
 
 				if (sessionsToOpen.length > 0) {
-					setOpenSessions(sessionsToOpen);
+					if (!notificationNavigationHandledRef.current) {
+						setOpenSessions(sessionsToOpen);
+					}
 					const validIds = sessionsToOpen.map((s) => s.id);
 					const activeId =
 						lastSessionId && validIds.includes(lastSessionId)
 							? lastSessionId
 							: validIds[0];
-					setActiveSessionId(activeId);
+					if (!notificationNavigationHandledRef.current) {
+						setActiveSessionId(activeId);
+					}
 				} else if (allSessions.length > 0) {
 					const mostRecent = apiToOpenSession(allSessions[0]);
-					setOpenSessions([mostRecent]);
-					setActiveSessionId(mostRecent.id);
+					if (!notificationNavigationHandledRef.current) {
+						setOpenSessions([mostRecent]);
+						setActiveSessionId(mostRecent.id);
+					}
 				} else {
+					if (notificationNavigationHandledRef.current) return;
 					const initialSession = await createInitialSession();
 					if (initialSession) {
-						setOpenSessions([initialSession]);
-						setActiveSessionId(initialSession.id);
+						if (!notificationNavigationHandledRef.current) {
+							setOpenSessions([initialSession]);
+							setActiveSessionId(initialSession.id);
+						}
 					} else {
 						setShowSessionList(true);
 					}
@@ -830,35 +854,90 @@ export function App() {
 		};
 	}, [showOverlay, showSessionList, isLoading, startOverlayTimer]);
 
-	// Navigate to session from notification tap
-	// SW client.navigate() reloads page with ?notify-session=<ccSessionId>
-	// Store in ref until openSessions loads, then switch once
-	const pendingNotifyRef = useRef<string | null>(null);
-
+	// Receive notification navigation from either a deep link (new window) or
+	// Service Worker / Notification click event (existing window, no reload).
 	useEffect(() => {
-		const params = new URLSearchParams(window.location.search);
-		const urlSessionId = params.get("notify-session");
-		if (urlSessionId) {
-			pendingNotifyRef.current = urlSessionId;
-			window.history.replaceState({}, "", "/");
-			// Auto-clear after 15s to prevent stale switches
-			setTimeout(() => {
-				pendingNotifyRef.current = null;
-			}, 15_000);
+		const handleNotificationNavigation = (event: Event) => {
+			const detail = (event as CustomEvent<NotificationTarget>).detail;
+			if (detail && typeof detail.sessionId === "string") {
+				setPendingNotificationTarget(detail);
+			}
+		};
+		window.addEventListener(
+			NOTIFICATION_NAVIGATION_EVENT,
+			handleNotificationNavigation,
+		);
+
+		const deepLinkTarget = parseNotificationTarget(window.location.search);
+		if (deepLinkTarget) {
+			setPendingNotificationTarget(deepLinkTarget);
+			const url = new URL(window.location.href);
+			url.searchParams.delete("notify-session");
+			url.searchParams.delete("notify-peer");
+			window.history.replaceState(
+				{},
+				"",
+				`${url.pathname}${url.search}${url.hash}`,
+			);
 		}
+
+		return () => {
+			window.removeEventListener(
+				NOTIFICATION_NAVIGATION_EVENT,
+				handleNotificationNavigation,
+			);
+		};
 	}, []);
 
-	// When openSessions updates, check if we have a pending notification switch
+	// Give session watchers time to deliver a newly-created target, but do not
+	// retain an unresolved click indefinitely.
 	useEffect(() => {
-		const pending = pendingNotifyRef.current;
-		if (!pending || openSessions.length === 0) return;
-		const match = openSessions.find((s) => s.ccSessionId === pending);
-		if (match) {
-			pendingNotifyRef.current = null;
-			setActiveSessionId(match.id);
-			setShowSessionList(false);
-		}
-	}, [openSessions]);
+		if (!pendingNotificationTarget) return;
+		const target = pendingNotificationTarget;
+		const timer = window.setTimeout(() => {
+			setPendingNotificationTarget((current) =>
+				current === target ? null : current,
+			);
+		}, 15_000);
+		return () => window.clearTimeout(timer);
+	}, [pendingNotificationTarget]);
+
+	// Resolve against the full live API list first so notifications can open a
+	// session that this device has never opened before. openSessions remains a
+	// fallback while the watcher is still hydrating.
+	useEffect(() => {
+		if (!pendingNotificationTarget) return;
+		const match = findNotificationSession(
+			[...apiSessions, ...openSessions],
+			pendingNotificationTarget,
+		);
+		if (!match) return;
+
+		const apiMatch = apiSessions.find(
+			(session) =>
+				session.id === match.id &&
+				isSameNotificationPeer(session.peerId, match.peerId),
+		);
+		const openMatch = apiMatch ? apiToOpenSession(apiMatch) : (match as OpenSession);
+		notificationNavigationHandledRef.current = true;
+		setOpenSessions((previous) =>
+			previous.some(
+				(session) =>
+					session.id === openMatch.id &&
+					isSameNotificationPeer(session.peerId, openMatch.peerId),
+			)
+				? previous
+				: [...previous, openMatch],
+		);
+		setPendingNotificationTarget(null);
+		setActiveSessionId(openMatch.id);
+		setDesktopSessionSwitchRequest({
+			sessionId: openMatch.id,
+			requestId: ++notificationRequestIdRef.current,
+		});
+		setShowSessionList(false);
+		setMobileActivePaneId(null);
+	}, [apiSessions, openSessions, pendingNotificationTarget]);
 
 	// Diagnostic: log render state for debugging black screen issues
 	useEffect(() => {
@@ -923,6 +1002,7 @@ export function App() {
 				<DesktopLayout
 					sessions={openSessions}
 					activeSessionId={activeSessionId}
+					sessionSwitchRequest={desktopSessionSwitchRequest}
 					onSessionStateChange={updateSessionState}
 				/>
 				{showOnboarding && <Onboarding onComplete={completeOnboarding} />}
@@ -937,6 +1017,7 @@ export function App() {
 				<DesktopLayout
 					sessions={openSessions}
 					activeSessionId={activeSessionId}
+					sessionSwitchRequest={desktopSessionSwitchRequest}
 					onSessionStateChange={updateSessionState}
 					isTablet={true}
 					keyboardControlRef={keyboardControlRef}

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -61,6 +61,10 @@ interface DesktopState {
 interface DesktopLayoutProps {
 	sessions: OpenSession[];
 	activeSessionId: string | null;
+	sessionSwitchRequest?: {
+		sessionId: string;
+		requestId: number;
+	} | null;
 	onSessionStateChange: (id: string, state: SessionState) => void;
 	isTablet?: boolean;
 	keyboardControlRef?: React.RefObject<{
@@ -257,6 +261,7 @@ const KEYBOARD_VISIBLE_KEY = "cchub-floating-keyboard-visible";
 export function DesktopLayout({
 	sessions: propSessions,
 	activeSessionId,
+	sessionSwitchRequest,
 	onSessionStateChange,
 	isTablet = false,
 	keyboardControlRef,
@@ -426,6 +431,27 @@ export function DesktopLayout({
 			}));
 		}
 	}, [activeSessionId, desktopState.root]);
+
+	// Notification navigation is an explicit external switch. Keep the ordinary
+	// activeSessionId prop from overwriting the user's persisted desktop state,
+	// while still allowing a notification to move every pane to its target.
+	const appliedSessionSwitchRequestRef = useRef(0);
+	useEffect(() => {
+		if (
+			!sessionSwitchRequest ||
+			sessionSwitchRequest.requestId === appliedSessionSwitchRequestRef.current
+		) {
+			return;
+		}
+		appliedSessionSwitchRequestRef.current = sessionSwitchRequest.requestId;
+		setDesktopState((previous) => ({
+			...previous,
+			root: updateAllSessionIds(
+				previous.root,
+				sessionSwitchRequest.sessionId,
+			),
+		}));
+	}, [sessionSwitchRequest]);
 
 	// =========================================================================
 	// Control Mode
@@ -614,7 +640,14 @@ export function DesktopLayout({
 			setTimeout(() => requestAllViewports(), 500);
 		},
 		onHookEvent: (event, cwd, sessionId, data, message) => {
-			fireHookNotification(event, cwd, sessionId, data, message);
+			fireHookNotification(
+				event,
+				cwd,
+				sessionId,
+				data,
+				message,
+				peerConn.peerId,
+			);
 			// 全useSessions インスタンスのindicatorStateを即座に更新
 			updateCachedSessionsByHookEvent(event, sessionId);
 		},

--- a/frontend/src/hooks/usePeerSessionsWatcher.ts
+++ b/frontend/src/hooks/usePeerSessionsWatcher.ts
@@ -149,6 +149,7 @@ function openWatcher(peer: PeerClientView) {
 					ccSessionId,
 					msg.data,
 					msg.message,
+					peer.id,
 				);
 				return;
 			}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { initRemoteLogger } from "./utils/remoteLogger";
 import { applyUiScale, getStoredUiScale } from "./utils/uiScale";
+import { dispatchNotificationNavigation } from "./utils/notificationNavigation";
 import "./i18n";
 import "./index.css";
 
@@ -52,6 +53,18 @@ if ("serviceWorker" in navigator) {
 	navigator.serviceWorker.addEventListener("message", (event) => {
 		if (event.data?.type === "sw-log") {
 			console.log(event.data.message);
+		}
+		if (
+			event.data?.type === "notification-click" &&
+			typeof event.data.sessionId === "string"
+		) {
+			dispatchNotificationNavigation({
+				sessionId: event.data.sessionId,
+				peerId:
+					typeof event.data.peerId === "string"
+						? event.data.peerId
+						: undefined,
+			});
 		}
 	});
 }

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -198,7 +198,16 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 					controlTerminal.requestViewport(pane.paneId, offset);
 				}
 			},
-			onHookEvent: fireHookNotification,
+			onHookEvent: (event, cwd, agentSessionId, data, message) => {
+				fireHookNotification(
+					event,
+					cwd,
+					agentSessionId,
+					data,
+					message,
+					sessionPeerId,
+				);
+			},
 			onDisconnect: () => {
 				onStateChange?.("disconnected");
 			},

--- a/frontend/src/utils/hookNotification.ts
+++ b/frontend/src/utils/hookNotification.ts
@@ -6,6 +6,7 @@
  */
 
 import { toHomeShortPath } from "./path";
+import { dispatchNotificationNavigation } from "./notificationNavigation";
 
 const EVENT_MESSAGES: Record<string, string> = {
 	Stop: "応答が完了しました",
@@ -38,6 +39,16 @@ async function showNotification(title: string, options: NotificationOptions) {
 		const notification = new Notification(title, options);
 		notification.onclick = () => {
 			window.focus();
+			const sessionId = options.data?.sessionId;
+			if (typeof sessionId === "string") {
+				dispatchNotificationNavigation({
+					sessionId,
+					peerId:
+						typeof options.data?.peerId === "string"
+							? options.data.peerId
+							: undefined,
+				});
+			}
 			notification.close();
 		};
 	} catch {
@@ -54,13 +65,14 @@ export function fireHookNotification(
 	_sessionId?: string,
 	_data?: Record<string, unknown>,
 	smartMessage?: string,
+	peerId?: string,
 ) {
 	if (!("Notification" in window) || Notification.permission !== "granted") {
 		return;
 	}
 
 	// デバウンス
-	const key = `${event}:${cwd || ""}`;
+	const key = `${peerId || "local"}:${_sessionId || ""}:${event}:${cwd || ""}`;
 	const now = Date.now();
 	if (
 		key === lastNotification.key &&
@@ -79,6 +91,6 @@ export function fireHookNotification(
 		body,
 		icon: "/icon-192.png",
 		tag: `hook-${event}-${now}`,
-		data: { sessionId: _sessionId, event },
+		data: { sessionId: _sessionId, peerId, event },
 	});
 }

--- a/frontend/src/utils/notificationNavigation.test.ts
+++ b/frontend/src/utils/notificationNavigation.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import {
+	findNotificationSession,
+	isSameNotificationPeer,
+	parseNotificationTarget,
+} from "./notificationNavigation";
+
+const sessions = [
+	{
+		id: "claude-local",
+		ccSessionId: "claude-thread",
+		peerId: "local",
+	},
+	{
+		id: "codex-local",
+		agentSessionId: "codex-thread",
+		peerId: "local",
+	},
+	{
+		id: "codex-remote",
+		agentSessionId: "codex-thread",
+		peerId: "peer-1",
+	},
+];
+
+describe("parseNotificationTarget", () => {
+	test("parses session and peer from a notification deep link", () => {
+		expect(
+			parseNotificationTarget(
+				"?notify-session=thread%2F1&notify-peer=peer%201",
+			),
+		).toEqual({ sessionId: "thread/1", peerId: "peer 1" });
+	});
+
+	test("rejects a deep link without a session", () => {
+		expect(parseNotificationTarget("?notify-peer=peer-1")).toBeNull();
+	});
+});
+
+describe("findNotificationSession", () => {
+	test("matches Claude sessions by ccSessionId", () => {
+		expect(
+			findNotificationSession(sessions, { sessionId: "claude-thread" })?.id,
+		).toBe("claude-local");
+	});
+
+	test("matches Codex sessions by agentSessionId", () => {
+		expect(
+			findNotificationSession(sessions, { sessionId: "codex-thread" })?.id,
+		).toBe("codex-local");
+	});
+
+	test("uses peerId to select the remote session", () => {
+		expect(
+			findNotificationSession(sessions, {
+				sessionId: "codex-thread",
+				peerId: "peer-1",
+			})?.id,
+		).toBe("codex-remote");
+	});
+
+	test("does not fall through to another peer when the requested peer is absent", () => {
+		expect(
+			findNotificationSession(sessions, {
+				sessionId: "codex-thread",
+				peerId: "peer-missing",
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe("isSameNotificationPeer", () => {
+	test("treats an omitted peer as the local peer", () => {
+		expect(isSameNotificationPeer(undefined, "local")).toBeTrue();
+	});
+});
+
+describe("notification Service Worker", () => {
+	async function loadClickHandler(clients: unknown[], openWindow = () => {}) {
+		const handlers = new Map<string, (event: unknown) => void>();
+		const worker = {
+			addEventListener: (type: string, handler: (event: unknown) => void) => {
+				handlers.set(type, handler);
+			},
+			clients: {
+				matchAll: async () => clients,
+				openWindow,
+			},
+		};
+		const source = await Bun.file(
+			new URL("../../public/sw-notification.js", import.meta.url),
+		).text();
+		new Function("self", source)(worker);
+		return handlers.get("notificationclick");
+	}
+
+	test("posts to and focuses an existing client without navigating it", async () => {
+		const messages: unknown[] = [];
+		let focusCount = 0;
+		let navigateCount = 0;
+		const handler = await loadClickHandler([
+			{
+				postMessage: (message: unknown) => messages.push(message),
+				focus: async () => {
+					focusCount++;
+				},
+				navigate: async () => {
+					navigateCount++;
+				},
+			},
+		]);
+		let completion: Promise<unknown> | undefined;
+		handler?.({
+			notification: {
+				data: { sessionId: "codex-thread", peerId: "peer-1" },
+				close: () => {},
+			},
+			waitUntil: (promise: Promise<unknown>) => {
+				completion = promise;
+			},
+		});
+		await completion;
+
+		expect(focusCount).toBe(1);
+		expect(navigateCount).toBe(0);
+		expect(messages).toContainEqual({
+			type: "notification-click",
+			sessionId: "codex-thread",
+			peerId: "peer-1",
+		});
+	});
+
+	test("opens an encoded deep link when no client exists", async () => {
+		let openedUrl = "";
+		const handler = await loadClickHandler([], (url?: string) => {
+			openedUrl = url || "";
+		});
+		let completion: Promise<unknown> | undefined;
+		handler?.({
+			notification: {
+				data: { sessionId: "thread/1", peerId: "peer 1" },
+				close: () => {},
+			},
+			waitUntil: (promise: Promise<unknown>) => {
+				completion = promise;
+			},
+		});
+		await completion;
+
+		expect(openedUrl).toBe(
+			"/?notify-session=thread%2F1&notify-peer=peer+1",
+		);
+	});
+});

--- a/frontend/src/utils/notificationNavigation.ts
+++ b/frontend/src/utils/notificationNavigation.ts
@@ -1,0 +1,66 @@
+import { LOCAL_PEER_ID } from "../../../shared/types";
+
+export const NOTIFICATION_NAVIGATION_EVENT = "cchub-notification-click";
+
+export interface NotificationTarget {
+	sessionId: string;
+	peerId?: string;
+}
+
+export interface NotificationSession {
+	id: string;
+	ccSessionId?: string;
+	agentSessionId?: string;
+	peerId?: string;
+}
+
+function normalizedPeerId(peerId?: string): string {
+	return peerId || LOCAL_PEER_ID;
+}
+
+export function isSameNotificationPeer(
+	leftPeerId?: string,
+	rightPeerId?: string,
+): boolean {
+	return normalizedPeerId(leftPeerId) === normalizedPeerId(rightPeerId);
+}
+
+export function parseNotificationTarget(
+	search: string,
+): NotificationTarget | null {
+	const params = new URLSearchParams(search);
+	const sessionId = params.get("notify-session");
+	if (!sessionId) return null;
+	const peerId = params.get("notify-peer") || undefined;
+	return { sessionId, peerId };
+}
+
+export function findNotificationSession<T extends NotificationSession>(
+	sessions: readonly T[],
+	target: NotificationTarget,
+): T | undefined {
+	const idMatches = sessions.filter(
+		(session) =>
+			session.ccSessionId === target.sessionId ||
+			session.agentSessionId === target.sessionId,
+	);
+	if (target.peerId) {
+		return idMatches.find(
+			(session) =>
+				isSameNotificationPeer(session.peerId, target.peerId),
+		);
+	}
+	return (
+		idMatches.find(
+			(session) => normalizedPeerId(session.peerId) === LOCAL_PEER_ID,
+		) ?? idMatches[0]
+	);
+}
+
+export function dispatchNotificationNavigation(target: NotificationTarget) {
+	window.dispatchEvent(
+		new CustomEvent<NotificationTarget>(NOTIFICATION_NAVIGATION_EVENT, {
+			detail: target,
+		}),
+	);
+}


### PR DESCRIPTION
## Summary
- route notification clicks without reloading an existing SPA client
- resolve both Claude and Codex session ids, including unopened and peer sessions
- explicitly switch desktop/tablet layouts and cover the Service Worker paths

## Verification
- bun run test (339 passed)
- bun run typecheck
- bun run lint
- bun run build
- browser checks on desktop, tablet, and mobile

Closes #400