### PR TITLE
Release v0.2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.19] - 2026-07-19
+
+### Fixed
+- **スマホで複数paneセッションをzoom中にリロードするとタブバーが消える問題を修正** (#437): zoom はサーバ共有状態なのにプロトコル上「1-leaf layout」としてしか表現されず、本物の1paneセッションと区別できなかった。リロード時にサーバが1-leaf初期layoutを再送 → クライアントが「pane 1個」と誤認 → タブバーが消えてpane切替・zoom解除が不能になっていた。layout を常にフルツリーで送信し、zoom は `zoomedPaneId` メタデータとして別送する方式に変更（`toTmuxLayout` の 1-leaf collapse 廃止、`computeRects` に `ignoreZoom` opt、`zoom-pane` に明示 `zoomed` intent）。モバイルは `isZoomedRef` 推測を廃止してサーバの `zoomedPaneId` 基準に冪等に zoom を再表明し、リロード後のタブハイライトもサーバ復元 pane に一致させる。副次的に、スマホで zoom したセッションをデスクトップで開いても分割が潰れなくなった
+
 ## [0.2.18] - 2026-07-19
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- fix(mobile): スマホで複数paneセッションをzoom中にリロードするとタブバーが消える問題を修正 (#437)

zoom を layout の 1-leaf collapse でなく `zoomedPaneId` メタデータとして別送し、layout を常にフルツリーで送信する方式に変更。モバイルのタブバーがリロード後も維持され、pane 切替・zoom 解除が可能になる。デスクトップの zoom/分割も非回帰。

## Notes
dev + agent-browser 実機検証済（リロードでタブバー維持、%2 zoom中リロードでタブが%2ハイライト、pane切替、desktop zoom/unzoomサイズ整合）。lint / typecheck / test（既存 + 新規 herdr-layout zoom 25件）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)