### PR TITLE
fix(herdr): revive agent-status watcher (dead lifecycle branch)

### DIFF
--- a/backend/src/services/__tests__/herdr-agent-status.test.ts
+++ b/backend/src/services/__tests__/herdr-agent-status.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import { classifyHerdrEvent } from '../herdr-agent-status';
+
+/**
+ * herdr sends event names in two namings on one socket (verified live against
+ * herdr 0.7.4 / protocol 16): the per-pane `pane.agent_status_changed`
+ * subscription echoes the dotted subscription type, while the global lifecycle
+ * bus uses snake_case. The watcher compared everything against dotted names, so
+ * the lifecycle branch never matched and new panes stopped getting an
+ * agent-status subscription. These lock the observed wire names in.
+ */
+describe('classifyHerdrEvent', () => {
+  it('classifies the dotted per-pane status event', () => {
+    // report-agent on a live pane emits exactly this envelope name.
+    expect(classifyHerdrEvent('pane.agent_status_changed')).toBe('status');
+    // A future snake_case form from the global bus must classify the same.
+    expect(classifyHerdrEvent('pane_agent_status_changed')).toBe('status');
+  });
+
+  it('classifies the snake_case lifecycle events herdr actually sends', () => {
+    // workspace.create / pane close emit these snake_case names on the bus.
+    expect(classifyHerdrEvent('pane_created')).toBe('lifecycle');
+    expect(classifyHerdrEvent('pane_closed')).toBe('lifecycle');
+    expect(classifyHerdrEvent('pane_exited')).toBe('lifecycle');
+    expect(classifyHerdrEvent('pane_agent_detected')).toBe('lifecycle');
+  });
+
+  it('still classifies dotted lifecycle names (normalization is symmetric)', () => {
+    expect(classifyHerdrEvent('pane.created')).toBe('lifecycle');
+    expect(classifyHerdrEvent('pane.agent_detected')).toBe('lifecycle');
+  });
+
+  it('ignores unrelated events and non-strings', () => {
+    expect(classifyHerdrEvent('pane_focused')).toBe('ignore');
+    expect(classifyHerdrEvent('layout_updated')).toBe('ignore');
+    expect(classifyHerdrEvent('')).toBe('ignore');
+    expect(classifyHerdrEvent(undefined)).toBe('ignore');
+    expect(classifyHerdrEvent(null)).toBe('ignore');
+    expect(classifyHerdrEvent(42)).toBe('ignore');
+  });
+});

--- a/backend/src/services/herdr-agent-status.ts
+++ b/backend/src/services/herdr-agent-status.ts
@@ -16,8 +16,38 @@
 
 import { herdrSubscribe, listPanes } from './herdr-client';
 
-/** Events that change which panes exist — each one re-subscribes the pane set. */
-const LIFECYCLE_EVENTS = ['pane.created', 'pane.closed', 'pane.exited', 'pane.agent_detected'];
+/**
+ * herdr's event naming is asymmetric across three surfaces (verified live
+ * against herdr 0.7.4 / protocol 16):
+ *   1. Subscription *request* types are dotted — `events.subscribe` rejects
+ *      anything else (`unknown variant "pane_created"`).
+ *   2. Received lifecycle events echo back in snake_case (`pane_created`).
+ *   3. The received per-pane status event stays dotted
+ *      (`pane.agent_status_changed`).
+ * So the request list must stay dotted, while classification of *received*
+ * events has to accept both forms — hence the `.`→`_` normalization below.
+ */
+const LIFECYCLE_SUBSCRIPTION_TYPES = [
+  'pane.created',
+  'pane.closed',
+  'pane.exited',
+  'pane.agent_detected',
+];
+const LIFECYCLE_EVENT_NAMES = new Set([
+  'pane_created',
+  'pane_closed',
+  'pane_exited',
+  'pane_agent_detected',
+]);
+
+/** Classify a *received* herdr event, normalizing its two namings to snake_case. */
+export function classifyHerdrEvent(rawEvent: unknown): 'status' | 'lifecycle' | 'ignore' {
+  if (typeof rawEvent !== 'string') return 'ignore';
+  const kind = rawEvent.replace(/\./g, '_');
+  if (kind === 'pane_agent_status_changed') return 'status';
+  if (LIFECYCLE_EVENT_NAMES.has(kind)) return 'lifecycle';
+  return 'ignore';
+}
 
 const CHANGE_DEBOUNCE_MS = 150;
 const RESUBSCRIBE_DEBOUNCE_MS = 400;
@@ -77,17 +107,17 @@ async function subscribeToPanes(): Promise<void> {
   unsubscribe = null;
 
   const subscriptions: Array<Record<string, unknown>> = [
-    ...LIFECYCLE_EVENTS.map((type) => ({ type })),
+    ...LIFECYCLE_SUBSCRIPTION_TYPES.map((type) => ({ type })),
     ...panes.map((p) => ({ type: 'pane.agent_status_changed', pane_id: p.pane_id })),
   ];
 
   unsubscribe = herdrSubscribe(
     subscriptions,
     (ev) => {
-      const kind = typeof ev.event === 'string' ? ev.event : '';
-      if (kind === 'pane.agent_status_changed') {
+      const kind = classifyHerdrEvent(ev.event);
+      if (kind === 'status') {
         scheduleChangePush();
-      } else if (LIFECYCLE_EVENTS.includes(kind)) {
+      } else if (kind === 'lifecycle') {
         // A new pane needs its own status subscription; a closed one should
         // stop holding one. Push too — pane sets are user-visible.
         scheduleResubscribe();


### PR DESCRIPTION
## 概要

herdr の agent-status watcher (`herdr-agent-status.ts`) のライフサイクル分岐が**一度も発火していなかった**バグを修正する。UI は 5 秒間隔のセッションポーリングにサイレントにフォールバックしていた。

## 根本原因: herdr のイベント命名が3面で非対称

実機 (herdr 0.7.4 / protocol 16) のソケットを直接叩いて確認:

| 面 | 命名 | 例 |
|----|------|----|
| 購読リクエストの type | **ドット** | `pane.created`（他を送ると `unknown variant` で拒否） |
| 受信するライフサイクルイベントの `event` | **snake_case** | `pane_created` |
| 受信する per-pane status の `event` | **ドット** | `pane.agent_status_changed` |

watcher は受信イベント名をドットのリスト（`pane.created` 等）と比較していたため、snake_case で届くライフサイクル分岐が永遠に一致しなかった。結果:

- 起動後に新規作成されたペインが `pane.agent_status_changed` 購読を張り直してもらえない（`scheduleResubscribe` が発火しない）
- ペインの生成/消滅が即時 push されず 5 秒ポーリング待ちになる

docstring が「イベント取りこぼしはレイテンシ低下のみで正しさは損なわない」と設計していたため、取りこぼし率100%が正常動作と見分けられず露見しなかった（テストも無し）。なお `pane.agent_status_changed`（主機能）分岐はドット同士で一致しており動作していた。

## 修正

購読リクエストと受信イベント分類の関心を分離:
- 購読リクエストはドットのまま (`LIFECYCLE_SUBSCRIPTION_TYPES`)
- 受信イベントは正規化ヘルパ `classifyHerdrEvent`（`.`→`_`）で両形式を受理

## 検証（dev 環境, herdr 実機）

WS クライアントで「herdr 操作 → `sessions-updated` 到達」の遅延を実測:

| ケース | 修正前 | 修正後 |
|--------|--------|--------|
| `pane_created`（ライフサイクル即時 push） | ~2.5–3.5s（間隔ポーリング） | **79 / 170 / 173 ms** |
| 新規ペインの `agent_status_changed`（resubscribe 経由） | 到達せず | **183 / 46 / 91 ms** |

- 中間で誤って購読リクエストまで snake_case にした版は herdr に `unknown variant` で拒否され、dev ログで即座に検出できた（ユニットテストだけでは見逃していた）。
- `classifyHerdrEvent` の純粋関数ユニットテストを追加（実機で観測した両命名を固定）。
- `bun test` 全 307 pass、tsgo 型チェック・biome クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)