### PR TITLE
Release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.7] - 2026-07-17
+
+### Changed
+- **セッションの並び順を herdr 単一情報源にした**: 並び順は二重に持たれていた — herdr のワークスペース順の上に、cchub 独自の `sessionOrder`（`session-metadata.json` とクロス peer 用の `peers.json`）が乗っていた。どちらか一方で並べ替えるともう一方とズレ、実際に本番でズレていた（cchub 側は「ギガ残量通知」が先頭、herdr 側は5番目）。cchub 側のストアを両方消し、ドラッグは herdr の `workspace.move` へ直接書き込むようにした。`listSessions()` は元々 `workspace.list` の順で組み立てているので、実装はソート層2枚（`sessions.ts` のサーバ側ソートと `useSessions.ts` の `sortByMergedOrder`）の**削除**が主で、永続化する状態が1つ減った。herdr の TUI で並べ替えても cchub に反映されるようになり、逆も同様（`backend/src/services/herdr.ts`, `routes/sessions.ts`, `services/session-metadata.ts`, `services/peer-registry.ts`, `routes/peers.ts`, `frontend/src/hooks/useSessions.ts`, `components/SessionList.tsx`）
+  - `PUT /api/sessions/order` と `GET|PUT /api/peers/session-order` を廃止し、`POST /api/sessions/:id/move { index }` を新設。peer のセッションは `sessionFetch` 経由でその peer の cchub → その peer の herdr に届く
+  - herdr の `insert_index` は「そのインデックスに現在いるワークスペースの手前に挿入」という意味で、移動元がまだリストに居る状態で評価される。後方→前方の移動はインデックスちょうどに着地するが、前方→後方は1つ手前に着地するため補正している（herdr 0.7.3/0.7.4 で実測）
+  - **並び順は peer ごとにグループ化される**（peer 間は `PUT /api/peers/order` の表示順、peer 内は各 herdr の順）。herdr は自分のマシンのワークスペースしか知らないため、peer 境界をまたぐドラッグは保存先が無く無視される。`state: 'lost'` のセッションはワークスペースが無いので末尾に並ぶ
+  - 移行時、既存の cchub 側の並び順は破棄され herdr の順が正になる（`peers.json` の死んだ `sessionOrder` キーは次回保存時に自動削除）
+
 ## [0.2.6] - 2026-07-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,12 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - **HerdrClient** (`services/herdr-client.ts`) - Low-level herdr socket API client: NDJSON RPC over `~/.config/herdr/herdr.sock` (one connection per request; `events.subscribe` held open), streaming-safe UTF-8 line reader, pane id mapping (`%N ↔ wK:pN`), and `PaneController` — a persistent `herdr terminal session control` subprocess per pane carrying raw PTY input (base64, no sanitization), absolute PTY resizes, and `terminal.frame` output records
 - **HerdrControlSession** (`services/herdr-control.ts`) - One instance per CC Hub session (= one herdr workspace). Owns the pane split tree, tracks the focused pane, spawns lazy per-pane controllers (WS subscribe / first input only — read-only REST never takes over a pane), scans frames for cursor position and alt-screen state, client lifecycle with 30s grace period. Also `captureViewportHerdr`: viewport composition from `pane.read` (visible at offset 0, `recent` slice for scrollback, capped at herdr's 1000-line read limit)
 - **HerdrLayout** (`services/herdr-layout.ts`) - CC Hub-owned split tree (herdr's own grid can't be resized headlessly): split/close/zoom/ratio adjust/absolute pane sizing, rendered to tmux-convention `TmuxLayoutNode` rects for the frontend
-- **HerdrService** (`services/herdr.ts`) - Session-level operations mapping CC Hub sessions onto herdr workspaces: list (with agent detection from `pane.process_info`, native agent session ids from `agent.list`, `blocked` status), create/kill, previews
+- **HerdrService** (`services/herdr.ts`) - Session-level operations mapping CC Hub sessions onto herdr workspaces: list (with agent detection from `pane.process_info`, native agent session ids from `agent.list`, `blocked` status), create/kill, previews, and `moveSession` — herdr's workspace order **is** the session display order, so a reorder is a `workspace.move` and nothing is stored on the cchub side
 - **HerdrUpdateService** (`services/herdr-update.ts`) - Detects herdr binary-vs-server version skew (`herdr update` swaps the binary but leaves the running server old) by parsing `herdr status --json`, cached 30s and refreshed off the dashboard poll. Reports only — applying (`herdr update` + supervised restart) is an explicit user action via `POST /api/herdr/apply-update`; never the `cchub update --auto` timer, never `--handoff`. Unreadable status degrades to no warning
 - **PaneState** (`services/pane-state.ts`) - Backend-agnostic `stripAnsi` / `detectPaneState` heuristics for peer-dialog tooling (`cchub send --wait`, `cchub peek`)
 - **ClaudeCodeService** (`services/claude-code.ts`) - Monitors Claude Code state from `.jsonl` files; session matching via herdr's native agent session id, falling back to working-dir path matching
 - **SessionHistoryService** (`services/session-history.ts`) - Reads past Claude Code session history and conversations
-- **SessionMetadataService** (`services/session-metadata.ts`) - Persists session metadata (theme, title, session order, last known sessions for recovery after reboot)
+- **SessionMetadataService** (`services/session-metadata.ts`) - Persists session metadata (theme, title, last known sessions for recovery after reboot). Deliberately *not* session order — that lives in herdr
 - **SessionsService** (`services/sessions.ts`) - Session CRUD operations with file-based persistence
 - **PromptHistoryService** (`services/prompt-history.ts`) - Searches prompt history across sessions
 - **FileService** (`services/file-service.ts`) - Secure file operations with path traversal prevention
@@ -94,7 +94,7 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - `GET /:id/copy-mode` - Get tmux copy mode selection
 - `PUT /:id/theme` - Set session color theme
 - `PUT /:id/title` - Set session custom title
-- `PUT /order` - Set session display order
+- `POST /:id/move` - Move a session to `{ index }` in the display order (writes straight through to herdr's workspace order — cchub stores no order of its own)
 - `GET /clipboard` - Get clipboard content
 - `GET /prompts/search` - Search prompt history
 
@@ -128,7 +128,6 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - `POST /` - Register a peer / `DELETE /:id` - Remove a peer
 - `POST /:id/verify` - Re-verify connectivity and auth for a peer
 - `PUT /order` - Set peer display order
-- `GET|PUT /session-order` - Get/set cross-peer session display order
 - `GET /sessions` - Aggregate active sessions across all peers
 - `GET /history/projects` - Aggregate project history across peers
 - `GET /history/:peerId/projects/:dirName` - Sessions for a peer's project

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "generated": "2026-07-17",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "generated": "2026-07-17",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -4,7 +4,6 @@ import {
   PeerCreateSchema,
   PeerUpdateSchema,
   PeerOrderSchema,
-  CrossPeerSessionOrderSchema,
   LOCAL_PEER_ID,
   SELF_PEER_URL,
   type PeerClientView,
@@ -22,8 +21,6 @@ import {
   updatePeer,
   deletePeer,
   setPeerOrder,
-  getCrossPeerSessionOrder,
-  setCrossPeerSessionOrder,
   type StoredPeer,
 } from '../services/peer-registry';
 import { loginToPeer, verifyPeer, peerFetch, PeerAuthError } from '../services/peer-auth';
@@ -135,19 +132,6 @@ peers.delete('/:id', async (c) => {
 peers.put('/order', zValidator('json', PeerOrderSchema), async (c) => {
   const { order } = c.req.valid('json');
   await setPeerOrder(order);
-  return c.json({ success: true });
-});
-
-// GET /api/peers/session-order - peer 横断のセッション並び順を取得
-peers.get('/session-order', async (c) => {
-  const order = await getCrossPeerSessionOrder();
-  return c.json({ order });
-});
-
-// PUT /api/peers/session-order - peer 横断のセッション並び順を保存
-peers.put('/session-order', zValidator('json', CrossPeerSessionOrderSchema), async (c) => {
-  const { order } = c.req.valid('json');
-  await setCrossPeerSessionOrder(order);
   return c.json({ success: true });
 });
 

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -14,7 +14,7 @@ import { CodexConversationService } from '../services/codex-conversation';
 import { SessionHistoryService } from '../services/session-history';
 import { CodexHistoryService } from '../services/codex-history';
 import { PromptHistoryService } from '../services/prompt-history';
-import { getAllSessionMetadata, setSessionTheme, setSessionTitle, getSessionOrder, setSessionOrder, getLastKnownSessions, saveLastKnownSessions, removeLastKnownSession, type LastKnownSession } from '../services/session-metadata';
+import { getAllSessionMetadata, setSessionTheme, setSessionTitle, getLastKnownSessions, saveLastKnownSessions, removeLastKnownSession, type LastKnownSession } from '../services/session-metadata';
 import { computeSessionMetrics } from '../services/session-metrics';
 import { getIndicatorOverride } from './notify';
 import { pushSessionsNow } from './terminal-mux';
@@ -181,8 +181,6 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
   // Remote Control deep-link map: Claude Code sessionId -> bridgeSessionId.
   // Read once per build (cheap: a handful of small ~/.claude/sessions/*.json).
   const bridgeSessionIds = await claudeCodeService.getBridgeSessionIds();
-
-  const order = await getSessionOrder();
 
   const results = await Promise.all(tmuxSessions.map(async (s) => {
     let ccSession: Awaited<ReturnType<typeof claudeCodeService.getSessionForPath>> | undefined;
@@ -388,15 +386,9 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
   // Fire async, don't block response
   saveLastKnownSessions(snapshot).catch(() => {});
 
-  // Apply custom order if set
-  if (order.length > 0) {
-    const orderMap = new Map(order.map((id, i) => [id, i]));
-    results.sort((a, b) => {
-      const ai = orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER;
-      const bi = orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER;
-      return ai - bi;
-    });
-  }
+  // No sort: `results` is already in herdr's workspace order (listSessions
+  // maps over `workspace.list`), and herdr is the only source of session
+  // order. Lost sessions have no workspace, so they trail the live ones.
 
   return results;
 }
@@ -866,19 +858,26 @@ sessions.put('/:id/title', async (c) => {
   }
 });
 
-// PUT /sessions/order - Save session display order
-sessions.put('/order', async (c) => {
+// POST /sessions/:id/move - Move a session to `index` in the display order.
+// The order lives in herdr (workspace order), not in cchub — so this is a
+// write straight through to herdr rather than to a cchub-side store.
+sessions.post('/:id/move', async (c) => {
+  const id = c.req.param('id');
   const body = await c.req.json().catch(() => ({}));
-  const order = body.order;
-  if (!Array.isArray(order) || !order.every((id: unknown) => typeof id === 'string')) {
-    return c.json({ error: 'Invalid order' }, 400);
+  const index = (body as { index?: unknown }).index;
+  if (typeof index !== 'number' || !Number.isInteger(index) || index < 0) {
+    return c.json({ error: 'Invalid index' }, 400);
   }
   try {
-    await setSessionOrder(order);
+    const moved = await tmuxService.moveSession(id, index);
+    if (!moved) return c.json({ error: 'Session not found' }, 404);
     notifySessionChange();
     return c.json({ success: true });
-  } catch {
-    return c.json({ error: 'Failed to save order' }, 500);
+  } catch (error) {
+    return c.json(
+      { error: error instanceof Error ? error.message : 'Failed to move session' },
+      500,
+    );
   }
 });
 

--- a/backend/src/services/__tests__/session-metadata-lock.test.ts
+++ b/backend/src/services/__tests__/session-metadata-lock.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 });
 
 describe('session-metadata mutation lock', () => {
-  test('concurrent theme/title/order updates do not overwrite each other', async () => {
+  test('concurrent theme/title updates do not overwrite each other', async () => {
     const meta = await import('../session-metadata');
 
     // Interleave updates that all do load→mutate→save on the same file.
@@ -31,14 +31,14 @@ describe('session-metadata mutation lock', () => {
     for (let i = 0; i < 20; i++) {
       ops.push(meta.setSessionTheme('ses-a', 'blue'));
       ops.push(meta.setSessionTitle('ses-b', `title ${i}`));
-      ops.push(meta.setSessionOrder([`ses-a`, `ses-b`, `ses-${i}`]));
+      ops.push(meta.setSessionTheme(`ses-${i}`, 'green'));
     }
     await Promise.all(ops);
 
     const sessions = await meta.getAllSessionMetadata();
     expect(sessions['ses-a']?.theme).toBe('blue');
     expect(sessions['ses-b']?.title).toBe('title 19');
-    expect(await meta.getSessionOrder()).toEqual(['ses-a', 'ses-b', 'ses-19']);
+    expect(sessions['ses-19']?.theme).toBe('green');
 
     // The file on disk must always be complete JSON (atomic temp+rename).
     const text = await readFile(join(tempDir, 'herdr-session-metadata.json'), 'utf-8');

--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -311,6 +311,38 @@ export class HerdrService {
     return name;
   }
 
+  /**
+   * Move a session's workspace to `targetIndex` in herdr's workspace order.
+   * herdr IS the session order — there is no cchub-side order to keep in sync.
+   *
+   * herdr's `insert_index` means "insert before the workspace currently at
+   * that index", evaluated against the list with the moved workspace still in
+   * it. Moving backward (to a smaller index) therefore lands exactly on the
+   * index, but moving forward lands one slot short, so compensate. Verified
+   * against herdr 0.7.3/0.7.4: index 13 → insert 0 lands at 0; index 0 →
+   * insert 5 lands at 4.
+   */
+  async moveSession(sessionId: string, targetIndex: number): Promise<boolean> {
+    const workspaces = await listWorkspaces();
+    const current = workspaces.findIndex(
+      (w) => workspaceSessionId(w) === sessionId || w.workspace_id === sessionId,
+    );
+    if (current === -1) return false;
+
+    const clamped = Math.max(0, Math.min(targetIndex, workspaces.length - 1));
+    if (clamped === current) return true;
+
+    const insertIndex = current < clamped ? clamped + 1 : clamped;
+    await herdrRpc('workspace.move', {
+      workspace_id: workspaces[current].workspace_id,
+      insert_index: insertIndex,
+    });
+    // The 2s list cache would otherwise serve the pre-move order back to the
+    // very next sessions push and snap the dragged row back.
+    this.invalidateCache();
+    return true;
+  }
+
   async killSession(sessionId: string): Promise<void> {
     this.invalidateCache();
     const ws = await this.resolveWorkspace(sessionId);

--- a/backend/src/services/peer-registry.ts
+++ b/backend/src/services/peer-registry.ts
@@ -50,9 +50,6 @@ interface StoredPeer extends Peer {
 
 interface PeersStore {
   peers: StoredPeer[];
-  // Cross-peer session display order. Entries are `${peerId}:${sessionId}`
-  // composite keys so identical session names on different peers don't collide.
-  sessionOrder?: string[];
 }
 
 async function getFilePath(): Promise<string> {
@@ -68,7 +65,10 @@ async function load(): Promise<PeersStore> {
     if (!Array.isArray(parsed.peers)) {
       return { peers: [] };
     }
-    return parsed;
+    // Rebuild rather than pass `parsed` through, so keys we no longer own —
+    // notably the pre-herdr `sessionOrder` — get dropped on the next save
+    // instead of round-tripping forever.
+    return { peers: parsed.peers };
   } catch {
     return { peers: [] };
   }
@@ -256,23 +256,6 @@ export async function recordPeerFailure(id: string, message: string): Promise<vo
     if (!peer) return;
     peer.lastErrorAt = new Date().toISOString();
     peer.lastErrorMessage = message;
-    await save(store);
-  });
-}
-
-/**
- * Cross-peer session order persisted on the Hub. Each entry is a
- * `${peerId}:${sessionId}` composite key.
- */
-export async function getCrossPeerSessionOrder(): Promise<string[]> {
-  const store = await load();
-  return store.sessionOrder ?? [];
-}
-
-export async function setCrossPeerSessionOrder(order: string[]): Promise<void> {
-  return withMutationLock(async () => {
-    const store = await load();
-    store.sessionOrder = order;
     await save(store);
   });
 }

--- a/backend/src/services/session-metadata.ts
+++ b/backend/src/services/session-metadata.ts
@@ -34,7 +34,6 @@ export interface LastKnownSession {
 
 interface MetadataStore {
   sessions: Record<string, SessionMeta>;
-  sessionOrder?: string[];
 }
 
 async function getFilePath(): Promise<string> {
@@ -52,7 +51,7 @@ async function load(): Promise<MetadataStore> {
   try {
     const data = await readFile(filePath, 'utf-8');
     const parsed = JSON.parse(data) as MetadataStore;
-    return { sessions: parsed.sessions || {}, sessionOrder: parsed.sessionOrder };
+    return { sessions: parsed.sessions || {} };
   } catch {
     // Fresh store. Deliberately NO migration from the tmux-era files
     // (session-metadata.json etc.) — they belong to the tmux install and
@@ -85,19 +84,6 @@ export async function setSessionTheme(sessionId: string, theme: SessionTheme | n
     } else {
       data.sessions[sessionId].theme = theme;
     }
-    await save(data);
-  });
-}
-
-export async function getSessionOrder(): Promise<string[]> {
-  const data = await load();
-  return data.sessionOrder || [];
-}
-
-export async function setSessionOrder(order: string[]): Promise<void> {
-  await withMetadataLock(async () => {
-    const data = await load();
-    data.sessionOrder = order;
     await save(data);
   });
 }

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -39,7 +39,7 @@ import {
 import { openClaudeAppSession } from "../utils/claude-app";
 import { usePeers } from "../hooks/usePeers";
 import {
-	applyLocalSessionOrder,
+	applyLocalSessionReorder,
 	useSessions,
 } from "../hooks/useSessions";
 import { sessionFetch } from "../services/peer-fetch";
@@ -1535,10 +1535,12 @@ export function SessionList({
 		[sessions, peers],
 	);
 
-	// Drag-to-reorder handler. Session order is a cross-peer merged list stored
-	// on the Hub (`/api/peers/session-order`) so the same ordering applies to
-	// every peer's sessions, including drags across peer boundaries. Each entry
-	// in the saved order is a `${peerId}:${sessionId}` composite key.
+	// Drag-to-reorder handler. The order lives in herdr (workspace order) and
+	// nowhere else, so a drag writes straight through to the owning peer's
+	// herdr and the resulting `sessions-updated` push is what actually reorders
+	// the list. A herdr only knows its own machine's workspaces, so the list is
+	// grouped by peer and a drag across a peer boundary has nowhere to be
+	// stored — ignore it rather than half-applying it.
 	const handleDragEnd = useCallback(
 		async (event: DragEndEvent) => {
 			const { active, over } = event;
@@ -1552,26 +1554,43 @@ export function SessionList({
 			);
 			if (oldIndex === -1 || newIndex === -1) return;
 
+			const moved = sessions[oldIndex];
+			const peerOf = (s: ExtendedSessionResponse) => s.peerId ?? LOCAL_PEER_ID;
+			if (peerOf(moved) !== peerOf(sessions[newIndex])) return;
+
 			const reordered = [...sessions];
-			const [moved] = reordered.splice(oldIndex, 1);
+			reordered.splice(oldIndex, 1);
 			reordered.splice(newIndex, 0, moved);
 
-			const compositeOrder = reordered.map(sessionCompositeKey);
+			// herdr indexes within one machine's workspaces, so translate the
+			// merged-list position into the target's index among its own peer.
+			const targetIndex = reordered
+				.filter((s) => peerOf(s) === peerOf(moved))
+				.findIndex((s) => sessionCompositeKey(s) === active.id);
+			if (targetIndex === -1) return;
 
 			// Optimistic local update so the UI reorders before the round-trip.
-			applyLocalSessionOrder(compositeOrder);
+			applyLocalSessionReorder(reordered);
 
 			try {
-				await authFetch(`${API_BASE}/api/peers/session-order`, {
-					method: "PUT",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ order: compositeOrder }),
-				});
+				const res = await sessionFetch(
+					moved,
+					peers,
+					`/api/sessions/${encodeURIComponent(moved.id)}/move`,
+					{
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ index: targetIndex }),
+					},
+				);
+				if (!res.ok) {
+					console.error("Failed to move session:", await res.text());
+				}
 			} catch (err) {
-				console.error("Failed to save session order:", err);
+				console.error("Failed to move session:", err);
 			}
 		},
-		[sessions],
+		[sessions, peers],
 	);
 
 	const [createError, setCreateError] = useState<string | null>(null);

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	type AgentProvider,
 	DEFAULT_AGENT_PROVIDER,
@@ -8,7 +8,7 @@ import {
 	type SessionResponse,
 	type SessionTheme,
 } from "../../../shared/types";
-import { authFetch, isTransientNetworkError } from "../services/api";
+import { isTransientNetworkError } from "../services/api";
 import { sessionFetch } from "../services/peer-fetch";
 import {
 	applyHookIndicatorUpdate,
@@ -16,60 +16,20 @@ import {
 } from "./usePeerSessionsWatcher";
 import { usePeers } from "./usePeers";
 
-const API_BASE = import.meta.env.VITE_API_URL || "";
-
 // Module-level merged cache produced by the peer sessions watcher.
 // Every peer — including the local Hub — pushes `sessions-updated` over its
 // own WS, so this is the single source of truth.
 let cachedSessions: ExtendedSessionResponse[] = [];
 
-// Cross-peer session order persisted on the Hub. Each entry is the composite
-// key `${peerId}:${sessionId}`. `null` = not yet fetched.
-let cachedMergedOrder: string[] | null = null;
-let mergedOrderFetched = false;
-
-function compositeKey(s: ExtendedSessionResponse): string {
-	return `${s.peerId ?? "local"}:${s.id}`;
-}
-
-function sortByMergedOrder(
-	list: ExtendedSessionResponse[],
-): ExtendedSessionResponse[] {
-	if (!cachedMergedOrder || cachedMergedOrder.length === 0) return list;
-	const orderMap = new Map(cachedMergedOrder.map((key, i) => [key, i]));
-	return [...list].sort((a, b) => {
-		const ai = orderMap.get(compositeKey(a)) ?? Number.MAX_SAFE_INTEGER;
-		const bi = orderMap.get(compositeKey(b)) ?? Number.MAX_SAFE_INTEGER;
-		return ai - bi;
-	});
-}
-
 /**
- * Apply a new cross-peer order locally and re-sort the cached sessions.
- * Used by the drag-end handler for optimistic update — the same value is
- * also PUT to the Hub so reload / other clients pick it up.
+ * Optimistically show a drag reorder before the round-trip completes. The
+ * next `sessions-updated` push overwrites this with herdr's order, which is
+ * authoritative — so a rejected/failed move self-corrects within one push
+ * instead of needing a rollback path.
  */
-export function applyLocalSessionOrder(order: string[]) {
-	cachedMergedOrder = order;
-	cachedSessions = sortByMergedOrder(cachedSessions);
+export function applyLocalSessionReorder(ordered: ExtendedSessionResponse[]) {
+	cachedSessions = ordered;
 	window.dispatchEvent(new CustomEvent("cchub-sessions-reorder"));
-}
-
-async function fetchMergedOrderOnce(): Promise<void> {
-	if (mergedOrderFetched) return;
-	mergedOrderFetched = true;
-	try {
-		const res = await authFetch(`${API_BASE}/api/peers/session-order`);
-		if (!res.ok) return;
-		const data = (await res.json()) as { order?: string[] };
-		if (Array.isArray(data.order)) {
-			cachedMergedOrder = data.order;
-			cachedSessions = sortByMergedOrder(cachedSessions);
-			window.dispatchEvent(new CustomEvent("cchub-sessions-reorder"));
-		}
-	} catch {
-		mergedOrderFetched = false;
-	}
 }
 
 /** hookイベントで Hub local セッションの indicatorState を即座に更新する */
@@ -119,12 +79,28 @@ interface UseSessionsReturn {
 	) => Promise<boolean>;
 }
 
+/**
+ * Session order comes from each peer's herdr workspace order — every peer's
+ * `/api/sessions` already returns its sessions in it — so the merged list only
+ * has to concatenate peers in their display order. `sessionsByPeer` is keyed
+ * by insertion (whichever watcher delivered first), which isn't stable across
+ * reconnects, hence the explicit ordering. Peers missing from `peerOrder`
+ * (a watcher outliving a peer removal) trail in map order.
+ */
 function flattenPeerSessions(
 	sessionsByPeer: ReadonlyMap<string, PeerSession[]>,
+	peerOrder: string[],
 ): ExtendedSessionResponse[] {
 	const out: ExtendedSessionResponse[] = [];
-	for (const sessions of sessionsByPeer.values()) {
-		out.push(...sessions);
+	const seen = new Set<string>();
+	for (const peerId of peerOrder) {
+		const list = sessionsByPeer.get(peerId);
+		if (!list) continue;
+		seen.add(peerId);
+		out.push(...list);
+	}
+	for (const [peerId, list] of sessionsByPeer) {
+		if (!seen.has(peerId)) out.push(...list);
 	}
 	return out;
 }
@@ -141,18 +117,26 @@ export function useSessions(): UseSessionsReturn {
 		const reorderHandler = () => setSessions(cachedSessions);
 		window.addEventListener("cchub-hook-event", hookHandler);
 		window.addEventListener("cchub-sessions-reorder", reorderHandler);
-		void fetchMergedOrderOnce();
 		return () => {
 			window.removeEventListener("cchub-hook-event", hookHandler);
 			window.removeEventListener("cchub-sessions-reorder", reorderHandler);
 		};
 	}, []);
 
+	// Read through a ref: `usePeers()` hands back a fresh array on every poll,
+	// so depending on it directly would re-register the watcher listener (and
+	// re-fire it) constantly.
+	const peerOrderRef = useRef<string[]>([]);
+	peerOrderRef.current = peers.map((p) => p.id);
+
 	// Per-peer WS watcher already dedups by payload before notifying, so a
 	// listener firing here implies the data actually changed for some peer.
 	const handlePeerSessions = useCallback(
 		(sessionsByPeer: ReadonlyMap<string, PeerSession[]>) => {
-			cachedSessions = sortByMergedOrder(flattenPeerSessions(sessionsByPeer));
+			cachedSessions = flattenPeerSessions(
+				sessionsByPeer,
+				peerOrderRef.current,
+			);
 			setSessions(cachedSessions);
 			setIsLoading(false);
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- feat(sessions): セッションの並び順を herdr 単一情報源にした（cchub 側の `sessionOrder` ストアを廃止し、ドラッグは `workspace.move` へ直接書き込む）
- chore: bump version to 0.2.7

## Notes
- `PUT /api/sessions/order` と `GET|PUT /api/peers/session-order` を廃止、`POST /api/sessions/:id/move { index }` を新設
- 並び順は peer ごとにグループ化される（peer 境界をまたぐドラッグは herdr に保存先が無いため無視）
- 移行時、既存の cchub 側の並び順は破棄され herdr の順が正になる
- herdr 0.7.4 に対して move の両方向・両端・クランプ・未知セッションを実測検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)