### PR TITLE
Release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.6] - 2026-07-17
+
+### Fixed
+- **OS通知をタップしても対象セッションへ遷移しない問題（#400）**: 既存ウィンドウには Service Worker から `postMessage` して SPA を再読込せずに切り替え、ウィンドウがない場合だけ deep link で開くようにした。通知先は Claude の `ccSessionId` と Codex の `agentSessionId` の両方から解決し、未オープンのセッションもライブAPI一覧から追加して開く。desktop / tablet の保存済みペイン状態、remote peer の `peerId`、Service Workerを使わない通常ブラウザ通知にも同じ遷移を配線した（`frontend/public/sw-notification.js`, `frontend/src/App.tsx`, `frontend/src/components/DesktopLayout.tsx`, `frontend/src/utils/notificationNavigation.ts`）
+
 ## [0.2.5] - 2026-07-16
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.5",
-  "generated": "2026-07-16",
+  "version": "0.2.6",
+  "generated": "2026-07-17",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.2.5",
-  "generated": "2026-07-16",
+  "version": "0.2.6",
+  "generated": "2026-07-17",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix: make notification taps navigate to the intended Claude or Codex session
- fix: switch unopened, desktop/tablet, and peer sessions without reloading an existing SPA client
- test: cover notification target resolution and Service Worker click routing

## Verification
- bun run test (339 passed)
- bun run typecheck

## Notes
Fixes #400. Existing windows switch through Service Worker postMessage; a deep link is used only when no window is open.