### PR TITLE
perf(herdr): filter pane lifecycle events by workspace before reconciling

### DIFF
--- a/backend/src/services/__tests__/herdr-event-workspace.test.ts
+++ b/backend/src/services/__tests__/herdr-event-workspace.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+import { eventWorkspaceId } from '../herdr-client';
+
+/**
+ * herdr's pane lifecycle subscriptions can't be filtered server-side
+ * (protocol 16), so each HerdrControlSession filters received events by
+ * workspace before reconciling. These fixtures are verbatim captures from a
+ * live herdr 0.7.4 socket — the workspace id sits in a different place per
+ * event shape.
+ */
+describe('eventWorkspaceId', () => {
+  it('reads pane_created events (workspace nested in data.pane)', () => {
+    const ev = {
+      data: {
+        pane: {
+          agent_status: 'unknown',
+          cwd: '/home/m0a',
+          focused: false,
+          pane_id: 'w1W:p1',
+          tab_id: 'w1W:t1',
+          workspace_id: 'w1W',
+        },
+        type: 'pane_created',
+      },
+      event: 'pane_created',
+    };
+    expect(eventWorkspaceId(ev)).toBe('w1W');
+  });
+
+  it('reads pane_closed events (workspace directly in data)', () => {
+    const ev = {
+      data: { pane_id: 'w1N:p2', type: 'pane_closed', workspace_id: 'w1N' },
+      event: 'pane_closed',
+    };
+    expect(eventWorkspaceId(ev)).toBe('w1N');
+  });
+
+  it('prefers the direct data.workspace_id over the nested pane one', () => {
+    const ev = {
+      data: { workspace_id: 'w2', pane: { workspace_id: 'w3' } },
+      event: 'pane_closed',
+    };
+    expect(eventWorkspaceId(ev)).toBe('w2');
+  });
+
+  it('returns null when no workspace is present (caller fails open)', () => {
+    expect(eventWorkspaceId({ event: 'pane_created' })).toBeNull();
+    expect(eventWorkspaceId({ data: {} })).toBeNull();
+    expect(eventWorkspaceId({ data: { pane: {} } })).toBeNull();
+    expect(eventWorkspaceId({ data: 'not-an-object' })).toBeNull();
+    expect(eventWorkspaceId({ data: { workspace_id: 42 } })).toBeNull();
+  });
+});

--- a/backend/src/services/herdr-client.ts
+++ b/backend/src/services/herdr-client.ts
@@ -236,6 +236,25 @@ export function herdrSubscribe(
   };
 }
 
+/**
+ * Workspace id of a received pane lifecycle event, or null when absent.
+ * Wire shapes differ per event (verified live against herdr 0.7.4 /
+ * protocol 16): `pane_created` nests it as `data.pane.workspace_id`, while
+ * `pane_closed` / `pane_exited` carry `data.workspace_id` directly.
+ */
+export function eventWorkspaceId(ev: Record<string, unknown>): string | null {
+  const data = ev.data;
+  if (!data || typeof data !== 'object') return null;
+  const d = data as Record<string, unknown>;
+  if (typeof d.workspace_id === 'string') return d.workspace_id;
+  const pane = d.pane;
+  if (pane && typeof pane === 'object') {
+    const p = pane as Record<string, unknown>;
+    if (typeof p.workspace_id === 'string') return p.workspace_id;
+  }
+  return null;
+}
+
 /** `w1:p3` → `%3` (null if the id doesn't match the herdr shape) */
 export function toTmuxPaneId(herdrPaneId: string): string | null {
   const m = herdrPaneId.match(/:p(\d+)$/);

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -21,6 +21,7 @@
 
 import type { PaneCursor, PaneModes, PaneViewport, TmuxLayoutNode } from '../../../shared/types';
 import {
+  eventWorkspaceId,
   exportLayout,
   getPane,
   type HerdrPane,
@@ -267,11 +268,21 @@ export class HerdrControlSession {
       }
     }
 
-    // Structural events → reconcile pane set. Payload shapes are treated as
-    // opaque; any of these events triggers a pane.list diff.
+    // Structural events → reconcile pane set. herdr's lifecycle subscriptions
+    // accept no server-side filter (protocol 16), so every session receives
+    // every pane event; filter on the event's workspace here so pane churn in
+    // other workspaces (previews, throwaway workspaces, other sessions) does
+    // not fan out into a pane.list reconcile per session. An event with no
+    // recognizable workspace still reconciles — a wasted reconcile is
+    // harmless, a missed one would cost correctness.
     this.unsubscribeEvents = herdrSubscribe(
       [{ type: 'pane.created' }, { type: 'pane.closed' }, { type: 'pane.exited' }],
-      () => void this.reconcilePanes(),
+      (ev) => {
+        const wsId = eventWorkspaceId(ev);
+        if (wsId === null || wsId === this.workspaceId) {
+          void this.reconcilePanes();
+        }
+      },
       () => {
         if (!this.destroyed) this.handleExit('herdr event stream closed');
       },


### PR DESCRIPTION
## Summary

各 `HerdrControlSession` は pane.created/closed/exited を購読してペイン集合を reconcile するが、herdr のライフサイクル購読は**サーバー側フィルタ非対応**（protocol 16 で確認 — pane_id フィルタがあるのは `pane.agent_status_changed` 等のみ）。ハンドラはペイロードを完全に無視していたため、**どこかの workspace の pane イベント1つで全アクティブセッションが pane.list reconcile を実行**していた。しかも herdr は新規購読に**過去イベント約50件をリプレイ**することが実測で判明 — セッション開始のたびに無関係な reconcile が走っていた。

受信イベントの workspace を見てフィルタする: `pane_created` は `data.pane.workspace_id`、`pane_closed`/`exited` は `data.workspace_id`（ライブキャプチャした実ペイロードをテストフィクスチャとして固定）。workspace を特定できないイベントは従来どおり reconcile（fail open — 無駄な reconcile は無害）。

## Verification

- backend `bun test`: 323 pass / 0 fail（`eventWorkspaceId` の新規4テスト含む）
- tsgo / biome clean
- **実機 E2E**（`/ws/mux`）: 自 workspace への外部分割が、温めた購読で **~180ms** で layout push として届くことを確認（フィルタが自イベントを落とさない）
- 計測中に herdr の既知でなかった挙動を発見: **新規購読への配信は約4秒遅延**する（生ソケットプローブで cchub 抜きでも同一の遅延を確認 — 本変更とは無関係の herdr 側挙動。購読が温まれば ~40ms）

🤖 Generated with [Claude Code](https://claude.com/claude-code)