### PR TITLE
fix(mobile): 下部バーでセッション名が切れる問題（空いている領域を使わせる）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1042,15 +1042,18 @@ export function App() {
 				showOverlay ? "opacity-100" : "opacity-0 pointer-events-none"
 			}`}
 		>
-			{/* Left: Session selector */}
+			{/* Left: Session selector. Takes the bar's free space so the name gets
+			    every pixel the action buttons don't need — a fixed cap truncated
+			    names like "cchub-work-1" while the bar sat half empty. The action
+			    group is shrink-0, so this only ever grows into real slack. */}
 			<button
 				type="button"
 				onClick={() => handleShowSessionList()}
-				className="flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-white/[0.06] transition-colors"
+				className="flex flex-1 min-w-0 items-center gap-1.5 px-2 py-1 rounded-md hover:bg-white/[0.06] transition-colors"
 				data-onboarding="session-list"
 			>
 				<div
-					className={`w-2 h-2 rounded-full ${
+					className={`w-2 h-2 rounded-full shrink-0 ${
 						activeSession?.state === "working"
 							? "bg-blue-500"
 							: (
@@ -1061,13 +1064,11 @@ export function App() {
 								: "bg-zinc-600"
 					}`}
 				/>
-				<span className="text-[13px] font-medium text-white truncate max-w-[84px]">
+				<span className="text-[13px] font-medium text-white truncate min-w-0">
 					{activeSession?.name || "-"}
 				</span>
-				<ChevronDown className="w-3 h-3 text-zinc-500" />
+				<ChevronDown className="w-3 h-3 text-zinc-500 shrink-0" />
 			</button>
-
-			<div className="flex-1" />
 
 			{/* Right: Core actions */}
 			<div className="flex items-center gap-1 shrink-0">


### PR DESCRIPTION
## 症状

モバイルの下部バーでセッション名が切れて、**どのセッションを見ているのか判別できない**。`cchub-work-1` が `cchub-work-…` になる。しかも切れている**すぐ隣のバーは空きっぱなし**。

## 原因

```jsx
<span className="text-[13px] font-medium text-white truncate max-w-[84px]">
  {activeSession?.name || "-"}
</span>
...
<div className="flex-1" />   ← 空きスペースはこのスペーサーが占有
```

名前を固定 84px で打ち切る一方、隣に `flex-1` のスペーサーを置いて余白を確保していた。**空いているのに使っていない。**

## 修正

スペーサーではなくセレクタ側に余白を吸わせる。名前はアクションボタンが使わない分の**全ピクセルを使える**ようになり、本当にバーからあふれる時だけ truncate する。右のアクション群は元から `shrink-0` で、ステータスドットとシェブロンも同様に固定したので、**縮むのは名前だけ**。

副次的に、セッション切替ボタンのタップ領域が広がる（モバイルでは望ましい）。

## 検証（dev / iPhone 13 ビューポート実測）

```
name text  : "hakoniwa-city"
name width : 88 px
scrollW/clientW: 88 / 88 => truncated: false
```

旧 84px 上限では切れていた幅（88px）が全表示になった。実画面のスクリーンショットでも下部バーに `hakoniwa-city` がフル表示されることを確認。

- `bun run test` — backend 294 pass / frontend 46 pass
- `bun run typecheck` / `bun run lint` — clean

## 補足

デスクトップ/タブレット (`DesktopLayout.tsx:1435`) も同じパターンだが上限が `max-w-[200px]` と広く、実害が出ていないため今回は触っていない。
