### PR TITLE
chore: herdr 移行で取り残された tmux の残骸を削除（死んだ往復2本・誤った install 依存を含む）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Codex and other coding agents should use this file as the single source of repos
 
 ## Project Overview
 
-CC Hub is a web-based terminal session manager for Claude Code. It runs Claude Code instances in tmux sessions and provides a web UI for remote access from tablets/mobile devices.
+CC Hub is a web-based terminal session manager for Claude Code. It runs Claude Code instances in herdr workspaces and provides a web UI for remote access from tablets/mobile devices.
 
 ## Commands
 
@@ -79,7 +79,7 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 ### Key API Routes
 
 **Sessions** (`/api/sessions`):
-- `GET /` - List all tmux sessions with Claude Code state and pane info
+- `GET /` - List all sessions with Claude Code state and pane info
 - `POST /` - Create new Claude Code session
 - `GET /:id` - Get session details
 - `DELETE /:id` - Close session
@@ -91,11 +91,9 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - `POST /:id/panes/input` - Send input to a pane over REST (used by `cchub send` / peers)
 - `GET /:id/panes/:paneId/viewport` - Capture a pane viewport over REST (used by `cchub peek` / `--wait`)
 - `POST /:id/prompt` - Send a prompt to the session's agent
-- `GET /:id/copy-mode` - Get tmux copy mode selection
 - `PUT /:id/theme` - Set session color theme
 - `PUT /:id/title` - Set session custom title
 - `POST /:id/move` - Move a session to `{ index }` in the display order (writes straight through to herdr's workspace order — cchub stores no order of its own)
-- `GET /clipboard` - Get clipboard content
 - `GET /prompts/search` - Search prompt history
 
 **Session History** (`/api/sessions/history`):
@@ -157,12 +155,12 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 ### Frontend Components
 
 **Layout**:
-- **DesktopLayout.tsx** - Main layout with tmux control mode integration, pane tree management, keyboard shortcuts. Supports desktop and tablet modes
-- **PaneContainer.tsx** - Tree-based pane renderer with `ControlModeContext` for tmux pane operations (split, close, zoom, resize)
+- **DesktopLayout.tsx** - Main layout with herdr control mode integration, pane tree management, keyboard shortcuts. Supports desktop and tablet modes
+- **PaneContainer.tsx** - Tree-based pane renderer with `ControlModeContext` for pane operations (split, close, zoom, resize)
 - **SessionModal.tsx** - Session picker modal (Ctrl+B) with pane count badges and expandable pane list
 
 **Terminal**:
-- **Terminal.tsx** - xterm.js terminal with WebGL rendering, **`scrollback: 0`** (server-side scrollback). `ControlModeConfig` for tmux size sync (`proposeDimensions()` instead of `fit()`, `setExactSize()` from tmux layout) and viewport delivery (`registerOnViewport`, `scrollBy`, `scrollToLive`). Each new viewport is converted to a VT escape sequence (`viewport-render.ts`) and `term.write()`-ed to refresh the screen. Supports font size adjustment, desktop text selection with auto-copy, touch selection mode for mobile/tablet
+- **Terminal.tsx** - xterm.js terminal with WebGL rendering, **`scrollback: 0`** (server-side scrollback). `ControlModeConfig` for pane size sync (`proposeDimensions()` instead of `fit()`, `setExactSize()` from the layout) and viewport delivery (`registerOnViewport`, `scrollBy`, `scrollToLive`). Each new viewport is converted to a VT escape sequence (`viewport-render.ts`) and `term.write()`-ed to refresh the screen. Supports font size adjustment, desktop text selection with auto-copy, touch selection mode for mobile/tablet
 - **SelectionOverlay.tsx** - Touch-selection overlay rendered above the terminal: draggable start/end handles, copy/cancel controls, computed from xterm `_core` cell metrics
 - **viewport-render.ts** (`utils/viewport-render.ts`) - Converts a `PaneViewport` into a VT sequence (`\x1b[?25l` + per-row `\x1b[r;1H\x1b[2K<line>` + cursor restore) that xterm.js can apply with a single `term.write()`
 

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -20,7 +20,7 @@ import { getIndicatorOverride } from './notify';
 import { pushSessionsNow } from './terminal-mux';
 import { detectPaneState, stripAnsi, type DetectedPaneState } from '../services/pane-state';
 
-const tmuxService = new HerdrService();
+const herdrService = new HerdrService();
 const claudeCodeService = new ClaudeCodeService();
 const codexService = new CodexService();
 const codexConversationService = new CodexConversationService();
@@ -166,14 +166,14 @@ export const sessions = new Hono();
 
 /** Build the full sessions list (shared by HTTP handler and WS push) */
 export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
-  const tmuxSessions = await tmuxService.listSessions();
+  const herdrSessions = await herdrService.listSessions();
   const sessionMetadata = await getAllSessionMetadata();
 
-  const claudePaths = tmuxSessions
+  const claudePaths = herdrSessions
     .filter((s): s is typeof s & { currentPath: string } => agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && !!s.currentPath)
     .map(s => s.currentPath);
   const ccSessionsByPath = await claudeCodeService.getSessionsForPaths(claudePaths);
-  const codexPaths = tmuxSessions
+  const codexPaths = herdrSessions
     .filter((s): s is typeof s & { currentPath: string } => (s.agent ?? s.currentCommand) === 'codex' && !!s.currentPath)
     .map(s => s.currentPath);
   const codexThreadsByPath = await codexService.getThreadsForPaths(codexPaths);
@@ -182,7 +182,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
   // Read once per build (cheap: a handful of small ~/.claude/sessions/*.json).
   const bridgeSessionIds = await claudeCodeService.getBridgeSessionIds();
 
-  const results = await Promise.all(tmuxSessions.map(async (s) => {
+  const results = await Promise.all(herdrSessions.map(async (s) => {
     let ccSession: Awaited<ReturnType<typeof claudeCodeService.getSessionForPath>> | undefined;
     const codexThread = s.currentPath ? codexThreadsByPath.get(s.currentPath) : undefined;
 
@@ -316,7 +316,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     };
   }));
 
-  // Add lost sessions (existed before reboot but not in tmux now)
+  // Add lost sessions (existed before reboot but not in herdr now)
   const activeIds = new Set(results.map(s => s.id));
   const activePaths = new Set(results.map(s => s.currentPath).filter(Boolean));
   const lastKnown = await getLastKnownSessions();
@@ -356,7 +356,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
   }
 
   // Save snapshot: active sessions + still-lost sessions (so lost ones persist across refreshes).
-  // Fall back to previously-known values when tmux didn't report a field this round —
+  // Fall back to previously-known values when herdr did not report a field this round —
   // otherwise a transient gap (e.g. currentPath missing on first capture) erases the data
   // and lost-session resume can't find the project path.
   const prevById = new Map(lastKnown.map(s => [s.id, s]));
@@ -400,13 +400,13 @@ const ResumeSessionSchema = z.object({
   agent: z.enum(AGENT_PROVIDER_IDS).optional(),
 });
 
-// GET /sessions - List all tmux sessions (debug/fallback only, frontend uses WS push)
+// GET /sessions - List all sessions (debug/fallback only, frontend uses WS push)
 sessions.get('/', async (c) => {
   const sessionsList = await buildSessionsList();
   return c.json({ sessions: sessionsList });
 });
 
-// POST /sessions - Create a new tmux session
+// POST /sessions - Create a new session
 sessions.post('/', async (c) => {
   notifySessionChange();
   const body = await c.req.json().catch(() => ({}));
@@ -414,27 +414,27 @@ sessions.post('/', async (c) => {
   const agent = parsed.success ? parsed.data.agent : DEFAULT_AGENT_PROVIDER;
 
   // Generate session name
-  const tmuxSessions = await tmuxService.listSessions();
+  const herdrSessions = await herdrService.listSessions();
   const name = parsed.success && parsed.data.name
     ? parsed.data.name
-    : `session-${tmuxSessions.length + 1}`;
+    : `session-${herdrSessions.length + 1}`;
 
   // Check if session already exists
-  const exists = await tmuxService.sessionExists(name);
+  const exists = await herdrService.sessionExists(name);
   if (exists) {
     return c.json({ error: 'Session already exists' }, 400);
   }
 
   // Guard: reject if the same agent is already running in the same directory
   if (parsed.success && parsed.data.workingDir) {
-    const conflicting = findDuplicateAgentWorkingDirSession(tmuxSessions, agent, parsed.data.workingDir);
+    const conflicting = findDuplicateAgentWorkingDirSession(herdrSessions, agent, parsed.data.workingDir);
     if (conflicting) {
       return c.json({ error: 'duplicate_working_dir', existingSession: conflicting.name }, 409);
     }
   }
 
   try {
-    await tmuxService.createSession(name);
+    await herdrService.createSession(name);
 
     // Start the selected agent if workingDir is specified
     if (parsed.success && parsed.data.workingDir) {
@@ -448,7 +448,7 @@ sessions.post('/', async (c) => {
         (async () => {
           for (let i = 0; i < 30; i++) { // up to 30 seconds
             await new Promise(r => setTimeout(r, 1000));
-            const sessions = await tmuxService.listSessions();
+            const sessions = await herdrService.listSessions();
             const session = sessions.find(s => s.name === sessionName);
             if (session?.currentCommand === agent) {
               // Wait a bit more for the TUI to be fully ready, then submit
@@ -644,7 +644,7 @@ sessions.get('/prompts/search', async (c) => {
   return c.json({ prompts });
 });
 
-// POST /sessions/history/resume - Resume a session from history (creates new tmux session)
+// POST /sessions/history/resume - Resume a session from history (creates a new session)
 // NOTE: Must be defined BEFORE /:id routes
 const ResumeHistorySchema = z.object({
   sessionId: SessionIdSchema,
@@ -671,37 +671,37 @@ sessions.post('/history/resume', async (c) => {
   const projectPath = recordedCwd ?? parsed.data.projectPath;
 
   try {
-    // Generate a unique tmux session name based on project
+    // Generate a unique session name based on project
     const projectName = projectPath.split('/').pop() || 'session';
-    const tmuxSessions = await tmuxService.listSessions();
+    const herdrSessions = await herdrService.listSessions();
 
     // Guard: reject if the same agent is already running in the same directory
-    const conflicting = findDuplicateAgentWorkingDirSession(tmuxSessions, agent, projectPath);
+    const conflicting = findDuplicateAgentWorkingDirSession(herdrSessions, agent, projectPath);
     if (conflicting) {
       return c.json({ error: 'duplicate_working_dir', existingSession: conflicting.name }, 409);
     }
-    let tmuxSessionName = projectName;
+    let sessionName = projectName;
     let counter = 1;
-    while (tmuxSessions.some(s => s.name === tmuxSessionName)) {
-      tmuxSessionName = `${projectName}-${counter++}`;
+    while (herdrSessions.some(s => s.name === sessionName)) {
+      sessionName = `${projectName}-${counter++}`;
     }
 
-    // Create new tmux session
-    await tmuxService.createSession(tmuxSessionName);
+    // Create new session
+    await herdrService.createSession(sessionName);
 
     // Change to project directory and run the agent's resume command
     const command = `cd ${shellQuote(expandHome(projectPath))} && ${agentResumeCommand(agent, sessionId)}`;
     try {
-      await sendTextToSession(tmuxSessionName, command);
+      await sendTextToSession(sessionName, command);
     } catch {
       // Clean up the session if command failed
-      await tmuxService.killSession(tmuxSessionName);
+      await herdrService.killSession(sessionName);
       return c.json({ error: 'Failed to start agent session' }, 500);
     }
 
     return c.json({
       success: true,
-      tmuxSessionId: tmuxSessionName,
+      tmuxSessionId: sessionName,
       ccSessionId: sessionId,
       agent,
     });
@@ -710,21 +710,11 @@ sessions.post('/history/resume', async (c) => {
   }
 });
 
-// GET /sessions/clipboard - Get tmux paste buffer (global)
-// NOTE: Must be defined BEFORE /:id routes
-sessions.get('/clipboard', async (c) => {
-  const buffer = await tmuxService.getBuffer();
-  if (buffer === null) {
-    return c.json({ error: 'No buffer content' }, 404);
-  }
-  return c.json({ content: buffer });
-});
-
 // GET /sessions/:id - Get a specific session
 sessions.get('/:id', async (c) => {
   const id = c.req.param('id');
-  const tmuxSessions = await tmuxService.listSessions();
-  const session = tmuxSessions.find(s => s.id === id);
+  const herdrSessions = await herdrService.listSessions();
+  const session = herdrSessions.find(s => s.id === id);
 
   if (!session) {
     return c.json({ error: 'Session not found' }, 404);
@@ -742,25 +732,12 @@ sessions.get('/:id', async (c) => {
   });
 });
 
-// GET /sessions/:id/copy-mode - Check if session is in copy mode
-sessions.get('/:id/copy-mode', async (c) => {
-  const id = c.req.param('id');
-
-  const exists = await tmuxService.sessionExists(id);
-  if (!exists) {
-    return c.json({ error: 'Session not found' }, 404);
-  }
-
-  const inCopyMode = await tmuxService.isInCopyMode(id);
-  return c.json({ inCopyMode });
-});
-
-// DELETE /sessions/:id - Delete (kill) a tmux session
+// DELETE /sessions/:id - Delete (kill) a session
 sessions.delete('/:id', async (c) => {
   notifySessionChange();
   const id = c.req.param('id');
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     // Already lost — purge from last-known so it disappears from the list.
     await removeLastKnownSession(id).catch(() => {});
@@ -768,7 +745,7 @@ sessions.delete('/:id', async (c) => {
   }
 
   try {
-    await tmuxService.killSession(id);
+    await herdrService.killSession(id);
     // Keep the entry in last-known so the session shows up as "Lost" and can
     // be resumed via the Resume button without going to the history tab.
     // To purge entirely, delete the Lost session again.
@@ -778,14 +755,14 @@ sessions.delete('/:id', async (c) => {
   }
 });
 
-// POST /sessions/:id/resume - Resume an agent session in an existing tmux session
+// POST /sessions/:id/resume - Resume an agent session in an existing session
 sessions.post('/:id/resume', async (c) => {
   const id = c.req.param('id');
   const body = await c.req.json().catch(() => ({}));
   const parsed = ResumeSessionSchema.safeParse(body);
 
-  const tmuxSessions = await tmuxService.listSessions();
-  const session = tmuxSessions.find(s => s.id === id);
+  const herdrSessions = await herdrService.listSessions();
+  const session = herdrSessions.find(s => s.id === id);
   if (!session) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -818,7 +795,7 @@ sessions.put('/:id/theme', async (c) => {
     return c.json({ error: 'Invalid theme' }, 400);
   }
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -845,7 +822,7 @@ sessions.put('/:id/title', async (c) => {
     return c.json({ error: 'Invalid title' }, 400);
   }
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -869,7 +846,7 @@ sessions.post('/:id/move', async (c) => {
     return c.json({ error: 'Invalid index' }, 400);
   }
   try {
-    const moved = await tmuxService.moveSession(id, index);
+    const moved = await herdrService.moveSession(id, index);
     if (!moved) return c.json({ error: 'Session not found' }, 404);
     notifySessionChange();
     return c.json({ success: true });
@@ -924,14 +901,14 @@ sessions.post('/:id/panes/focus', async (c) => {
     return c.json({ error: 'Invalid pane ID' }, 400);
   }
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
 
   try {
     await withControlSession(id, (cs) => cs.selectPane(parsed.data.paneId));
-    tmuxService.invalidateCache();
+    herdrService.invalidateCache();
     notifySessionChange();
     return c.json({ success: true });
   } catch (_error) {
@@ -949,7 +926,7 @@ sessions.post('/:id/panes/close', async (c) => {
     return c.json({ error: 'Invalid pane ID' }, 400);
   }
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -957,7 +934,7 @@ sessions.post('/:id/panes/close', async (c) => {
   try {
     // rejects the last pane itself
     await withControlSession(id, (cs) => cs.closePane(parsed.data.paneId));
-    tmuxService.invalidateCache();
+    herdrService.invalidateCache();
     notifySessionChange();
     return c.json({ success: true });
   } catch (error) {
@@ -977,14 +954,14 @@ sessions.post('/:id/panes/split', async (c) => {
     return c.json({ error: 'Invalid request' }, 400);
   }
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
 
   try {
     await withControlSession(id, (cs) => cs.splitPane(parsed.data.paneId, parsed.data.direction));
-    tmuxService.invalidateCache();
+    herdrService.invalidateCache();
     notifySessionChange();
     return c.json({ success: true });
   } catch (_error) {
@@ -1002,7 +979,7 @@ sessions.post('/:id/panes/respawn', async (c) => {
     return c.json({ error: 'Invalid request' }, 400);
   }
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -1021,7 +998,7 @@ sessions.post('/:id/panes/input', async (c) => {
     return c.json({ error: 'Invalid request', issues: parsed.error.issues }, 400);
   }
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -1071,7 +1048,7 @@ sessions.get('/:id/panes/:paneId/viewport', async (c) => {
     return c.json({ error: 'paneId must start with %' }, 400);
   }
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -1103,7 +1080,7 @@ sessions.post('/:id/prompt', async (c) => {
     return c.json({ error: 'text is required' }, 400);
   }
 
-  const exists = await tmuxService.sessionExists(id);
+  const exists = await herdrService.sessionExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }

--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -359,12 +359,4 @@ export class HerdrService {
   async sessionExists(sessionId: string): Promise<boolean> {
     return (await this.resolveWorkspace(sessionId)) !== null;
   }
-
-  async isInCopyMode(_sessionId: string): Promise<boolean> {
-    return false;
-  }
-
-  async getBuffer(): Promise<string | null> {
-    return null;
-  }
 }

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -24,7 +24,6 @@ import {
 	updateCachedSessionsByHookEvent,
 	useSessions,
 } from "../hooks/useSessions";
-import { authFetch } from "../services/api";
 import { fireHookNotification } from "../utils/hookNotification";
 import { uploadImage } from "../utils/upload-image";
 import { makePseudoViewport } from "../utils/viewport-pseudo";
@@ -39,7 +38,6 @@ import {
 import { SessionModal } from "./SessionModal";
 import type { ControlModeConfig, TerminalRef } from "./Terminal";
 
-const API_BASE = import.meta.env.VITE_API_URL || "";
 const DESKTOP_STATE_KEY = "cchub-desktop-state";
 
 interface OpenSession {
@@ -1046,12 +1044,11 @@ export function DesktopLayout({
 				return;
 			}
 
-			// Ctrl/Cmd + C: Copy from tmux buffer or terminal selection
+			// Ctrl/Cmd + C: Copy the terminal selection
 			if (!e.shiftKey && e.key.toLowerCase() === "c") {
 				const ref = terminalRefs.current?.get(activePaneRef.current);
 				const selection = ref?.getSelection();
 
-				// First try xterm selection
 				if (selection) {
 					e.preventDefault();
 					navigator.clipboard.writeText(selection).catch((err) => {
@@ -1060,20 +1057,9 @@ export function DesktopLayout({
 					return;
 				}
 
-				// Then try tmux buffer
+				// No selection: suppress the browser's own copy and leave the key to
+				// xterm, which sends it on to the pane as SIGINT.
 				e.preventDefault();
-				authFetch(`${API_BASE}/api/sessions/clipboard`)
-					.then((res) => res.json())
-					.then((data) => {
-						if (data.content) {
-							navigator.clipboard.writeText(data.content).catch((err) => {
-								console.error("Clipboard write failed:", err);
-							});
-						}
-					})
-					.catch(() => {
-						// No buffer content, ignore
-					});
 				return;
 			}
 

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1216,27 +1216,11 @@ export const TerminalComponent = memo(
 			const viewport = window.visualViewport;
 			if (!viewport) return;
 
-			let prevViewportHeight = viewport.height;
-
 			const updateKeyboardOffset = async () => {
 				const isStandalone = window.matchMedia(
 					"(display-mode: standalone)",
 				).matches;
 				const isBrowserFullscreen = document.fullscreenElement !== null;
-
-				const heightDiff = prevViewportHeight - viewport.height;
-				if (heightDiff > 100) {
-					try {
-						const res = await authFetch(
-							`${API_BASE}/api/sessions/${encodeURIComponent(sessionId)}/copy-mode`,
-						);
-						if (res.ok) {
-							const data = await res.json();
-							if (data.inCopyMode) sendRef.current("q");
-						}
-					} catch {}
-				}
-				prevViewportHeight = viewport.height;
 
 				if (isStandalone || !isBrowserFullscreen) {
 					setKeyboardOffset(0);

--- a/install.sh
+++ b/install.sh
@@ -46,15 +46,14 @@ detect_platform() {
 check_dependencies() {
   info "依存関係を確認中..."
 
-  # tmux
-  if ! command -v tmux &> /dev/null; then
-    warn "tmuxがインストールされていません"
-    echo "  Ubuntu/Debian: sudo apt install tmux"
-    echo "  macOS: brew install tmux"
-    echo "  Arch: sudo pacman -S tmux"
+  # herdr — CC Hub runs every session in a herdr workspace, so this is required.
+  if ! command -v herdr &> /dev/null; then
+    warn "herdrがインストールされていません"
+    echo "  curl -fsSL https://herdr.dev/install.sh | sh"
+    echo "  macOS: brew install herdr"
     exit 1
   fi
-  info "  tmux: $(tmux -V)"
+  info "  herdr: $(herdr --version 2>/dev/null || echo 'installed')"
 
   # Tailscale
   if ! command -v tailscale &> /dev/null; then


### PR DESCRIPTION
「もう tmux は使わないので関連コードを削除」の対応。**棚卸ししたら前提と実態が少し違った**ので、そこも含めて報告する。

## 分かったこと

- **ファイル名に tmux を含むものは 0**。旧 tmux サービス（`tmux-control.ts` 等）は v0.2.0 移行時に削除済みだった
- 残っていた54ファイルの大半は**歴史的記録**（CHANGELOG 69件 / specs/ / poc/）と、**生きている herdr コードに付いた tmux 由来の名前**
- ただし**本当に壊れているもの**と**本当に死んでいるもの**が混ざっていた ↓

## 1. install.sh が tmux を必須にしていた（実害）

新規インストールで **tmux が無いと exit 1** し、`sudo apt install tmux` を案内していた。一方 **herdr のチェックは1つも無かった** — CC Hub が本当に無いと動かない方。「使わないパッケージを要求し、必要なパッケージは案内しない」状態だったので herdr チェックに置き換えた。

## 2. copy mode / paste buffer は死んだまま配線されていた

どちらも herdr に対応物が無い tmux 固有機能で、移行時にスタブ化された:

```typescript
async isInCopyMode(_sessionId: string): Promise<boolean> { return false; }  // 常に false
async getBuffer(): Promise<string | null> { return null; }                  // 常に null
```

**が、配線は全部生きていた**:
- `Terminal.tsx` は**ソフトキーボードが閉じるたびに** HTTP 往復して copy mode を問い合わせていた。答えは常に false なので、その先の `sendRef.current("q")` は**絶対に発火しない**
- `DesktopLayout.tsx` の Ctrl+C（選択なし）は常に null のバッファを取りに行っていた。`data.content` は常に undefined

スタブ2つ・ルート2本（`GET /:id/copy-mode`, `GET /clipboard`）・呼び出し2箇所を削除。**Ctrl+C の挙動は厳密に維持**した（ブラウザのコピーは従来どおり抑止し、キーは xterm に渡って SIGINT になる）。掃除ついでに意味論を変えるのは避けた。

## 3. 嘘になっていた命名

`const tmuxService = new HerdrService()`、`tmuxSessions`、「tmux が報告しなかった場合」といったコメント。実際に喋っている相手に合わせて改名。

## 意図的に残したもの

- **CHANGELOG / specs/ / poc/** — 歴史的記録なので触らない
- **`TmuxLayoutNode` / `toTmuxPaneId` / `%N` ペイン ID** — 生きている規約。`%N` はフロントエンドと **glasses アプリ**（型を手動複製）と共有する**ワイヤ形式**。改名の価値はあるが、cleanup に混ぜず単独の変更としてやるべき
- **`tmuxSessionId`（レスポンスフィールド）** — フロント4ファイルが消費し、**peer 経由の resume も通る**。未更新の peer とのバージョン混在で壊れうるので単独で扱う

## 検証（dev 実測）

- `GET /api/sessions/clipboard` → **404**（削除済み）
- `GET /api/sessions/:id/copy-mode` → API に一致せず SPA へフォールスルー（削除済み）
- セッション一覧健全（10件）、ターミナル描画OK、**削除したルートへのリクエストはクライアントから1件も飛ばない**（Playwright で request 監視）
- Ctrl+C（選択なし）で例外なし
- `bun run test` — backend 294 pass / frontend 46 pass、`typecheck` / `lint` clean
