### PR TITLE
fix(herdr): agent-status ウォッチャーの再購読ループを止める

### DIFF
--- a/backend/src/services/__tests__/herdr-agent-status.test.ts
+++ b/backend/src/services/__tests__/herdr-agent-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { classifyHerdrEvent } from '../herdr-agent-status';
+import { classifyHerdrEvent, paneSetRequiresResubscribe } from '../herdr-agent-status';
 
 /**
  * herdr sends event names in two namings on one socket (verified live against
@@ -37,5 +37,44 @@ describe('classifyHerdrEvent', () => {
     expect(classifyHerdrEvent(undefined)).toBe('ignore');
     expect(classifyHerdrEvent(null)).toBe('ignore');
     expect(classifyHerdrEvent(42)).toBe('ignore');
+  });
+});
+
+/**
+ * The resubscribe gate, keyed off `pane.list` (ground truth) rather than the
+ * event payload. herdr replays lifecycle events on every subscribe, and its
+ * replay buffer can hold a phantom `pane_created` for a pane that no longer
+ * exists anywhere in `pane.list` (observed live: `w2N:p1`). Resubscribing on
+ * such an event reopened a stream that drew the same phantom — a self-sustaining
+ * ~2.5/s loop. Diffing the real pane set makes phantoms and echoes no-ops.
+ */
+describe('paneSetRequiresResubscribe', () => {
+  const subscribed = new Set(['w1:p1', 'w1:p2']);
+
+  it('does not resubscribe when the live pane set is unchanged', () => {
+    // The loop driver: a snapshot/phantom event leaves pane.list identical.
+    expect(paneSetRequiresResubscribe(new Set(['w1:p1', 'w1:p2']), subscribed, true)).toBe(false);
+  });
+
+  it('ignores a phantom pane that pane.list never reports', () => {
+    // pane.list still returns exactly the subscribed set even though herdr
+    // replayed pane_created for a phantom — no resubscribe, loop broken.
+    const listAfterPhantom = new Set(['w1:p1', 'w1:p2']);
+    expect(paneSetRequiresResubscribe(listAfterPhantom, subscribed, true)).toBe(false);
+  });
+
+  it('resubscribes when a pane is genuinely added or removed', () => {
+    expect(paneSetRequiresResubscribe(new Set(['w1:p1', 'w1:p2', 'w1:p3']), subscribed, true)).toBe(true);
+    expect(paneSetRequiresResubscribe(new Set(['w1:p1']), subscribed, true)).toBe(true);
+  });
+
+  it('resubscribes on a same-size membership swap', () => {
+    // p2 closed and p3 opened between polls — size matches, members differ.
+    expect(paneSetRequiresResubscribe(new Set(['w1:p1', 'w1:p3']), subscribed, true)).toBe(true);
+  });
+
+  it('always subscribes when there is no live subscription (startup / after a drop)', () => {
+    expect(paneSetRequiresResubscribe(subscribed, subscribed, false)).toBe(true);
+    expect(paneSetRequiresResubscribe(new Set(), new Set(), false)).toBe(true);
   });
 });

--- a/backend/src/services/herdr-agent-status.ts
+++ b/backend/src/services/herdr-agent-status.ts
@@ -49,12 +49,47 @@ export function classifyHerdrEvent(rawEvent: unknown): 'status' | 'lifecycle' | 
   return 'ignore';
 }
 
+function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const x of a) if (!b.has(x)) return false;
+  return true;
+}
+
+/**
+ * Should a lifecycle event trigger a full resubscribe (rebuild of the per-pane
+ * `pane.agent_status_changed` subscriptions)? Only when the *actual* pane set —
+ * `pane.list`, the ground truth — differs from what we're subscribed to, or
+ * when there's no live subscription to keep.
+ *
+ * Crucially this ignores the event payload. herdr replays lifecycle events on
+ * every `events.subscribe` (a snapshot), and its replay buffer can hold a
+ * *phantom* `pane_created` for a pane that `pane.list`, `workspace.list` and
+ * `pane.get` all agree no longer exists (observed live: `w2N:p1`). The old code
+ * resubscribed on any such event; each resubscribe opened a fresh stream that
+ * drew the same phantom again — a ~2.5/s busy loop (one `pane.list` RPC + socket
+ * teardown per turn). An event-payload gate can't fix it: the phantom pane never
+ * appears in `pane.list`, so it reads as "new" forever. Diffing `pane.list`
+ * against the subscribed set makes phantoms and echoes no-ops while still
+ * catching genuine adds/removes.
+ */
+export function paneSetRequiresResubscribe(
+  nextPaneIds: ReadonlySet<string>,
+  subscribedPaneIds: ReadonlySet<string>,
+  hasLiveSubscription: boolean,
+): boolean {
+  if (!hasLiveSubscription) return true;
+  return !setsEqual(nextPaneIds, subscribedPaneIds);
+}
+
 const CHANGE_DEBOUNCE_MS = 150;
 const RESUBSCRIBE_DEBOUNCE_MS = 400;
 /** Backoff after a dropped/rejected subscription. herdr restarts land here. */
 const RETRY_DELAY_MS = 5_000;
 
 let unsubscribe: (() => void) | null = null;
+/** Pane ids our live subscription covers — diffed against pane.list to decide
+ *  whether a lifecycle event is a genuine change or a replay/phantom. */
+let subscribedPaneIds: Set<string> = new Set();
 let running = false;
 let changeTimer: ReturnType<typeof setTimeout> | null = null;
 let resubscribeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -103,8 +138,18 @@ async function subscribeToPanes(): Promise<void> {
   }
   if (!running) return;
 
+  // A lifecycle event schedules us, but the pane set may be unchanged — a herdr
+  // snapshot replay or the phantom `pane_created` (see paneSetRequiresResubscribe).
+  // Keep the live stream open in that case: tearing it down and reopening is what
+  // draws the next replay and sustains the loop.
+  const nextPaneIds = new Set(panes.map((p) => p.pane_id));
+  if (!paneSetRequiresResubscribe(nextPaneIds, subscribedPaneIds, unsubscribe !== null)) {
+    return;
+  }
+
   unsubscribe?.();
   unsubscribe = null;
+  subscribedPaneIds = nextPaneIds;
 
   const subscriptions: Array<Record<string, unknown>> = [
     ...LIFECYCLE_SUBSCRIPTION_TYPES.map((type) => ({ type })),
@@ -118,8 +163,8 @@ async function subscribeToPanes(): Promise<void> {
       if (kind === 'status') {
         scheduleChangePush();
       } else if (kind === 'lifecycle') {
-        // A new pane needs its own status subscription; a closed one should
-        // stop holding one. Push too — pane sets are user-visible.
+        // Re-check pane.list (debounced) and rebuild only if the set genuinely
+        // changed. Push either way — pane state is user-visible regardless.
         scheduleResubscribe();
         scheduleChangePush();
       }
@@ -147,6 +192,7 @@ export function stopAgentStatusWatcher(): void {
   onStatusChange = null;
   unsubscribe?.();
   unsubscribe = null;
+  subscribedPaneIds = new Set();
   changeTimer = clearTimer(changeTimer);
   resubscribeTimer = clearTimer(resubscribeTimer);
   retryTimer = clearTimer(retryTimer);


### PR DESCRIPTION
## 症状

herdr サーバーログで `events.subscribe` が **約2.5回/秒（毎分88〜131件）で延々と開いては閉じ**続ける。cchub がアイドルでも常時CPUを消費し（コアの十数%〜、エージェント稼働中はもっと）、`pane.list` RPC とソケット再接続を連打、`sessions-updated` push も回り続ける。

## 根本原因

`HerdrAgentStatusWatcher`（`herdr-agent-status.ts`）が herdr の pane lifecycle イベントを受けるたびに**無条件で再購読**していた。herdr は:

1. `events.subscribe` のたびに既存 pane のスナップショットを lifecycle イベントとして再送する
2. その replay バッファに、`pane.list` / `workspace.list` / `pane.get` のどれにも存在しない**亡霊 `pane_created`** を保持することがある（実機で確認: `w2N:p1` — `pane.get` は `pane_not_found`）

このため「再購読 → 亡霊を含むスナップショット再送 → また再購読」の自己増殖ループになっていた（400ms デバウンス = 実測の約2.5回/秒と一致）。

イベントの `pane_id` を見るゲートでは直せない — 亡霊 pane は `pane.list` に現れないので永久に「新規」と判定されるため。

## 修正

再購読の判断を**イベントではなく `pane.list`（真実）の集合差分**に変更。lifecycle イベント時に `pane.list` を引き直し、購読中の集合と**実際に変わった時だけ**再購読する（`paneSetRequiresResubscribe`）。集合が同じなら**ストリームを開いたまま**にする＝再送を引き起こさない＝ループが止まる。変更 push は従来どおり発火（pane 状態はユーザー可視のため）。

## 検証（実 herdr ソケットに対して実施）

- 亡霊 `w2N:p1` が毎回再送される状況で、**旧挙動 12/12 再購読（ループ）→ 修正 0/12（停止）**
- 使い捨てワークスペースの作成/削除では**修正でも再購読が発火**（新 pane が status 購読を得られることを担保）
- backend 全 346 テスト green、`bun run lint` / `tsc --noEmit` パス。`paneSetRequiresResubscribe` のユニットテスト追加（同集合/亡霊/増減/同サイズ入替/接続なし）

## 備考

亡霊 `w2N:p1` は herdr 側の stale event。cchub からは replay バッファを消せないので、cchub 側を堅牢にする本修正が正しい層。herdr 再起動で亡霊自体は消えるが、本修正は再発しても影響を受けない。今回のリリース(v0.2.16)とは無関係の既存バグ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL