### PR TITLE
feat(sessions): show active model instead of cumulative token count

### DIFF
--- a/backend/src/services/codex.ts
+++ b/backend/src/services/codex.ts
@@ -11,6 +11,7 @@ interface CodexTokenUsage {
   totalCacheReadTokens?: number;
   totalOutputTokens?: number;
   totalTokens?: number;
+  model?: string;
 }
 
 export interface CodexThread {
@@ -101,15 +102,30 @@ function tokenUsageFromLine(line: string): CodexTokenUsage | undefined {
   };
 }
 
+function modelFromLine(line: string): string | undefined {
+  try {
+    const event = JSON.parse(line) as { type?: string; payload?: { model?: unknown } };
+    if (event.type !== 'turn_context') return undefined;
+    const model = event.payload?.model;
+    return typeof model === 'string' && model ? model : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function findLatestTokenUsageInText(text: string): CodexTokenUsage | undefined {
   const lines = text.split('\n');
+  let usage: CodexTokenUsage | undefined;
+  let model: string | undefined;
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i]?.trim();
-    if (!line?.includes('"token_count"')) continue;
-    const usage = tokenUsageFromLine(line);
-    if (usage) return usage;
+    if (!line) continue;
+    if (!usage && line.includes('"token_count"')) usage = tokenUsageFromLine(line);
+    if (!model && line.includes('"turn_context"')) model = modelFromLine(line);
+    if (usage && model) break;
   }
-  return undefined;
+  if (!usage && !model) return undefined;
+  return { ...usage, model };
 }
 
 function readLatestTokenUsage(rolloutPath?: string | null): CodexTokenUsage | undefined {

--- a/backend/src/services/session-metrics.ts
+++ b/backend/src/services/session-metrics.ts
@@ -172,6 +172,7 @@ export async function computeSessionMetrics(input: MetricsInput): Promise<Sessio
       metrics.totalOutputTokens = usage.totalOutputTokens;
       // Effective usage = input + cache_creation + output (cache_read is billed at 10%, treated as noise)
       metrics.totalTokens = usage.totalInputTokens + usage.totalCacheCreationTokens + usage.totalOutputTokens;
+      metrics.model = usage.latestModel;
     }
   }
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -43,7 +43,7 @@ import {
 	useSessions,
 } from "../hooks/useSessions";
 import { sessionFetch } from "../services/peer-fetch";
-import { formatRelativeTime } from "../utils/format";
+import { formatModelName, formatRelativeTime } from "../utils/format";
 import { toHomeShortPath } from "../utils/path";
 
 // Theme color mapping
@@ -1124,16 +1124,11 @@ function SessionItem({
 									{formatBytes(extSession.metrics.memoryRssBytes)}
 								</span>
 							)}
-						{typeof extSession.metrics?.totalTokens === "number" &&
-							extSession.metrics.totalTokens > 0 && (
-								<span
-									className="font-mono tabular-nums"
-									title={`input + cache_creation + output (excludes cache_read)\n\nin: ${extSession.metrics.totalInputTokens?.toLocaleString() ?? 0}\ncache create: ${extSession.metrics.totalCacheCreationTokens?.toLocaleString() ?? 0}\ncache read: ${extSession.metrics.totalCacheReadTokens?.toLocaleString() ?? 0}\nout: ${extSession.metrics.totalOutputTokens?.toLocaleString() ?? 0}`}
-								>
-									<span className="text-zinc-600">used</span>{" "}
-									{formatTokenCount(extSession.metrics.totalTokens)}
-								</span>
-							)}
+						{extSession.metrics?.model && (
+							<span title={extSession.metrics.model}>
+								{formatModelName(extSession.metrics.model)}
+							</span>
+						)}
 					</div>
 				)}
 

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { formatModelName } from "./format";
+
+describe("formatModelName", () => {
+	test("new-style Claude ids with minor version", () => {
+		expect(formatModelName("claude-opus-4-8-20250815")).toBe("Opus 4.8");
+		expect(formatModelName("claude-haiku-4-5-20251001")).toBe("Haiku 4.5");
+	});
+
+	test("new-style Claude ids without date", () => {
+		expect(formatModelName("claude-fable-5")).toBe("Fable 5");
+		expect(formatModelName("claude-sonnet-5")).toBe("Sonnet 5");
+	});
+
+	test("major-only version", () => {
+		expect(formatModelName("claude-sonnet-4-20250514")).toBe("Sonnet 4");
+	});
+
+	test("legacy version-first ids", () => {
+		expect(formatModelName("claude-3-5-sonnet-20241022")).toBe("Sonnet 3.5");
+		expect(formatModelName("claude-3-opus-20240229")).toBe("Opus 3");
+	});
+
+	test("non-Claude ids pass through unchanged", () => {
+		expect(formatModelName("gpt-5.6-sol")).toBe("gpt-5.6-sol");
+		expect(formatModelName("gpt-5.4-mini")).toBe("gpt-5.4-mini");
+	});
+
+	test("unparseable Claude ids fall back to the raw id", () => {
+		expect(formatModelName("claude-2.1")).toBe("claude-2.1");
+	});
+});

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -21,6 +21,25 @@ export function formatRelativeTime(
 }
 
 /**
+ * Compress a model id into a short display name.
+ * Claude ids ("claude-opus-4-8-20250815", "claude-3-5-sonnet-20241022") become
+ * "Opus 4.8" / "Sonnet 3.5"; anything else (e.g. Codex "gpt-5.6-sol") is
+ * returned unchanged.
+ */
+export function formatModelName(modelId: string): string {
+	if (!modelId.startsWith("claude-")) return modelId;
+	const tokens = modelId
+		.slice("claude-".length)
+		.split("-")
+		.filter((tok) => !/^\d{8}$/.test(tok)); // drop the release-date suffix
+	const family = tokens.find((tok) => /^[a-z]/i.test(tok));
+	if (!family) return modelId;
+	const version = tokens.filter((tok) => /^\d+$/.test(tok)).join(".");
+	const name = family.charAt(0).toUpperCase() + family.slice(1);
+	return version ? `${name} ${version}` : name;
+}
+
+/**
  * Format a duration in minutes into a localized "Xm" / "Xh Ym" / "Xh" string.
  * Returns null for zero/undefined so callers can omit the field entirely.
  */

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -160,6 +160,7 @@ export interface SessionMetrics {
   totalOutputTokens?: number;          // cumulative output tokens
   totalTokens?: number;                // effective usage: input + cache_creation + output (cache_read excluded)
   memoryRssBytes?: number;             // total RSS across session's panes
+  model?: string;                      // latest model id used by the agent (e.g. "claude-opus-4-8", "gpt-5.6-sol")
 }
 
 // Session names become herdr workspace labels; legacy parsers also split on


### PR DESCRIPTION
## Summary
- セッションリストの `used NNk`（累計トークン）表示を削除し、代わりにエージェントが現在使っているモデルを表示する
- Claude: `.jsonl` から既に抽出していた `latestModel` を `metrics.model` として公開
- Codex: rollout の最新 `turn_context` イベントの `payload.model` を token_count スキャンと同時に抽出
- Frontend: `formatModelName()` で Claude の model id を短縮表示（`claude-opus-4-8` → `Opus 4.8`、`claude-3-5-sonnet-20241022` → `Sonnet 3.5`）。Codex 等の非 Claude id（`gpt-5.6-sol`）はそのまま表示。ツールチップにフル id

## Test plan
- [x] `bun run test` 全パス（backend 323 / frontend 52 + formatModelName の新規6ケース）
- [x] `bun run lint` クリーン
- [x] dev 環境（5173）で実表示確認: 各セッションに `Opus 4.8` / `Fable 5` が表示され `used` が消えている
- [x] Codex rollout 実ファイルで `turn_context.payload.model` = `gpt-5.6-sol` が取れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrPeukDny8ipqP2ao2HmE3