### PR TITLE
feat: Grok Build (xAI) support as a third agent provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,9 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - **CodexConversationService** (`services/codex-conversation.ts`) - Reads Codex conversation transcripts and exposes them to the UI
 - **CodexUsageService** (`services/codex-usage.ts`) - Tracks Codex token usage and rate-limit state
 - **CodexHistoryService** (`services/codex-history.ts`) - Reads Codex rollout transcripts (`~/.codex/sessions`) and merges them into project history alongside Claude Code sessions
+- **AgentProviders** (`services/agent-providers.ts`) - Common `AgentThreadService` / `AgentHistoryProvider` interfaces for thread-based agents (Codex, Grok, ...). Routes iterate provider maps in `routes/sessions.ts` instead of hardcoding an agent; adding an agent = one `AGENT_PROVIDERS` registry entry in `shared/types.ts` + implementations of these interfaces
+- **GrokService / GrokSessionStore** (`services/grok.ts`) - Grok Build (xAI) integration: scans `~/.grok/sessions/<URL-encoded cwd>/<uuid>/` (`summary.json` metadata, `prompt_history.jsonl` first prompts, `updates.jsonl` `turn_completed` token usage), resolves the latest thread per working directory
+- **GrokHistoryService** (`services/grok-history.ts`) - Grok session history + conversation reader: parses `chat_history.jsonl` (user records with `prompt_index`, assistant `tool_calls`, `tool_result`) into Claude-shaped conversation turns
 - **ConversationWatcher** (`services/conversation-watcher.ts`) - Watches Claude Code / Codex `.jsonl` files and emits conversation updates to subscribed WebSocket clients
 - **HookStatusService** (`services/hook-status.ts`) - Reports whether the hooks CC Hub still needs are installed (`Stop` for notification text, `PostToolUse`/`AskUserQuestion` for the question's tool name). Indicator transitions come from herdr, not hooks
 - **HerdrAgentStatusWatcher** (`services/herdr-agent-status.ts`) - Subscribes to herdr's per-pane `pane.agent_status_changed` (plus pane lifecycle events, which re-subscribe the pane set) and triggers an immediate sessions push. Decides *when* to rebuild the list, never what's in it — a dropped event costs latency, not correctness
@@ -231,8 +234,8 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - **useSelectionMode.ts** - Touch-selection state machine for `SelectionOverlay` (start/end cell, drag handles, copy-to-clipboard)
 - **useInputEcho.ts** - Echoes characters typed into the InputBar back into the conversation/chat view while the terminal is hidden
 - **useConversationStream.ts** - Subscribes to `/ws/mux` conversation streams (`subscribe-conversation`) and exposes incremental conversation updates
-- **useAgentConversation.ts** - Unified conversation hook that selects between Claude Code and Codex sources for the active session
-- **useCodexConversation.ts** - Codex-specific conversation loader (transcript + token usage)
+- **useAgentConversation.ts** - Unified conversation hook: Claude streams over the WebSocket, thread agents (Codex/Grok) poll over HTTP — chosen from the shared `AGENT_PROVIDERS` registry
+- **useThreadConversation.ts** - Polling conversation loader for thread-based agents (`?agent=codex|grok`)
 - **usePeers.ts** - Peer list CRUD and state management (`/api/peers`)
 - **usePeerConnection.ts** - Resolves connection info (HTTP/WS URLs, auth) for the active peer
 - **usePeerSessionsWatcher.ts** - Persistent `/ws/mux` WebSocket per remote peer so `sessions-updated` pushes arrive without polling
@@ -338,9 +341,11 @@ cchub --version
 - herdr must be installed (`curl -fsSL https://herdr.dev/install.sh | sh` or `brew install herdr`); cchub auto-starts `herdr server` if it isn't running, but a supervised setup (systemd user unit with `Restart=always` + `~/.config/herdr/config.toml` with `resume_agents_on_restore = true`) is strongly recommended so agent sessions survive server restarts
 - For Claude session identity/restore, install the herdr agent integration once: `herdr integration install claude`
 
-## Claude Code / Codex Hook通知連携
+## Claude Code / Codex / Grok Hook通知連携
 
-Claude Code と Codex のhookイベント（応答完了、ユーザー入力待ち等）をCC Hub経由でブラウザのOS通知として受け取れる。
+Claude Code・Codex・Grok Build のhookイベント（応答完了、ユーザー入力待ち等）をCC Hub経由でブラウザのOS通知として受け取れる。
+
+Grok Build は `~/.claude/settings.json` の hooks を互換レイヤでデフォルト読み込みするため、Claude 用の `cchub notify` 設定がそのまま発火する（追加設定不要）。ただし stdin JSON は camelCase 独自形式（`hookEventName: "stop"`, `sessionId`, `transcriptPath`）なので、`/api/notify` 側で Claude 形式に正規化している（`routes/notify.ts` の `normalizeHookBody`）。
 
 ### 仕組み
 

--- a/backend/src/routes/notify.ts
+++ b/backend/src/routes/notify.ts
@@ -39,11 +39,90 @@ export async function isAllowedTranscriptPath(path: string): Promise<boolean> {
   } catch {
     return false;
   }
-  for (const dir of ['.claude', '.codex']) {
+  for (const dir of ['.claude', '.codex', '.grok']) {
     const root = await realpath(`${homedir()}/${dir}`).catch(() => null);
     if (root && resolved.startsWith(`${root}/`)) return true;
   }
   return false;
+}
+
+/**
+ * Grok Build sends hook JSON with camelCase keys and snake_case event names
+ * (`{"hookEventName":"stop","sessionId":...,"transcriptPath":...}`) — even for
+ * hooks it loaded from Claude's settings.json via its compat layer. Map that
+ * shape onto the Claude field names the rest of this route understands.
+ * Bodies already in Claude shape pass through untouched.
+ */
+const GROK_EVENT_NAMES: Record<string, string> = {
+  stop: 'Stop',
+  notification: 'Notification',
+  subagent_stop: 'SubagentStop',
+  post_tool_use: 'PostToolUse',
+  pre_tool_use: 'PreToolUse',
+  user_prompt_submit: 'UserPromptSubmit',
+  session_start: 'SessionStart',
+  session_end: 'SessionEnd',
+};
+
+export function normalizeHookBody(body: Record<string, unknown>): Record<string, unknown> {
+  if (body.hook_event_name || typeof body.hookEventName !== 'string') return body;
+  const { hookEventName, sessionId, transcriptPath, toolName, ...rest } = body;
+  const normalized: Record<string, unknown> = {
+    ...rest,
+    hook_event_name: GROK_EVENT_NAMES[hookEventName as string] ?? hookEventName,
+  };
+  if (typeof sessionId === 'string') normalized.session_id = sessionId;
+  if (typeof transcriptPath === 'string') normalized.transcript_path = transcriptPath;
+  if (typeof toolName === 'string') normalized.tool_name = toolName;
+  return normalized;
+}
+
+/**
+ * Grok の transcript (updates.jsonl, JSON-RPC session/update ストリーム) から
+ * 通知メッセージを生成する。最後の user_message_chunk 以降の
+ * agent_message_chunk を連結して最後の応答本文とみなす。
+ */
+function generateGrokSmartMessage(entries: Array<Record<string, unknown>>): string | undefined {
+  const tools: string[] = [];
+  let responseText = '';
+  for (const entry of entries) {
+    const update = (entry.params as { update?: Record<string, unknown> } | undefined)?.update;
+    if (!update) continue;
+    switch (update.sessionUpdate) {
+      case 'user_message_chunk':
+        responseText = '';
+        break;
+      case 'agent_message_chunk': {
+        const text = (update.content as { text?: string } | undefined)?.text;
+        if (typeof text === 'string') responseText += text;
+        break;
+      }
+      case 'tool_call': {
+        const name = typeof update.title === 'string' ? update.title : undefined;
+        if (name && !tools.includes(name)) tools.push(name);
+        break;
+      }
+    }
+  }
+
+  let action: string;
+  const hasTool = (pattern: RegExp) => tools.some((t) => pattern.test(t));
+  if (hasTool(/edit|write|create_file|apply_patch/i)) action = 'ファイル編集完了';
+  else if (hasTool(/terminal|bash|command/i)) action = 'コマンド実行完了';
+  else if (hasTool(/read|search|grep|glob/i)) action = '調査完了';
+  else action = '完了';
+
+  let inCodeBlock = false;
+  for (const line of responseText.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('```')) { inCodeBlock = !inCodeBlock; continue; }
+    if (inCodeBlock) continue;
+    if (trimmed && trimmed.length > 5) {
+      const summary = trimmed.length > 80 ? `${trimmed.slice(0, 77)}...` : trimmed;
+      return `${action}: ${summary}`;
+    }
+  }
+  return action;
 }
 
 /** transcriptファイルからコンテキストに応じた通知メッセージを生成する */
@@ -54,6 +133,11 @@ async function generateSmartMessage(transcriptPath: string, _event: string): Pro
     for (const line of recentLines) {
       if (!line) continue;
       try { entries.push(JSON.parse(line)); } catch {}
+    }
+
+    // Grok transcript は Claude の .jsonl と行形式が違うので専用パスへ
+    if (entries.some((e) => e?.method === 'session/update')) {
+      return generateGrokSmartMessage(entries);
     }
 
     // 使用されたツールを収集
@@ -170,8 +254,8 @@ export function getIndicatorOverride(ccSessionId: string): { state: IndicatorSta
  */
 notify.post('/', async (c) => {
   try {
-    const body = await c.req.json();
-    const event = body.hook_event_name || body.event || 'unknown';
+    const body = normalizeHookBody(await c.req.json());
+    const event = String(body.hook_event_name || body.event || 'unknown');
     const cwd = body.cwd as string | undefined;
     const sessionId = body.session_id as string | undefined;
 

--- a/backend/src/routes/notify.ts
+++ b/backend/src/routes/notify.ts
@@ -100,6 +100,9 @@ function generateGrokSmartMessage(entries: Array<Record<string, unknown>>): stri
       case 'tool_call': {
         const name = typeof update.title === 'string' ? update.title : undefined;
         if (name && !tools.includes(name)) tools.push(name);
+        // Chunks before a tool call are intermediate narration; the summary
+        // should quote the FINAL message of the turn (same as the Claude path).
+        responseText = '';
         break;
       }
     }

--- a/backend/src/routes/peers.ts
+++ b/backend/src/routes/peers.ts
@@ -14,6 +14,7 @@ import {
   type PeerHistoryProject,
   type PeerHistoryProjectsResponse,
   type HistorySession,
+  isAgentProvider,
 } from '../../../shared/types';
 import {
   listPeers,
@@ -26,7 +27,7 @@ import {
 import { loginToPeer, verifyPeer, peerFetch, PeerAuthError } from '../services/peer-auth';
 import { isSafePeerUrl } from '../services/peer-url';
 import { discoverPeers } from '../services/peer-discovery';
-import { buildSessionsList, sessionHistoryService, codexHistoryService } from './sessions';
+import { buildSessionsList, sessionHistoryService, agentHistoryProviders } from './sessions';
 import { buildDashboard } from './dashboard';
 import { saveUploadedImage } from './upload';
 import type { DashboardResponse } from '../../../shared/types';
@@ -171,13 +172,13 @@ interface HistoryProjectsResp {
 }
 
 async function buildLocalHistoryProjects(): Promise<HistoryProjectsResp['projects']> {
-  const [claudeProjects, codexProjects] = await Promise.all([
+  const [claudeProjects, ...agentProjects] = await Promise.all([
     sessionHistoryService.getProjects(),
-    codexHistoryService.getProjects(),
+    ...Object.values(agentHistoryProviders).map(p => p.getProjects()),
   ]);
   const byDir = new Map<string, HistoryProjectsResp['projects'][number]>();
   for (const p of claudeProjects) byDir.set(p.dirName, p);
-  for (const p of codexProjects) {
+  for (const p of agentProjects.flat()) {
     const existing = byDir.get(p.dirName);
     if (existing) {
       existing.sessionCount += p.sessionCount;
@@ -260,13 +261,13 @@ peers.get('/history/projects', async (c) => {
 });
 
 async function buildLocalProjectSessions(dirName: string): Promise<HistorySession[]> {
-  const [claudeSessions, codexSessions] = await Promise.all([
+  const [claudeSessions, ...agentSessions] = await Promise.all([
     sessionHistoryService.getProjectSessions(dirName),
-    codexHistoryService.getProjectSessions(dirName),
+    ...Object.values(agentHistoryProviders).map(p => p.getProjectSessions(dirName)),
   ]);
   const merged: HistorySession[] = [
     ...claudeSessions.map(s => ({ ...s, agent: s.agent ?? 'claude' as const })),
-    ...codexSessions,
+    ...agentSessions.flat(),
   ].sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
   return merged;
 }
@@ -311,8 +312,9 @@ peers.get('/history/:peerId/:sessionId/conversation', async (c) => {
   const last = lastQuery ? parseInt(lastQuery, 10) : undefined;
 
   if (peer.url === SELF_PEER_URL) {
-    const messages = agent === 'codex'
-      ? await codexHistoryService.getConversation(sessionId)
+    const provider = agent && isAgentProvider(agent) ? agentHistoryProviders[agent] : undefined;
+    const messages = provider
+      ? await provider.getConversation(sessionId)
       : await sessionHistoryService.getConversation(sessionId, projectDirName);
     return c.json({ messages: last ? messages.slice(-last) : messages });
   }

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { homedir } from 'node:os';
-import { AGENT_PROVIDERS, AGENT_PROVIDER_IDS, CreateSessionSchema, DEFAULT_AGENT_PROVIDER, PaneIdSchema, SessionIdSchema, agentResumeCommand, agentSupportsConversationMetadata, type AgentProvider, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
+import { AGENT_PROVIDERS, AGENT_PROVIDER_IDS, CreateSessionSchema, DEFAULT_AGENT_PROVIDER, PaneIdSchema, SessionIdSchema, agentResumeCommand, agentSupportsConversationMetadata, isAgentProvider, threadAgentOf, type AgentProvider, type IndicatorState, type PaneInfo, type ExtendedSessionResponse, type SessionState } from '../../../shared/types';
 import { HerdrService } from '../services/herdr';
 import {
   captureViewportHerdr,
@@ -13,6 +13,9 @@ import { CodexService } from '../services/codex';
 import { CodexConversationService } from '../services/codex-conversation';
 import { SessionHistoryService } from '../services/session-history';
 import { CodexHistoryService } from '../services/codex-history';
+import { GrokService } from '../services/grok';
+import { GrokHistoryService } from '../services/grok-history';
+import type { AgentHistoryProvider, AgentThread, AgentThreadService } from '../services/agent-providers';
 import { PromptHistoryService } from '../services/prompt-history';
 import { getAllSessionMetadata, setSessionTheme, setSessionTitle, getLastKnownSessions, saveLastKnownSessions, removeLastKnownSession, type LastKnownSession } from '../services/session-metadata';
 import { computeSessionMetrics } from '../services/session-metrics';
@@ -22,11 +25,20 @@ import { detectPaneState, stripAnsi, type DetectedPaneState } from '../services/
 
 const herdrService = new HerdrService();
 const claudeCodeService = new ClaudeCodeService();
-const codexService = new CodexService();
 const codexConversationService = new CodexConversationService();
 // peers.ts からも参照するため export
 export const sessionHistoryService = new SessionHistoryService();
-export const codexHistoryService = new CodexHistoryService(undefined, codexConversationService);
+
+// Thread-based agents (everything except Claude). Adding an agent means adding
+// its two service instances here — the routes below iterate these maps.
+const threadServices: Partial<Record<AgentProvider, AgentThreadService>> = {
+  codex: new CodexService(),
+  grok: new GrokService(),
+};
+export const agentHistoryProviders: Partial<Record<AgentProvider, AgentHistoryProvider>> = {
+  codex: new CodexHistoryService(undefined, codexConversationService),
+  grok: new GrokHistoryService(),
+};
 const promptHistoryService = new PromptHistoryService();
 
 export function shellQuote(value: string): string {
@@ -173,10 +185,17 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     .filter((s): s is typeof s & { currentPath: string } => agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && !!s.currentPath)
     .map(s => s.currentPath);
   const ccSessionsByPath = await claudeCodeService.getSessionsForPaths(claudePaths);
-  const codexPaths = herdrSessions
-    .filter((s): s is typeof s & { currentPath: string } => (s.agent ?? s.currentCommand) === 'codex' && !!s.currentPath)
-    .map(s => s.currentPath);
-  const codexThreadsByPath = await codexService.getThreadsForPaths(codexPaths);
+
+  // One thread map per thread-based agent (codex, grok, ...): latest thread
+  // in each working directory, resolved from the agent's own session store.
+  const threadsByAgent = new Map<AgentProvider, Map<string, AgentThread>>();
+  await Promise.all((Object.entries(threadServices) as [AgentProvider, AgentThreadService][]).map(async ([agentId, service]) => {
+    const paths = herdrSessions
+      .filter((s): s is typeof s & { currentPath: string } => (s.agent ?? s.currentCommand) === agentId && !!s.currentPath)
+      .map(s => s.currentPath);
+    if (paths.length === 0) return;
+    threadsByAgent.set(agentId, await service.getThreadsForPaths(paths));
+  }));
 
   // Remote Control deep-link map: Claude Code sessionId -> bridgeSessionId.
   // Read once per build (cheap: a handful of small ~/.claude/sessions/*.json).
@@ -184,7 +203,10 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
 
   const results = await Promise.all(herdrSessions.map(async (s) => {
     let ccSession: Awaited<ReturnType<typeof claudeCodeService.getSessionForPath>> | undefined;
-    const codexThread = s.currentPath ? codexThreadsByPath.get(s.currentPath) : undefined;
+    const threadAgent = threadAgentOf(s.agent ?? s.currentCommand);
+    const agentThread = threadAgent && s.currentPath
+      ? threadsByAgent.get(threadAgent)?.get(s.currentPath)
+      : undefined;
 
     if (agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && s.currentPath) {
       // Prefer the native session id reported via the herdr agent
@@ -197,12 +219,10 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     }
 
     const includeClaudeInfo = agentSupportsConversationMetadata(s.agent ?? s.currentCommand);
-    const includeCodexInfo = (s.agent ?? s.currentCommand) === 'codex';
+    const includeThreadInfo = !!threadAgent;
     const conversationSessionId = includeClaudeInfo
       ? ccSession?.sessionId
-      : includeCodexInfo
-        ? codexThread?.sessionId
-        : undefined;
+      : agentThread?.sessionId;
 
     // Indicator state: herdr's own agent detection is the source of truth —
     // it tracks the pane itself, so it can't go stale when a hook is missing,
@@ -231,11 +251,12 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     // ccSession.projectPath === s.currentPath.
     const isExactPathMatch = !!ccSession && !!s.currentPath && ccSession.projectPath === s.currentPath;
 
-    // Codex keeps hooks first: herdr detects Codex panes too, but its status
-    // accuracy there hasn't been verified the way it has for Claude (#390).
+    // Thread agents keep hooks first: herdr detects these panes too, but its
+    // status accuracy there hasn't been verified the way it has for Claude
+    // (#390), and Grok isn't integrated with herdr at all.
     const sessionIndicatorState = includeClaudeInfo
       ? indicatorState
-      : includeCodexInfo
+      : includeThreadInfo
         ? (hookState ?? herdrState ?? undefined)
         : undefined;
 
@@ -245,11 +266,11 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       workingDir: s.currentPath,
       pids: panePids,
     });
-    const sessionMetrics = includeCodexInfo && codexThread
+    const sessionMetrics = agentThread
       ? {
           ...metrics,
-          ...codexThread.tokenUsage,
-          totalTokens: codexThread.tokenUsage?.totalTokens ?? codexThread.tokensUsed,
+          ...agentThread.tokenUsage,
+          totalTokens: agentThread.tokenUsage?.totalTokens ?? agentThread.tokensUsed,
         }
       : metrics;
 
@@ -263,9 +284,9 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       agent: s.agent,
       currentPath: s.currentPath,
       paneTitle: s.paneTitle,
-      waitingToolName: includeClaudeInfo ? effectiveWaitingToolName : includeCodexInfo ? hookToolName : undefined,
-      ccSummary: includeClaudeInfo ? (isExactPathMatch ? ccSession?.summary : undefined) : includeCodexInfo ? codexThread?.title : undefined,
-      ccFirstPrompt: includeClaudeInfo ? (isExactPathMatch ? ccSession?.firstPrompt : undefined) : includeCodexInfo ? codexThread?.firstPrompt : undefined,
+      waitingToolName: includeClaudeInfo ? effectiveWaitingToolName : includeThreadInfo ? hookToolName : undefined,
+      ccSummary: includeClaudeInfo ? (isExactPathMatch ? ccSession?.summary : undefined) : agentThread?.title,
+      ccFirstPrompt: includeClaudeInfo ? (isExactPathMatch ? ccSession?.firstPrompt : undefined) : agentThread?.firstPrompt,
       ccRecap: includeClaudeInfo && isExactPathMatch ? ccSession?.lastRecap?.content : undefined,
       ccRecapAt: includeClaudeInfo && isExactPathMatch ? ccSession?.lastRecap?.timestamp : undefined,
       indicatorState: sessionIndicatorState,
@@ -274,10 +295,10 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         includeClaudeInfo && ccSession?.sessionId
           ? bridgeSessionIds.get(ccSession.sessionId)
           : undefined,
-      agentSessionId: includeCodexInfo ? codexThread?.sessionId : undefined,
+      agentSessionId: agentThread?.sessionId,
       messageCount: includeClaudeInfo ? ccSession?.messageCount : undefined,
-      gitBranch: includeClaudeInfo ? ccSession?.gitBranch : includeCodexInfo ? codexThread?.gitBranch : undefined,
-      durationMinutes: includeClaudeInfo ? durationMinutes : includeCodexInfo && codexThread?.updatedAt ? Math.round((Date.now() - new Date(codexThread.updatedAt).getTime()) / 60000) : undefined,
+      gitBranch: includeClaudeInfo ? ccSession?.gitBranch : agentThread?.gitBranch,
+      durationMinutes: includeClaudeInfo ? durationMinutes : agentThread?.updatedAt ? Math.round((Date.now() - new Date(agentThread.updatedAt).getTime()) / 60000) : undefined,
       firstMessageId: includeClaudeInfo ? ccSession?.firstMessageId : undefined,
       theme: sessionMetadata[s.id]?.theme,
       customTitle: sessionMetadata[s.id]?.title,
@@ -294,7 +315,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         } else if (isClaudeOnPane) {
           // Use session-level indicator for Claude panes (hook/jsonl based)
           paneIndicator = indicatorState === 'completed' ? 'waiting_input' : indicatorState;
-        } else if (includeCodexInfo && isSessionAgentOnPane) {
+        } else if (includeThreadInfo && isSessionAgentOnPane) {
           paneIndicator = hookState ?? 'idle';
         } else {
           paneIndicator = 'idle';
@@ -478,16 +499,17 @@ sessions.post('/', async (c) => {
 });
 
 // GET /sessions/history/projects - Get list of projects (fast, no file content reading)
-// Merges Claude (~/.claude/projects/*) and Codex (~/.codex/sessions/**) buckets
-// by encoded cwd so the same directory shows up once.
+// Merges Claude (~/.claude/projects/*) and every thread agent's buckets
+// (Codex rollouts, Grok sessions, ...) by encoded cwd so the same directory
+// shows up once.
 sessions.get('/history/projects', async (c) => {
-  const [claudeProjects, codexProjects] = await Promise.all([
+  const [claudeProjects, ...agentProjects] = await Promise.all([
     sessionHistoryService.getProjects(),
-    codexHistoryService.getProjects(),
+    ...Object.values(agentHistoryProviders).map(p => p.getProjects()),
   ]);
   const byDir = new Map<string, typeof claudeProjects[number]>();
   for (const p of claudeProjects) byDir.set(p.dirName, p);
-  for (const p of codexProjects) {
+  for (const p of agentProjects.flat()) {
     const existing = byDir.get(p.dirName);
     if (existing) {
       existing.sessionCount += p.sessionCount;
@@ -506,13 +528,13 @@ sessions.get('/history/projects', async (c) => {
 sessions.get('/history/search', async (c) => {
   const query = c.req.query('q') || '';
   const limit = parseInt(c.req.query('limit') || '50', 10);
-  const [claudeMatches, codexMatches] = await Promise.all([
+  const [claudeMatches, ...agentMatches] = await Promise.all([
     sessionHistoryService.searchSessions(query, limit),
-    codexHistoryService.searchSessions(query, limit),
+    ...Object.values(agentHistoryProviders).map(p => p.searchSessions(query, limit)),
   ]);
   const merged = [
     ...claudeMatches.map(s => ({ ...s, agent: s.agent ?? 'claude' as const })),
-    ...codexMatches,
+    ...agentMatches.flat(),
   ].sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime()).slice(0, limit);
   return c.json({ sessions: merged });
 });
@@ -533,9 +555,11 @@ sessions.get('/history/search/stream', async (c) => {
       let yielded = 0;
 
       try {
-        // Emit Codex matches up-front (small set, scanned in one pass).
-        const codexMatches = await codexHistoryService.searchSessions(query, limit);
-        for (const session of codexMatches) {
+        // Emit thread-agent matches up-front (small sets, scanned in one pass).
+        const agentMatches = await Promise.all(
+          Object.values(agentHistoryProviders).map(p => p.searchSessions(query, limit)),
+        );
+        for (const session of agentMatches.flat()) {
           if (yielded >= limit) break;
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(session)}\n\n`));
           yielded++;
@@ -567,16 +591,16 @@ sessions.get('/history/search/stream', async (c) => {
 });
 
 // GET /sessions/history/projects/:dirName - Get sessions for a specific project
-// Returns merged Claude + Codex sessions in the same project bucket.
+// Returns merged Claude + thread-agent sessions in the same project bucket.
 sessions.get('/history/projects/:dirName', async (c) => {
   const dirName = c.req.param('dirName');
-  const [claudeSessions, codexSessions] = await Promise.all([
+  const [claudeSessions, ...agentSessions] = await Promise.all([
     sessionHistoryService.getProjectSessions(dirName),
-    codexHistoryService.getProjectSessions(dirName),
+    ...Object.values(agentHistoryProviders).map(p => p.getProjectSessions(dirName)),
   ]);
   const merged = [
     ...claudeSessions.map(s => ({ ...s, agent: s.agent ?? 'claude' as const })),
-    ...codexSessions,
+    ...agentSessions.flat(),
   ].sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
   return c.json({ sessions: merged });
 });
@@ -585,28 +609,29 @@ sessions.get('/history/projects/:dirName', async (c) => {
 // NOTE: This must be defined BEFORE /:id to prevent "history" being interpreted as an id
 sessions.get('/history', async (c) => {
   const includeMetadata = c.req.query('metadata') === 'true';
-  const [claudeHistory, codexHistory] = await Promise.all([
+  const [claudeHistory, ...agentHistory] = await Promise.all([
     sessionHistoryService.getRecentSessions(30, includeMetadata),
-    codexHistoryService.getRecentSessions(30),
+    ...Object.values(agentHistoryProviders).map(p => p.getRecentSessions(30)),
   ]);
   const merged = [
     ...claudeHistory.map(s => ({ ...s, agent: s.agent ?? 'claude' as const })),
-    ...codexHistory,
+    ...agentHistory.flat(),
   ].sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime()).slice(0, 30);
   return c.json({ sessions: merged });
 });
 
 // GET /sessions/history/:sessionId/conversation - Get conversation history for a session
 // ?last=N returns only the last N messages (for lightweight clients like G2 glasses)
-// ?agent=codex routes to the Codex rollout reader instead of Claude's jsonl
+// ?agent=<provider> routes to that thread agent's reader instead of Claude's jsonl
 sessions.get('/history/:sessionId/conversation', async (c) => {
   const sessionId = c.req.param('sessionId');
   const projectDirName = c.req.query('projectDirName');
   const lastQuery = c.req.query('last');
   const last = lastQuery ? parseInt(lastQuery, 10) : undefined;
   const agent = c.req.query('agent');
-  const messages = agent === 'codex'
-    ? await codexHistoryService.getConversation(sessionId)
+  const provider = agent && isAgentProvider(agent) ? agentHistoryProviders[agent] : undefined;
+  const messages = provider
+    ? await provider.getConversation(sessionId)
     : await sessionHistoryService.getConversation(sessionId, projectDirName);
   return c.json({ messages: last ? messages.slice(-last) : messages });
 });

--- a/backend/src/services/agent-providers.ts
+++ b/backend/src/services/agent-providers.ts
@@ -1,0 +1,47 @@
+import type { ConversationMessage, HistorySession } from '../../../shared/types';
+import type { ProjectInfo } from './session-history';
+
+/**
+ * Common surface for thread-based agents (Codex, Grok, ...). Claude stays on
+ * its own path (jsonl metadata + WebSocket stream); every other agent plugs in
+ * through these two interfaces, and the routes iterate provider maps instead
+ * of hardcoding a specific agent. Adding an agent = one registry entry in
+ * shared/types.ts + one implementation of each interface here.
+ */
+
+export interface AgentTokenUsage {
+  contextTokens?: number;
+  contextMaxTokens?: number;
+  contextPercent?: number;
+  totalInputTokens?: number;
+  totalCacheReadTokens?: number;
+  totalOutputTokens?: number;
+  totalTokens?: number;
+}
+
+/** Latest thread/session of an agent in a working directory. */
+export interface AgentThread {
+  sessionId: string;
+  title?: string;
+  firstPrompt?: string;
+  tokensUsed?: number;
+  tokenUsage?: AgentTokenUsage;
+  gitBranch?: string;
+  cwd: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** Resolves the latest thread per working directory for active sessions. */
+export interface AgentThreadService {
+  getThreadsForPaths(paths: string[]): Promise<Map<string, AgentThread>>;
+}
+
+/** Past-session history + conversation reader for one agent. */
+export interface AgentHistoryProvider {
+  getProjects(): Promise<ProjectInfo[]>;
+  getProjectSessions(dirName: string): Promise<HistorySession[]>;
+  getRecentSessions(limit?: number): Promise<HistorySession[]>;
+  searchSessions(query: string, limit?: number): Promise<HistorySession[]>;
+  getConversation(sessionId: string): Promise<ConversationMessage[]>;
+}

--- a/backend/src/services/agent-providers.ts
+++ b/backend/src/services/agent-providers.ts
@@ -17,6 +17,8 @@ export interface AgentTokenUsage {
   totalCacheReadTokens?: number;
   totalOutputTokens?: number;
   totalTokens?: number;
+  /** Latest model id the agent ran with (shown in the session list, #424). */
+  model?: string;
 }
 
 /** Latest thread/session of an agent in a working directory. */

--- a/backend/src/services/grok-history.ts
+++ b/backend/src/services/grok-history.ts
@@ -1,0 +1,220 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { ConversationMessage, HistorySession, ToolResultInfo, ToolUseInfo } from '../../../shared/types';
+import { claudeProjectDirName } from '../utils/claude-project-path';
+import type { AgentHistoryProvider } from './agent-providers';
+import { GrokSessionStore, type GrokSessionInfo } from './grok';
+import type { ProjectInfo } from './session-history';
+
+interface GrokChatRecord {
+  type?: string;
+  content?: unknown;
+  synthetic_reason?: string;
+  prompt_index?: number;
+  tool_calls?: Array<{ id?: string; name?: string; arguments?: string }>;
+  tool_call_id?: string;
+}
+
+/** Flatten a Grok content field (plain string or `[{type:'text',text}]` parts). */
+function contentText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    return value
+      .map((part) => (part && typeof part === 'object' && typeof (part as { text?: unknown }).text === 'string'
+        ? (part as { text: string }).text
+        : ''))
+      .filter(Boolean)
+      .join('\n');
+  }
+  return '';
+}
+
+/** Headless (`grok -p`) prompts arrive wrapped in `<user_query>` tags. */
+function stripUserQueryWrapper(text: string): string {
+  const match = text.match(/^\s*<user_query>\n?([\s\S]*?)\n?<\/user_query>\s*$/);
+  return match ? match[1] : text;
+}
+
+function parseToolArguments(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== 'string') return {};
+  try {
+    const value = JSON.parse(raw);
+    return value && typeof value === 'object' ? (value as Record<string, unknown>) : { value };
+  } catch {
+    return { raw };
+  }
+}
+
+/**
+ * Collapse a Grok `chat_history.jsonl` into Claude-shaped conversation turns:
+ *  - `user` with `prompt_index`      → role=user (real prompts; records with a
+ *    `synthetic_reason` or no index are injected context, not conversation)
+ *  - `assistant`                     → role=assistant text + ToolUseInfo from
+ *    `tool_calls`
+ *  - `tool_result`                   → ToolResultInfo on a user turn (toolName
+ *    resolved from the matching tool_call id)
+ *  - `system` / `reasoning`          → dropped (reasoning is encrypted)
+ */
+export function parseGrokChatHistory(text: string): ConversationMessage[] {
+  const messages: ConversationMessage[] = [];
+  let current: ConversationMessage | null = null;
+  const callIdToName = new Map<string, string>();
+
+  const flush = () => {
+    if (!current) return;
+    const hasContent = !!current.content || !!current.toolUse?.length || !!current.toolResult?.length;
+    if (hasContent) messages.push(current);
+    current = null;
+  };
+
+  const ensureRole = (role: 'user' | 'assistant'): ConversationMessage => {
+    if (current?.role !== role) {
+      flush();
+      current = { role, content: '' };
+    }
+    return current as ConversationMessage;
+  };
+
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let record: GrokChatRecord;
+    try {
+      record = JSON.parse(trimmed) as GrokChatRecord;
+    } catch {
+      continue;
+    }
+
+    if (record.type === 'user') {
+      if (record.synthetic_reason !== undefined || record.prompt_index === undefined) continue;
+      flush();
+      const content = stripUserQueryWrapper(contentText(record.content)).trim();
+      if (content) messages.push({ role: 'user', content });
+      continue;
+    }
+
+    if (record.type === 'assistant') {
+      const content = contentText(record.content);
+      const toolCalls = Array.isArray(record.tool_calls) ? record.tool_calls : [];
+      if (!content && toolCalls.length === 0) continue;
+      const turn = ensureRole('assistant');
+      if (content) {
+        turn.content = turn.content ? `${turn.content}\n\n${content}` : content;
+      }
+      for (const call of toolCalls) {
+        const id = typeof call.id === 'string' ? call.id : '';
+        const name = typeof call.name === 'string' ? call.name : 'tool';
+        if (id) callIdToName.set(id, name);
+        const tool: ToolUseInfo = { id, name, input: parseToolArguments(call.arguments) };
+        turn.toolUse = turn.toolUse ? [...turn.toolUse, tool] : [tool];
+      }
+      continue;
+    }
+
+    if (record.type === 'tool_result') {
+      const callId = typeof record.tool_call_id === 'string' ? record.tool_call_id : '';
+      const turn = ensureRole('user');
+      const result: ToolResultInfo = {
+        toolUseId: callId,
+        toolName: callIdToName.get(callId),
+        output: contentText(record.content),
+      };
+      turn.toolResult = turn.toolResult ? [...turn.toolResult, result] : [result];
+    }
+    // 'system' and 'reasoning' records are intentionally dropped.
+  }
+
+  flush();
+  return messages;
+}
+
+/** Reads Grok Build session history from `~/.grok/sessions`. */
+export class GrokHistoryService implements AgentHistoryProvider {
+  private store: GrokSessionStore;
+
+  constructor(store = new GrokSessionStore()) {
+    this.store = store;
+  }
+
+  async getProjects(): Promise<ProjectInfo[]> {
+    const sessions = await this.store.listSessions();
+    const byDir = new Map<string, ProjectInfo>();
+    for (const s of sessions) {
+      const dirName = claudeProjectDirName(s.cwd);
+      const existing = byDir.get(dirName);
+      if (existing) {
+        existing.sessionCount++;
+        if (!existing.latestModified || s.updatedAt > existing.latestModified) {
+          existing.latestModified = s.updatedAt;
+        }
+      } else {
+        byDir.set(dirName, {
+          dirName,
+          projectPath: s.cwd,
+          projectName: s.cwd.replace(/^\/home\/[^/]+\//, '~/'),
+          sessionCount: 1,
+          latestModified: s.updatedAt,
+        });
+      }
+    }
+    return Array.from(byDir.values());
+  }
+
+  async getProjectSessions(dirName: string): Promise<HistorySession[]> {
+    const sessions = await this.store.listSessions();
+    return sessions
+      .filter((s) => claudeProjectDirName(s.cwd) === dirName)
+      .map((s) => this.toHistorySession(s))
+      .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+  }
+
+  async getRecentSessions(limit = 30): Promise<HistorySession[]> {
+    const sessions = await this.store.listSessions();
+    return sessions
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .slice(0, limit)
+      .map((s) => this.toHistorySession(s));
+  }
+
+  async searchSessions(query: string, limit = 50): Promise<HistorySession[]> {
+    if (!query.trim()) return [];
+    const needle = query.toLowerCase();
+    const sessions = await this.store.listSessions();
+    const matches: HistorySession[] = [];
+    for (const s of sessions) {
+      const haystack = `${s.cwd} ${s.title ?? ''} ${s.firstPrompt ?? ''}`.toLowerCase();
+      if (haystack.includes(needle)) {
+        matches.push(this.toHistorySession(s));
+        if (matches.length >= limit) break;
+      }
+    }
+    matches.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+    return matches;
+  }
+
+  async getConversation(sessionId: string): Promise<ConversationMessage[]> {
+    const session = await this.store.findSession(sessionId);
+    if (!session) return [];
+    try {
+      const text = await readFile(join(session.dir, 'chat_history.jsonl'), 'utf8');
+      return parseGrokChatHistory(text);
+    } catch {
+      return [];
+    }
+  }
+
+  private toHistorySession(s: GrokSessionInfo): HistorySession {
+    return {
+      sessionId: s.sessionId,
+      projectPath: s.cwd,
+      projectName: s.cwd.replace(/^\/home\/[^/]+\//, '~/'),
+      firstPrompt: s.firstPrompt,
+      lastPrompt: s.firstPrompt,
+      summary: s.title,
+      // Grok transcripts have no recap (Claude-only feature).
+      recap: undefined,
+      modified: s.updatedAt,
+      agent: 'grok',
+    };
+  }
+}

--- a/backend/src/services/grok.ts
+++ b/backend/src/services/grok.ts
@@ -14,6 +14,7 @@ export interface GrokSessionInfo {
   firstPrompt?: string;
   createdAt?: string;
   updatedAt: string;
+  modelId?: string;
 }
 
 interface GrokSummaryJson {
@@ -23,6 +24,7 @@ interface GrokSummaryJson {
   created_at?: string;
   updated_at?: string;
   last_active_at?: string;
+  current_model_id?: string;
 }
 
 /**
@@ -102,6 +104,7 @@ export class GrokSessionStore {
           firstPrompt: firstPrompts.get(sessionId) ?? summary.session_summary,
           createdAt: summary.created_at,
           updatedAt,
+          modelId: summary.current_model_id,
         });
       }));
     }));
@@ -237,7 +240,7 @@ export class GrokService implements AgentThreadService {
         sessionId: s.sessionId,
         title: s.title,
         firstPrompt: s.firstPrompt,
-        tokenUsage,
+        tokenUsage: s.modelId ? { ...tokenUsage, model: s.modelId } : tokenUsage,
         cwd,
         createdAt: s.createdAt,
         updatedAt: s.updatedAt,

--- a/backend/src/services/grok.ts
+++ b/backend/src/services/grok.ts
@@ -1,0 +1,248 @@
+import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs';
+import { readFile, readdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { AgentThread, AgentThreadService, AgentTokenUsage } from './agent-providers';
+
+/** One Grok Build session as recorded under `~/.grok/sessions`. */
+export interface GrokSessionInfo {
+  sessionId: string;
+  cwd: string;
+  /** Absolute session directory (holds chat_history.jsonl etc.). */
+  dir: string;
+  title?: string;
+  firstPrompt?: string;
+  createdAt?: string;
+  updatedAt: string;
+}
+
+interface GrokSummaryJson {
+  info?: { id?: string; cwd?: string };
+  session_summary?: string;
+  generated_title?: string;
+  created_at?: string;
+  updated_at?: string;
+  last_active_at?: string;
+}
+
+/**
+ * Grok Build stores each session under
+ * `~/.grok/sessions/<URL-encoded cwd>/<session-uuid>/` with a `summary.json`
+ * (id / cwd / title / timestamps), the full conversation in
+ * `chat_history.jsonl`, and a `session/update` JSON-RPC stream in
+ * `updates.jsonl` whose `turn_completed` records carry token usage.
+ * Each project dir also has a `prompt_history.jsonl` with the real first
+ * prompt per session id.
+ *
+ * The scanner decodes the directory name instead of re-encoding cwds so it
+ * can never disagree with Grok's own percent-encoding.
+ */
+export class GrokSessionStore {
+  private sessionsDir: string;
+  private cache: { timestamp: number; sessions: GrokSessionInfo[] } | null = null;
+  private static readonly CACHE_TTL = 5000;
+
+  constructor(sessionsDir = join(homedir(), '.grok', 'sessions')) {
+    this.sessionsDir = sessionsDir;
+  }
+
+  async listSessions(): Promise<GrokSessionInfo[]> {
+    if (this.cache && Date.now() - this.cache.timestamp < GrokSessionStore.CACHE_TTL) {
+      return this.cache.sessions;
+    }
+    const sessions = await this.scan();
+    this.cache = { timestamp: Date.now(), sessions };
+    return sessions;
+  }
+
+  async findSession(sessionId: string): Promise<GrokSessionInfo | undefined> {
+    const sessions = await this.listSessions();
+    return sessions.find((s) => s.sessionId === sessionId);
+  }
+
+  private async scan(): Promise<GrokSessionInfo[]> {
+    let projectDirs: string[];
+    try {
+      projectDirs = await readdir(this.sessionsDir);
+    } catch {
+      return [];
+    }
+
+    const results: GrokSessionInfo[] = [];
+    await Promise.all(projectDirs.map(async (encoded) => {
+      let cwd: string;
+      try {
+        cwd = decodeURIComponent(encoded);
+      } catch {
+        return;
+      }
+      if (!cwd.startsWith('/')) return; // sqlite / lock files etc.
+      const projectDir = join(this.sessionsDir, encoded);
+
+      let entries: string[];
+      try {
+        entries = await readdir(projectDir);
+      } catch {
+        return;
+      }
+      const firstPrompts = await this.readPromptHistory(join(projectDir, 'prompt_history.jsonl'));
+
+      await Promise.all(entries.map(async (name) => {
+        const sessionDir = join(projectDir, name);
+        const summary = await this.readSummary(join(sessionDir, 'summary.json'));
+        if (!summary) return;
+        const sessionId = summary.info?.id ?? name;
+        const updatedAt = summary.last_active_at ?? summary.updated_at ?? summary.created_at;
+        if (!updatedAt) return;
+        results.push({
+          sessionId,
+          cwd: summary.info?.cwd ?? cwd,
+          dir: sessionDir,
+          title: summary.generated_title ?? summary.session_summary,
+          firstPrompt: firstPrompts.get(sessionId) ?? summary.session_summary,
+          createdAt: summary.created_at,
+          updatedAt,
+        });
+      }));
+    }));
+    return results;
+  }
+
+  private async readSummary(path: string): Promise<GrokSummaryJson | null> {
+    try {
+      return JSON.parse(await readFile(path, 'utf8')) as GrokSummaryJson;
+    } catch {
+      return null;
+    }
+  }
+
+  /** First prompt per session id from the project-level prompt_history.jsonl. */
+  private async readPromptHistory(path: string): Promise<Map<string, string>> {
+    const result = new Map<string, string>();
+    let content: string;
+    try {
+      content = await readFile(path, 'utf8');
+    } catch {
+      return result;
+    }
+    for (const line of content.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line) as { session_id?: string; prompt?: string };
+        if (entry.session_id && entry.prompt && !result.has(entry.session_id)) {
+          result.set(entry.session_id, entry.prompt);
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+    return result;
+  }
+}
+
+interface GrokTurnUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cachedReadTokens?: number;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Tail-read updates.jsonl and return the usage block of the last
+ * `turn_completed` record. Bounded read (like the Codex reader) so multi-MB
+ * streams don't get re-parsed on every sessions push.
+ */
+export function readLatestGrokTokenUsage(sessionDir: string): AgentTokenUsage | undefined {
+  const updatesPath = join(sessionDir, 'updates.jsonl');
+  if (!existsSync(updatesPath)) return undefined;
+  let text: string;
+  try {
+    const stat = statSync(updatesPath);
+    const maxTailBytes = 1024 * 1024;
+    if (stat.size <= maxTailBytes) {
+      const fd = openSync(updatesPath, 'r');
+      try {
+        const buffer = Buffer.alloc(stat.size);
+        readSync(fd, buffer, 0, stat.size, 0);
+        text = buffer.toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+    } else {
+      const fd = openSync(updatesPath, 'r');
+      try {
+        const buffer = Buffer.alloc(maxTailBytes);
+        readSync(fd, buffer, 0, maxTailBytes, stat.size - maxTailBytes);
+        text = buffer.toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  const lines = text.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line?.includes('"turn_completed"')) continue;
+    try {
+      const record = JSON.parse(line) as {
+        params?: { update?: { sessionUpdate?: string; usage?: GrokTurnUsage } };
+      };
+      const update = record.params?.update;
+      if (update?.sessionUpdate !== 'turn_completed' || !update.usage) continue;
+      const usage = update.usage;
+      return {
+        totalInputTokens: numberOrUndefined(usage.inputTokens),
+        totalOutputTokens: numberOrUndefined(usage.outputTokens),
+        totalCacheReadTokens: numberOrUndefined(usage.cachedReadTokens),
+        totalTokens: numberOrUndefined(usage.totalTokens),
+      };
+    } catch {
+      // partial first line of the tail slice, or a malformed record
+    }
+  }
+  return undefined;
+}
+
+/** Latest Grok session per working directory, for the active-sessions list. */
+export class GrokService implements AgentThreadService {
+  private store: GrokSessionStore;
+
+  constructor(store = new GrokSessionStore()) {
+    this.store = store;
+  }
+
+  async getThreadsForPaths(paths: string[]): Promise<Map<string, AgentThread>> {
+    const uniquePaths = new Set(paths.filter(Boolean));
+    if (uniquePaths.size === 0) return new Map();
+
+    const sessions = await this.store.listSessions();
+    const latestByCwd = new Map<string, GrokSessionInfo>();
+    for (const s of sessions) {
+      if (!uniquePaths.has(s.cwd)) continue;
+      const existing = latestByCwd.get(s.cwd);
+      if (!existing || s.updatedAt > existing.updatedAt) latestByCwd.set(s.cwd, s);
+    }
+
+    const result = new Map<string, AgentThread>();
+    for (const [cwd, s] of latestByCwd) {
+      const tokenUsage = readLatestGrokTokenUsage(s.dir);
+      result.set(cwd, {
+        sessionId: s.sessionId,
+        title: s.title,
+        firstPrompt: s.firstPrompt,
+        tokenUsage,
+        cwd,
+        createdAt: s.createdAt,
+        updatedAt: s.updatedAt,
+      });
+    }
+    return result;
+  }
+}

--- a/backend/src/services/hook-status.ts
+++ b/backend/src/services/hook-status.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -26,6 +26,7 @@ type HookStatus = HookProviderStatus & {
   providers: {
     claude: HookProviderStatus;
     codex: HookProviderStatus;
+    grok: HookProviderStatus;
   };
 };
 
@@ -169,24 +170,43 @@ async function getProviderStatus(paths: string[]): Promise<HookProviderStatus> {
   return finalizeHookStatus(aggregated);
 }
 
+/** All .json files in a directory (for Grok's native `~/.grok/hooks/`). */
+async function listJsonFiles(dir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir);
+    return entries.filter((name) => name.endsWith('.json')).map((name) => join(dir, name));
+  } catch {
+    return [];
+  }
+}
+
 export async function getHookStatus(): Promise<HookStatus> {
   const cwd = process.cwd();
-  const claude = await getProviderStatus([
+  const claudePaths = [
     join(cwd, '.claude', 'settings.json'),
     join(cwd, '.claude', 'hooks.json'),
     join(homedir(), '.claude', 'settings.json'),
     join(homedir(), '.claude', 'hooks.json'),
-  ]);
+  ];
+  const claude = await getProviderStatus(claudePaths);
   const codex = await getProviderStatus([
     join(cwd, '.codex', 'config.toml'),
     join(cwd, '.codex', 'hooks.json'),
     join(homedir(), '.codex', 'config.toml'),
     join(homedir(), '.codex', 'hooks.json'),
   ]);
+  // Grok Build scans Claude's settings.json hooks by default (compat layer),
+  // plus its own native hook files (same JSON shape as Claude's settings).
+  const grok = await getProviderStatus([
+    ...claudePaths,
+    ...(await listJsonFiles(join(homedir(), '.grok', 'hooks'))),
+  ]);
 
+  const providers = { claude, codex, grok };
+  const providerList = Object.values(providers);
   const events = {
-    stop: claude.events.stop || codex.events.stop,
-    askUserQuestion: claude.events.askUserQuestion || codex.events.askUserQuestion,
+    stop: providerList.some((p) => p.events.stop),
+    askUserQuestion: providerList.some((p) => p.events.askUserQuestion),
   };
 
   const missing = Object.entries(events)
@@ -194,9 +214,9 @@ export async function getHookStatus(): Promise<HookStatus> {
     .map(([key]) => key as keyof HookEventStatus);
 
   return {
-    configured: claude.configured || codex.configured,
+    configured: providerList.some((p) => p.configured),
     events,
     missing,
-    providers: { claude, codex },
+    providers,
   };
 }

--- a/backend/tests/unit/agent-providers.test.ts
+++ b/backend/tests/unit/agent-providers.test.ts
@@ -6,6 +6,7 @@ import {
   agentResumeCommand,
   agentSupportsConversationMetadata,
   detectAgentProviderFromArgs,
+  threadAgentOf,
 } from '../../../shared/types';
 import { homedir } from 'node:os';
 import { agentStartCommand, expandHome, findDuplicateAgentWorkingDirSession, shellQuote } from '../../src/routes/sessions';
@@ -29,6 +30,12 @@ describe('Agent provider registry', () => {
     expect(parsed.agent).toBe('codex');
   });
 
+  test('accepts Grok as a create-session agent', () => {
+    const parsed = CreateSessionSchema.parse({ name: 'example', agent: 'grok' });
+
+    expect(parsed.agent).toBe('grok');
+  });
+
   test('rejects unsupported create-session agents', () => {
     const parsed = CreateSessionSchema.safeParse({ name: 'example', agent: 'gemini' });
 
@@ -41,11 +48,22 @@ describe('Agent provider registry', () => {
     expect(detectAgentProviderFromArgs('/home/user/.local/share/claude/versions/2.1.123/claude')).toBe('claude');
     expect(detectAgentProviderFromArgs('codex')).toBe('codex');
     expect(detectAgentProviderFromArgs('/home/user/.bun/install/global/node_modules/@openai/codex/bin/codex.js')).toBe('codex');
+    expect(detectAgentProviderFromArgs('grok')).toBe('grok');
+    expect(detectAgentProviderFromArgs('/home/user/.grok/bin/grok -p prompt')).toBe('grok');
   });
 
   test('does not detect provider names inside unrelated paths', () => {
     expect(detectAgentProviderFromArgs('/tmp/.claude/shell-snapshots/claude-foo-cwd')).toBeUndefined();
     expect(detectAgentProviderFromArgs('/tmp/codex-project/run.sh')).toBeUndefined();
+    expect(detectAgentProviderFromArgs('vim /home/user/.grok/config.toml')).toBeUndefined();
+  });
+
+  test('threadAgentOf identifies thread-based agents only', () => {
+    expect(threadAgentOf('codex')).toBe('codex');
+    expect(threadAgentOf('grok')).toBe('grok');
+    expect(threadAgentOf('claude')).toBeUndefined();
+    expect(threadAgentOf('bash')).toBeUndefined();
+    expect(threadAgentOf(undefined)).toBeUndefined();
   });
 
   test('exposes provider capabilities', () => {
@@ -92,5 +110,7 @@ describe('Agent provider registry', () => {
     expect(agentResumeCommand('claude', 'abc-123')).toBe("claude -r 'abc-123'");
     expect(agentResumeCommand('codex')).toBe('codex resume');
     expect(agentResumeCommand('codex', 'thread-xyz')).toBe("codex resume 'thread-xyz'");
+    expect(agentResumeCommand('grok')).toBe('grok --resume');
+    expect(agentResumeCommand('grok', 'session-abc')).toBe("grok --resume 'session-abc'");
   });
 });

--- a/backend/tests/unit/grok-service.test.ts
+++ b/backend/tests/unit/grok-service.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { GrokService, GrokSessionStore, readLatestGrokTokenUsage } from '../../src/services/grok';
+import { GrokHistoryService, parseGrokChatHistory } from '../../src/services/grok-history';
+import { claudeProjectDirName } from '../../src/utils/claude-project-path';
+
+const TEST_DIR = join(tmpdir(), `cchub-grok-service-${Date.now()}`);
+const SESSIONS_DIR = join(TEST_DIR, 'sessions');
+
+const CWD = '/home/user/my-project';
+// Grok percent-encodes the cwd for the project directory name.
+const ENCODED_CWD = encodeURIComponent(CWD);
+const SESSION_ID = '019f7599-9759-78b1-9141-e8f187717ba5';
+
+function summaryJson(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    info: { id: SESSION_ID, cwd: CWD },
+    session_summary: 'Run the shell command: echo hello',
+    created_at: '2026-07-18T14:20:27.905723571Z',
+    updated_at: '2026-07-18T14:21:00.578011476Z',
+    last_active_at: '2026-07-18T14:21:00.578011476Z',
+    num_messages: 12,
+    current_model_id: 'grok-4.5',
+    generated_title: 'Run the shell command: echo hello',
+    ...overrides,
+  });
+}
+
+// Verbatim record shapes from a real grok 0.2.103 chat_history.jsonl.
+const CHAT_HISTORY = [
+  JSON.stringify({ type: 'system', content: 'You are Grok 4.5 released by xAI.' }),
+  JSON.stringify({ type: 'user', content: [{ type: 'text', text: 'env context' }] }),
+  JSON.stringify({ type: 'user', content: [{ type: 'text', text: 'CLAUDE.md contents' }], synthetic_reason: 'project_instructions' }),
+  JSON.stringify({ type: 'user', content: [{ type: 'text', text: 'reminder' }], synthetic_reason: 'system_reminder' }),
+  JSON.stringify({ type: 'user', content: [{ type: 'text', text: '<user_query>\nRun the shell command: echo hello\n</user_query>' }], prompt_index: 0 }),
+  JSON.stringify({ type: 'reasoning', id: 'rs_1', summary: [], encrypted_content: 'xxxx', status: 'completed' }),
+  JSON.stringify({
+    type: 'assistant',
+    content: '',
+    tool_calls: [{ id: 'call-1-0', name: 'run_terminal_command', arguments: '{"command":"echo hello"}' }],
+    model_id: 'grok-4.5-build-free',
+  }),
+  JSON.stringify({ type: 'tool_result', tool_call_id: 'call-1-0', content: 'exit: 0\nhello\n' }),
+  JSON.stringify({ type: 'assistant', content: 'It printed `hello`.', model_id: 'grok-4.5-build-free' }),
+].join('\n');
+
+const UPDATES_JSONL = [
+  JSON.stringify({
+    timestamp: 1784383666,
+    method: 'session/update',
+    params: { sessionId: SESSION_ID, update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'It printed' } } },
+  }),
+  JSON.stringify({
+    timestamp: 1784383667,
+    method: 'session/update',
+    params: {
+      sessionId: SESSION_ID,
+      update: {
+        sessionUpdate: 'turn_completed',
+        prompt_id: 'p-1',
+        stop_reason: 'end_turn',
+        usage: { inputTokens: 26109, outputTokens: 83, totalTokens: 26192, cachedReadTokens: 0 },
+      },
+    },
+  }),
+].join('\n');
+
+beforeEach(async () => {
+  const sessionDir = join(SESSIONS_DIR, ENCODED_CWD, SESSION_ID);
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(join(sessionDir, 'summary.json'), summaryJson());
+  await writeFile(join(sessionDir, 'chat_history.jsonl'), CHAT_HISTORY);
+  await writeFile(join(sessionDir, 'updates.jsonl'), UPDATES_JSONL);
+  await writeFile(
+    join(SESSIONS_DIR, ENCODED_CWD, 'prompt_history.jsonl'),
+    `${JSON.stringify({ timestamp: '2026-07-18T14:20:29Z', session_id: SESSION_ID, prompt: 'Run the shell command: echo hello. Then report.', is_bash: false })}\n`,
+  );
+  // Non-project files that live alongside the encoded dirs must be skipped.
+  await writeFile(join(SESSIONS_DIR, 'session_search.sqlite'), '');
+});
+
+afterEach(async () => {
+  await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('parseGrokChatHistory', () => {
+  test('collapses records into Claude-shaped turns', () => {
+    const messages = parseGrokChatHistory(CHAT_HISTORY);
+    expect(messages).toHaveLength(4);
+
+    // Real prompt only (system / synthetic / no-index user records dropped),
+    // with the <user_query> wrapper stripped.
+    expect(messages[0]).toEqual({ role: 'user', content: 'Run the shell command: echo hello' });
+
+    expect(messages[1]?.role).toBe('assistant');
+    expect(messages[1]?.toolUse).toEqual([
+      { id: 'call-1-0', name: 'run_terminal_command', input: { command: 'echo hello' } },
+    ]);
+
+    expect(messages[2]?.role).toBe('user');
+    expect(messages[2]?.toolResult).toEqual([
+      { toolUseId: 'call-1-0', toolName: 'run_terminal_command', output: 'exit: 0\nhello\n' },
+    ]);
+
+    expect(messages[3]).toEqual({ role: 'assistant', content: 'It printed `hello`.' });
+  });
+
+  test('returns empty for garbage input', () => {
+    expect(parseGrokChatHistory('not json\n{"type":"reasoning"}')).toEqual([]);
+  });
+});
+
+describe('GrokService', () => {
+  test('resolves the latest thread per cwd with token usage', async () => {
+    const service = new GrokService(new GrokSessionStore(SESSIONS_DIR));
+    const threads = await service.getThreadsForPaths([CWD, '/nonexistent']);
+    expect(threads.size).toBe(1);
+    const thread = threads.get(CWD);
+    expect(thread?.sessionId).toBe(SESSION_ID);
+    expect(thread?.title).toBe('Run the shell command: echo hello');
+    expect(thread?.firstPrompt).toBe('Run the shell command: echo hello. Then report.');
+    expect(thread?.tokenUsage?.totalTokens).toBe(26192);
+    expect(thread?.tokenUsage?.totalOutputTokens).toBe(83);
+  });
+
+  test('returns empty map when the sessions dir does not exist', async () => {
+    const service = new GrokService(new GrokSessionStore(join(TEST_DIR, 'missing')));
+    expect((await service.getThreadsForPaths([CWD])).size).toBe(0);
+  });
+});
+
+describe('readLatestGrokTokenUsage', () => {
+  test('reads usage from the last turn_completed record', () => {
+    const usage = readLatestGrokTokenUsage(join(SESSIONS_DIR, ENCODED_CWD, SESSION_ID));
+    expect(usage).toEqual({
+      totalInputTokens: 26109,
+      totalOutputTokens: 83,
+      totalCacheReadTokens: 0,
+      totalTokens: 26192,
+    });
+  });
+});
+
+describe('GrokHistoryService', () => {
+  test('groups sessions into Claude-encoded project buckets', async () => {
+    const service = new GrokHistoryService(new GrokSessionStore(SESSIONS_DIR));
+    const projects = await service.getProjects();
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.dirName).toBe(claudeProjectDirName(CWD));
+    expect(projects[0]?.projectPath).toBe(CWD);
+    expect(projects[0]?.sessionCount).toBe(1);
+  });
+
+  test('lists project sessions tagged agent=grok', async () => {
+    const service = new GrokHistoryService(new GrokSessionStore(SESSIONS_DIR));
+    const sessions = await service.getProjectSessions(claudeProjectDirName(CWD));
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.sessionId).toBe(SESSION_ID);
+    expect(sessions[0]?.agent).toBe('grok');
+    expect(sessions[0]?.firstPrompt).toBe('Run the shell command: echo hello. Then report.');
+  });
+
+  test('search matches cwd and prompts', async () => {
+    const service = new GrokHistoryService(new GrokSessionStore(SESSIONS_DIR));
+    expect(await service.searchSessions('echo hello')).toHaveLength(1);
+    expect(await service.searchSessions('no-such-text')).toHaveLength(0);
+  });
+
+  test('reads a conversation by session id', async () => {
+    const service = new GrokHistoryService(new GrokSessionStore(SESSIONS_DIR));
+    const messages = await service.getConversation(SESSION_ID);
+    expect(messages).toHaveLength(4);
+    expect(await service.getConversation('unknown-id')).toEqual([]);
+  });
+});

--- a/backend/tests/unit/hook-status.test.ts
+++ b/backend/tests/unit/hook-status.test.ts
@@ -144,4 +144,37 @@ command = "cchub notify"
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test('grok provider follows Claude-compat hook files', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cchub-hook-status-'));
+    const claudeDir = join(dir, '.claude');
+    const originalCwd = process.cwd();
+
+    try {
+      mkdirSync(claudeDir, { recursive: true });
+      // Grok Build scans Claude's settings.json hooks by default, so a
+      // cchub-notify entry there configures grok too.
+      writeFileSync(
+        join(claudeDir, 'settings.json'),
+        JSON.stringify({
+          hooks: {
+            Stop: [{ hooks: [{ type: 'command', command: 'cchub notify' }] }],
+            PostToolUse: [{ matcher: 'AskUserQuestion', hooks: [{ type: 'command', command: 'cchub notify' }] }],
+          },
+        }),
+      );
+
+      process.chdir(dir);
+      const status = await getHookStatus();
+
+      expect(status.providers.grok.configured).toBe(true);
+      expect(status.providers.grok.events).toEqual({
+        stop: true,
+        askUserQuestion: true,
+      });
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/backend/tests/unit/notify-normalize.test.ts
+++ b/backend/tests/unit/notify-normalize.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeHookBody } from '../../src/routes/notify';
+
+describe('normalizeHookBody', () => {
+  test('maps Grok camelCase hook fields onto Claude names', () => {
+    // Verbatim shape of a grok 0.2.103 Stop hook stdin payload.
+    const normalized = normalizeHookBody({
+      hookEventName: 'stop',
+      sessionId: '019f759e-35bb-7d72-8a9e-17f1601318a3',
+      cwd: '/home/user/project',
+      workspaceRoot: '/home/user/project',
+      timestamp: '2026-07-18T14:25:47.529937971+00:00',
+      transcriptPath: '/home/user/.grok/sessions/%2Fhome%2Fuser%2Fproject/019f759e/updates.jsonl',
+      promptId: '21289f19-f3be-44fb-acdb-44b3094c8f21',
+      reason: 'end_turn',
+    });
+
+    expect(normalized.hook_event_name).toBe('Stop');
+    expect(normalized.session_id).toBe('019f759e-35bb-7d72-8a9e-17f1601318a3');
+    expect(normalized.transcript_path).toBe(
+      '/home/user/.grok/sessions/%2Fhome%2Fuser%2Fproject/019f759e/updates.jsonl',
+    );
+    expect(normalized.cwd).toBe('/home/user/project');
+    // camelCase originals are consumed, not duplicated
+    expect(normalized.hookEventName).toBeUndefined();
+    expect(normalized.sessionId).toBeUndefined();
+  });
+
+  test('maps grok tool events and tool names', () => {
+    const normalized = normalizeHookBody({
+      hookEventName: 'post_tool_use',
+      sessionId: 'abc-123',
+      toolName: 'run_terminal_command',
+    });
+    expect(normalized.hook_event_name).toBe('PostToolUse');
+    expect(normalized.tool_name).toBe('run_terminal_command');
+  });
+
+  test('passes Claude-shaped bodies through untouched', () => {
+    const body = {
+      hook_event_name: 'Stop',
+      session_id: 'abc-123',
+      cwd: '/home/user/project',
+      transcript_path: '/home/user/.claude/projects/x/abc.jsonl',
+    };
+    expect(normalizeHookBody(body)).toBe(body);
+  });
+
+  test('leaves unknown event names as-is after normalization', () => {
+    const normalized = normalizeHookBody({ hookEventName: 'something_new', sessionId: 's1' });
+    expect(normalized.hook_event_name).toBe('something_new');
+    expect(normalized.session_id).toBe('s1');
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,13 +12,14 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type {
-	AgentProvider,
-	ExtendedSessionResponse,
-	IndicatorState,
-	PaneInfo,
-	SessionState,
-	SessionTheme,
+import {
+	type AgentProvider,
+	type ExtendedSessionResponse,
+	type IndicatorState,
+	type PaneInfo,
+	type SessionState,
+	type SessionTheme,
+	threadAgentOf,
 } from "../../shared/types";
 import { ChatView } from "./components/chat/ChatView";
 import { DesktopLayout } from "./components/DesktopLayout";
@@ -645,16 +646,15 @@ export function App() {
 	const handleSelectSession = useCallback(
 		async (session: ExtendedSessionResponse) => {
 			// Lost session: resume with the original agent's resume command when we have
-			// a conversation id (Claude → ccSessionId, Codex → agentSessionId), otherwise
-			// recreate a fresh session preserving the original agent.
+			// a conversation id (Claude → ccSessionId, thread agents → agentSessionId),
+			// otherwise recreate a fresh session preserving the original agent.
 			if (session.state === "lost") {
 				try {
 					let newSessionId: string;
 					let newSessionName: string;
-					const conversationId =
-						session.agent === "codex"
-							? session.agentSessionId
-							: session.ccSessionId;
+					const conversationId = threadAgentOf(session.agent)
+						? session.agentSessionId
+						: session.ccSessionId;
 					if (conversationId && session.currentPath) {
 						const response = await authFetch(
 							`${API_BASE}/api/sessions/history/resume`,

--- a/frontend/src/components/ConversationViewer.tsx
+++ b/frontend/src/components/ConversationViewer.tsx
@@ -6,12 +6,15 @@ import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import type {
-	ConversationMessage,
-	SessionTheme,
-	ToolResultInfo,
-	ToolUseInfo,
+import {
+	type AgentProvider,
+	type ConversationMessage,
+	type SessionTheme,
+	type ToolResultInfo,
+	type ToolUseInfo,
+	isAgentProvider,
 } from "../../../shared/types";
+import { agentBadge } from "../utils/agentDisplay";
 import { getTerminalThemes } from "./terminal-themes";
 
 const API_BASE = import.meta.env.VITE_API_URL || "";
@@ -408,19 +411,20 @@ const markdownComponents = {
 // Role → sidebar bar color + role-label color.
 // Terminal-style compact layout: a thin colored bar at the left edge
 // identifies the speaker; the role label sits on its own dim line and
-// the body is indented under the bar.
-function getRoleColors(kind: "you" | "claude" | "codex" | "system" | "summary") {
+// the body is indented under the bar. Agent kinds pull their colors from
+// the per-provider styles in agentDisplay.ts.
+function getRoleColors(kind: "you" | "system" | "summary" | AgentProvider) {
 	switch (kind) {
 		case "you":
 			return { bar: "bg-blue-400/70", label: "text-blue-300" };
-		case "claude":
-			return { bar: "bg-violet-400/70", label: "text-violet-300" };
-		case "codex":
-			return { bar: "bg-cyan-400/70", label: "text-cyan-300" };
 		case "summary":
 			return { bar: "bg-amber-400/70", label: "text-amber-300" };
-		default:
+		case "system":
 			return { bar: "bg-zinc-500/50", label: "text-zinc-500" };
+		default: {
+			const badge = agentBadge(kind);
+			return { bar: badge.barClassName, label: badge.labelClassName };
+		}
 	}
 }
 
@@ -446,7 +450,7 @@ const MessageItem = memo(function MessageItem({
 		msg.role === "user" && msg.content && isSystemSummary(msg.content);
 
 	let displayRole: string;
-	let kind: "you" | "claude" | "codex" | "system" | "summary";
+	let kind: "you" | "system" | "summary" | AgentProvider;
 
 	if (isSummaryMessage) {
 		displayRole = t("conversation.systemSummary");
@@ -457,12 +461,10 @@ const MessageItem = memo(function MessageItem({
 	} else if (msg.role === "user") {
 		displayRole = t("conversation.you");
 		kind = "you";
-	} else if (agent === "codex") {
-		displayRole = t("conversation.codex");
-		kind = "codex";
 	} else {
-		displayRole = t("conversation.claude");
-		kind = "claude";
+		// Assistant turn: label and color come from the session's provider.
+		kind = agent && isAgentProvider(agent) ? agent : "claude";
+		displayRole = t(`conversation.${kind}`);
 	}
 
 	const { bar, label } = getRoleColors(kind);

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -7,11 +7,12 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type {
-	AgentProvider,
-	PaneInfo,
-	SessionState,
-	SessionTheme,
+import {
+	type AgentProvider,
+	type PaneInfo,
+	type SessionState,
+	type SessionTheme,
+	isAgentProvider,
 } from "../../../shared/types";
 import { authFetch } from "../services/api";
 import { openClaudeAppSession } from "../utils/claude-app";
@@ -306,9 +307,9 @@ function TerminalPane({
 	// first render after remount (e.g. after a split) sees panes=undefined and
 	// would wrongly clear chat mode.
 	const activeTmuxPane = session?.panes?.find((p) => p.isActive);
-	const claudeRunning = activeTmuxPane?.currentCommand === "claude";
-	const codexRunning = activeTmuxPane?.currentCommand === "codex";
-	const conversationAvailable = claudeRunning || codexRunning;
+	const conversationAvailable = isAgentProvider(
+		activeTmuxPane?.currentCommand ?? "",
+	);
 	const panesLoaded = !!session?.panes;
 	useEffect(() => {
 		if (!panesLoaded) return;

--- a/frontend/src/components/SessionHistory.tsx
+++ b/frontend/src/components/SessionHistory.tsx
@@ -21,6 +21,7 @@ import {
 	useSessionHistory,
 } from "../hooks/useSessionHistory";
 import { authFetch } from "../services/api";
+import { agentBadge } from "../utils/agentDisplay";
 import { formatRelativeTime } from "../utils/format";
 import { ConversationViewer } from "./ConversationViewer";
 
@@ -80,11 +81,7 @@ function HistoryItem({
 	const messageCount = session.messageCount;
 	const gitBranch = session.gitBranch;
 
-	const agent = session.agent ?? "claude";
-	const agentBadge =
-		agent === "codex"
-			? { label: "Codex", className: "text-cyan-300 bg-cyan-400/10 border-cyan-400/20" }
-			: { label: "Claude", className: "text-violet-300 bg-violet-400/10 border-violet-400/20" };
+	const badge = agentBadge(session.agent);
 
 	return (
 		<div
@@ -109,9 +106,9 @@ function HistoryItem({
 					)}
 					<div className="flex items-center gap-3 mt-1.5 text-[11px] text-zinc-600">
 						<span
-							className={`inline-flex items-center px-1.5 py-px rounded border text-[10px] font-medium ${agentBadge.className}`}
+							className={`inline-flex items-center px-1.5 py-px rounded border text-[10px] font-medium ${badge.badgeClassName}`}
 						>
-							{agentBadge.label}
+							{badge.label}
 						</span>
 						<span>
 							{formatRelativeTime(session.modified, t, i18n.language)}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -35,6 +35,7 @@ import {
 	type PeerClientView,
 	type SessionResponse,
 	type SessionTheme,
+	threadAgentOf,
 } from "../../../shared/types";
 import { openClaudeAppSession } from "../utils/claude-app";
 import { usePeers } from "../hooks/usePeers";
@@ -458,7 +459,7 @@ function CreateSessionModal({
 					<div className="text-xs text-th-text-secondary mb-1">
 						{t("session.agent")}
 					</div>
-					<div className="grid grid-cols-2 gap-2">
+					<div className="grid grid-cols-3 gap-2">
 						{AGENT_PROVIDER_IDS.map((option) => (
 							<button
 								key={option}
@@ -1368,13 +1369,13 @@ export function SessionList({
 			try {
 				const session = sessions.find((s) => s.id === sessionId);
 				const isLost = session?.state === "lost";
-				// Per-agent conversation id: Claude → ccSessionId, Codex → agentSessionId.
-				// Pick the one matching the session's agent so we don't accidentally
-				// hand a Codex thread id to `claude -r` (or vice versa).
-				const conversationId =
-					session?.agent === "codex"
-						? session.agentSessionId
-						: (ccSessionId ?? session?.ccSessionId);
+				// Per-agent conversation id: Claude → ccSessionId, thread agents
+				// (codex / grok / ...) → agentSessionId. Pick the one matching the
+				// session's agent so we don't accidentally hand a Codex thread id to
+				// `claude -r` (or vice versa).
+				const conversationId = threadAgentOf(session?.agent)
+					? session?.agentSessionId
+					: (ccSessionId ?? session?.ccSessionId);
 
 				if (isLost && session?.currentPath) {
 					if (conversationId) {

--- a/frontend/src/components/history/HistoryRowV2.tsx
+++ b/frontend/src/components/history/HistoryRowV2.tsx
@@ -2,6 +2,7 @@
 import { Clock, FolderOpen, MessageCircle, Tag } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { HistorySession } from "../../../../shared/types";
+import { agentBadge } from "../../utils/agentDisplay";
 import { formatDuration, formatRelativeTime } from "../../utils/format";
 
 interface HistoryRowV2Props {
@@ -37,17 +38,7 @@ export function HistoryRowV2({
 		displayText.length > 70 ? `${displayText.substring(0, 70)}…` : displayText;
 
 	const duration = formatDuration(session.durationMinutes, t);
-	const agent = session.agent ?? "claude";
-	const agentBadge =
-		agent === "codex"
-			? {
-					label: "Codex",
-					className: "text-cyan-300 bg-cyan-400/10 border-cyan-400/20",
-				}
-			: {
-					label: "Claude",
-					className: "text-violet-300 bg-violet-400/10 border-violet-400/20",
-				};
+	const badge = agentBadge(session.agent);
 
 	const showPeer =
 		session.peerId && session.peerId !== "local" && session.peerNickname;
@@ -68,9 +59,9 @@ export function HistoryRowV2({
 						<FolderOpen className="w-3 h-3 shrink-0" />
 						<span className="truncate">{session.projectName}</span>
 						<span
-							className={`shrink-0 inline-flex items-center px-1.5 py-px rounded border text-[10px] font-medium ${agentBadge.className}`}
+							className={`shrink-0 inline-flex items-center px-1.5 py-px rounded border text-[10px] font-medium ${badge.badgeClassName}`}
 						>
-							{agentBadge.label}
+							{badge.label}
 						</span>
 						{showPeer && (
 							<span

--- a/frontend/src/hooks/useAgentConversation.ts
+++ b/frontend/src/hooks/useAgentConversation.ts
@@ -1,6 +1,11 @@
-import type { AgentProvider, ConversationMessage } from "../../../shared/types";
-import { useCodexConversation } from "./useCodexConversation";
+import {
+	type AgentProvider,
+	type ConversationMessage,
+	agentSupportsConversationMetadata,
+	threadAgentOf,
+} from "../../../shared/types";
 import { useConversationStream } from "./useConversationStream";
+import { useThreadConversation } from "./useThreadConversation";
 
 export interface UseAgentConversationOptions {
 	/** Provider for the active session. Drives which underlying source is read. */
@@ -33,10 +38,10 @@ export interface UseAgentConversationResult {
 /**
  * Single entry point ChatView uses to read a session's conversation.
  *
- * Each provider has its own delivery mechanism (WebSocket push for Claude,
- * HTTP polling for Codex), but the consumer only needs `messages` /
- * `isReady` / `conversationId`. Adding a new provider means adding a new
- * branch here, not editing ChatView.
+ * Delivery is chosen from the shared registry: Claude-style agents
+ * (`supportsConversationMetadata`) stream over the WebSocket; thread agents
+ * (Codex, Grok, ...) poll their transcript over HTTP. Adding a provider to
+ * `AGENT_PROVIDERS` wires it up here with no further edits.
  */
 export function useAgentConversation({
 	agent,
@@ -44,38 +49,40 @@ export function useAgentConversation({
 	agentSessionId,
 	enabled = true,
 }: UseAgentConversationOptions): UseAgentConversationResult {
+	const isStream = agentSupportsConversationMetadata(agent);
+	const threadAgent = threadAgentOf(agent);
 	const claude = useConversationStream({
 		sessionId,
-		enabled: enabled && agent === "claude",
+		enabled: enabled && isStream,
 	});
-	const codex = useCodexConversation({
+	const thread = useThreadConversation({
+		agent: threadAgent,
 		threadId: agentSessionId,
-		enabled: enabled && agent === "codex",
+		enabled: enabled && !!threadAgent,
 	});
 
-	switch (agent) {
-		case "claude":
-			return {
-				messages: claude.messages,
-				isReady: claude.isReady,
-				conversationId: claude.ccSessionId,
-				error: null,
-			};
-		case "codex":
-			return {
-				messages: codex.messages,
-				isReady: codex.isReady,
-				conversationId: agentSessionId ?? null,
-				error: null,
-			};
-		default:
-			// `isReady=true` so consumers fall through to their error state instead
-			// of showing a loading skeleton that would never resolve.
-			return {
-				messages: [],
-				isReady: true,
-				conversationId: null,
-				error: agent === undefined ? "missing-agent" : "unsupported-agent",
-			};
+	if (isStream) {
+		return {
+			messages: claude.messages,
+			isReady: claude.isReady,
+			conversationId: claude.ccSessionId,
+			error: null,
+		};
 	}
+	if (threadAgent) {
+		return {
+			messages: thread.messages,
+			isReady: thread.isReady,
+			conversationId: agentSessionId ?? null,
+			error: null,
+		};
+	}
+	// `isReady=true` so consumers fall through to their error state instead
+	// of showing a loading skeleton that would never resolve.
+	return {
+		messages: [],
+		isReady: true,
+		conversationId: null,
+		error: agent === undefined ? "missing-agent" : "unsupported-agent",
+	};
 }

--- a/frontend/src/hooks/useSessionHistory.ts
+++ b/frontend/src/hooks/useSessionHistory.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type {
+	AgentProvider,
 	ConversationMessage,
 	HistorySession,
 	PeerHistoryProject,
@@ -44,13 +45,13 @@ interface UseSessionHistoryResult {
 	resumeSession: (
 		sessionId: string,
 		projectPath: string,
-		agent?: "claude" | "codex",
+		agent?: AgentProvider,
 		peerId?: string,
 	) => Promise<{ tmuxSessionId: string } | null>;
 	fetchConversation: (
 		sessionId: string,
 		projectDirName?: string,
-		agent?: "claude" | "codex",
+		agent?: AgentProvider,
 		peerId?: string,
 	) => Promise<ConversationMessage[]>;
 }
@@ -152,7 +153,7 @@ export function useSessionHistory(): UseSessionHistoryResult {
 		async (
 			sessionId: string,
 			projectPath: string,
-			agent?: "claude" | "codex",
+			agent?: AgentProvider,
 			peerId?: string,
 		) => {
 			try {
@@ -185,7 +186,7 @@ export function useSessionHistory(): UseSessionHistoryResult {
 		async (
 			sessionId: string,
 			projectDirName?: string,
-			agent?: "claude" | "codex",
+			agent?: AgentProvider,
 			peerId?: string,
 		): Promise<ConversationMessage[]> => {
 			try {
@@ -197,8 +198,10 @@ export function useSessionHistory(): UseSessionHistoryResult {
 				if (projectDirName) {
 					url.searchParams.set("projectDirName", projectDirName);
 				}
-				if (agent === "codex") {
-					url.searchParams.set("agent", "codex");
+				// Thread agents (codex, grok, ...) read from their own transcript
+				// store; Claude stays on the default jsonl path.
+				if (agent && agent !== "claude") {
+					url.searchParams.set("agent", agent);
 				}
 				const response = await authFetch(url.toString(), { cache: "no-store" });
 				if (!response.ok) {

--- a/frontend/src/hooks/useThreadConversation.ts
+++ b/frontend/src/hooks/useThreadConversation.ts
@@ -1,32 +1,36 @@
 import { useEffect, useState } from "react";
-import type { ConversationMessage } from "../../../shared/types";
+import type { AgentProvider, ConversationMessage } from "../../../shared/types";
 import { authFetch } from "../services/api";
 
 const API_BASE = import.meta.env.VITE_API_URL || "";
 
-interface UseCodexConversationOptions {
-	/** Codex thread id (rollout-keyed UUID). */
+interface UseThreadConversationOptions {
+	/** Thread-based provider (codex, grok, ...) the thread id belongs to. */
+	agent: AgentProvider | undefined;
+	/** The agent's own session/thread id. */
 	threadId: string | undefined | null;
 	enabled?: boolean;
 	/** Refresh interval in ms. Default 5000. */
 	pollIntervalMs?: number;
 }
 
-interface UseCodexConversationResult {
+interface UseThreadConversationResult {
 	messages: ConversationMessage[];
 	isReady: boolean;
 }
 
 /**
- * Polling-based conversation reader for Codex sessions. Codex doesn't expose
- * a hook/event stream, so we tail the rollout via the HTTP endpoint at a
- * fixed interval. Only the active thread for a tmux session is fetched.
+ * Polling-based conversation reader for thread-based agents (Codex, Grok).
+ * These agents don't expose a hook/event stream, so we tail the transcript
+ * via the HTTP endpoint at a fixed interval. Only the active thread for a
+ * session is fetched.
  */
-export function useCodexConversation({
+export function useThreadConversation({
+	agent,
 	threadId,
 	enabled = true,
 	pollIntervalMs = 5000,
-}: UseCodexConversationOptions): UseCodexConversationResult {
+}: UseThreadConversationOptions): UseThreadConversationResult {
 	const [messages, setMessages] = useState<ConversationMessage[]>([]);
 	const [isReady, setIsReady] = useState(false);
 
@@ -38,13 +42,13 @@ export function useCodexConversation({
 		setMessages([]);
 		setIsReady(false);
 
-		if (!enabled || !threadId) {
+		if (!enabled || !threadId || !agent) {
 			return;
 		}
 
 		const fetchOnce = async () => {
 			try {
-				const url = `${API_BASE}/api/sessions/history/${threadId}/conversation?agent=codex`;
+				const url = `${API_BASE}/api/sessions/history/${threadId}/conversation?agent=${agent}`;
 				const response = await authFetch(url, { cache: "no-store" });
 				if (!response.ok) throw new Error(`status ${response.status}`);
 				const data = await response.json();
@@ -52,7 +56,7 @@ export function useCodexConversation({
 				setMessages(data.messages ?? []);
 			} catch (err) {
 				if (!cancelled)
-					console.error("Failed to fetch codex conversation:", err);
+					console.error(`Failed to fetch ${agent} conversation:`, err);
 			} finally {
 				if (!cancelled) setIsReady(true);
 			}
@@ -65,7 +69,7 @@ export function useCodexConversation({
 			cancelled = true;
 			window.clearInterval(id);
 		};
-	}, [threadId, enabled, pollIntervalMs]);
+	}, [agent, threadId, enabled, pollIntervalMs]);
 
 	return { messages, isReady };
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -52,7 +52,8 @@
 		"agent": "Agent",
 		"agentProvider": {
 			"claude": "Claude",
-			"codex": "Codex"
+			"codex": "Codex",
+			"grok": "Grok"
 		},
 		"workingDirectory": "Working Directory",
 		"newFolder": "New Folder",
@@ -212,6 +213,7 @@
 		"you": "You",
 		"claude": "Claude",
 		"codex": "Codex",
+		"grok": "Grok",
 		"system": "System",
 		"errorTitle": "Conversation unavailable",
 		"errorMissingAgent": "Session has no agent information. Try refreshing the session list.",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -52,7 +52,8 @@
 		"agent": "エージェント",
 		"agentProvider": {
 			"claude": "Claude",
-			"codex": "Codex"
+			"codex": "Codex",
+			"grok": "Grok"
 		},
 		"workingDirectory": "作業ディレクトリ",
 		"newFolder": "新規フォルダ",
@@ -212,6 +213,7 @@
 		"you": "You",
 		"claude": "Claude",
 		"codex": "Codex",
+		"grok": "Grok",
 		"system": "System",
 		"errorTitle": "会話を表示できません",
 		"errorMissingAgent": "セッションのエージェント情報が取得できませんでした。セッション一覧を再読み込みしてください。",

--- a/frontend/src/utils/agentDisplay.ts
+++ b/frontend/src/utils/agentDisplay.ts
@@ -1,0 +1,46 @@
+import {
+	AGENT_PROVIDERS,
+	type AgentProvider,
+	isAgentProvider,
+} from "../../../shared/types";
+
+/**
+ * Per-provider display styling. The single place to touch when adding an
+ * agent's colors — labels come from the shared registry (`displayName`).
+ * Tailwind needs literal class strings, so these can't be computed.
+ */
+interface AgentBadgeStyle {
+	label: string;
+	/** History/session badge chip. */
+	badgeClassName: string;
+	/** ConversationViewer speaker bar. */
+	barClassName: string;
+	/** ConversationViewer role label. */
+	labelClassName: string;
+}
+
+const AGENT_BADGES: Record<AgentProvider, AgentBadgeStyle> = {
+	claude: {
+		label: AGENT_PROVIDERS.claude.displayName,
+		badgeClassName: "text-violet-300 bg-violet-400/10 border-violet-400/20",
+		barClassName: "bg-violet-400/70",
+		labelClassName: "text-violet-300",
+	},
+	codex: {
+		label: AGENT_PROVIDERS.codex.displayName,
+		badgeClassName: "text-cyan-300 bg-cyan-400/10 border-cyan-400/20",
+		barClassName: "bg-cyan-400/70",
+		labelClassName: "text-cyan-300",
+	},
+	grok: {
+		label: AGENT_PROVIDERS.grok.displayName,
+		badgeClassName: "text-emerald-300 bg-emerald-400/10 border-emerald-400/20",
+		barClassName: "bg-emerald-400/70",
+		labelClassName: "text-emerald-300",
+	},
+};
+
+/** Badge style for a provider; unknown/undefined falls back to Claude. */
+export function agentBadge(agent: string | undefined): AgentBadgeStyle {
+	return AGENT_BADGES[agent && isAgentProvider(agent) ? agent : "claude"];
+}

--- a/frontend/src/utils/historyFacets.ts
+++ b/frontend/src/utils/historyFacets.ts
@@ -1,4 +1,4 @@
-import type { HistorySession } from "../../../shared/types";
+import { agentDisplayName, type HistorySession } from "../../../shared/types";
 
 type TFunction = (key: string, options?: Record<string, unknown>) => string;
 
@@ -152,9 +152,7 @@ export function computeFacetData(
 
 	return {
 		projects: sortedValues(tally(items, (s) => s.projectName), projectLabel),
-		agents: sortedValues(tally(items, agentOf), (v) =>
-			v === "codex" ? "Codex" : "Claude",
-		),
+		agents: sortedValues(tally(items, agentOf), agentDisplayName),
 		branches: sortedValues(tally(items, branchOf), (v) =>
 			v === UNKNOWN_BRANCH ? t("history.facetBranchUnknown") : v,
 		),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -54,6 +54,7 @@ export const AGENT_PROVIDERS = {
     command: 'claude',
     resumeCommand: 'claude -r',
     labelKey: 'session.agentProvider.claude',
+    displayName: 'Claude',
     processPatterns: [/(?:^|\/)claude(?:\s|$)/, /\/claude\/versions\//],
     supportsConversationMetadata: true,
   },
@@ -62,7 +63,17 @@ export const AGENT_PROVIDERS = {
     command: 'codex',
     resumeCommand: 'codex resume',
     labelKey: 'session.agentProvider.codex',
+    displayName: 'Codex',
     processPatterns: [/(?:^|\/)codex(?:\s|$)/, /\/@openai\/codex\//],
+    supportsConversationMetadata: false,
+  },
+  grok: {
+    id: 'grok',
+    command: 'grok',
+    resumeCommand: 'grok --resume',
+    labelKey: 'session.agentProvider.grok',
+    displayName: 'Grok',
+    processPatterns: [/(?:^|\/)grok(?:\s|$)/],
     supportsConversationMetadata: false,
   },
 } as const;
@@ -86,6 +97,25 @@ export function detectAgentProviderFromArgs(args: string): AgentProvider | undef
 
 export function agentSupportsConversationMetadata(agent: string | undefined): boolean {
   return !!agent && isAgentProvider(agent) && AGENT_PROVIDERS[agent].supportsConversationMetadata;
+}
+
+/**
+ * Thread-based agents (everything except Claude): their conversation and
+ * identity come from the agent's own session store, keyed by `agentSessionId`,
+ * and the conversation is read via HTTP polling instead of the Claude
+ * WebSocket stream. Returns the provider id, or undefined for Claude /
+ * unknown commands — so it doubles as both a predicate and a narrowing cast.
+ */
+export function threadAgentOf(agent: string | undefined): AgentProvider | undefined {
+  if (!agent || !isAgentProvider(agent)) return undefined;
+  return AGENT_PROVIDERS[agent].supportsConversationMetadata ? undefined : agent;
+}
+
+/** Human-readable provider name; unknown/undefined falls back to Claude. */
+export function agentDisplayName(agent: string | undefined): string {
+  return agent && isAgentProvider(agent)
+    ? AGENT_PROVIDERS[agent].displayName
+    : AGENT_PROVIDERS.claude.displayName;
 }
 
 export function agentResumeCommand(agent: AgentProvider, sessionId?: string): string {


### PR DESCRIPTION
## Summary

Grok Build (xAI の CLI エージェント) を Claude / Codex に続く3つ目のエージェントとして統合。同時に「N番目のエージェントを足せる」よう codex ハードコード分岐を抽象化した。

### 抽象化 (今後のエージェント追加向け)
- `shared/types.ts` の `AGENT_PROVIDERS` レジストリに `displayName` を追加し、`threadAgentOf()` / `agentDisplayName()` ヘルパーを新設。`supportsConversationMetadata: false` が「スレッド型エージェント」(agentSessionId で自前ストアを持つ) の共通判定になった
- backend: `AgentThreadService` / `AgentHistoryProvider` 共通インターフェース (`services/agent-providers.ts`)。`routes/sessions.ts` / `routes/peers.ts` はプロバイダマップをループし、`=== 'codex'` 分岐を排除
- frontend: `useCodexConversation` → `useThreadConversation(agent, ...)` に汎用化。バッジ/色は `utils/agentDisplay.ts` に集約。ConversationViewer / PaneContainer / SessionList / App / 履歴ビューはレジストリ参照に

### Grok 対応
- **検出/起動/resume**: レジストリエントリのみ (`grok` / `grok --resume '<id>'`)
- **セッションストア**: `~/.grok/sessions/<URLエンコードcwd>/<uuid>/` を走査 (`summary.json` メタ、`prompt_history.jsonl` 初回プロンプト、`updates.jsonl` の `turn_completed` からトークン使用量 + `current_model_id` でモデル表示 #424 対応)
- **会話ビュー**: `chat_history.jsonl` を Claude 形の会話ターンに変換 (`prompt_index` 付き user / assistant `tool_calls` / `tool_result`、synthetic・reasoning は除外)
- **hook 通知**: Grok は `~/.claude/settings.json` の hooks を互換レイヤで読むため設定不要で発火済み。ただし stdin JSON が camelCase 独自形式 (`hookEventName: "stop"` 等) のため `/api/notify` で正規化 (`normalizeHookBody`)。transcript (updates.jsonl) 用のスマートメッセージ生成も追加
- **hook-status**: `providers.grok` (Claude 互換ファイル + `~/.grok/hooks/*.json`)
- **履歴/検索/peers**: プロバイダループに乗るため自動対応

### 検証
- backend 339 tests pass (grok サービス/パーサ/正規化のユニットテスト追加、実キャプチャ形式の fixture)
- dev 環境 E2E: grok セッション作成 → `agent: "grok"` 検出 / `agentSessionId` 解決 / 会話 API / 履歴 API / トークン+モデル metrics / WS hook-event (camelCase→正規化→通知本文生成) をすべて実測確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL