### PR TITLE
fix(herdr): restore pane layout from herdr on session start

### DIFF
--- a/backend/src/services/__tests__/herdr-layout.test.ts
+++ b/backend/src/services/__tests__/herdr-layout.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { PaneLayoutTree } from '../herdr-layout';
+import type { HerdrLayoutNode } from '../herdr-client';
+import { toTmuxPaneId } from '../herdr-client';
+import { herdrLayoutToNode, PaneLayoutTree } from '../herdr-layout';
 
 function twoPane(): PaneLayoutTree {
   const t = new PaneLayoutTree();
@@ -60,6 +62,88 @@ describe('PaneLayoutTree.setPaneSize', () => {
     t.setPaneSize('%1', 1000, 40, 160, 40);
     const rects = t.computeRects(160, 40);
     expect(rects.get('%2')?.width ?? 0).toBeGreaterThanOrEqual(15); // >= 10% of usable
+  });
+});
+
+describe('herdrLayoutToNode', () => {
+  test('a single pane becomes a single leaf', () => {
+    const node: HerdrLayoutNode = { type: 'pane', pane_id: 'w1:p1' };
+    expect(herdrLayoutToNode(node, toTmuxPaneId)).toEqual({ type: 'leaf', paneId: '%1' });
+  });
+
+  test('right split maps to h, down split maps to v; first/second become a/b', () => {
+    const right: HerdrLayoutNode = {
+      type: 'split',
+      direction: 'right',
+      ratio: 0.5,
+      first: { type: 'pane', pane_id: 'w1:p1' },
+      second: { type: 'pane', pane_id: 'w1:p2' },
+    };
+    expect(herdrLayoutToNode(right, toTmuxPaneId)).toEqual({
+      type: 'split',
+      dir: 'h',
+      ratio: 0.5,
+      a: { type: 'leaf', paneId: '%1' },
+      b: { type: 'leaf', paneId: '%2' },
+    });
+
+    const down: HerdrLayoutNode = { ...right, direction: 'down' };
+    expect(herdrLayoutToNode(down, toTmuxPaneId)).toMatchObject({ dir: 'v' });
+  });
+
+  test('reconstructs the nested tree herdr actually exports', () => {
+    // The exact shape observed from a live `layout.export`: split right {p1,
+    // split down {p2, p3}} — p1 on the left, p2 over p3 on the right.
+    const exported: HerdrLayoutNode = {
+      type: 'split',
+      direction: 'right',
+      ratio: 0.5,
+      first: { type: 'pane', pane_id: 'w10:p1' },
+      second: {
+        type: 'split',
+        direction: 'down',
+        ratio: 0.5,
+        first: { type: 'pane', pane_id: 'w10:p2' },
+        second: { type: 'pane', pane_id: 'w10:p3' },
+      },
+    };
+    const root = herdrLayoutToNode(exported, toTmuxPaneId);
+    expect(root).not.toBeNull();
+
+    const t = new PaneLayoutTree();
+    // biome-ignore lint/style/noNonNullAssertion: asserted non-null above
+    t.setInitialTree(root!);
+    expect(t.paneIds().sort()).toEqual(['%1', '%2', '%3']);
+
+    const rects = t.computeRects(160, 40);
+    // %1 is the whole left half; %2/%3 stack in the right half.
+    expect(rects.get('%1')?.height).toBe(40);
+    expect(rects.get('%2')?.x).toBe(rects.get('%3')?.x); // same column
+    expect((rects.get('%2')?.height ?? 0) + (rects.get('%3')?.height ?? 0)).toBeLessThan(40);
+  });
+
+  test('an unmappable pane id anywhere collapses the whole tree to null', () => {
+    const bad: HerdrLayoutNode = {
+      type: 'split',
+      direction: 'right',
+      ratio: 0.5,
+      first: { type: 'pane', pane_id: 'w1:p1' },
+      second: { type: 'pane', pane_id: 'not-a-herdr-id' },
+    };
+    expect(herdrLayoutToNode(bad, toTmuxPaneId)).toBeNull();
+  });
+
+  test('ratio is clamped into the tree\'s valid range', () => {
+    const hi: HerdrLayoutNode = {
+      type: 'split',
+      direction: 'right',
+      ratio: 0.99,
+      first: { type: 'pane', pane_id: 'w1:p1' },
+      second: { type: 'pane', pane_id: 'w1:p2' },
+    };
+    const lo: HerdrLayoutNode = { ...hi, ratio: 0.01 };
+    expect((herdrLayoutToNode(hi, toTmuxPaneId) as { ratio: number }).ratio).toBeCloseTo(0.9);
+    expect((herdrLayoutToNode(lo, toTmuxPaneId) as { ratio: number }).ratio).toBeCloseTo(0.1);
   });
 });
 

--- a/backend/src/services/herdr-client.ts
+++ b/backend/src/services/herdr-client.ts
@@ -267,6 +267,46 @@ export async function getPane(herdrPaneId: string): Promise<HerdrPane | null> {
   }
 }
 
+/**
+ * A node in herdr's `layout.export` split tree (recursive). `direction`
+ * describes where the `second` child sits relative to `first`: `right` =
+ * side-by-side, `down` = stacked. `ratio` is the first child's share.
+ */
+export type HerdrLayoutNode =
+  | { type: 'pane'; pane_id: string }
+  | {
+      type: 'split';
+      direction: 'right' | 'down';
+      ratio: number;
+      first: HerdrLayoutNode;
+      second: HerdrLayoutNode;
+    };
+
+export interface HerdrLayoutExport {
+  workspace_id: string;
+  tab_id: string;
+  zoomed: boolean;
+  focused_pane_id: string | null;
+  root: HerdrLayoutNode;
+}
+
+/**
+ * Export a workspace's split tree via any pane it contains. herdr retains the
+ * real geometry (structure + direction) across a cchub restart, so this is how
+ * CC Hub rehydrates its layout instead of guessing a flat chain. Null on any
+ * failure — the caller falls back to a flat layout.
+ */
+export async function exportLayout(herdrPaneId: string): Promise<HerdrLayoutExport | null> {
+  try {
+    const res = await herdrRpc<{ layout?: HerdrLayoutExport }>('layout.export', {
+      pane_id: herdrPaneId,
+    });
+    return res.layout ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export interface HerdrReadResult {
   pane_id: string;
   source: string;

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -21,6 +21,7 @@
 
 import type { PaneCursor, PaneModes, PaneViewport, TmuxLayoutNode } from '../../../shared/types';
 import {
+  exportLayout,
   getPane,
   type HerdrPane,
   herdrRpc,
@@ -32,7 +33,7 @@ import {
   toHerdrPaneId,
   toTmuxPaneId,
 } from './herdr-client';
-import { PaneLayoutTree } from './herdr-layout';
+import { herdrLayoutToNode, PaneLayoutTree } from './herdr-layout';
 
 const GRACE_PERIOD_MS = 30_000;
 const RESIZE_DEBOUNCE_MS = 50;
@@ -247,7 +248,7 @@ export class HerdrControlSession {
     const tmuxIds = panes
       .map((p) => toTmuxPaneId(p.pane_id))
       .filter((id): id is string => id !== null);
-    this.tree.setInitialPanes(tmuxIds);
+    await this.hydrateLayout(panes, tmuxIds);
 
     const focused = panes.find((p) => p.focused);
     this.activePaneId = (focused ? toTmuxPaneId(focused.pane_id) : null) ?? tmuxIds[0] ?? null;
@@ -279,6 +280,35 @@ export class HerdrControlSession {
     console.log(
       `[herdr-control] Session ready: ${this.sessionId} (workspace=${ws.workspace_id}, panes=${tmuxIds.length})`,
     );
+  }
+
+  /**
+   * Rebuild the split tree, preferring herdr's exported layout so a session's
+   * pane geometry (structure + direction) survives a cchub restart instead of
+   * collapsing to a flat horizontal chain. Falls back to a flat chain when the
+   * export is unavailable or its pane set disagrees with the live panes — the
+   * worst case is then exactly the old behavior, never a corrupt tree.
+   */
+  private async hydrateLayout(panes: HerdrPane[], tmuxIds: string[]): Promise<void> {
+    const anchor = panes[0]?.pane_id;
+    if (anchor) {
+      const exported = await exportLayout(anchor);
+      const root = exported ? herdrLayoutToNode(exported.root, toTmuxPaneId) : null;
+      if (root) {
+        this.tree.setInitialTree(root);
+        const treeIds = this.tree.paneIds();
+        const matches =
+          treeIds.length === tmuxIds.length && treeIds.every((id) => tmuxIds.includes(id));
+        if (matches) {
+          if (exported?.zoomed && exported.focused_pane_id) {
+            const zoomed = toTmuxPaneId(exported.focused_pane_id);
+            if (zoomed && this.tree.has(zoomed)) this.tree.toggleZoom(zoomed);
+          }
+          return;
+        }
+      }
+    }
+    this.tree.setInitialPanes(tmuxIds);
   }
 
   /** Map a tmux-style `%N` pane id to this session's herdr pane id. */

--- a/backend/src/services/herdr-layout.ts
+++ b/backend/src/services/herdr-layout.ts
@@ -9,6 +9,7 @@
  * `TmuxLayoutNode` unchanged.
  */
 
+import type { HerdrLayoutNode } from './herdr-client';
 import type { TmuxLayoutNode } from '../../../shared/types';
 
 export interface LeafNode {
@@ -37,9 +38,40 @@ export interface PaneRect {
 const MIN_RATIO = 0.1;
 const MAX_RATIO = 0.9;
 
+/**
+ * Convert a herdr `layout.export` tree into a CC Hub `LayoutNode`. `mapPaneId`
+ * maps a herdr pane id (`wK:pN`) to a tmux-style `%N`, returning null when the
+ * id is unmappable. Returns null if *any* node fails to convert, so the caller
+ * can fall back to a flat chain rather than render a partial/corrupt tree.
+ *
+ * herdr `right`/`down` split directions map to CC Hub `h`/`v`; `first`/`second`
+ * children map to `a`/`b`; the ratio is clamped into the tree's valid range.
+ */
+export function herdrLayoutToNode(
+  node: HerdrLayoutNode,
+  mapPaneId: (herdrPaneId: string) => string | null,
+): LayoutNode | null {
+  if (node.type === 'pane') {
+    const paneId = mapPaneId(node.pane_id);
+    return paneId ? { type: 'leaf', paneId } : null;
+  }
+  const a = herdrLayoutToNode(node.first, mapPaneId);
+  const b = herdrLayoutToNode(node.second, mapPaneId);
+  if (!a || !b) return null;
+  const rawRatio = Number.isFinite(node.ratio) ? node.ratio : 0.5;
+  const ratio = Math.min(MAX_RATIO, Math.max(MIN_RATIO, rawRatio));
+  return { type: 'split', dir: node.direction === 'right' ? 'h' : 'v', ratio, a, b };
+}
+
 export class PaneLayoutTree {
   private root: LayoutNode | null = null;
   private zoomedPane: string | null = null;
+
+  /** Hydrate directly from a prebuilt tree (e.g. herdr's exported layout). */
+  setInitialTree(root: LayoutNode): void {
+    this.root = root;
+    this.zoomedPane = null;
+  }
 
   /** Initialize from an existing pane list (chained side-by-side, even). */
   setInitialPanes(paneIds: string[]): void {


### PR DESCRIPTION
## Problem

tmux 時代の前提が herdr 移行後も残っていた。`setInitialPanes` はセッションの split tree を「均等な横一列」で再構築するため、CC Hub が `HerdrControlSession` を作り直すたび（バックエンド再起動後、または 30s グレースピリオドを過ぎた再subscribe時）に、**複数ペインのグリッドが横並び一列に潰れて**いた — herdr 側は実レイアウトを保持しているにもかかわらず。

## Fix

herdr の `layout.export` は実際の split tree（`pane`/`split` のネスト、`direction`+`ratio` 付き）を返し、CC Hub 自身の `LayoutNode` にほぼ 1:1 でマップできる。`hydrateLayout` はこの木を優先し、export が取れない/ペイン集合が実ペインと不一致な場合のみ従来の flat chain にフォールバックする（**最悪でも従来挙動**、決して壊れた木にはならない）。zoom/focus 状態も復元する。

- **herdr-client**: `exportLayout()` + `HerdrLayoutNode`/`HerdrLayoutExport` wire 型
- **herdr-layout**: 純粋関数 `herdrLayoutToNode()`（`right`/`down`→`h`/`v`、`first`/`second`→`a`/`b`、ratio クランプ）+ `setInitialTree()`
- **herdr-control**: `hydrateLayout()`（ペイン集合検証＋フォールバック）
- **tests**: 変換関数のユニットテスト（herdr が実際に返すネスト木を含む）

## Verification

- backend `bun test`: 312 pass / 0 fail（+5 new）
- `bunx tsgo --noEmit`: clean / `biome lint`: clean
- **実機 herdr 0.7.4 検証**: L 字 workspace（左ペイン＋右を上下分割）を実際の `start()` パスに通し、`horizontal[leaf, vertical[leaf, leaf]]` のネスト木が復元されることを確認（従来なら全 horizontal の flat 木に潰れる）。dev backend 起動スモーク `/health` 200 OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)