### PR TITLE
feat(sessions): move model name into the agent badge

### DIFF
--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -1087,6 +1087,14 @@ function SessionItem({
 						{agentLabel && (
 							<span className="inline-flex items-center px-2 py-0.5 rounded-full font-medium bg-zinc-500/15 text-zinc-400">
 								{agentLabel}
+								{extSession.metrics?.model && (
+									<span
+										className="ml-1.5 text-zinc-500"
+										title={extSession.metrics.model}
+									>
+										{formatModelName(extSession.metrics.model)}
+									</span>
+								)}
 							</span>
 						)}
 						{typeof extSession.metrics?.contextPercent === "number" && (
@@ -1124,11 +1132,6 @@ function SessionItem({
 									{formatBytes(extSession.metrics.memoryRssBytes)}
 								</span>
 							)}
-						{extSession.metrics?.model && (
-							<span title={extSession.metrics.model}>
-								{formatModelName(extSession.metrics.model)}
-							</span>
-						)}
 					</div>
 				)}
 


### PR DESCRIPTION
## Summary
- モデル名表示をメタデータ行の末尾からエージェントバッジ内に移動し、`Claude Opus 4.8` のような一体のピル表示にする（#424 のフォローアップ）

## Test plan
- [x] frontend テスト 52 全パス / lint クリーン
- [x] dev 環境（5173）モバイルビューで `Claude Opus 4.8` / `Claude Fable 5` の一体バッジ表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrPeukDny8ipqP2ao2HmE3