### PR TITLE
fix(usage): 429 以外の失敗にもクールダウンを入れる（cchub 自身が 429 を誘発しうる穴）

### DIFF
--- a/backend/src/services/__tests__/anthropic-usage-cooldown.test.ts
+++ b/backend/src/services/__tests__/anthropic-usage-cooldown.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { AnthropicUsageService } from '../anthropic-usage';
+
+/**
+ * The dashboard polls every 30s, per open client, and `/api/oauth/usage` is
+ * rate limited per ACCOUNT — cchub's cache is the only thing standing between
+ * that poll rate and a 429 that then blinds every client for up to an hour.
+ *
+ * The cache used to require a stored success to engage, and only a 429 set a
+ * backoff. So any other failure — a 500, a token 401ing mid-refresh, a network
+ * blip — removed all rate control at once: no result to serve, no cooldown to
+ * wait on, so every poll became a live request until Anthropic 429'd us.
+ *
+ * The invariant these lock down: at most ONE upstream request per TTL, however
+ * the previous attempt ended.
+ */
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Service with a stubbed token and a counting fetch. */
+function serviceWith(respond: () => Promise<Response> | Response) {
+  const svc = new AnthropicUsageService();
+  // biome-ignore lint/suspicious/noExplicitAny: test seam into private method.
+  (svc as any).getAccessToken = async () => 'test-token';
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls++;
+    return await respond();
+  }) as unknown as typeof fetch;
+  return { svc, calls: () => calls };
+}
+
+const ok = (body: unknown) =>
+  new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+
+const USAGE = {
+  five_hour: { utilization: 7, resets_at: '2026-07-16T01:59:59Z' },
+  seven_day: { utilization: 68, resets_at: '2026-07-18T05:59:59Z' },
+};
+
+describe('AnthropicUsageService request cooldown', () => {
+  test('a successful fetch is cached for the TTL', async () => {
+    const { svc, calls } = serviceWith(() => ok(USAGE));
+    await svc.getUsageLimits();
+    await svc.getUsageLimits();
+    await svc.getUsageLimits();
+    expect(calls()).toBe(1);
+  });
+
+  // Each of these used to leave the service with no cached result AND no
+  // backoff, so every subsequent poll hit Anthropic again.
+  test.each([
+    ['500 server error', () => new Response('boom', { status: 500 })],
+    ['401 unauthorized (token mid-refresh)', () => new Response('nope', { status: 401 })],
+    ['403 forbidden', () => new Response('nope', { status: 403 })],
+  ])('does not retry within the TTL after %s', async (_label, respond) => {
+    const { svc, calls } = serviceWith(respond);
+    expect(await svc.getUsageLimits()).toBeNull();
+    expect(await svc.getUsageLimits()).toBeNull();
+    expect(await svc.getUsageLimits()).toBeNull();
+    expect(calls()).toBe(1);
+  });
+
+  test('does not retry within the TTL after a network error', async () => {
+    const { svc, calls } = serviceWith(() => {
+      throw new Error('ECONNRESET');
+    });
+    expect(await svc.getUsageLimits()).toBeNull();
+    expect(await svc.getUsageLimits()).toBeNull();
+    expect(calls()).toBe(1);
+  });
+
+  test('a 429 still backs off far beyond the TTL', async () => {
+    const { svc, calls } = serviceWith(
+      () => new Response('slow down', { status: 429, headers: { 'retry-after': '600' } }),
+    );
+    await svc.getUsageLimits();
+    expect(calls()).toBe(1);
+
+    const status = svc.getStatus();
+    expect(status.errorReason).toBe('rate-limited');
+    // Honoured Retry-After (600s) is well past the 60s TTL floor.
+    const until = new Date(status.rateLimitedUntil as string).getTime();
+    expect(until - Date.now()).toBeGreaterThan(9 * 60_000);
+
+    // Expire the TTL floor only; the 429 window must still hold the request.
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into private state.
+    (svc as any).lastFetchAt = Date.now() - 61_000;
+    await svc.getUsageLimits();
+    expect(calls()).toBe(1);
+  });
+
+  test('retries once the cooldown expires', async () => {
+    const { svc, calls } = serviceWith(() => new Response('boom', { status: 500 }));
+    await svc.getUsageLimits();
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into private state.
+    (svc as any).lastFetchAt = Date.now() - 61_000;
+    await svc.getUsageLimits();
+    expect(calls()).toBe(2);
+  });
+
+  test('concurrent callers share one request', async () => {
+    const { svc, calls } = serviceWith(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+      return ok(USAGE);
+    });
+    await Promise.all([svc.getUsageLimits(), svc.getUsageLimits(), svc.getUsageLimits()]);
+    expect(calls()).toBe(1);
+  });
+
+  test('keeps serving the last good result while failing', async () => {
+    const svc = new AnthropicUsageService();
+    // biome-ignore lint/suspicious/noExplicitAny: test seam into private method.
+    (svc as any).getAccessToken = async () => 'test-token';
+    globalThis.fetch = (async () => ok(USAGE)) as unknown as typeof fetch;
+    const first = await svc.getUsageLimits();
+    expect(first?.sevenDay.utilization).toBe(68);
+
+    globalThis.fetch = (async () => new Response('boom', { status: 500 })) as unknown as typeof fetch;
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into private state.
+    (svc as any).lastFetchAt = Date.now() - 61_000;
+    const stale = await svc.getUsageLimits();
+    expect(stale?.sevenDay.utilization).toBe(68);
+    expect(svc.getStatus().isStale).toBe(true);
+  });
+});

--- a/backend/src/services/anthropic-usage.ts
+++ b/backend/src/services/anthropic-usage.ts
@@ -107,17 +107,23 @@ export interface UsageLimits {
 
 export class AnthropicUsageService {
   private lastSuccessfulResult: UsageLimits | null = null;
+  /**
+   * When the last attempt STARTED, whatever came of it. This gates every
+   * request, so the TTL is a hard floor between calls rather than a cache that
+   * only exists once one has succeeded. Keying it on success instead left every
+   * failure — a 500, a token mid-refresh 401ing, a network blip — with no
+   * cooldown at all: the cache could not engage without a stored result, and
+   * only a 429 set a backoff, so the dashboard's 30s poll (times every open
+   * client) went straight through to Anthropic and earned the very 429 this
+   * class exists to avoid. Also subsumes the #352 no-credentials cooldown: a
+   * missing token is just another attempt that yielded nothing.
+   */
   private lastFetchAt = 0;
   private inflight: Promise<UsageLimits | null> | null = null;
   // Anthropic /api/oauth/usage has strict rate limits. Cache for 60s.
   private readonly CACHE_TTL_MS = 60_000;
   // On 429, back off for 5 minutes before retrying.
   private rateLimitedUntil = 0;
-  // When no credentials are present there is nothing to fetch, but the
-  // dashboard still polls every few seconds. Without a cooldown each poll
-  // re-reads the credentials file (disk I/O). Skip refetching until this
-  // timestamp. #352
-  private noCredentialsUntil = 0;
   private lastErrorReason: UsageLimitsErrorReason | undefined;
 
   private async getAccessToken(): Promise<string | null> {
@@ -143,19 +149,15 @@ export class AnthropicUsageService {
   async getUsageLimits(): Promise<UsageLimits | null> {
     const now = Date.now();
 
-    // Serve from cache if fresh
-    if (this.lastSuccessfulResult && now - this.lastFetchAt < this.CACHE_TTL_MS) {
+    // At most one attempt per TTL, no matter how the last one ended. On success
+    // this serves the cached result; on failure it serves whatever we last had
+    // (possibly null) rather than retrying at the caller's polling rate.
+    if (now - this.lastFetchAt < this.CACHE_TTL_MS) {
       return this.lastSuccessfulResult;
     }
 
-    // Respect rate-limit backoff window
+    // Respect rate-limit backoff window (longer than the TTL floor above)
     if (now < this.rateLimitedUntil) {
-      return this.lastSuccessfulResult;
-    }
-
-    // Respect the no-credentials cooldown so polling doesn't re-read the
-    // credentials file on every request.
-    if (now < this.noCredentialsUntil) {
       return this.lastSuccessfulResult;
     }
 
@@ -173,11 +175,15 @@ export class AnthropicUsageService {
   }
 
   private async fetchUsageLimits(): Promise<UsageLimits | null> {
+    // Stamp the attempt up front so every exit below — a missing token, a
+    // non-429 status, a thrown network error — starts the cooldown. Stamping
+    // it only where a request "counted" is what left the failure paths
+    // unthrottled.
+    this.lastFetchAt = Date.now();
+
     const token = await this.getAccessToken();
     if (!token) {
       this.lastErrorReason = 'no-credentials';
-      this.lastFetchAt = Date.now();
-      this.noCredentialsUntil = Date.now() + this.CACHE_TTL_MS;
       return this.lastSuccessfulResult;
     }
 
@@ -234,7 +240,6 @@ export class AnthropicUsageService {
       };
 
       this.lastSuccessfulResult = result;
-      this.lastFetchAt = Date.now();
       return result;
     } catch (err) {
       console.error('Error fetching usage:', err);


### PR DESCRIPTION
ダッシュボードの 429 調査（「レート制御入れてるはずなのになぜ？」）で見つけた**潜在バグ**の修正。

## まず: 今回の 429 の原因は cchub ではない

サービスログ上、cchub が 12時間で叩いたのは**2回だけ**で、どちらも正しく backoff している:

```
Jul 17 20:40:26  Failed to fetch usage: 429   ← Retry-After に従い backoff
Jul 17 21:15:41  Failed to fetch usage: 429   ← backoff 明けの再試行が、また 429
```

`/api/oauth/usage` のレート制限は**アカウント単位**なので、同一アカウントを使う他プロセス（未配線の `statusline-command.sh`、停止中の limit-tracker / openclaw-docker、オフラインの mac）が枠を食えば cchub も巻き添えを食う。cchub 側のキャッシュは他人を制御できない。**この PR はそれとは別の、cchub 自身が 429 を自作しうる穴を塞ぐもの。**

## 穴

```typescript
if (this.lastSuccessfulResult && now - this.lastFetchAt < this.CACHE_TTL_MS) { ... }
```

キャッシュが**成功結果を持っていないと成立しない**。そして `lastFetchAt` は**成功時（とトークン無し時）にしか更新されない**。backoff を張るのは **429 のときだけ**。

つまり **429 以外の失敗（500 / トークン更新中の 401 / ネットワークエラー）で、レート制御が全部同時に外れる**:
- 返せる結果が無い → キャッシュ不成立
- クールダウンも無い → 待つものが無い
- → **ダッシュボードのポーリング（30秒 × 開いているクライアント数）がそのまま Anthropic に素通り**

**一番絞る必要がある経路（＝上流が不調な時）に限って、絞りが完全に消える。** これは 429 を自作する動作で、本番でも `lastFetchAt` 不在（＝一度も成功していない）を実際に観測した。

## 修正

**試行を開始時にスタンプし、それでゲートする。** 前回がどう終わったかに関係なく TTL が「リクエスト間の下限」になる。429 の backoff は従来どおりそれより長い窓で上書きする。

副産物として **#352 の no-credentials 専用クールダウンを吸収**した（トークンが無いのも「何も得られなかった試行」の一種）。専用フィールドとタイマーを削除でき、状態が1つ減った。

`UsageLimitsStatus.lastFetchAt` は型定義で既に **"when the last attempt happened"** と書いてあったが実装は成功時しか入れていなかった。**型の記述どおりの意味**になり、失敗中の UI 表示としても正しくなった。

## 検証

**dev（実際にレート制限中のアカウント）で3秒間に3回ポーリング:**
```
poll1: errorReason=rate-limited lastFetchAt=2026-07-17T12:25:01.787Z
poll2: errorReason=rate-limited lastFetchAt=2026-07-17T12:25:01.787Z   ← 動かない
poll3: errorReason=rate-limited lastFetchAt=2026-07-17T12:25:01.787Z
```
上流への実リクエストはログ上 **1回のみ**。失敗しているのに `lastFetchAt` が入っている＝クールダウンが効いている（修正前は不在だった）。

**新規テスト 9件**（`anthropic-usage-cooldown.test.ts`）— 500 / 401 / 403 / ネットワーク例外それぞれで TTL 内に再試行しないこと、429 は TTL を超える窓で待つこと、クールダウン明けには再試行すること、同時呼び出しの合流、失敗中も最後の成功結果を返し `isStale` が立つこと。

- `bun run test` — backend **303 pass** / frontend 46 pass
- `bun run typecheck` / `bun run lint` — clean

## 残る課題（別途）

- **使用量キャッシュがプロセス内メモリのみ** → `cchub update` のたびに消え、再起動直後は必ず素の上流リクエストになる（提案2: ディスク永続化）
- **`statusline-command.sh` にキャッシュが無い**（`curl` を無条件実行）。このマシンでは未配線だが、mac 側の設定は未確認（提案3）
