### PR TITLE
Release v0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.12] - 2026-07-18
+
+### Fixed
+- **ペインのディバイダドラッグを境界セマンティクスに全面刷新（タブレット実機で検証）**: リサイズ周りの4つの不具合をまとめて修正。(1) **ドラッグ追従**: タブレットでは1回の指移動が pointer と touch の両方を発火させペインツリーを毎回2回再構築、さらに touch リスナーを move ごとに張り替えていた。rAF で1フレーム1更新に集約し、リスナーはドラッグ開始時に1回だけ登録、離した瞬間に最終位置を flush。(2) **4分割時の激しい振動**: viewport 到着時の `forceResize` がペイン1枚分の提案サイズをクライアント全体のサイズとして送信し、全体幅が 38↔151 で無限往復していた（実測）。複数ペイン時は forceResize を無効化。(3) **ドラッグ結果が反映されない/無関係ペインが動く**: 従来はドラッグ確定時に全ペインの丸め済みサイズを送り、各 resize-pane が共有祖先分割を奪い合っていた。ペインサイズ方式では入れ子同方向分割（h[h[A,B],C]）の外側ディバイダを原理的に指定できない。新設の `set-split-ratios` バッチメッセージ（各分割を両側リーフの最小共通祖先で特定）で離した瞬間に1回だけ原子的に適用し、ドラッグ中はローカル楽観更新のみ＆サーバーレイアウト適用を保留。`applyBoundaryDrag` により動かした境界の両隣だけが伸縮し、他ペインは絶対サイズを維持（tmux 同様）。(4) **分割 ID 衝突**: フロントの分割 ID が座標由来（`split-${x}-${y}`）だったため、親と左上角を共有する入れ子分割（2x2 の左列、4カラムの内側左）が親と同一 ID になり、一番左のディバイダを動かすとルートのディバイダが動いていた。木のパス由来 ID に変更（`frontend/src/components/DesktopLayout.tsx`, `PaneContainer.tsx`, `useMultiplexedTerminal.ts`, `shared/types.ts`, `backend/src/services/herdr-layout.ts`, `herdr-control.ts`, `backend/src/routes/terminal-mux.ts`）
+  - backend に `PaneLayoutTree.setSplitRatio`（LCA 特定＋クランプ、ユニットテスト7件）と `setSplitRatios` バッチ（applyLayout 1回）を追加。実機 herdr + `/ws/mux` の E2E で、4カラム構成への3エントリバッチが1回の layout push で期待どおり適用されることを確認
+
 ## [0.2.11] - 2026-07-18
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "generated": "2026-07-18",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "generated": "2026-07-18",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- fix(ui): ペインのディバイダドラッグを境界セマンティクスに全面刷新（#419）。タブレットでのドラッグ追従不良・4分割時の振動・ドラッグ結果の不忠実・分割ID衝突をまとめて修正

## Notes
- タブレット実機で全ディバイダの動作をユーザー確認済み。backend 319 tests pass、実機 E2E（/ws/mux）検証済み
- 新メッセージ `set-split-ratios` 追加（旧クライアントには影響なし — zod 検証で未知メッセージは drop）

🤖 Generated with [Claude Code](https://claude.com/claude-code)