### PR TITLE
fix(mobile): keep pane tab bar after reload for zoomed multi-pane sessions

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -300,9 +300,9 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
 
     // Layout listener
     cleanupFns.push(
-      controlSession.onLayoutChange((layout) => {
+      controlSession.onLayoutChange((layout, zoomedPaneId) => {
         try {
-          ws.send(JSON.stringify({ type: 'layout', layout, sessionId }));
+          ws.send(JSON.stringify({ type: 'layout', layout, zoomedPaneId, sessionId }));
         } catch { /* disconnected */ }
       })
     );
@@ -350,7 +350,14 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
     try {
       const layout = controlSession.getCurrentLayout();
       if (layout) {
-        ws.send(JSON.stringify({ type: 'layout', layout, sessionId }));
+        ws.send(
+          JSON.stringify({
+            type: 'layout',
+            layout,
+            zoomedPaneId: controlSession.zoomedPaneId,
+            sessionId,
+          }),
+        );
       }
     } catch (err) {
       console.error(`[mux] Failed to send initial layout for ${sessionId}:`, err);
@@ -641,7 +648,7 @@ async function handleControlMessage(
       }
       case 'zoom-pane': {
         try {
-          await controlSession.zoomPane(msg.paneId);
+          await controlSession.zoomPane(msg.paneId, msg.zoomed);
           await new Promise(resolve => setTimeout(resolve, 100));
           // Zoom changes pane size; emit a fresh viewport in live mode.
           if ((sub.liveOffset.get(msg.paneId) ?? 0) === 0) {

--- a/backend/src/services/__tests__/herdr-layout.test.ts
+++ b/backend/src/services/__tests__/herdr-layout.test.ts
@@ -224,3 +224,66 @@ describe('PaneLayoutTree.split duplicate guard', () => {
     expect(ids.filter((id) => id === '%3').length).toBe(1);
   });
 });
+
+/**
+ * Zoom is metadata, never a structural collapse. `toTmuxLayout` must keep the
+ * full split tree even while a pane is zoomed — that is what makes a zoomed
+ * multi-pane session distinguishable from a genuine single-pane one on the
+ * wire, so the client can still render every pane (mobile tab bar) and decide
+ * how to present zoom itself. Regressing this reintroduces the "tab bar
+ * disappears on reload" bug.
+ */
+describe('PaneLayoutTree zoom', () => {
+  test('toTmuxLayout keeps the full tree while zoomed', () => {
+    const t = twoPane();
+    t.setZoom('%1');
+    const layout = t.toTmuxLayout(160, 40);
+    expect(layout?.type).not.toBe('leaf'); // still a split, not a lone leaf
+    expect(layout?.children?.length).toBe(2);
+  });
+
+  test('zoomed getter reflects setZoom / toggleZoom', () => {
+    const t = twoPane();
+    expect(t.zoomed).toBeNull();
+    t.setZoom('%2');
+    expect(t.zoomed).toBe('%2');
+    t.setZoom(null);
+    expect(t.zoomed).toBeNull();
+    t.toggleZoom('%1');
+    expect(t.zoomed).toBe('%1');
+    t.toggleZoom('%1'); // toggling the same pane clears it
+    expect(t.zoomed).toBeNull();
+  });
+
+  test('setZoom is idempotent (unlike toggle)', () => {
+    const t = twoPane();
+    t.setZoom('%1');
+    t.setZoom('%1');
+    expect(t.zoomed).toBe('%1'); // still zoomed, not toggled off
+  });
+
+  test('computeRects: zoomed pane fills the client for PTY sizing', () => {
+    const t = twoPane();
+    t.setZoom('%1');
+    const rects = t.computeRects(160, 40);
+    // Only the zoomed pane, at full size — this drives its PTY resize.
+    expect(rects.size).toBe(1);
+    expect(rects.get('%1')).toEqual({ x: 0, y: 0, width: 160, height: 40 });
+  });
+
+  test('computeRects(ignoreZoom): full split geometry regardless of zoom', () => {
+    const t = twoPane();
+    t.setZoom('%1');
+    const rects = t.computeRects(161, 40, { ignoreZoom: true });
+    expect(rects.size).toBe(2);
+    expect(rects.get('%1')?.width).toBeCloseTo(80, -1);
+    expect(rects.get('%2')?.width).toBeCloseTo(80, -1);
+  });
+
+  test('removing the zoomed pane clears zoom', () => {
+    const t = twoPane();
+    t.setZoom('%2');
+    t.remove('%2');
+    expect(t.zoomed).toBeNull();
+  });
+});

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -49,7 +49,7 @@ export function assertPaneId(paneId: string): void {
   }
 }
 
-type LayoutListener = (layout: TmuxLayoutNode) => void;
+type LayoutListener = (layout: TmuxLayoutNode, zoomedPaneId: string | null) => void;
 type ExitListener = (reason: string) => void;
 type PaneDeadListener = (paneId: string) => void;
 
@@ -535,13 +535,19 @@ export class HerdrControlSession {
   private emitLayout(): void {
     const layout = this.tree.toTmuxLayout(this.clientSize.cols, this.clientSize.rows);
     if (!layout) return;
+    const zoomed = this.tree.zoomed;
     for (const listener of this.layoutListeners) {
-      listener(layout);
+      listener(layout, zoomed);
     }
   }
 
   getCurrentLayout(): TmuxLayoutNode | null {
     return this.tree.toTmuxLayout(this.clientSize.cols, this.clientSize.rows);
+  }
+
+  /** Which pane is zoomed (tmux-style `%N`), or null. Sent alongside layout. */
+  get zoomedPaneId(): string | null {
+    return this.tree.zoomed;
   }
 
   get layout(): TmuxLayoutNode | null {
@@ -683,9 +689,19 @@ export class HerdrControlSession {
     }
   }
 
-  async zoomPane(paneId: string): Promise<void> {
+  /**
+   * Zoom (or unzoom) a pane. `zoomed` states the intent explicitly; when
+   * omitted the zoom is toggled (legacy behavior for clients that don't send
+   * it). Explicit intent lets a client re-assert "this pane is zoomed" on
+   * reconnect without accidentally toggling it back off.
+   */
+  async zoomPane(paneId: string, zoomed?: boolean): Promise<void> {
     assertPaneId(paneId);
-    this.tree.toggleZoom(paneId);
+    if (zoomed === undefined) {
+      this.tree.toggleZoom(paneId);
+    } else {
+      this.tree.setZoom(zoomed ? paneId : null);
+    }
     await this.applyLayout();
   }
 

--- a/backend/src/services/herdr-layout.ts
+++ b/backend/src/services/herdr-layout.ts
@@ -157,6 +157,11 @@ export class PaneLayoutTree {
     this.zoomedPane = this.zoomedPane === paneId ? null : paneId;
   }
 
+  /** Explicitly zoom `paneId` (or clear zoom with `null`). Idempotent. */
+  setZoom(paneId: string | null): void {
+    this.zoomedPane = paneId;
+  }
+
   /**
    * Nudge the split ratio of the nearest ancestor split matching the
    * direction. L/R adjust an 'h' split, U/D adjust a 'v' split; amount is
@@ -302,11 +307,13 @@ export class PaneLayoutTree {
   /**
    * Compute integer cell rects for every pane at the given client size,
    * tmux convention: children partition the parent with a 1-cell separator.
-   * A zoomed pane occupies the full client area.
+   * A zoomed pane occupies the full client area — unless `ignoreZoom` is set,
+   * in which case the full split geometry is returned regardless of zoom
+   * (used to render the wire layout tree, which always carries every pane).
    */
-  computeRects(cols: number, rows: number): Map<string, PaneRect> {
+  computeRects(cols: number, rows: number, opts?: { ignoreZoom?: boolean }): Map<string, PaneRect> {
     const rects = new Map<string, PaneRect>();
-    if (this.zoomedPane && this.has(this.zoomedPane)) {
+    if (!opts?.ignoreZoom && this.zoomedPane && this.has(this.zoomedPane)) {
       rects.set(this.zoomedPane, { x: 0, y: 0, width: cols, height: rows });
       return rects;
     }
@@ -333,20 +340,18 @@ export class PaneLayoutTree {
     return rects;
   }
 
-  /** Render the tree as a TmuxLayoutNode for the frontend. */
+  /**
+   * Render the tree as a TmuxLayoutNode for the frontend.
+   *
+   * Always the FULL split tree — a zoomed pane is NOT collapsed to a single
+   * leaf here. Zoom travels separately (see `zoomed` / the layout message's
+   * `zoomedPaneId`) so the client keeps the whole pane list and decides how to
+   * present zoom itself. Collapsing here is what made a zoomed multi-pane
+   * session indistinguishable from a genuine single-pane one on reconnect.
+   */
   toTmuxLayout(cols: number, rows: number): TmuxLayoutNode | null {
     if (!this.root) return null;
-    if (this.zoomedPane && this.has(this.zoomedPane)) {
-      return {
-        type: 'leaf',
-        width: cols,
-        height: rows,
-        x: 0,
-        y: 0,
-        paneId: paneNumber(this.zoomedPane),
-      };
-    }
-    const rects = this.computeRects(cols, rows);
+    const rects = this.computeRects(cols, rows, { ignoreZoom: true });
     const convert = (n: LayoutNode, rect: PaneRect): TmuxLayoutNode => {
       if (n.type === 'leaf') {
         const r = rects.get(n.paneId) ?? rect;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1260,6 +1260,14 @@ export function App() {
 										setMobileActivePaneId(null);
 									}
 								}}
+								onActivePaneChange={(paneId) => {
+									// Keep the tab-bar selection in sync with the pane the
+									// TerminalPage actually shows (e.g. server-restored zoom on a
+									// non-first pane after reload).
+									setMobileActivePaneId((prev) =>
+										prev === paneId ? prev : paneId,
+									);
+								}}
 								externalActivePaneId={mobileActivePaneId}
 								mainOverlay={chatOverlay}
 								mainOverlayVisible={showConversation}

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -684,9 +684,19 @@ export function DesktopLayout({
 			layoutSizeTimerRef.current = window.setTimeout(() => {
 				requestAnimationFrame(() => {
 					const sizes = extractPaneSizes(layout);
+					// The layout tree is always the full split tree now, even while a
+					// pane is zoomed. A zoomed pane's PTY fills the whole client, but
+					// its tree rect is still the normal (e.g. half-width) split rect —
+					// so size the zoomed pane to the full container to match its PTY.
+					const zoomedId = zoomedPaneIdRef.current;
 					for (const [paneId, size] of sizes) {
 						const ref = terminalRefs.current?.get(paneId);
-						ref?.setExactSize(size.cols, size.rows);
+						if (!ref) continue;
+						if (zoomedId && paneId === zoomedId) {
+							ref.setExactSize(layout.width, layout.height);
+						} else {
+							ref.setExactSize(size.cols, size.rows);
+						}
 					}
 					// Re-enable sendControlResize but do NOT send one here.
 					// The layout-change is tmux's response to our resize — sending
@@ -996,7 +1006,9 @@ export function DesktopLayout({
 			} else {
 				setZoomedPaneId(paneId);
 			}
-			controlTerminalRef.current.zoomPane(paneId);
+			// Send explicit intent so the server's zoom matches this client's
+			// frontend zoom state rather than relying on toggle parity.
+			controlTerminalRef.current.zoomPane(paneId, !isUnzooming);
 			setTimeout(() => {
 				sendControlResize();
 				if (isUnzooming) {

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -16,7 +16,10 @@ interface UseMultiplexedTerminalOptions {
 	// mux WebSocket is closed. #256
 	peerApiBase?: string | null;
 	onPaneViewport?: (paneId: string, viewport: PaneViewport) => void;
-	onLayoutChange?: (layout: TmuxLayoutNode) => void;
+	onLayoutChange?: (
+		layout: TmuxLayoutNode,
+		zoomedPaneId: string | null,
+	) => void;
 	onNewSession?: (sessionId: string, sessionName: string) => void;
 	onPaneDead?: (paneId: string) => void;
 	onHookEvent?: (
@@ -61,7 +64,7 @@ interface UseMultiplexedTerminalReturn {
 	// updates whenever output arrives. offset>0 silences unsolicited pushes
 	// until the next request-viewport.
 	requestViewport: (paneId: string, offset: number) => void;
-	zoomPane: (paneId: string) => void;
+	zoomPane: (paneId: string, zoomed?: boolean) => void;
 	respawnPane: (paneId: string) => void;
 	deadPanes: Set<string>;
 }
@@ -129,7 +132,10 @@ function flushConversationPending() {
 
 type MuxCallbacks = {
 	onPaneViewport?: (paneId: string, viewport: PaneViewport) => void;
-	onLayoutChange?: (layout: TmuxLayoutNode) => void;
+	onLayoutChange?: (
+		layout: TmuxLayoutNode,
+		zoomedPaneId: string | null,
+	) => void;
 	onNewSession?: (sessionId: string, sessionName: string) => void;
 	onPaneDead?: (paneId: string) => void;
 	onHookEvent?: (
@@ -332,7 +338,10 @@ function ensureConnection(token?: string | null, wsBase?: string | null) {
 			}
 			case "layout": {
 				if (msgSessionId !== currentSession) return;
-				cb?.onLayoutChange?.(msg.layout as TmuxLayoutNode);
+				cb?.onLayoutChange?.(
+					msg.layout as TmuxLayoutNode,
+					(msg.zoomedPaneId as string | null | undefined) ?? null,
+				);
 				break;
 			}
 			case "pong": {
@@ -571,7 +580,7 @@ export function useMultiplexedTerminal(
 	useEffect(() => {
 		activeCallbacks = {
 			onPaneViewport: (p, v) => onPaneViewportRef.current?.(p, v),
-			onLayoutChange: (l) => onLayoutChangeRef.current?.(l),
+			onLayoutChange: (l, z) => onLayoutChangeRef.current?.(l, z),
 			onNewSession: (s, n) => onNewSessionRef.current?.(s, n),
 			onPaneDead: (p) => onPaneDeadRef.current?.(p),
 			onHookEvent: (e, c, s, d, m) => onHookEventRef.current?.(e, c, s, d, m),
@@ -682,8 +691,8 @@ export function useMultiplexedTerminal(
 		sendSessionMessage({ type: "request-viewport", paneId, offset });
 	}, []);
 
-	const zoomPane = useCallback((paneId: string) => {
-		sendSessionMessage({ type: "zoom-pane", paneId });
+	const zoomPane = useCallback((paneId: string, zoomed?: boolean) => {
+		sendSessionMessage({ type: "zoom-pane", paneId, zoomed });
 	}, []);
 
 	const respawnPane = useCallback(

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -41,6 +41,10 @@ interface TerminalPageProps {
 	showOverlay?: boolean;
 	theme?: SessionTheme;
 	onPanesChange?: (panes: PaneLeafInfo[]) => void;
+	/** Fires when the pane actually shown full-screen changes, so the parent can
+	 *  keep its tab-bar selection in sync with server truth (e.g. after a reload
+	 *  where the server restores a zoom on a non-first pane). */
+	onActivePaneChange?: (paneId: string | null) => void;
 	externalActivePaneId?: string | null;
 	/** When set, replaces the xterm area while keeping the InputBar visible below.
 	 *  Always rendered (when truthy) so React state/subscriptions persist; visibility
@@ -62,6 +66,7 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 			showOverlay,
 			theme,
 			onPanesChange,
+			onActivePaneChange,
 			externalActivePaneId,
 			mainOverlay,
 			mainOverlayVisible,
@@ -94,15 +99,19 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 
 		const onPanesChangeRef = useRef(onPanesChange);
 		onPanesChangeRef.current = onPanesChange;
+		const onActivePaneChangeRef = useRef(onActivePaneChange);
+		onActivePaneChangeRef.current = onActivePaneChange;
 
-		// Track previous external pane ID for detecting actual switches
-		const prevExternalPaneIdRef = useRef<string | null | undefined>(undefined);
-
-		// Zoom state: when zoomed, layout shows only 1 pane but we preserve the full list
-		const isZoomedRef = useRef(false);
+		// Full pane list mirror (used by onConnect to re-request every pane's
+		// viewport). Always the complete list — zoom no longer collapses it.
 		const cachedPanesRef = useRef<PaneLeafInfo[]>([]);
-		// Tracks whether initial zoom has been done (for multi-pane sessions)
-		const initialZoomDoneRef = useRef(false);
+		// The pane the server currently has zoomed (tmux `%N`), taken from the
+		// layout message. Lets us re-assert zoom idempotently on reconnect
+		// instead of toggling it back off.
+		const serverZoomedPaneIdRef = useRef<string | null>(null);
+		// Previous effective active pane — distinguishes a real user switch (drop
+		// stale viewport) from the first assignment.
+		const prevActivePaneIdRef = useRef<string | null>(null);
 
 		// Multi-server: sessionId が remote peer のものなら、その peer の WS に接続する
 		const { peers } = usePeers();
@@ -146,46 +155,27 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 					}
 				}
 			},
-			onLayoutChange: (layout: TmuxLayoutNode) => {
+			onLayoutChange: (layout: TmuxLayoutNode, zoomedPaneId) => {
 				// Pane sizes may have changed; cached viewport `lines` no longer
 				// match the new column width, so drop the viewport cache.
 				paneViewportCacheRef.current.clear();
-				// Extract all leaf panes from the layout
+				// The layout is always the FULL split tree now (zoom is carried
+				// separately as zoomedPaneId), so the leaf list is the real,
+				// complete pane list — no client-side preservation needed.
 				const leaves = collectLeaves(layout);
-				console.log(
-					`[TP] layout-change: ${leaves.length} panes, zoomed=${isZoomedRef.current}, cached=${cachedPanesRef.current.length}`,
-				);
+				serverZoomedPaneIdRef.current = zoomedPaneId;
+				cachedPanesRef.current = leaves;
+				setAllPanes(leaves);
+				onPanesChangeRef.current?.(leaves);
 
-				if (
-					isZoomedRef.current &&
-					leaves.length === 1 &&
-					cachedPanesRef.current.length > 1
-				) {
-					// Zoomed: layout shows only the zoomed pane.
-					// Keep the cached pane list but update the zoomed pane's dimensions.
-					const zoomed = leaves[0];
-					const updated = cachedPanesRef.current.map((p) =>
-						p.paneId === zoomed.paneId
-							? { ...p, width: zoomed.width, height: zoomed.height }
-							: p,
-					);
-					cachedPanesRef.current = updated;
-					setAllPanes(updated);
-					onPanesChangeRef.current?.(updated);
-				} else {
-					// Normal: update the full pane list
-					cachedPanesRef.current = leaves;
-					setAllPanes(leaves);
-					onPanesChangeRef.current?.(leaves);
-				}
-
-				// If no active pane set, or active pane was removed, select the first one
+				// Pick a shown pane when none is valid: prefer the server's zoomed
+				// pane (the one that's actually full-size), else the first.
 				setActivePaneId((prev) => {
-					const currentPanes = cachedPanesRef.current;
-					if (!prev || !currentPanes.some((l) => l.paneId === prev)) {
-						return currentPanes[0]?.paneId ?? null;
+					if (prev && leaves.some((l) => l.paneId === prev)) return prev;
+					if (zoomedPaneId && leaves.some((l) => l.paneId === zoomedPaneId)) {
+						return zoomedPaneId;
 					}
-					return prev;
+					return leaves[0]?.paneId ?? null;
 				});
 			},
 			onNewSession: onNewSession,
@@ -225,61 +215,49 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 			[controlTerminal],
 		);
 
-		// When external active pane changes, zoom the pane and re-request content
+		// Keep the shown pane zoomed to fill the mobile screen. Idempotent against
+		// the server's zoom state (serverZoomedPaneIdRef), so a reconnect that
+		// finds the pane already zoomed re-asserts nothing — no accidental
+		// toggle-off, no lost tab bar. On a genuine switch we drop the target
+		// pane's stale viewport so it repaints fresh at the live edge.
 		useEffect(() => {
-			if (
-				!externalActivePaneId ||
-				!allPanes.some((p) => p.paneId === externalActivePaneId)
-			) {
-				prevExternalPaneIdRef.current = externalActivePaneId ?? null;
+			const active = effectiveActivePaneId;
+			if (!active || !allPanes.some((p) => p.paneId === active)) {
+				prevActivePaneIdRef.current = active ?? null;
 				return;
 			}
-
 			const isActualSwitch =
-				prevExternalPaneIdRef.current !== undefined &&
-				prevExternalPaneIdRef.current !== null &&
-				prevExternalPaneIdRef.current !== externalActivePaneId;
-			prevExternalPaneIdRef.current = externalActivePaneId;
+				prevActivePaneIdRef.current !== null &&
+				prevActivePaneIdRef.current !== active;
+			prevActivePaneIdRef.current = active;
 
-			const isMultiPane = cachedPanesRef.current.length > 1;
-
-			if (isMultiPane) {
-				if (!isZoomedRef.current || isActualSwitch) {
-					console.log(
-						`[TP] zoom-pane ${externalActivePaneId} (switch=${isActualSwitch}, wasZoomed=${isZoomedRef.current})`,
-					);
-					isZoomedRef.current = true;
-					initialZoomDoneRef.current = true;
-					controlTerminal.zoomPane(externalActivePaneId);
+			if (allPanes.length > 1) {
+				if (serverZoomedPaneIdRef.current !== active) {
+					controlTerminal.zoomPane(active, true);
+					// Optimistic; the next layout message confirms it.
+					serverZoomedPaneIdRef.current = active;
 				}
 			} else {
-				controlTerminal.selectPane(externalActivePaneId);
+				controlTerminal.selectPane(active);
 			}
 
 			if (isActualSwitch) {
-				lastViewportRef.current.delete(externalActivePaneId);
-				paneOffsetRef.current.delete(externalActivePaneId);
+				lastViewportRef.current.delete(active);
+				paneOffsetRef.current.delete(active);
 			}
-		}, [externalActivePaneId, allPanes, controlTerminal]);
+		}, [effectiveActivePaneId, allPanes, controlTerminal]);
+
+		// Report the shown pane up so the parent's tab bar highlights it (matters
+		// when the server restored a zoom on a non-first pane after reload).
+		useEffect(() => {
+			onActivePaneChangeRef.current?.(effectiveActivePaneId);
+		}, [effectiveActivePaneId]);
 
 		useEffect(() => {
-			if (externalActivePaneId || initialZoomDoneRef.current) return;
-			if (activePaneId && allPanes.length > 1) {
-				console.log(
-					`[TP] auto-zoom ${activePaneId} (${allPanes.length} panes)`,
-				);
-				initialZoomDoneRef.current = true;
-				isZoomedRef.current = true;
-				controlTerminal.zoomPane(activePaneId);
-			}
-		}, [activePaneId, allPanes, externalActivePaneId, controlTerminal]);
-
-		useEffect(() => {
-			prevExternalPaneIdRef.current = undefined;
+			prevActivePaneIdRef.current = null;
+			serverZoomedPaneIdRef.current = null;
 			lastViewportRef.current.clear();
 			paneOffsetRef.current.clear();
-			initialZoomDoneRef.current = false;
-			isZoomedRef.current = false;
 			cachedPanesRef.current = [];
 			controlTerminal.connect();
 			return () => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -787,7 +787,11 @@ export type ControlClientMessage =
       entries: Array<{ paneA: string; paneB: string; dir: 'h' | 'v'; ratio: number }>;
     }
   | { type: 'equalize-panes'; direction: 'horizontal' | 'vertical' }
-  | { type: 'zoom-pane'; paneId: string }
+  // Zoom a pane to fill the client area. `zoomed` makes the intent explicit
+  // (true = zoom, false = unzoom); when omitted the server toggles (kept for
+  // older clients / the glasses app). Mobile always sends an explicit value so
+  // that re-issuing zoom on reconnect is idempotent rather than a toggle.
+  | { type: 'zoom-pane'; paneId: string; zoomed?: boolean }
   | { type: 'respawn-pane'; paneId: string }
   // Ask the server for a viewport `offset` rows above the live edge.
   // offset=0 means live mode; the server will also push fresh viewports
@@ -796,7 +800,12 @@ export type ControlClientMessage =
 
 // Server → Client messages
 export type ControlServerMessage =
-  | { type: 'layout'; layout: TmuxLayoutNode }
+  // The layout tree is ALWAYS the full split tree, even while a pane is zoomed —
+  // zoom is carried separately as `zoomedPaneId` (tmux-style `%N`, or null when
+  // nothing is zoomed). This keeps a zoomed session distinguishable from a real
+  // single-pane one, so clients (esp. mobile) can render the full pane list /
+  // tab bar from server truth instead of guessing.
+  | { type: 'layout'; layout: TmuxLayoutNode; zoomedPaneId?: string | null }
   // Viewport payload. Sent in reply to `request-viewport` and pushed
   // unsolicited to live-mode (offset=0) subscribers when the pane emits output.
   | { type: 'viewport'; viewport: PaneViewport }


### PR DESCRIPTION
## 問題

スマホで複数paneセッションを **zoom中にリロードするとタブバーが消え、pane切替・zoom解除が不能** になっていた。

**根本原因**: zoom はサーバ共有状態なのに、プロトコル上「1-leaf layout」としてしか表現されず、本物の1paneセッションと区別できなかった。リロード時にサーバが1-leaf初期layoutを再送 → クライアントが「pane 1個」と誤認 → タブバー（`mobilePanes.length > 1`）消失。

## 修正: zoom をメタデータ化

layout を **常にフルツリーで送信**し、zoom は `zoomedPaneId` として別送する。

- **backend** (`herdr-layout` / `herdr-control` / `terminal-mux`): `toTmuxLayout` は 1-leaf collapse を廃止し常にフルツリー。`computeRects` に `ignoreZoom` opt（PTYサイズ計算は従来通りzoom考慮、wireツリーは全pane）。`setZoom` 追加。`zoom-pane` に明示 `zoomed` intent（省略時 toggle=旧互換）。layout メッセージに `zoomedPaneId` を付与。
- **mobile** (`TerminalPage` / `App`): `isZoomedRef` 推測を廃止。常にフルツリーから pane リストを構築。サーバの `zoomedPaneId` 基準に **冪等** に zoom を再表明（reconnect で toggle-off しない）。`onActivePaneChange` で表示中 pane を親へ通知し、リロード後のタブハイライトをサーバ復元 pane（先頭でなくても）に一致させる。
- **desktop** (`DesktopLayout`): zoom 中 pane の xterm をフルコンテナサイズに上書き（フルツリー化で rect が分割サイズになるため）、`zoomPane` に明示 intent 送信。

副次的に、スマホで zoom したセッションをデスクトップで開いても分割が潰れなくなる（フルツリー維持）。

## 検証（dev + agent-browser 実機）

- ✅ リロードでタブバー維持（旧: `tabbars=[]` → 新: `["zsh","zsh"]`）
- ✅ %2 zoom中リロード → タブが %2 をハイライト（サーバ真実同期）
- ✅ pane 切替（タブタップ → zoom）
- ✅ デスクトップ分割維持
- ✅ デスクトップ zoom/unzoom サイズ整合（179 ↔ 89 cols）非回帰
- ✅ lint / typecheck / test（既存346 + 新規25 herdr-layout zoom）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)