### PR TITLE
fix(ui): tablet pane-resize overhaul — boundary-drag semantics, oscillation fix, smooth tracking

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -631,6 +631,10 @@ async function handleControlMessage(
         await controlSession.adjustPaneSize(msg.paneId, msg.direction, msg.amount);
         break;
       }
+      case 'set-split-ratios': {
+        await controlSession.setSplitRatios(msg.entries);
+        break;
+      }
       case 'equalize-panes': {
         await controlSession.equalizePanes(msg.direction);
         break;

--- a/backend/src/services/__tests__/herdr-layout.test.ts
+++ b/backend/src/services/__tests__/herdr-layout.test.ts
@@ -147,6 +147,73 @@ describe('herdrLayoutToNode', () => {
   });
 });
 
+describe('PaneLayoutTree.setSplitRatio', () => {
+	test('sets the ratio of a simple two-pane split', () => {
+		const t = twoPane(); // h[%1, %2]
+		expect(t.setSplitRatio('%1', '%2', 'h', 0.25)).toBe(true);
+		const rects = t.computeRects(161, 40); // usable 160
+		expect(rects.get('%1')?.width).toBeCloseTo(40, -1);
+	});
+
+	test('reversed pane order inverts the share', () => {
+		const t = twoPane();
+		expect(t.setSplitRatio('%2', '%1', 'h', 0.25)).toBe(true);
+		// %2's side gets 25% → %1 gets 75%
+		const rects = t.computeRects(161, 40);
+		expect(rects.get('%1')?.width).toBeCloseTo(120, -1);
+	});
+
+	test('nested same-direction splits: outer divider is addressable', () => {
+		// h[h[%1,%3], %2] — the exact shape setPaneSize cannot reach: every
+		// pane's deepest h-ancestor is the inner split.
+		const t = new PaneLayoutTree();
+		t.setInitialPanes(['%1']);
+		t.split('%1', 'h', '%2');
+		t.split('%1', 'h', '%3');
+		expect(t.setSplitRatio('%3', '%2', 'h', 0.75)).toBe(true);
+		const rects = t.computeRects(161, 40);
+		// Outer first side (containing %1+%3) gets ~75% of usable 160 = ~120.
+		const leftSide = (rects.get('%1')?.width ?? 0) + (rects.get('%3')?.width ?? 0) + 1;
+		expect(leftSide).toBeCloseTo(120, -1);
+		// Inner split untouched: %1 and %3 still share their side evenly.
+		expect(Math.abs((rects.get('%1')?.width ?? 0) - (rects.get('%3')?.width ?? 0))).toBeLessThanOrEqual(1);
+	});
+
+	test('2x2 grid: root ratio changes, column-internal splits untouched', () => {
+		// h[v[%1,%3], v[%2,%4]]
+		const t = new PaneLayoutTree();
+		t.setInitialPanes(['%1']);
+		t.split('%1', 'h', '%2');
+		t.split('%1', 'v', '%3');
+		t.split('%2', 'v', '%4');
+		expect(t.setSplitRatio('%1', '%2', 'h', 0.25)).toBe(true);
+		const rects = t.computeRects(161, 41);
+		expect(rects.get('%1')?.width).toBeCloseTo(40, -1);
+		expect(rects.get('%3')?.width).toBeCloseTo(40, -1);
+		// Vertical splits keep their even share.
+		expect(Math.abs((rects.get('%1')?.height ?? 0) - (rects.get('%3')?.height ?? 0))).toBeLessThanOrEqual(1);
+	});
+
+	test('direction mismatch is rejected without modifying the tree', () => {
+		const t = twoPane(); // h split
+		expect(t.setSplitRatio('%1', '%2', 'v', 0.25)).toBe(false);
+		const rects = t.computeRects(161, 40);
+		expect(rects.get('%1')?.width).toBeCloseTo(80, -1); // still ~50%
+	});
+
+	test('unknown pane is rejected', () => {
+		const t = twoPane();
+		expect(t.setSplitRatio('%1', '%9', 'h', 0.25)).toBe(false);
+	});
+
+	test('ratio is clamped to the valid range', () => {
+		const t = twoPane();
+		expect(t.setSplitRatio('%1', '%2', 'h', 0.01)).toBe(true);
+		const rects = t.computeRects(161, 40);
+		expect(rects.get('%1')?.width ?? 0).toBeGreaterThanOrEqual(16); // >= 10%
+	});
+});
+
 describe('PaneLayoutTree.split duplicate guard', () => {
   test('splitting with an id already in the tree does not create a duplicate leaf', () => {
     const t = twoPane();

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -635,6 +635,28 @@ export class HerdrControlSession {
     await this.applyLayout();
   }
 
+  /**
+   * Set the ratios of several splits atomically (one relayout). Each entry
+   * targets the split whose divider separates paneA from paneB. Boundary-style
+   * divider drags renormalize a set of same-direction splits together, so
+   * applying them one-by-one would flash intermediate layouts.
+   */
+  async setSplitRatios(
+    entries: Array<{ paneA: string; paneB: string; dir: 'h' | 'v'; ratio: number }>,
+  ): Promise<void> {
+    let changed = false;
+    for (const e of entries) {
+      assertPaneId(e.paneA);
+      assertPaneId(e.paneB);
+      if (this.tree.setSplitRatio(e.paneA, e.paneB, e.dir, e.ratio)) {
+        changed = true;
+      }
+    }
+    if (changed) {
+      await this.applyLayout();
+    }
+  }
+
   async equalizePanes(direction: 'horizontal' | 'vertical'): Promise<void> {
     this.tree.equalize(direction);
     await this.applyLayout();

--- a/backend/src/services/herdr-layout.ts
+++ b/backend/src/services/herdr-layout.ts
@@ -242,6 +242,51 @@ export class PaneLayoutTree {
     f.node.ratio = Math.min(MAX_RATIO, Math.max(MIN_RATIO, ratio));
   }
 
+  /**
+   * Set the ratio of the lowest common ancestor split of two panes — the one
+   * split whose divider separates paneA's subtree from paneB's, i.e. exactly
+   * the divider the user dragged. setPaneSize cannot express this: it reaches
+   * a pane's *deepest* same-direction ancestor, so the outer divider of
+   * nested same-direction splits (h[h[A,B],C]) is unaddressable per-pane.
+   * `ratio` is paneA's side's share. Returns false (no-op) when the panes
+   * don't meet at a split of the expected direction.
+   */
+  setSplitRatio(paneA: string, paneB: string, dir: 'h' | 'v', ratio: number): boolean {
+    if (!this.root || !Number.isFinite(ratio)) return false;
+    const contains = (n: LayoutNode, id: string): boolean => {
+      if (n.type === 'leaf') return n.paneId === id;
+      return contains(n.a, id) || contains(n.b, id);
+    };
+    let target: SplitNode | null = null;
+    let aInFirst = true;
+    const walk = (n: LayoutNode): void => {
+      if (n.type !== 'split') return;
+      const firstHasA = contains(n.a, paneA);
+      const firstHasB = contains(n.a, paneB);
+      if (firstHasA && firstHasB) {
+        walk(n.a);
+        return;
+      }
+      if (!firstHasA && !firstHasB) {
+        walk(n.b);
+        return;
+      }
+      const secondHasA = contains(n.b, paneA);
+      const secondHasB = contains(n.b, paneB);
+      if ((firstHasA && secondHasB) || (firstHasB && secondHasA)) {
+        target = n;
+        aInFirst = firstHasA;
+      }
+    };
+    walk(this.root);
+    if (!target) return false;
+    const split = target as SplitNode;
+    if (split.dir !== dir) return false;
+    const share = aInFirst ? ratio : 1 - ratio;
+    split.ratio = Math.min(MAX_RATIO, Math.max(MIN_RATIO, share));
+    return true;
+  }
+
   /** Reset every split of the given orientation to an even ratio. */
   equalize(direction: 'horizontal' | 'vertical'): void {
     const dir: 'h' | 'v' = direction === 'horizontal' ? 'h' : 'v';

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -98,6 +98,18 @@ function findPaneById(node: PaneNode, id: string): PaneNode | null {
 	return null;
 }
 
+// First terminal (leaf) pane id under a node, in depth-first order.
+function firstLeafId(node: PaneNode): string | null {
+	if (node.type === "terminal") return node.id;
+	if (node.type === "split") {
+		for (const child of node.children) {
+			const id = firstLeafId(child);
+			if (id) return id;
+		}
+	}
+	return null;
+}
+
 // Compute total tmux window size by summing pane sizes from the layout tree.
 // tmux needs: horizontal splits → sum cols + borders, vertical → sum rows + borders.
 // When useProposed=true, uses proposeDimensions() (what fits the container) instead of
@@ -149,22 +161,89 @@ function getAllPaneIds(node: PaneNode): string[] {
 	return [node.id];
 }
 
-// Update split ratio in tree
-function updateRatio(
+// Boundary-style divider drag. Moving the divider between children[i] and
+// children[i+1] of `splitId` must move ONLY that boundary on screen: the two
+// panes touching it absorb the delta, every other pane keeps its absolute
+// size (tmux semantics). Inside each adjacent child, same-direction splits
+// along the touching edge renormalize their ratios to hold the interior
+// boundaries still; cross-direction splits pass the change through to all
+// children (each of their rows/columns touches the dragged boundary).
+// Returns the original root unchanged when any resulting ratio would leave
+// [10, 90] — the drag hard-stops at the limit instead of crushing a pane.
+function applyBoundaryDrag(
 	root: PaneNode,
-	nodeId: string,
-	ratio: number[],
+	splitId: string,
+	newRatio: number[],
+	dividerIndex: number,
 ): PaneNode {
-	if (root.id === nodeId && root.type === "split") {
-		return { ...root, ratio };
-	}
-	if (root.type === "split") {
+	let valid = true;
+
+	// `node`'s extent along `dir` changes oldExtent→newExtent (any consistent
+	// unit); only the pane touching the dragged boundary — via `edge` — absorbs
+	// the difference.
+	const renormalize = (
+		node: PaneNode,
+		dir: "horizontal" | "vertical",
+		edge: "start" | "end",
+		oldExtent: number,
+		newExtent: number,
+	): PaneNode => {
+		if (node.type !== "split" || oldExtent <= 0 || newExtent <= 0) return node;
+		if (node.direction !== dir) {
+			return {
+				...node,
+				children: node.children.map((c) =>
+					renormalize(c, dir, edge, oldExtent, newExtent),
+				),
+			};
+		}
+		const abs = node.ratio.map((r) => (r / 100) * oldExtent);
+		const idx = edge === "end" ? abs.length - 1 : 0;
+		const absorbedOld = abs[idx] ?? 0;
+		const absorbedNew = absorbedOld + (newExtent - oldExtent);
+		abs[idx] = absorbedNew;
+		const ratio = abs.map((w) => (w / newExtent) * 100);
+		for (const r of ratio) {
+			if (r < 10 || r > 90) valid = false;
+		}
 		return {
-			...root,
-			children: root.children.map((c) => updateRatio(c, nodeId, ratio)),
+			...node,
+			ratio,
+			children: node.children.map((c, i) =>
+				i === idx ? renormalize(c, dir, edge, absorbedOld, absorbedNew) : c,
+			),
 		};
-	}
-	return root;
+	};
+
+	const walk = (node: PaneNode): PaneNode => {
+		if (node.type !== "split") return node;
+		if (node.id !== splitId) {
+			return { ...node, children: node.children.map(walk) };
+		}
+		const i = dividerIndex;
+		const oldA = node.ratio[i];
+		const oldB = node.ratio[i + 1];
+		const newA = newRatio[i];
+		const newB = newRatio[i + 1];
+		if (
+			oldA === undefined ||
+			oldB === undefined ||
+			newA === undefined ||
+			newB === undefined
+		) {
+			return node;
+		}
+		const children = node.children.map((c, ci) => {
+			if (ci === i) return renormalize(c, node.direction, "end", oldA, newA);
+			if (ci === i + 1)
+				return renormalize(c, node.direction, "start", oldB, newB);
+			return c;
+		});
+		return { ...node, ratio: newRatio, children };
+	};
+
+	const next = walk(root);
+	return valid ? next : root;
 }
 
 // Update session ID in tree
@@ -199,10 +278,16 @@ function updateAllSessionIds(root: PaneNode, sessionId: string): PaneNode {
 	return root;
 }
 
-// Convert TmuxLayoutNode to PaneNode with session IDs
+// Convert TmuxLayoutNode to PaneNode with session IDs.
+// Split ids derive from the node's PATH in the tree, not its x/y position:
+// a nested split starting at the same corner as its parent (e.g. the left
+// column of a 2x2, or the inner-left split of 4 columns) would collide under
+// position-based ids, and ratio updates addressed by id would then hit the
+// ancestor instead of the dragged split.
 function tmuxLayoutToPaneNode(
 	node: TmuxLayoutNode,
 	sessionId: string,
+	path = "r",
 ): PaneNode {
 	if (node.type === "leaf") {
 		return {
@@ -212,8 +297,8 @@ function tmuxLayoutToPaneNode(
 		};
 	}
 
-	const children = (node.children || []).map((c) =>
-		tmuxLayoutToPaneNode(c, sessionId),
+	const children = (node.children || []).map((c, i) =>
+		tmuxLayoutToPaneNode(c, sessionId, `${path}.${i}`),
 	);
 	const isHorizontal = node.type === "horizontal";
 	const totalSize = (node.children || []).reduce(
@@ -232,7 +317,7 @@ function tmuxLayoutToPaneNode(
 		direction: isHorizontal ? "horizontal" : "vertical",
 		children,
 		ratio,
-		id: `split-${node.x}-${node.y}`,
+		id: `split-${path}`,
 	};
 }
 
@@ -761,19 +846,35 @@ export function DesktopLayout({
 		return tmuxLayoutToPaneNode(controlLayout, controlSessionId);
 	}, [controlLayout, controlSessionId]);
 
-	// Update desktopState when control pane tree changes
-	useEffect(() => {
-		if (!controlPaneTree) return;
-		const allPanes = getAllPaneIds(controlPaneTree);
+	// While a divider is actively dragged (real pointer/touch down..up, reported
+	// by SplitContainer), keep the optimistic local ratios and defer any
+	// incoming server tree. Applying it mid-drag would snap every divider to
+	// the server's freshly-rounded ratios, so dragging one divider visibly
+	// nudges the others.
+	const dividerDragActiveRef = useRef(false);
+	const pendingControlTreeRef = useRef<PaneNode | null>(null);
+
+	const applyControlTree = useCallback((tree: PaneNode) => {
+		const allPanes = getAllPaneIds(tree);
 		setDesktopState((prev) => ({
-			root: controlPaneTree,
+			root: tree,
 			activePane: allPanes.includes(prev.activePane)
 				? prev.activePane
 				: allPanes[0] || prev.activePane,
 		}));
+	}, []);
+
+	// Update desktopState when control pane tree changes
+	useEffect(() => {
+		if (!controlPaneTree) return;
+		if (dividerDragActiveRef.current) {
+			pendingControlTreeRef.current = controlPaneTree;
+			return;
+		}
 		// Note: tmux zoom does NOT change %layout-change notifications.
 		// Zoom state is tracked purely in frontend via zoomedPaneId.
-	}, [controlPaneTree]);
+		applyControlTree(controlPaneTree);
+	}, [controlPaneTree, applyControlTree]);
 
 	// Build control mode context for PaneContainer.
 	// Always defined - Terminal components always use control mode.
@@ -818,6 +919,14 @@ export function DesktopLayout({
 				},
 				forceResize: (cols: number, rows: number) => {
 					if (!controlTerminalRef.current.isConnected) return;
+					// forceResize sets the WHOLE client size. That is only correct when a
+					// single pane fills the window (pane size == client size). With
+					// multiple panes, a per-pane proposal (~1/N of the width) must NOT be
+					// sent as the client size — doing so collapses the layout and the
+					// client oscillates violently between one pane's width and the real
+					// window width. Let normal convergence (sendControlResize + the ±3
+					// tolerance) reconcile the per-pane rounding instead.
+					if (getAllPaneIds(desktopStateRef.current.root).length > 1) return;
 					// Send the requested geometry without consulting the dedup cache;
 					// this is the escape hatch when tmux's pane size disagrees with
 					// what we last sent (e.g. window-size policy held it stuck).
@@ -1285,41 +1394,64 @@ export function DesktopLayout({
 		[],
 	);
 
-	// Debounced per-pane resize after drag: sends resize-pane to tmux for each pane
-	const paneResizeTimerRef = useRef<number | null>(null);
+	// True when at least one ratio change happened during the current drag, so
+	// drag-end knows whether there is anything to sync to the server.
+	const dividerDragDirtyRef = useRef(false);
 
-	const sendPaneResizes = useCallback(() => {
-		if (paneResizeTimerRef.current) {
-			clearTimeout(paneResizeTimerRef.current);
-		}
-		paneResizeTimerRef.current = window.setTimeout(() => {
-			if (!controlTerminalRef.current.isConnected) return;
-			const root = desktopStateRef.current.root;
-			const allPanes = getAllPaneIds(root);
-			for (const paneId of allPanes) {
-				const ref = terminalRefs.current?.get(paneId);
-				const proposed = ref?.getProposedSize?.();
-				if (proposed && proposed.cols > 0 && proposed.rows > 0) {
-					controlTerminalRef.current.resizePane(
-						paneId,
-						proposed.cols,
-						proposed.rows,
-					);
-				}
-			}
-		}, 200);
-	}, []);
-
+	// During a drag, only the local (optimistic) tree updates — nothing is
+	// sent. On release, handleSplitDragStateChange syncs the ratios once.
 	const handleSplitRatioChange = useCallback(
-		(nodeId: string, ratio: number[]) => {
+		(nodeId: string, ratio: number[], dividerIndex: number) => {
+			dividerDragDirtyRef.current = true;
 			setDesktopState((prev) => ({
 				...prev,
-				root: updateRatio(prev.root, nodeId, ratio),
+				root: applyBoundaryDrag(prev.root, nodeId, ratio, dividerIndex),
 			}));
-			// After CSS ratio changes, tell tmux to resize individual panes
-			sendPaneResizes();
 		},
-		[sendPaneResizes],
+		[],
+	);
+
+	const handleSplitDragStateChange = useCallback(
+		(active: boolean) => {
+			dividerDragActiveRef.current = active;
+			if (active) return;
+			// Drag ended. Any tree deferred mid-drag predates the final ratios —
+			// drop it; the layout push answering set-split-ratios supersedes it.
+			pendingControlTreeRef.current = null;
+			const dirty = dividerDragDirtyRef.current;
+			dividerDragDirtyRef.current = false;
+			if (!dirty || !controlTerminalRef.current.isConnected) return;
+			// A boundary drag renormalizes several splits, so sync ALL split
+			// ratios in one atomic relayout — idempotent, no diffing needed. Each
+			// split is identified for the server by one leaf from each side:
+			// their lowest common ancestor is exactly that split, which sidesteps
+			// the "deepest same-direction ancestor" ambiguity of pane-size-based
+			// resizing (h[h[A,B],C]'s outer divider is unreachable per-pane).
+			const entries: Array<{
+				paneA: string;
+				paneB: string;
+				dir: "h" | "v";
+				ratio: number;
+			}> = [];
+			const collect = (node: PaneNode): void => {
+				if (node.type !== "split") return;
+				node.children.forEach(collect);
+				if (node.children.length !== 2) return; // server splits are binary
+				const paneA = firstLeafId(node.children[0]);
+				const paneB = firstLeafId(node.children[1]);
+				const share = (node.ratio[0] ?? 50) / 100;
+				if (!paneA || !paneB || !Number.isFinite(share)) return;
+				entries.push({
+					paneA,
+					paneB,
+					dir: node.direction === "horizontal" ? "h" : "v",
+					ratio: Math.min(0.9, Math.max(0.1, share)),
+				});
+			};
+			collect(desktopStateRef.current.root);
+			controlTerminalRef.current.setSplitRatios(entries.slice(0, 32));
+		},
+		[],
 	);
 
 	// Compute the display root: when zoomed, show only the zoomed pane full-screen.
@@ -1515,6 +1647,7 @@ export function DesktopLayout({
 						onSelectSession={handleSelectSessionForPane}
 						onSessionStateChange={onSessionStateChange}
 						onSplitRatioChange={handleSplitRatioChange}
+						onSplitDragStateChange={handleSplitDragStateChange}
 						onClosePane={handleClosePane}
 						onSplit={handleSplit}
 						sessions={sessions}

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -73,7 +73,16 @@ interface PaneContainerProps {
 	onFocusPane: (paneId: string) => void;
 	onSelectSession: (paneId: string, sessionId?: string) => void;
 	onSessionStateChange: (sessionId: string, state: SessionState) => void;
-	onSplitRatioChange: (nodeId: string, ratio: number[]) => void;
+	// dividerIndex = which divider moved (between children[i] and children[i+1]);
+	// parents use it for boundary-style renormalization of nested splits.
+	onSplitRatioChange: (
+		nodeId: string,
+		ratio: number[],
+		dividerIndex: number,
+	) => void;
+	// Fires when a divider drag physically starts (pointer/touch down) and
+	// ends (release). Lets the parent defer server layout application mid-drag.
+	onSplitDragStateChange?: (active: boolean) => void;
 	onClosePane: (paneId: string) => void;
 	onSplit?: (direction: "horizontal" | "vertical") => void;
 	sessions: ExtendedSession[];
@@ -90,6 +99,7 @@ export function PaneContainer({
 	onSelectSession,
 	onSessionStateChange,
 	onSplitRatioChange,
+	onSplitDragStateChange,
 	onClosePane,
 	onSplit,
 	sessions,
@@ -127,6 +137,7 @@ export function PaneContainer({
 				onSelectSession={onSelectSession}
 				onSessionStateChange={onSessionStateChange}
 				onSplitRatioChange={onSplitRatioChange}
+				onSplitDragStateChange={onSplitDragStateChange}
 				onClosePane={onClosePane}
 				onSplit={onSplit}
 				sessions={sessions}
@@ -751,7 +762,12 @@ interface SplitContainerProps {
 	onFocusPane: (paneId: string) => void;
 	onSelectSession: (paneId: string, sessionId?: string) => void;
 	onSessionStateChange: (sessionId: string, state: SessionState) => void;
-	onSplitRatioChange: (nodeId: string, ratio: number[]) => void;
+	onSplitRatioChange: (
+		nodeId: string,
+		ratio: number[],
+		dividerIndex: number,
+	) => void;
+	onSplitDragStateChange?: (active: boolean) => void;
 	onClosePane: (paneId: string) => void;
 	onSplit?: (direction: "horizontal" | "vertical") => void;
 	sessions: ExtendedSession[];
@@ -768,6 +784,7 @@ function SplitContainer({
 	onSelectSession,
 	onSessionStateChange,
 	onSplitRatioChange,
+	onSplitDragStateChange,
 	onClosePane,
 	onSplit,
 	sessions,
@@ -789,15 +806,18 @@ function SplitContainer({
 	// pointer AND touch events for the same finger, so without this each physical
 	// move rebuilt the whole pane tree twice and the divider lagged behind.
 	const rafRef = useRef<number | null>(null);
-	const pendingRatioRef = useRef<number[] | null>(null);
+	const pendingRatioRef = useRef<{ ratio: number[]; index: number } | null>(
+		null,
+	);
 	const flushRatio = useCallback(() => {
 		const pending = pendingRatioRef.current;
 		pendingRatioRef.current = null;
-		if (pending) onSplitRatioChange(nodeRef.current.id, pending);
+		if (pending)
+			onSplitRatioChange(nodeRef.current.id, pending.ratio, pending.index);
 	}, [onSplitRatioChange]);
 	const scheduleRatioChange = useCallback(
-		(ratio: number[]) => {
-			pendingRatioRef.current = ratio;
+		(ratio: number[], index: number) => {
+			pendingRatioRef.current = { ratio, index };
 			if (rafRef.current !== null) return;
 			rafRef.current = requestAnimationFrame(() => {
 				rafRef.current = null;
@@ -806,6 +826,10 @@ function SplitContainer({
 		},
 		[flushRatio],
 	);
+	// Keep the latest drag-state callback in a ref so drag handlers stay stable.
+	const dragStateChangeRef = useRef(onSplitDragStateChange);
+	dragStateChangeRef.current = onSplitDragStateChange;
+
 	const endDrag = useCallback(() => {
 		if (rafRef.current !== null) {
 			cancelAnimationFrame(rafRef.current);
@@ -814,6 +838,7 @@ function SplitContainer({
 		flushRatio(); // land exactly under the finger, not on the last frame
 		setIsDragging(null);
 		draggingRef.current = null;
+		dragStateChangeRef.current?.(false);
 	}, [flushRatio]);
 
 	// Shared ratio math for both the pointer and touch drag paths.
@@ -861,19 +886,21 @@ function SplitContainer({
 			e.currentTarget.setPointerCapture(e.pointerId);
 			setIsDragging(index);
 			draggingRef.current = index;
+			dragStateChangeRef.current?.(true);
 		},
 		[],
 	);
 
 	const handlePointerMove = useCallback(
 		(e: React.PointerEvent) => {
-			if (draggingRef.current === null) return;
+			const dragIndex = draggingRef.current;
+			if (dragIndex === null) return;
 			e.preventDefault();
 			const currentNode = nodeRef.current;
 			const clientPos =
 				currentNode.direction === "horizontal" ? e.clientX : e.clientY;
 			const ratio = computeNewRatio(clientPos);
-			if (ratio) scheduleRatioChange(ratio);
+			if (ratio) scheduleRatioChange(ratio, dragIndex);
 		},
 		[computeNewRatio, scheduleRatioChange],
 	);
@@ -893,6 +920,7 @@ function SplitContainer({
 			e.preventDefault();
 			setIsDragging(index);
 			draggingRef.current = index;
+			dragStateChangeRef.current?.(true);
 		},
 		[],
 	);
@@ -902,13 +930,15 @@ function SplitContainer({
 
 		const handleTouchMove = (e: TouchEvent) => {
 			e.preventDefault();
+			const dragIndex = draggingRef.current;
+			if (dragIndex === null) return;
 			const touch = e.touches[0];
 			if (!touch) return;
 			const currentNode = nodeRef.current;
 			const clientPos =
 				currentNode.direction === "horizontal" ? touch.clientX : touch.clientY;
 			const ratio = computeNewRatio(clientPos);
-			if (ratio) scheduleRatioChange(ratio);
+			if (ratio) scheduleRatioChange(ratio, dragIndex);
 		};
 
 		document.addEventListener("touchmove", handleTouchMove, { passive: false });
@@ -954,6 +984,7 @@ function SplitContainer({
 					onSelectSession={onSelectSession}
 					onSessionStateChange={onSessionStateChange}
 					onSplitRatioChange={onSplitRatioChange}
+					onSplitDragStateChange={onSplitDragStateChange}
 					onClosePane={onClosePane}
 					onSplit={onSplit}
 					sessions={sessions}

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -780,6 +780,80 @@ function SplitContainer({
 	const [isDragging, setIsDragging] = useState<number | null>(null);
 	const draggingRef = useRef<number | null>(null);
 
+	// Always-current node so the drag handlers read the latest ratios without
+	// re-subscribing document listeners on every move.
+	const nodeRef = useRef(node);
+	nodeRef.current = node;
+
+	// Coalesce ratio updates to one per animation frame. A tablet drag fires
+	// pointer AND touch events for the same finger, so without this each physical
+	// move rebuilt the whole pane tree twice and the divider lagged behind.
+	const rafRef = useRef<number | null>(null);
+	const pendingRatioRef = useRef<number[] | null>(null);
+	const flushRatio = useCallback(() => {
+		const pending = pendingRatioRef.current;
+		pendingRatioRef.current = null;
+		if (pending) onSplitRatioChange(nodeRef.current.id, pending);
+	}, [onSplitRatioChange]);
+	const scheduleRatioChange = useCallback(
+		(ratio: number[]) => {
+			pendingRatioRef.current = ratio;
+			if (rafRef.current !== null) return;
+			rafRef.current = requestAnimationFrame(() => {
+				rafRef.current = null;
+				flushRatio();
+			});
+		},
+		[flushRatio],
+	);
+	const endDrag = useCallback(() => {
+		if (rafRef.current !== null) {
+			cancelAnimationFrame(rafRef.current);
+			rafRef.current = null;
+		}
+		flushRatio(); // land exactly under the finger, not on the last frame
+		setIsDragging(null);
+		draggingRef.current = null;
+	}, [flushRatio]);
+
+	// Shared ratio math for both the pointer and touch drag paths.
+	const computeNewRatio = useCallback((clientPos: number): number[] | null => {
+		const dragIndex = draggingRef.current;
+		if (dragIndex === null || !containerRef.current) return null;
+		const currentNode = nodeRef.current;
+		const rect = containerRef.current.getBoundingClientRect();
+		const containerSize =
+			currentNode.direction === "horizontal" ? rect.width : rect.height;
+		const offset =
+			currentNode.direction === "horizontal" ? rect.left : rect.top;
+
+		const newRatio = [...currentNode.ratio];
+		const beforeSum = currentNode.ratio
+			.slice(0, dragIndex + 1)
+			.reduce((a, b) => a + b, 0);
+		const afterSum = currentNode.ratio
+			.slice(dragIndex + 1)
+			.reduce((a, b) => a + b, 0);
+		const position = ((clientPos - offset) / containerSize) * 100;
+		const minRatio = 10;
+		const newBefore = Math.max(
+			minRatio,
+			Math.min(beforeSum + afterSum - minRatio, position),
+		);
+		const diff = newBefore - beforeSum;
+
+		if (
+			newRatio[dragIndex] === undefined ||
+			newRatio[dragIndex + 1] === undefined
+		)
+			return null;
+		newRatio[dragIndex] = newRatio[dragIndex] + diff;
+		newRatio[dragIndex + 1] = newRatio[dragIndex + 1] - diff;
+		if (newRatio[dragIndex] < minRatio || newRatio[dragIndex + 1] < minRatio)
+			return null;
+		return newRatio;
+	}, []);
+
 	// Pointer-capture based drag: all pointer events go to the captured element
 	const handlePointerDown = useCallback(
 		(index: number) => (e: React.PointerEvent) => {
@@ -793,54 +867,25 @@ function SplitContainer({
 
 	const handlePointerMove = useCallback(
 		(e: React.PointerEvent) => {
-			const dragIndex = draggingRef.current;
-			if (dragIndex === null) return;
+			if (draggingRef.current === null) return;
 			e.preventDefault();
-			if (!containerRef.current) return;
-			const rect = containerRef.current.getBoundingClientRect();
-			const clientPos = node.direction === "horizontal" ? e.clientX : e.clientY;
-			const containerSize =
-				node.direction === "horizontal" ? rect.width : rect.height;
-			const offset = node.direction === "horizontal" ? rect.left : rect.top;
-
-			const newRatio = [...node.ratio];
-			const beforeSum = node.ratio
-				.slice(0, dragIndex + 1)
-				.reduce((a, b) => a + b, 0);
-			const afterSum = node.ratio
-				.slice(dragIndex + 1)
-				.reduce((a, b) => a + b, 0);
-			const position = ((clientPos - offset) / containerSize) * 100;
-			const minRatio = 10;
-			const newBefore = Math.max(
-				minRatio,
-				Math.min(beforeSum + afterSum - minRatio, position),
-			);
-			const diff = newBefore - beforeSum;
-
-			if (
-				newRatio[dragIndex] !== undefined &&
-				newRatio[dragIndex + 1] !== undefined
-			) {
-				newRatio[dragIndex] = newRatio[dragIndex] + diff;
-				newRatio[dragIndex + 1] = newRatio[dragIndex + 1] - diff;
-				if (
-					newRatio[dragIndex] >= minRatio &&
-					newRatio[dragIndex + 1] >= minRatio
-				) {
-					onSplitRatioChange(node.id, newRatio);
-				}
-			}
+			const currentNode = nodeRef.current;
+			const clientPos =
+				currentNode.direction === "horizontal" ? e.clientX : e.clientY;
+			const ratio = computeNewRatio(clientPos);
+			if (ratio) scheduleRatioChange(ratio);
 		},
-		[node, onSplitRatioChange],
+		[computeNewRatio, scheduleRatioChange],
 	);
 
-	const handlePointerUp = useCallback((e: React.PointerEvent) => {
-		if (draggingRef.current === null) return;
-		e.currentTarget.releasePointerCapture(e.pointerId);
-		setIsDragging(null);
-		draggingRef.current = null;
-	}, []);
+	const handlePointerUp = useCallback(
+		(e: React.PointerEvent) => {
+			if (draggingRef.current === null) return;
+			e.currentTarget.releasePointerCapture(e.pointerId);
+			endDrag();
+		},
+		[endDrag],
+	);
 
 	// Touch fallback for devices that don't support pointer capture well
 	const handleTouchStart = useCallback(
@@ -853,64 +898,35 @@ function SplitContainer({
 	);
 
 	useEffect(() => {
-		const dragIndex = draggingRef.current;
-		if (dragIndex === null) return;
+		if (draggingRef.current === null) return;
 
 		const handleTouchMove = (e: TouchEvent) => {
 			e.preventDefault();
-			if (!containerRef.current) return;
-			const rect = containerRef.current.getBoundingClientRect();
+			const touch = e.touches[0];
+			if (!touch) return;
+			const currentNode = nodeRef.current;
 			const clientPos =
-				node.direction === "horizontal"
-					? e.touches[0].clientX
-					: e.touches[0].clientY;
-			const containerSize =
-				node.direction === "horizontal" ? rect.width : rect.height;
-			const offset = node.direction === "horizontal" ? rect.left : rect.top;
-
-			const newRatio = [...node.ratio];
-			const beforeSum = node.ratio
-				.slice(0, dragIndex + 1)
-				.reduce((a, b) => a + b, 0);
-			const afterSum = node.ratio
-				.slice(dragIndex + 1)
-				.reduce((a, b) => a + b, 0);
-			const position = ((clientPos - offset) / containerSize) * 100;
-			const minRatio = 10;
-			const newBefore = Math.max(
-				minRatio,
-				Math.min(beforeSum + afterSum - minRatio, position),
-			);
-			const diff = newBefore - beforeSum;
-
-			if (
-				newRatio[dragIndex] !== undefined &&
-				newRatio[dragIndex + 1] !== undefined
-			) {
-				newRatio[dragIndex] = newRatio[dragIndex] + diff;
-				newRatio[dragIndex + 1] = newRatio[dragIndex + 1] - diff;
-				if (
-					newRatio[dragIndex] >= minRatio &&
-					newRatio[dragIndex + 1] >= minRatio
-				) {
-					onSplitRatioChange(node.id, newRatio);
-				}
-			}
-		};
-
-		const handleTouchEnd = () => {
-			setIsDragging(null);
-			draggingRef.current = null;
+				currentNode.direction === "horizontal" ? touch.clientX : touch.clientY;
+			const ratio = computeNewRatio(clientPos);
+			if (ratio) scheduleRatioChange(ratio);
 		};
 
 		document.addEventListener("touchmove", handleTouchMove, { passive: false });
-		document.addEventListener("touchend", handleTouchEnd);
+		document.addEventListener("touchend", endDrag);
 
 		return () => {
 			document.removeEventListener("touchmove", handleTouchMove);
-			document.removeEventListener("touchend", handleTouchEnd);
+			document.removeEventListener("touchend", endDrag);
 		};
-	}, [isDragging, node, onSplitRatioChange]);
+	}, [isDragging, computeNewRatio, scheduleRatioChange, endDrag]);
+
+	// Cancel any pending frame if the divider unmounts mid-drag.
+	useEffect(
+		() => () => {
+			if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+		},
+		[],
+	);
 
 	const isHorizontal = node.direction === "horizontal";
 

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -46,6 +46,14 @@ interface UseMultiplexedTerminalReturn {
 		direction: "L" | "R" | "U" | "D",
 		amount: number,
 	) => void;
+	setSplitRatios: (
+		entries: Array<{
+			paneA: string;
+			paneB: string;
+			dir: "h" | "v";
+			ratio: number;
+		}>,
+	) => void;
 	equalizePanes: (direction: "horizontal" | "vertical") => void;
 	sendClientInfo: (deviceType: "mobile" | "tablet" | "desktop") => void;
 	// Ask the server for the viewport `offset` rows above the live edge.
@@ -641,6 +649,24 @@ export function useMultiplexedTerminal(
 		[],
 	);
 
+	// Set several split ratios atomically (one server relayout). Each entry
+	// targets the split whose divider separates paneA from paneB; ratio =
+	// paneA's side's share, 0..1.
+	const setSplitRatios = useCallback(
+		(
+			entries: Array<{
+				paneA: string;
+				paneB: string;
+				dir: "h" | "v";
+				ratio: number;
+			}>,
+		) => {
+			if (entries.length === 0) return;
+			sendSessionMessage({ type: "set-split-ratios", entries });
+		},
+		[],
+	);
+
 	const equalizePanes = useCallback((direction: "horizontal" | "vertical") => {
 		sendSessionMessage({ type: "equalize-panes", direction });
 	}, []);
@@ -710,6 +736,7 @@ export function useMultiplexedTerminal(
 		resizePane,
 		selectPane,
 		adjustPane,
+		setSplitRatios,
 		equalizePanes,
 		sendClientInfo,
 		requestViewport,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -718,6 +718,15 @@ export type ControlClientMessage =
   | { type: 'ping'; timestamp: number }
   | { type: 'client-info'; deviceType: 'mobile' | 'tablet' | 'desktop' }
   | { type: 'adjust-pane'; paneId: string; direction: 'L' | 'R' | 'U' | 'D'; amount: number }
+  // Set the ratios of specific splits in one shot. Each entry identifies a
+  // split as the lowest common ancestor of paneA and paneB (expected direction
+  // `dir`). Sent when a divider drag ends: boundary-style dragging adjusts the
+  // dragged split plus the same-direction splits along the boundary, so the
+  // whole consistent set is applied atomically (one relayout).
+  | {
+      type: 'set-split-ratios';
+      entries: Array<{ paneA: string; paneB: string; dir: 'h' | 'v'; ratio: number }>;
+    }
   | { type: 'equalize-panes'; direction: 'horizontal' | 'vertical' }
   | { type: 'zoom-pane'; paneId: string }
   | { type: 'respawn-pane'; paneId: string }
@@ -770,6 +779,20 @@ const controlClientMessageOptions = [
   z.object({ type: z.literal('ping'), timestamp: z.number() }),
   z.object({ type: z.literal('client-info'), deviceType: z.enum(['mobile', 'tablet', 'desktop']) }),
   z.object({ type: z.literal('adjust-pane'), paneId: PaneIdSchema, direction: z.enum(['L', 'R', 'U', 'D']), amount: WsAmount }),
+  z.object({
+    type: z.literal('set-split-ratios'),
+    entries: z
+      .array(
+        z.object({
+          paneA: PaneIdSchema,
+          paneB: PaneIdSchema,
+          dir: z.enum(['h', 'v']),
+          ratio: z.number().gt(0).lt(1),
+        }),
+      )
+      .min(1)
+      .max(32),
+  }),
   z.object({ type: z.literal('equalize-panes'), direction: z.enum(['horizontal', 'vertical']) }),
   z.object({ type: z.literal('zoom-pane'), paneId: PaneIdSchema }),
   z.object({ type: z.literal('respawn-pane'), paneId: PaneIdSchema }),


### PR DESCRIPTION
## Summary

タブレット実機でのライブデバッグで特定した、ペインリサイズの一連の不具合を修正する。

## Fixes

1. **ドラッグ追従（rAF 集約）**: タブレットでは1回の指移動が pointer と touch の両方を発火させ、ペインツリーを毎回2回再構築していた。rAF で1フレーム1更新に集約し、touch リスナーの毎 move 張り替えも解消。離した瞬間に最終位置を flush。

2. **4分割時の激しい振動**: あるペインの viewport 到着時の `forceResize` が、**ペイン1枚分**の提案サイズを**クライアント全体**のサイズとして送信 → 全体幅が 38↔151 で無限往復（実測）。複数ペイン時は forceResize を無効化し、通常の収束（±3許容）に任せる。

3. **境界ドラッグ意味論**: 従来はドラッグ確定時に全ペインの丸め済み提案サイズを送り、各 resize-pane が共有祖先分割を奪い合ってレイアウトが壊れていた（ドラッグ結果が反映されない/無関係ペインが入れ替わる）。さらにペインサイズ方式では入れ子同方向分割の外側ディバイダを原理的に指定できない。新設の `set-split-ratios` バッチメッセージ（各分割を両側のリーフの LCA で特定）で、離した瞬間に1回だけ原子的に適用。ドラッグ中はローカル楽観更新のみ＆サーバーレイアウトの適用を保留。`applyBoundaryDrag` により**動かした境界の両隣だけ**が伸縮し、他ペインは絶対サイズ維持（tmux 同様）。

4. **分割 ID 衝突**: フロントの分割 ID が `split-${x}-${y}`（座標）だったため、親と左上角を共有する入れ子分割（2x2 の左列、4カラムの内側左）が親と同一 ID になり、**一番左のディバイダを動かすとルートのディバイダが動く**。木のパス由来 ID に変更。

## Verification

- backend `bun test`: 319 pass / 0 fail（`setSplitRatio` LCA の新規7テスト含む）
- tsgo（backend/frontend）clean、biome clean、`vite build` 成功
- **実機 E2E**（live herdr + `/ws/mux`）: 4カラム構成に3エントリのバッチを送信 → **1回の layout push** で期待どおりの幅に適用
- **タブレット実機**: 4分割で振動なし・全ディバイダが意図どおり動作（ドラッグ中に他ディバイダが動かない）をユーザー確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)