### PR TITLE
Release v0.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.14] - 2026-07-18
+
+### Changed
+- **セッションリストの `used`（累計トークン）表示を利用中モデル表示に置き換え** (#424): 累計トークン数はほぼ参照されていなかったため削除し、エージェントが現在使っているモデルを表示する。Claude は `.jsonl` から context 計算用に抽出済みだった `latestModel` を `metrics.model` として公開し、`claude-opus-4-8` → `Opus 4.8` のように短縮表示（旧形式 `claude-3-5-sonnet-*` → `Sonnet 3.5` も対応、フル id はツールチップ）。Codex は rollout 末尾スキャンで `token_count` と同時に最新 `turn_context` の `payload.model`（例: `gpt-5.6-sol`）を抽出し、そのまま表示（`shared/types.ts`, `backend/src/services/session-metrics.ts`, `codex.ts`, `frontend/src/components/SessionList.tsx`, `frontend/src/utils/format.ts`）
+
 ## [0.2.13] - 2026-07-18
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "generated": "2026-07-18",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "generated": "2026-07-18",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Changes
- feat(sessions): セッションリストの `used`（累計トークン）表示を利用中モデル表示に置き換え (#424) — Claude は `Opus 4.8` / `Fable 5` 形式で短縮表示、Codex は rollout の `turn_context` から `gpt-5.6-sol` 等を表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrPeukDny8ipqP2ao2HmE3