### PR TITLE
ci: drop tmux install from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
-
       - name: Install dependencies
         run: bun install
 


### PR DESCRIPTION
## Summary

tmux 時代の残渣である CI の `Install tmux` ステップを削除。herdr 移行後、テストにも実行時にも tmux を使う経路は存在しない（#416 で backend の死にコードは削除済み、これが最後の残り）。

この PR の CI 通過自体が「tmux なしで全テストが通る」ことの検証になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)