### PR TITLE
fix(herdr): runtime を持たないペインを subscribe できるようにする（再起動後にセッションが開けないデッドロック）

### DIFF
--- a/backend/src/services/__tests__/herdr-pane-scroll.test.ts
+++ b/backend/src/services/__tests__/herdr-pane-scroll.test.ts
@@ -1,26 +1,37 @@
 import { describe, expect, it } from 'bun:test';
-import { assertPanesHaveScroll } from '../herdr-control';
+import { paneViewportRows } from '../herdr-control';
 
 /**
- * herdr < protocol 16 (v0.7.1 and older) returns panes without `scroll`.
- * Subscribing then used to die with a bare TypeError deep in
- * HerdrControlSession.start(), reaching the client as an unexplained
- * "Failed to subscribe". The guard must name the actual fix instead.
+ * A pane has no `scroll` until it has a terminal runtime. herdr leaves restored
+ * panes runtime-less on purpose: it defers the agent resume until a client
+ * attaches with a non-zero size.
+ *
+ * cchub used to read a missing `scroll` as "herdr server is older than protocol
+ * 16" and refuse the subscribe. That misdiagnosis deadlocked exactly the panes a
+ * subscribe exists to revive — no subscribe → no client size → no resume → still
+ * no scroll — and blamed a fully up-to-date herdr for it. Version skew has its
+ * own accurate source (HerdrUpdateService reads the real protocol number), so a
+ * missing scroll must degrade to the client's size rather than throw.
  */
-describe('assertPanesHaveScroll', () => {
+describe('paneViewportRows', () => {
   const scroll = { offset_from_bottom: 0, max_offset_from_bottom: 460, viewport_rows: 23 };
 
-  it('accepts protocol 16 panes (scroll present)', () => {
-    expect(() => assertPanesHaveScroll([{ scroll }, { scroll }])).not.toThrow();
+  it('uses the pane rows once a runtime exists', () => {
+    expect(paneViewportRows({ scroll }, 40)).toBe(23);
   });
 
-  it('accepts an empty pane list', () => {
-    expect(() => assertPanesHaveScroll([])).not.toThrow();
+  it('falls back to the client rows on a runtime-less pane instead of throwing', () => {
+    expect(paneViewportRows({ scroll: undefined }, 40)).toBe(40);
   });
 
-  it('rejects protocol 14 panes with a message naming the fix', () => {
-    expect(() => assertPanesHaveScroll([{ scroll }, { scroll: undefined }])).toThrow(
-      /herdr server is too old.*protocol >= 16/,
-    );
+  // A restored pane awaiting resume is the whole reason this path must not
+  // throw: subscribing is what triggers the resume.
+  it('lets a restored pane awaiting agent resume be subscribed', () => {
+    expect(() => paneViewportRows({ scroll: undefined }, 24)).not.toThrow();
+    expect(paneViewportRows({ scroll: undefined }, 24)).toBe(24);
+  });
+
+  it('falls back when the runtime reports zero rows', () => {
+    expect(paneViewportRows({ scroll: { ...scroll, viewport_rows: 0 } }, 40)).toBe(40);
   });
 });

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -109,16 +109,18 @@ async function guessInitialAltScreen(
 }
 
 /**
- * herdr servers older than protocol 16 return panes without scroll state,
- * which every viewport computation depends on. Fail the subscribe with the
- * actual fix instead of letting it surface as a TypeError deep in start().
+ * A pane reports no scroll state until it has a terminal runtime, and a
+ * restored pane has none until its agent is resumed — herdr defers that resume
+ * until a client attaches with a non-zero size. So "no scroll" is a normal
+ * transient state on exactly the panes a subscribe is meant to revive, and
+ * refusing to subscribe over it deadlocks: no subscribe → no client size → no
+ * resume → still no scroll. It is NOT a signal about the server's version
+ * (version skew has its own accurate source in HerdrUpdateService, which reads
+ * the real protocol number from `herdr status --json`). Callers must treat a
+ * missing scroll as "unknown yet" and fall back to the client's own size.
  */
-export function assertPanesHaveScroll(panes: Array<Pick<HerdrPane, 'scroll'>>): void {
-  if (panes.some((p) => !p.scroll)) {
-    throw new Error(
-      'herdr server is too old: pane.list returned no scroll state (protocol >= 16 / v0.7.3+ required). Update herdr and restart the server.',
-    );
-  }
+export function paneViewportRows(pane: Pick<HerdrPane, 'scroll'>, fallbackRows: number): number {
+  return pane.scroll?.viewport_rows || fallbackRows;
 }
 
 /**
@@ -242,7 +244,6 @@ export class HerdrControlSession {
     this.workspaceId = ws.workspace_id;
 
     const panes = await listPanes(ws.workspace_id);
-    assertPanesHaveScroll(panes);
     const tmuxIds = panes
       .map((p) => toTmuxPaneId(p.pane_id))
       .filter((id): id is string => id !== null);
@@ -260,7 +261,7 @@ export class HerdrControlSession {
       if (tmuxId) {
         this.paneSizes.set(tmuxId, {
           cols: this.clientSize.cols,
-          rows: pane.scroll?.viewport_rows || this.clientSize.rows,
+          rows: paneViewportRows(pane, this.clientSize.rows),
         });
       }
     }


### PR DESCRIPTION
Fixes #407

## 症状

herdr を再起動するとセッションは一覧に並ぶのに**開けない**。開くと真っ暗な "Connecting..." と赤いエラー:

```
Failed to subscribe: herdr server is too old: pane.list returned no scroll state
(protocol >= 16 / v0.7.3+ required). Update herdr and restart the server.
```

**herdr は v0.7.4 / protocol 16 / compatible** でもこれが出る。指示に従って更新しても直らない（既に最新なので）。結果 `resume_agents_on_restore = true` でも会話は戻らず、履歴タブからの手動 `-r` しか手段が無かった。

## 原因: 相互待ちデッドロック

ガードの前提「`scroll` を返さないのは古いサーバだけ」が誤りだった。**ペインは terminal runtime を持つまで `scroll` を返さない**。そして復元されたペインは**エージェントが resume されるまで runtime を持たない**。herdr はその resume を「クライアントが非ゼロのサイズで接続するまで」遅延させる。

つまり `scroll` 欠損は、**subscribe が復活させようとしているまさにそのペインで起きる正常な過渡状態**。そこで拒否すると両者が固まる:

```
subscribe 拒否 → クライアントもサイズも付かない
  → herdr の pending_agent_resume_candidates() が 0x0 の terminal_area で即 return
    → resume されない → runtime が無いまま → scroll が無いまま → 最初に戻る
```

## 修正

`scroll` 欠損を「まだ不明」として扱い、クライアント側の rows にフォールバックする。他の消費箇所は既に `scroll?.` で許容済みだった。版ズレ検知は推測をやめ、正確な情報源（HerdrUpdateService が `herdr status --json` から実 protocol 番号を読む #393）に任せる。

## 検証（dev 実測）

修正前（同一 dev 環境で再現）:
```
[ws] error Failed to subscribe: herdr server is too old: pane.list returned no scroll state...
```

修正後、取り残されたペインを購読:
```
[ws] subscribed {"sessionId":"hakoniwa-city"}
[ws] layout   120x40
[ws] ready
```
→ herdr が保留していた resume を発火:
```
pid=2874925  /home/m0a/repos/hakoniwa-city  claude --resume 04b63ed9-1bc4-4776-ad86-edd200423154
```
この `04b63ed9-…` は再起動前に記録されていた**元の会話 ID**。**開くだけで元の会話に復帰する**ようになった。

生 `pane.list` RPC で runtime の有無と `scroll` の有無が一致することも確認済み:
```
w16:p1  agent=claude  status=idle     scroll=MISSING   ← 復元済み・resume 保留
w1C:p1  agent=claude  status=working  scroll={...}     ← 実在
```

- `bun run test` — backend 294 pass / frontend 46 pass
- `bun run typecheck` / `bun run lint` — clean

## 補足

このデッドロックは v0.2.3 の**前から**存在した（当時は `pane.scroll.viewport_rows` の TypeError で無言の "Failed to subscribe" になっていた）。v0.2.3 は原因ではなく、**自信を持って誤った診断名を付けた**だけ。裏を返すと **herdr 移行（v0.2.0）以降、herdr のネイティブ復元は cchub 経由で一度も成立していなかった**可能性が高い。

なお `herdr agent list` は runtime の無いペインも「claude / idle」と報告する（復元計画から楽観的に状態を設定するため）が、実プロセスは存在しない。cchub は実プロセスを見ているため正しく `agent=None` と報告しており、この点で誤っているのは herdr 側。
