### PR TITLE
Fix false Codex rate-limit warning

### DIFF
--- a/backend/src/services/codex-usage.ts
+++ b/backend/src/services/codex-usage.ts
@@ -9,18 +9,13 @@ interface RateLimitWindow {
   resets_at?: number; // unix epoch seconds
 }
 
-interface RateLimitsCredits {
-  has_credits?: boolean;
-  unlimited?: boolean;
-  balance?: string;
-}
-
 interface RateLimitsPayload {
   limit_id?: string;
   primary?: RateLimitWindow | null;
   secondary?: RateLimitWindow | null;
-  credits?: RateLimitsCredits | null;
   plan_type?: string;
+  /** Explicit Codex verdict; null while requests are still allowed. */
+  rate_limit_reached_type?: string | null;
 }
 
 interface TokenCountEvent {
@@ -124,7 +119,7 @@ function classifyWindow(minutes: number | undefined): 'fiveHour' | 'sevenDay' | 
 }
 
 interface RolloutScan {
-  /** Most recent rate_limits event regardless of populated windows. Carries plan/credits state. */
+  /** Most recent rate_limits event regardless of populated windows. Carries plan/limit state. */
   latest?: { event: TokenCountEvent; rateLimits: RateLimitsPayload };
   /** Most recent rate_limits event with at least one populated window. Carries cycle data. */
   windowed?: { event: TokenCountEvent; rateLimits: RateLimitsPayload };
@@ -280,20 +275,18 @@ export class CodexUsageService {
       if (info && !result[slot]) result[slot] = info;
     }
 
-    // Codex stops returning windows once the cycle is exhausted, so the windowed
-    // source can be stale by the time we read this. Detect exhaustion from the
-    // latest event's credits and override the short cycle status accordingly.
-    // If the cycle reset time has already passed, do not keep the exhausted
-    // override around; the next cycle should be reflected by a fresh event.
-    const credits = latestSource.rateLimits.credits;
-    const exhausted = !!credits && credits.has_credits === false && credits.unlimited !== true;
-    const fiveHourResetAtMs = result.fiveHour ? Date.parse(result.fiveHour.resetsAt) : Number.NaN;
-    const resetExpired = Number.isFinite(fiveHourResetAtMs) && now >= fiveHourResetAtMs;
+    // `credits.has_credits` only describes the separately purchased credit
+    // balance and is commonly false while the included plan allowance is still
+    // available. Codex exposes the actual blocking state explicitly instead.
+    // If the last known cycle has already reset, do not keep a stale exhausted
+    // verdict around while waiting for a fresh rollout event.
+    const reachedType = latestSource.rateLimits.rate_limit_reached_type;
+    const exhausted = typeof reachedType === 'string' && reachedType.length > 0;
+    const constrainingCycle = result.fiveHour ?? result.sevenDay;
+    const resetAtMs = constrainingCycle ? Date.parse(constrainingCycle.resetsAt) : Number.NaN;
+    const resetExpired = Number.isFinite(resetAtMs) && now >= resetAtMs;
     if (exhausted && !resetExpired) {
       result.rateLimitExceeded = true;
-      if (result.fiveHour) {
-        result.fiveHour = { ...result.fiveHour, utilization: 100, status: 'exceeded' };
-      }
     }
 
     if (!result.fiveHour && !result.sevenDay && !result.rateLimitExceeded) return null;

--- a/backend/tests/unit/codex-usage-service.test.ts
+++ b/backend/tests/unit/codex-usage-service.test.ts
@@ -141,7 +141,7 @@ describe('CodexUsageService', () => {
     expect(result?.capturedAt).toBe('2026-05-06T09:00:00Z');
   });
 
-  test('marks rate limit exceeded when latest event reports no credits', () => {
+  test('marks rate limit exceeded when latest event reports an explicit reached type', () => {
     const fiveHourReset = Math.floor(Date.UTC(2026, 4, 7, 16, 48, 0) / 1000);
     const sevenDayReset = Math.floor(Date.UTC(2026, 4, 14, 11, 48, 0) / 1000);
     placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
@@ -154,13 +154,14 @@ describe('CodexUsageService', () => {
           plan_type: 'plus',
         },
       }),
-      // Newer event after exhaustion: windows null, no credits
+      // Newer event after exhaustion: windows null with an explicit verdict
       makeRolloutLine({
         timestamp: '2026-05-07T14:03:01Z',
         rate_limits: {
           primary: null,
           secondary: null,
           credits: { has_credits: false, unlimited: false, balance: '0' },
+          rate_limit_reached_type: 'rate_limit_reached',
           plan_type: null,
         },
       }),
@@ -169,8 +170,8 @@ describe('CodexUsageService', () => {
     const svc = new CodexUsageService(sessionsDir);
     const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 14, 5, 0));
     expect(result?.rateLimitExceeded).toBe(true);
-    expect(result?.fiveHour?.utilization).toBe(100);
-    expect(result?.fiveHour?.status).toBe('exceeded');
+    // Preserve the last measured utilization instead of inventing 100%.
+    expect(result?.fiveHour?.utilization).toBe(75.0);
     // 7d cycle still reports the last known windowed value
     expect(result?.sevenDay?.utilization).toBe(12.0);
     // capturedAt comes from the latest (exhausted) event
@@ -179,22 +180,23 @@ describe('CodexUsageService', () => {
     expect(result?.planType).toBe('plus');
   });
 
-  test('does not mark exhaustion when credits are unlimited', () => {
-    const fiveHourReset = Math.floor(Date.UTC(2026, 4, 7, 16, 48, 0) / 1000);
+  test('does not treat an empty purchased-credit balance as rate-limit exhaustion', () => {
+    const sevenDayReset = Math.floor(Date.UTC(2026, 4, 14, 16, 48, 0) / 1000);
     placeRollout('2026/05/07', 'rollout-2026-05-07T09-47-05-aaa.jsonl', [
       makeRolloutLine({
         rate_limits: {
-          primary: { used_percent: 50.0, window_minutes: 300, resets_at: fiveHourReset },
+          primary: { used_percent: 9.0, window_minutes: 10080, resets_at: sevenDayReset },
           secondary: null,
-          credits: { has_credits: false, unlimited: true, balance: '0' },
-          plan_type: 'enterprise',
+          credits: { has_credits: false, unlimited: false, balance: '0' },
+          rate_limit_reached_type: null,
+          plan_type: 'plus',
         },
       }),
     ]);
     const svc = new CodexUsageService(sessionsDir);
     const result = svc.computeUsageLimits(Date.UTC(2026, 4, 7, 14, 5, 0));
     expect(result?.rateLimitExceeded).toBeUndefined();
-    expect(result?.fiveHour?.utilization).toBe(50.0);
+    expect(result?.sevenDay?.utilization).toBe(9.0);
   });
 
   test('does not keep exhaustion after the cycle reset time has passed', () => {
@@ -215,6 +217,7 @@ describe('CodexUsageService', () => {
           primary: null,
           secondary: null,
           credits: { has_credits: false, unlimited: false, balance: '0' },
+          rate_limit_reached_type: 'rate_limit_reached',
           plan_type: null,
         },
       }),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -481,9 +481,9 @@ export interface CodexUsageLimits {
   planType?: string;
   capturedAt?: string; // timestamp of the rollout event the limits were read from
   /**
-   * True when Codex's most recent rate_limits event reports `credits.has_credits === false`.
-   * OpenAI returns null primary/secondary windows once exhausted, so the cycle data
-   * may be from an earlier in-cycle measurement; this flag signals "currently exhausted".
+   * True when Codex's most recent rate_limits event reports a non-null
+   * `rate_limit_reached_type`. Cycle data may be from an earlier in-cycle
+   * measurement when the latest event omits its windows.
    */
   rateLimitExceeded?: boolean;
 }


### PR DESCRIPTION
## Summary
- use Codex `rate_limit_reached_type` as the explicit exhaustion signal
- stop treating an empty purchased-credit balance as plan exhaustion
- preserve the last measured utilization instead of forcing 100%

## Tests
- `bun test backend/tests/unit/codex-usage-service.test.ts`
- `bun run lint`