### PR TITLE
Release v0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.17] - 2026-07-19
+
+### Fixed
+- **herdr agent-status ウォッチャーの再購読ループを停止** (#433): `events.subscribe` が約2.5回/秒で開閉し続け、cchub がアイドルでも常時CPUを消費していた。herdr が購読のたびに既存paneのスナップショットを再送し、その replay バッファに `pane.list`/`workspace.list`/`pane.get` のどれにも存在しない亡霊 `pane_created`（実機 `w2N:p1`）を保持していたのが原因で、「再購読→スナップショット再送→再購読」の自己増殖ループになっていた。再購読の判定をイベントペイロードではなく `pane.list`（真実）の集合差分に変更し、pane集合が実際に変わった時だけ再購読するようにした（`paneSetRequiresResubscribe`）
+
 ## [0.2.16] - 2026-07-19
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- fix(herdr): agent-status ウォッチャーの再購読ループを停止 (#433)

## Notes
CHANGELOG / version / architecture ドキュメントの更新。#433 は cchub がアイドルでも常時CPUを食う既存バグの修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL