### PR TITLE
Release v0.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.18] - 2026-07-19
+
+### Fixed
+- **Codexの使用量リミット到達を誤表示する問題を修正** (#435): 追加購入クレジットが無いことを示す `credits.has_credits: false` をプラン内使用量の上限到達と誤解釈し、使用率が9%でも「リミット到達中」と表示していた。Codexが返す明示的な `rate_limit_reached_type` のみを到達判定に使い、実測使用率を推測で100%へ上書きしないようにした
+
 ## [0.2.17] - 2026-07-19
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- fix: Codexの追加購入クレジット残高をプラン使用量の上限到達と誤判定する問題を修正
- fix: 明示的な `rate_limit_reached_type` のみを上限到達判定に使用
- fix: 最終計測使用率を推測で100%へ上書きしない

## Validation
- `bun run build`
- `bun run lint`
- full test suite (391 tests)

## Notes
- release artifacts (`package.json`, `CHANGELOG.md`, `architecture.json`, `architecture.html`) updated for v0.2.18