### PR TITLE
fix: use herdr native agent session identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - **HerdrService** (`services/herdr.ts`) - Session-level operations mapping CC Hub sessions onto herdr workspaces: list (with agent detection from `pane.process_info`, native agent session ids from `agent.list`, `blocked` status), create/kill, previews, and `moveSession` — herdr's workspace order **is** the session display order, so a reorder is a `workspace.move` and nothing is stored on the cchub side
 - **HerdrUpdateService** (`services/herdr-update.ts`) - Detects herdr binary-vs-server version skew (`herdr update` swaps the binary but leaves the running server old) by parsing `herdr status --json`, cached 30s and refreshed off the dashboard poll. Reports only — applying (`herdr update` + supervised restart) is an explicit user action via `POST /api/herdr/apply-update`; never the `cchub update --auto` timer, never `--handoff`. Unreadable status degrades to no warning
 - **PaneState** (`services/pane-state.ts`) - Backend-agnostic `stripAnsi` / `detectPaneState` heuristics for peer-dialog tooling (`cchub send --wait`, `cchub peek`)
-- **ClaudeCodeService** (`services/claude-code.ts`) - Monitors Claude Code state from `.jsonl` files; session matching via herdr's native agent session id, falling back to working-dir path matching
+- **ClaudeCodeService** (`services/claude-code.ts`) - Monitors Claude Code state from `.jsonl` files; active-session matching uses only herdr's native agent session id
 - **SessionHistoryService** (`services/session-history.ts`) - Reads past Claude Code session history and conversations
 - **SessionMetadataService** (`services/session-metadata.ts`) - Persists session metadata (theme, title, last known sessions for recovery after reboot). Deliberately *not* session order — that lives in herdr
 - **SessionsService** (`services/sessions.ts`) - Session CRUD operations with file-based persistence
@@ -340,7 +340,7 @@ cchub --version
 - Run `sudo tailscale set --operator=$USER` once to allow cert generation
 - macOS: Install Tailscale via `brew install tailscale` (App Store version lacks CLI)
 - herdr must be installed (`curl -fsSL https://herdr.dev/install.sh | sh` or `brew install herdr`); cchub auto-starts `herdr server` if it isn't running, but a supervised setup (systemd user unit with `Restart=always` + `~/.config/herdr/config.toml` with `resume_agents_on_restore = true`) is strongly recommended so agent sessions survive server restarts
-- For Claude session identity/restore, install the herdr agent integration once: `herdr integration install claude`
+- For native session identity/restore, install the herdr integrations once: `herdr integration install claude` and `herdr integration install codex` (`cchub setup` installs both)
 
 ## Claude Code / Codex / Grok Hook通知連携
 
@@ -356,7 +356,7 @@ Hook → cchub notify (stdin JSON) → POST /api/notify → WebSocket broadcast 
 
 ### セットアップ手順
 
-1. Claude Code は `~/.claude/settings.json` の `hooks` に `cchub notify` を追加する。Codex は `~/.codex/config.toml` または `~/.codex/hooks.json` に追加する:
+1. Claude Code は `~/.claude/settings.json` の `hooks` に `cchub notify` を追加する。Codex は `~/.codex/hooks.json` に追加する（`config.toml` と併用するとCodexが警告するため、`cchub setup` が既存のCC Hub hookをJSONへ移行する）:
 
 ```json
 {
@@ -445,4 +445,3 @@ systemctl --user status herdr      # if supervised via systemd
 ```
 
 cchub auto-starts `herdr server` at boot when the socket (`~/.config/herdr/herdr.sock`, or `$HERDR_SOCKET_PATH`) is unreachable. herdr's own log lives at `~/.config/herdr/herdr-server.log`. Sessions (workspaces) live in the herdr server process — restarting cchub never kills them; restarting herdr restores workspaces from `session.json` and, with `resume_agents_on_restore`, resumes agent conversations natively.
-

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ sudo tailscale set --operator=$USER
 
 ### herdr Backend
 
-CC Hub runs every session as a [herdr](https://herdr.dev/) workspace. `cchub setup` provisions everything: a supervised `herdr server` (systemd on Linux, launchd on macOS), `~/.config/herdr/config.toml` with `resume_agents_on_restore = true` (agent conversations survive server restarts), and the Claude Code integration hook (native session identity).
+CC Hub runs every session as a [herdr](https://herdr.dev/) workspace. `cchub setup` provisions everything: a supervised `herdr server` (systemd on Linux, launchd on macOS), `~/.config/herdr/config.toml` with `resume_agents_on_restore = true` (agent conversations survive server restarts), and the Claude/Codex integration hooks (native session identity).
 
 To update herdr later: `herdr update`, then restart the supervised server (`systemctl --user restart herdr`). The update replaces the binary but leaves the running server on the old version, so the restart is what actually applies it — CC Hub notices that gap and shows a warning on the dashboard, with a button that does both steps for you. Restarting re-creates every pane: agent conversations come back automatically, but commands running in a pane do not, so it waits for you to press it.
 

--- a/backend/src/commands/setup.ts
+++ b/backend/src/commands/setup.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { t } from '../i18n';
 import { herdrBinaryPath } from '../services/herdr-client';
+import { migrateCodexHooksToJson } from '../services/codex-hook-config';
 import { storePassword as storePasswordInKeychain } from '../utils/keychain';
 
 /** Escape special characters for safe inclusion in XML/plist content. */
@@ -185,8 +186,8 @@ pane_history = true
 
 /**
  * Provision the herdr backend: supervised server (systemd / launchd),
- * config.toml with agent-resume enabled, and the Claude Code integration
- * hook (native session identity for restore).
+ * config.toml with agent-resume enabled, and native identity integrations for
+ * the supported agents that herdr can integrate with.
  */
 async function provisionHerdr(): Promise<void> {
   console.log('🐑 herdr バックエンドのセットアップ');
@@ -254,15 +255,26 @@ async function provisionHerdr(): Promise<void> {
     }
   }
 
-  // Claude Code integration: reports native session ids to herdr so agent
-  // conversations survive server restarts. Adds a SessionStart hook to
-  // ~/.claude/settings.json (coexists with cchub notify hooks).
-  const integ = Bun.spawnSync([herdrPath, 'integration', 'install', 'claude']);
-  if (integ.exitCode === 0) {
-    console.log('✅ herdr Claude integration を設定しました (~/.claude/settings.json に SessionStart hook)');
-  } else {
-    console.error('⚠️  herdr integration install claude に失敗しました:');
-    console.error(integ.stderr.toString());
+  // Native session identity is authoritative in CC Hub. Install every herdr
+  // integration available for our supported agents; without one, that
+  // provider stays visible as a terminal but conversation history is disabled.
+  for (const agent of ['claude', 'codex'] as const) {
+    const integ = Bun.spawnSync([herdrPath, 'integration', 'install', agent]);
+    if (integ.exitCode === 0) {
+      console.log(`✅ herdr ${agent} integration を設定しました`);
+    } else {
+      console.error(`⚠️  herdr integration install ${agent} に失敗しました:`);
+      console.error(integ.stderr.toString());
+    }
+  }
+  try {
+    const migration = await migrateCodexHooksToJson(join(homedir(), '.codex'));
+    if (migration.changed) {
+      console.log('✅ Codex hook を ~/.codex/hooks.json に統合しました');
+    }
+  } catch (error) {
+    console.error('⚠️  Codex hook の hooks.json 統合に失敗しました:');
+    console.error(error instanceof Error ? error.message : String(error));
   }
   console.log('');
 }

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -181,20 +181,17 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
   const herdrSessions = await herdrService.listSessions();
   const sessionMetadata = await getAllSessionMetadata();
 
-  const claudePaths = herdrSessions
-    .filter((s): s is typeof s & { currentPath: string } => agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && !!s.currentPath)
-    .map(s => s.currentPath);
-  const ccSessionsByPath = await claudeCodeService.getSessionsForPaths(claudePaths);
-
-  // One thread map per thread-based agent (codex, grok, ...): latest thread
-  // in each working directory, resolved from the agent's own session store.
+  // Enrich thread-based agents by the exact native session ids from herdr.
+  // A missing integration means no id and therefore no active conversation;
+  // never guess from cwd, where multiple sessions are ambiguous.
   const threadsByAgent = new Map<AgentProvider, Map<string, AgentThread>>();
   await Promise.all((Object.entries(threadServices) as [AgentProvider, AgentThreadService][]).map(async ([agentId, service]) => {
-    const paths = herdrSessions
-      .filter((s): s is typeof s & { currentPath: string } => (s.agent ?? s.currentCommand) === agentId && !!s.currentPath)
-      .map(s => s.currentPath);
-    if (paths.length === 0) return;
-    threadsByAgent.set(agentId, await service.getThreadsForPaths(paths));
+    const sessionIds = herdrSessions
+      .filter((s): s is typeof s & { agentSessionId: string } =>
+        (s.agent ?? s.currentCommand) === agentId && !!s.agentSessionId)
+      .map(s => s.agentSessionId);
+    if (sessionIds.length === 0) return;
+    threadsByAgent.set(agentId, await service.getThreadsByIds(sessionIds));
   }));
 
   // Remote Control deep-link map: Claude Code sessionId -> bridgeSessionId.
@@ -204,25 +201,23 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
   const results = await Promise.all(herdrSessions.map(async (s) => {
     let ccSession: Awaited<ReturnType<typeof claudeCodeService.getSessionForPath>> | undefined;
     const threadAgent = threadAgentOf(s.agent ?? s.currentCommand);
-    const agentThread = threadAgent && s.currentPath
-      ? threadsByAgent.get(threadAgent)?.get(s.currentPath)
+    const agentThread = threadAgent && s.agentSessionId
+      ? threadsByAgent.get(threadAgent)?.get(s.agentSessionId)
       : undefined;
 
-    if (agentSupportsConversationMetadata(s.agent ?? s.currentCommand) && s.currentPath) {
-      // Prefer the native session id reported via the herdr agent
-      // integration — it keeps two sessions in the SAME workingDir
-      // distinguishable. Fall back to most-recent-.jsonl path matching.
-      ccSession = s.agentSessionId
-        ? ((await claudeCodeService.getSessionById(s.agentSessionId, s.currentPath)) ??
-          ccSessionsByPath.get(s.currentPath))
-        : ccSessionsByPath.get(s.currentPath);
+    if (
+      agentSupportsConversationMetadata(s.agent ?? s.currentCommand) &&
+      s.agentSessionId &&
+      s.currentPath
+    ) {
+      ccSession =
+        (await claudeCodeService.getSessionById(s.agentSessionId, s.currentPath)) ??
+        undefined;
     }
 
     const includeClaudeInfo = agentSupportsConversationMetadata(s.agent ?? s.currentCommand);
     const includeThreadInfo = !!threadAgent;
-    const conversationSessionId = includeClaudeInfo
-      ? ccSession?.sessionId
-      : agentThread?.sessionId;
+    const conversationSessionId = s.agentSessionId;
 
     // Indicator state: herdr's own agent detection is the source of truth —
     // it tracks the pane itself, so it can't go stale when a hook is missing,
@@ -262,7 +257,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
 
     const panePids: (number | undefined)[] = s.panes ? s.panes.map((p: { pid?: number }) => p.pid) : [];
     const metrics = await computeSessionMetrics({
-      ccSessionId: includeClaudeInfo ? ccSession?.sessionId : undefined,
+      ccSessionId: includeClaudeInfo ? s.agentSessionId : undefined,
       workingDir: s.currentPath,
       pids: panePids,
     });
@@ -290,12 +285,12 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       ccRecap: includeClaudeInfo && isExactPathMatch ? ccSession?.lastRecap?.content : undefined,
       ccRecapAt: includeClaudeInfo && isExactPathMatch ? ccSession?.lastRecap?.timestamp : undefined,
       indicatorState: sessionIndicatorState,
-      ccSessionId: includeClaudeInfo ? ccSession?.sessionId : undefined,
+      ccSessionId: includeClaudeInfo ? s.agentSessionId : undefined,
       bridgeSessionId:
-        includeClaudeInfo && ccSession?.sessionId
-          ? bridgeSessionIds.get(ccSession.sessionId)
+        includeClaudeInfo && s.agentSessionId
+          ? bridgeSessionIds.get(s.agentSessionId)
           : undefined,
-      agentSessionId: agentThread?.sessionId,
+      agentSessionId: includeThreadInfo ? s.agentSessionId : undefined,
       messageCount: includeClaudeInfo ? ccSession?.messageCount : undefined,
       gitBranch: includeClaudeInfo ? ccSession?.gitBranch : agentThread?.gitBranch,
       durationMinutes: includeClaudeInfo ? durationMinutes : agentThread?.updatedAt ? Math.round((Date.now() - new Date(agentThread.updatedAt).getTime()) / 60000) : undefined,
@@ -303,11 +298,8 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       theme: sessionMetadata[s.id]?.theme,
       customTitle: sessionMetadata[s.id]?.title,
       metrics: sessionMetrics,
-      panes: s.panes ? s.panes.map((p: { paneId: string; command: string; path: string; title: string; tty: string; isActive: boolean; isDead: boolean; pid?: number }) => {
-        // Pane command comes from herdr's pane.process_info (foreground group
-        // leader), so `command === agent id` identifies the agent pane.
-        const sessionAgent = s.agent ?? s.currentCommand;
-        const isSessionAgentOnPane = !p.isDead && p.command === sessionAgent;
+      panes: s.panes ? s.panes.map((p) => {
+        const isSessionAgentOnPane = !p.isDead && !!p.agent;
         const isClaudeOnPane = isSessionAgentOnPane && includeClaudeInfo;
         let paneIndicator: IndicatorState | undefined;
         if (p.isDead) {
@@ -324,6 +316,8 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
           paneId: p.paneId,
           currentCommand: p.command,
           currentPath: p.path,
+          agent: p.agent,
+          agentSessionId: p.agentSessionId,
           title: p.title || undefined,
           isActive: p.isActive,
           isDead: p.isDead || undefined,

--- a/backend/src/services/agent-providers.ts
+++ b/backend/src/services/agent-providers.ts
@@ -21,7 +21,7 @@ export interface AgentTokenUsage {
   model?: string;
 }
 
-/** Latest thread/session of an agent in a working directory. */
+/** One exact agent thread/session, keyed by its native session id. */
 export interface AgentThread {
   sessionId: string;
   title?: string;
@@ -34,9 +34,9 @@ export interface AgentThread {
   updatedAt?: string;
 }
 
-/** Resolves the latest thread per working directory for active sessions. */
+/** Resolves exact threads by the native session ids reported by herdr. */
 export interface AgentThreadService {
-  getThreadsForPaths(paths: string[]): Promise<Map<string, AgentThread>>;
+  getThreadsByIds(sessionIds: string[]): Promise<Map<string, AgentThread>>;
 }
 
 /** Past-session history + conversation reader for one agent. */

--- a/backend/src/services/codex-hook-config.ts
+++ b/backend/src/services/codex-hook-config.ts
@@ -1,0 +1,159 @@
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+interface JsonHookCommand {
+  type?: string;
+  command?: string;
+  timeout?: number;
+  [key: string]: unknown;
+}
+
+interface JsonHookEntry {
+  matcher?: string;
+  hooks?: JsonHookCommand[];
+  [key: string]: unknown;
+}
+
+interface CodexHooksJson {
+  hooks?: Record<string, JsonHookEntry[]>;
+  [key: string]: unknown;
+}
+
+const CCHUB_NOTIFY_PATTERN = /(?:^|\/)cchub\s+notify(?:\s|$)/;
+
+function isCchubNotify(command: unknown): command is string {
+  return typeof command === 'string' && CCHUB_NOTIFY_PATTERN.test(command.trim());
+}
+
+function hasCchubHook(entries: JsonHookEntry[] | undefined, matcher?: string): boolean {
+  return !!entries?.some((entry) => {
+    if (matcher && entry.matcher !== matcher && !entry.matcher?.includes(matcher)) return false;
+    return entry.hooks?.some((hook) => isCchubNotify(hook.command));
+  });
+}
+
+/** Merge the two CC Hub notification hooks into Codex's canonical hooks.json. */
+export function mergeCchubNotifyHooksJson(content: string | null, command: string): string {
+  const parsed: CodexHooksJson = content?.trim()
+    ? JSON.parse(content) as CodexHooksJson
+    : {};
+  const hooks = parsed.hooks && typeof parsed.hooks === 'object' ? parsed.hooks : {};
+
+  if (!hasCchubHook(hooks.Stop)) {
+    hooks.Stop = [
+      ...(Array.isArray(hooks.Stop) ? hooks.Stop : []),
+      { hooks: [{ type: 'command', command }] },
+    ];
+  }
+  if (!hasCchubHook(hooks.PostToolUse, 'AskUserQuestion')) {
+    hooks.PostToolUse = [
+      ...(Array.isArray(hooks.PostToolUse) ? hooks.PostToolUse : []),
+      {
+        matcher: 'AskUserQuestion',
+        hooks: [{ type: 'command', command }],
+      },
+    ];
+  }
+
+  parsed.hooks = hooks;
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+function tomlHeader(line: string): string | null {
+  const trimmed = line.trim();
+  return trimmed.startsWith('[') ? trimmed : null;
+}
+
+function hookEventFromParent(header: string): string | null {
+  return header.match(/^\[\[hooks\.([A-Za-z0-9_]+)\]\]$/)?.[1] ?? null;
+}
+
+function isNestedHookHeader(header: string, event: string): boolean {
+  return header === `[[hooks.${event}.hooks]]`;
+}
+
+function blockHasCchubNotify(lines: string[]): boolean {
+  return lines.some((line) => {
+    const match = line.trim().match(/^command\s*=\s*(["'])(.*?)\1\s*$/);
+    return !!match && isCchubNotify(match[2]);
+  });
+}
+
+/**
+ * Remove only hook entries whose command is `cchub notify` from config.toml.
+ * Other TOML settings and unrelated hook commands keep their original text.
+ */
+export function removeCchubNotifyHooksToml(content: string): string {
+  const lines = content.split('\n');
+  const output: string[] = [];
+
+  for (let index = 0; index < lines.length;) {
+    const header = tomlHeader(lines[index] ?? '');
+    const event = header ? hookEventFromParent(header) : null;
+    if (!event) {
+      output.push(lines[index] ?? '');
+      index++;
+      continue;
+    }
+
+    const groupStart = index;
+    index++;
+    while (index < lines.length) {
+      const nextHeader = tomlHeader(lines[index] ?? '');
+      if (nextHeader && !isNestedHookHeader(nextHeader, event)) break;
+      index++;
+    }
+
+    const group = lines.slice(groupStart, index);
+    const segments: string[][] = [];
+    let current: string[] = [];
+    for (const line of group) {
+      const segmentHeader = tomlHeader(line);
+      if (segmentHeader && isNestedHookHeader(segmentHeader, event) && current.length > 0) {
+        segments.push(current);
+        current = [];
+      }
+      current.push(line);
+    }
+    if (current.length > 0) segments.push(current);
+
+    const parent = segments[0] ?? [];
+    if (blockHasCchubNotify(parent)) continue;
+    const remainingChildren = segments.slice(1).filter((segment) => !blockHasCchubNotify(segment));
+    if (remainingChildren.length === 0) continue;
+    output.push(...parent, ...remainingChildren.flat());
+  }
+
+  return output.join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+export function findCchubNotifyCommandInToml(content: string): string | undefined {
+  for (const line of content.split('\n')) {
+    const match = line.trim().match(/^command\s*=\s*(["'])(.*?)\1\s*$/);
+    if (match && isCchubNotify(match[2])) return match[2];
+  }
+  return undefined;
+}
+
+async function atomicWrite(path: string, content: string): Promise<void> {
+  const tempPath = `${path}.cchub-tmp-${process.pid}`;
+  await writeFile(tempPath, content, { mode: 0o600 });
+  await rename(tempPath, path);
+}
+
+export async function migrateCodexHooksToJson(
+  codexDir: string,
+): Promise<{ changed: boolean; command: string }> {
+  const configPath = join(codexDir, 'config.toml');
+  const hooksPath = join(codexDir, 'hooks.json');
+  const config = await readFile(configPath, 'utf8').catch(() => '');
+  const hooksJson = await readFile(hooksPath, 'utf8').catch(() => null);
+  const command = findCchubNotifyCommandInToml(config) ?? 'cchub notify';
+  const nextConfig = removeCchubNotifyHooksToml(config);
+  const nextHooksJson = mergeCchubNotifyHooksJson(hooksJson, command);
+  const changed = nextConfig !== config || nextHooksJson !== hooksJson;
+
+  if (nextConfig !== config) await atomicWrite(configPath, nextConfig);
+  if (nextHooksJson !== hooksJson) await atomicWrite(hooksPath, nextHooksJson);
+  return { changed, command };
+}

--- a/backend/src/services/codex.ts
+++ b/backend/src/services/codex.ts
@@ -175,31 +175,27 @@ export class CodexService {
     this.dbPath = dbPath;
   }
 
-  async getThreadsForPaths(paths: string[]): Promise<Map<string, CodexThread>> {
-    const uniquePaths = [...new Set(paths.filter(Boolean))];
-    if (uniquePaths.length === 0) return new Map();
+  async getThreadsByIds(sessionIds: string[]): Promise<Map<string, CodexThread>> {
+    const uniqueIds = [...new Set(sessionIds.filter(Boolean))];
+    if (uniqueIds.length === 0) return new Map();
 
     if (this.cache && Date.now() - this.cache.timestamp < CodexService.CACHE_TTL) {
-      return new Map(uniquePaths.flatMap(path => {
-        const thread = this.cache?.data.get(path);
-        return thread ? [[path, thread] as const] : [];
+      return new Map(uniqueIds.flatMap(sessionId => {
+        const thread = this.cache?.data.get(sessionId);
+        return thread ? [[sessionId, thread] as const] : [];
       }));
     }
 
-    const allThreads = this.loadLatestThreadsByCwd();
+    const allThreads = this.loadThreadsById();
     this.cache = { timestamp: Date.now(), data: allThreads };
 
-    return new Map(uniquePaths.flatMap(path => {
-      const thread = allThreads.get(path);
-      return thread ? [[path, thread] as const] : [];
+    return new Map(uniqueIds.flatMap(sessionId => {
+      const thread = allThreads.get(sessionId);
+      return thread ? [[sessionId, thread] as const] : [];
     }));
   }
 
-  async getThreadForPath(path: string): Promise<CodexThread | undefined> {
-    return (await this.getThreadsForPaths([path])).get(path);
-  }
-
-  private loadLatestThreadsByCwd(): Map<string, CodexThread> {
+  private loadThreadsById(): Map<string, CodexThread> {
     const result = new Map<string, CodexThread>();
     if (!existsSync(this.dbPath)) return result;
 
@@ -221,13 +217,10 @@ export class CodexService {
           updated_at_ms
         FROM threads
         WHERE archived = 0
-        ORDER BY COALESCE(updated_at_ms, updated_at * 1000, 0) DESC
       `).all();
 
       for (const row of rows) {
-        if (!result.has(row.cwd)) {
-          result.set(row.cwd, rowToThread(row));
-        }
+        result.set(row.id, rowToThread(row));
       }
     } catch {
       return new Map();

--- a/backend/src/services/grok.ts
+++ b/backend/src/services/grok.ts
@@ -213,7 +213,7 @@ export function readLatestGrokTokenUsage(sessionDir: string): AgentTokenUsage | 
   return undefined;
 }
 
-/** Latest Grok session per working directory, for the active-sessions list. */
+/** Exact Grok sessions by native session id, for the active-sessions list. */
 export class GrokService implements AgentThreadService {
   private store: GrokSessionStore;
 
@@ -221,27 +221,21 @@ export class GrokService implements AgentThreadService {
     this.store = store;
   }
 
-  async getThreadsForPaths(paths: string[]): Promise<Map<string, AgentThread>> {
-    const uniquePaths = new Set(paths.filter(Boolean));
-    if (uniquePaths.size === 0) return new Map();
+  async getThreadsByIds(sessionIds: string[]): Promise<Map<string, AgentThread>> {
+    const uniqueIds = new Set(sessionIds.filter(Boolean));
+    if (uniqueIds.size === 0) return new Map();
 
     const sessions = await this.store.listSessions();
-    const latestByCwd = new Map<string, GrokSessionInfo>();
-    for (const s of sessions) {
-      if (!uniquePaths.has(s.cwd)) continue;
-      const existing = latestByCwd.get(s.cwd);
-      if (!existing || s.updatedAt > existing.updatedAt) latestByCwd.set(s.cwd, s);
-    }
-
     const result = new Map<string, AgentThread>();
-    for (const [cwd, s] of latestByCwd) {
+    for (const s of sessions) {
+      if (!uniqueIds.has(s.sessionId)) continue;
       const tokenUsage = readLatestGrokTokenUsage(s.dir);
-      result.set(cwd, {
+      result.set(s.sessionId, {
         sessionId: s.sessionId,
         title: s.title,
         firstPrompt: s.firstPrompt,
         tokenUsage: s.modelId ? { ...tokenUsage, model: s.modelId } : tokenUsage,
-        cwd,
+        cwd: s.cwd,
         createdAt: s.createdAt,
         updatedAt: s.updatedAt,
       });

--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -2,11 +2,11 @@
  * HerdrService — session-level operations on the herdr backend.
  *
  * Maps CC Hub sessions onto herdr workspaces (session id = workspace label,
- * falling back to workspace_id). Panes expose no TTY; agent detection uses
- * the pane's foreground process group instead.
+ * falling back to workspace_id). herdr's agent.list response is authoritative
+ * for the agent provider and native session identity of each pane.
  */
 
-import { detectAgentProviderFromArgs, type AgentProvider } from '../../../shared/types';
+import { isAgentProvider, type AgentProvider } from '../../../shared/types';
 import {
   herdrRpc,
   listPanes,
@@ -22,6 +22,9 @@ interface HerdrPaneInfo {
   paneId: string;
   command: string;
   path: string;
+  agent?: AgentProvider;
+  agentSessionId?: string;
+  agentStatus?: HerdrAgentStatus;
   title: string;
   tty: string;
   isActive: boolean;
@@ -53,6 +56,41 @@ interface HerdrSessionInfo {
   agentStatus?: HerdrAgentStatus;
 }
 
+export interface HerdrAgentRecord {
+  pane_id?: string;
+  agent?: string;
+  agent_status?: HerdrAgentStatus;
+  agent_session?: { kind?: string; value?: string };
+}
+
+export interface HerdrAgentPane {
+  agent: AgentProvider;
+  sessionId?: string;
+  status?: HerdrAgentStatus;
+}
+
+export function indexHerdrAgentPanes(
+  agents: HerdrAgentRecord[],
+): Map<string, HerdrAgentPane> {
+  const map = new Map<string, HerdrAgentPane>();
+  for (const record of agents) {
+    if (!record.pane_id || !record.agent || !isAgentProvider(record.agent)) continue;
+    map.set(record.pane_id, {
+      agent: record.agent,
+      sessionId:
+        record.agent_session?.kind === 'id' && record.agent_session.value
+          ? record.agent_session.value
+          : undefined,
+      status: record.agent_status,
+    });
+  }
+  return map;
+}
+
+export function herdrPaneCommand(leader: string, agentPane?: HerdrAgentPane): string {
+  return agentPane?.agent ?? leader.split(/\s+/)[0]?.split('/').pop() ?? '';
+}
+
 /** Session id for a workspace: label when present, else the workspace id. */
 function workspaceSessionId(ws: HerdrWorkspace): string {
   return ws.label && ws.label.trim() !== '' ? ws.label : ws.workspace_id;
@@ -64,7 +102,7 @@ export class HerdrService {
   // pane process info cache (pane_id → foreground process snapshot)
   private processCmdCache = new Map<
     string,
-    { cmdlines: string[]; leader: string; pid?: number; timestamp: number }
+    { leader: string; pid?: number; timestamp: number }
   >();
   private static readonly PROCESS_CMD_CACHE_TTL = 3000;
 
@@ -83,7 +121,7 @@ export class HerdrService {
 
   private async paneProcesses(
     herdrPaneId: string,
-  ): Promise<{ cmdlines: string[]; leader: string; pid?: number }> {
+  ): Promise<{ leader: string; pid?: number }> {
     const cached = this.processCmdCache.get(herdrPaneId);
     if (cached && Date.now() - cached.timestamp < HerdrService.PROCESS_CMD_CACHE_TTL) {
       return cached;
@@ -100,16 +138,11 @@ export class HerdrService {
           }>;
         };
       }>('pane.process_info', { pane_id: herdrPaneId });
-      // foreground_processes lists the whole foreground group: its first
-      // entry is the group leader (e.g. `claude`), later entries are its
-      // children (MCP servers etc.). Agent detection scans all of them.
+      // The first foreground process is used only as the plain-shell command
+      // and metrics PID. Agent identity comes exclusively from agent.list.
       const procs = res.process_info?.foreground_processes ?? [];
-      const cmdlines = procs
-        .map((p) => p.cmdline || p.argv?.join(' ') || p.name || '')
-        .filter((c) => c.length > 0);
       const leaderProc = procs[0];
       const entry = {
-        cmdlines,
         leader: leaderProc?.name || leaderProc?.cmdline || '',
         pid: typeof leaderProc?.pid === 'number' ? leaderProc.pid : undefined,
         timestamp: Date.now(),
@@ -117,43 +150,25 @@ export class HerdrService {
       this.processCmdCache.set(herdrPaneId, entry);
       return entry;
     } catch {
-      const entry = { cmdlines: [], leader: '', timestamp: Date.now() };
+      const entry = { leader: '', timestamp: Date.now() };
       this.processCmdCache.set(herdrPaneId, entry);
       return entry;
     }
   }
 
-  private static detectAgent(cmdlines: string[]): AgentProvider | undefined {
-    for (const cmd of cmdlines) {
-      const detected = detectAgentProviderFromArgs(cmd);
-      if (detected) return detected;
-    }
-    return undefined;
-  }
-
   /**
-   * pane_id → native agent session id (Claude conversation UUID etc.),
-   * reported to herdr by its agent integration hooks. Best-effort: without
-   * the integration installed the map is simply empty.
+   * pane_id → agent provider + native session id, as reported by herdr.
+   * The provider is available from herdr's runtime detection; sessionId is
+   * present only when that provider's herdr integration is installed.
    */
-  private async listAgentSessions(): Promise<Map<string, string>> {
-    const map = new Map<string, string>();
+  private async listAgentPanes(): Promise<Map<string, HerdrAgentPane>> {
     try {
-      const res = await herdrRpc<{
-        agents?: Array<{
-          pane_id?: string;
-          agent_session?: { kind?: string; value?: string };
-        }>;
-      }>('agent.list', {});
-      for (const a of res.agents ?? []) {
-        if (a.pane_id && a.agent_session?.kind === 'id' && a.agent_session.value) {
-          map.set(a.pane_id, a.agent_session.value);
-        }
-      }
+      const res = await herdrRpc<{ agents?: HerdrAgentRecord[] }>('agent.list', {});
+      return indexHerdrAgentPanes(res.agents ?? []);
     } catch {
       // enrichment only
     }
-    return map;
+    return new Map();
   }
 
   async listSessions(): Promise<HerdrSessionInfo[]> {
@@ -165,10 +180,10 @@ export class HerdrService {
     }
 
     try {
-      const [workspaces, allPanes, agentSessions] = await Promise.all([
+      const [workspaces, allPanes, agentPanes] = await Promise.all([
         listWorkspaces(),
         listPanes(),
-        this.listAgentSessions(),
+        this.listAgentPanes(),
       ]);
 
       const result: HerdrSessionInfo[] = await Promise.all(
@@ -178,10 +193,14 @@ export class HerdrService {
             wsPanes.map(async (p) => {
               const tmuxId = toTmuxPaneId(p.pane_id) ?? p.pane_id;
               const { leader, pid } = await this.paneProcesses(p.pane_id);
+              const agentPane = agentPanes.get(p.pane_id);
               return {
                 paneId: tmuxId,
-                command: leader.split(/\s+/)[0]?.split('/').pop() ?? '',
+                command: herdrPaneCommand(leader, agentPane),
                 path: p.foreground_cwd || p.cwd || '',
+                agent: agentPane?.agent,
+                agentSessionId: agentPane?.sessionId,
+                agentStatus: agentPane?.status ?? p.agent_status,
                 title: '',
                 tty: '',
                 isActive: p.focused,
@@ -191,22 +210,11 @@ export class HerdrService {
             }),
           );
 
-          // Agent detection from the pane's foreground process group (herdr
-          // also exposes agent_status natively, but it doesn't tell us WHICH
-          // agent).
-          let agent: AgentProvider | undefined;
-          let agentPanePath: string | undefined;
-          let agentPaneStatus: HerdrAgentStatus | undefined;
-          for (const p of wsPanes) {
-            const { cmdlines } = await this.paneProcesses(p.pane_id);
-            const detected = HerdrService.detectAgent(cmdlines);
-            if (detected) {
-              agent = detected;
-              agentPanePath = p.foreground_cwd || p.cwd;
-              agentPaneStatus = p.agent_status;
-              break;
-            }
-          }
+          // Keep the representative session fields paired to one pane. Prefer
+          // the currently focused agent pane, then the first agent pane.
+          const agentPane =
+            panes.find((p) => p.isActive && p.agent) ?? panes.find((p) => p.agent);
+          const agent = agentPane?.agent;
 
           const rootPane = wsPanes[0];
           const rootHerdrId = rootPane?.pane_id;
@@ -225,10 +233,8 @@ export class HerdrService {
             }
           }
 
-          const currentPath = agentPanePath ?? rootPane?.foreground_cwd ?? rootPane?.cwd;
-          const agentSessionId = wsPanes
-            .map((p) => agentSessions.get(p.pane_id))
-            .find((id) => id !== undefined);
+          const currentPath = agentPane?.path ?? rootPane?.foreground_cwd ?? rootPane?.cwd;
+          const agentSessionId = agentPane?.agentSessionId;
           // `blocked` anywhere in the workspace wins: an agent waiting on a
           // prompt is the state the user has to act on, even if the split it
           // sits in isn't the one we matched an agent process to.
@@ -236,7 +242,7 @@ export class HerdrService {
             (p) => p.agent_status === 'blocked',
           )
             ? 'blocked'
-            : agentPaneStatus;
+            : agentPane?.agentStatus;
           return {
             id: workspaceSessionId(ws),
             name: workspaceSessionId(ws),

--- a/backend/tests/unit/codex-hook-config.test.ts
+++ b/backend/tests/unit/codex-hook-config.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  mergeCchubNotifyHooksJson,
+  migrateCodexHooksToJson,
+  removeCchubNotifyHooksToml,
+} from '../../src/services/codex-hook-config';
+
+const scratchDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(scratchDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Codex hook JSON migration', () => {
+  test('preserves herdr SessionStart and adds only required CC Hub hooks', () => {
+    const result = JSON.parse(mergeCchubNotifyHooksJson(JSON.stringify({
+      hooks: {
+        SessionStart: [{ hooks: [{ type: 'command', command: 'herdr-session-hook' }] }],
+      },
+    }), '/opt/cchub notify'));
+
+    expect(result.hooks.SessionStart).toHaveLength(1);
+    expect(result.hooks.Stop).toEqual([
+      { hooks: [{ type: 'command', command: '/opt/cchub notify' }] },
+    ]);
+    expect(result.hooks.PostToolUse).toEqual([{
+      matcher: 'AskUserQuestion',
+      hooks: [{ type: 'command', command: '/opt/cchub notify' }],
+    }]);
+    expect(result.hooks.PreToolUse).toBeUndefined();
+    expect(result.hooks.UserPromptSubmit).toBeUndefined();
+  });
+
+  test('is idempotent and does not duplicate existing CC Hub entries', () => {
+    const first = mergeCchubNotifyHooksJson(null, 'cchub notify');
+    const second = mergeCchubNotifyHooksJson(first, 'cchub notify');
+    expect(second).toBe(first);
+  });
+
+  test('removes only cchub notify hook entries from TOML', () => {
+    const input = `model = "gpt-test"
+
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = "/home/user/bin/cchub notify"
+
+[[hooks.PostToolUse]]
+matcher = "Bash"
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "keep-me"
+
+[hooks.state]
+[hooks.state."hooks.json:session_start:0:0"]
+trusted_hash = "sha256:abc"
+`;
+
+    const result = removeCchubNotifyHooksToml(input);
+    expect(result).toContain('model = "gpt-test"');
+    expect(result).not.toContain('cchub notify');
+    expect(result).toContain('command = "keep-me"');
+    expect(result).toContain('[hooks.state]');
+    expect(result).toContain('hooks.json:session_start:0:0');
+  });
+
+  test('migrates files atomically and keeps the existing absolute command', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cchub-codex-hook-migration-'));
+    scratchDirs.push(dir);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'config.toml'), `model = "gpt-test"
+
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+command = "/home/user/bin/cchub notify"
+`);
+    await writeFile(join(dir, 'hooks.json'), JSON.stringify({
+      hooks: {
+        SessionStart: [{ hooks: [{ command: 'herdr-hook' }] }],
+      },
+    }));
+
+    const result = await migrateCodexHooksToJson(dir);
+    const config = await readFile(join(dir, 'config.toml'), 'utf8');
+    const hooks = JSON.parse(await readFile(join(dir, 'hooks.json'), 'utf8'));
+
+    expect(result).toEqual({ changed: true, command: '/home/user/bin/cchub notify' });
+    expect(config).toBe('model = "gpt-test"\n');
+    expect(hooks.hooks.SessionStart).toHaveLength(1);
+    expect(hooks.hooks.Stop[0].hooks[0].command).toBe('/home/user/bin/cchub notify');
+  });
+});

--- a/backend/tests/unit/codex-service.test.ts
+++ b/backend/tests/unit/codex-service.test.ts
@@ -82,12 +82,12 @@ describe('CodexService', () => {
   test('returns an empty map when the state database does not exist', async () => {
     const service = new CodexService(join(TEST_DIR, 'missing.sqlite'));
 
-    const threads = await service.getThreadsForPaths(['/repo']);
+    const threads = await service.getThreadsByIds(['missing']);
 
     expect(threads.size).toBe(0);
   });
 
-  test('returns the latest unarchived thread for each cwd', async () => {
+  test('returns exact unarchived threads by native session id', async () => {
     const db = new Database(DB_PATH);
     createThreadsTable(db);
     insertThread(db, {
@@ -118,15 +118,15 @@ describe('CodexService', () => {
     db.close();
 
     const service = new CodexService(DB_PATH);
-    const threads = await service.getThreadsForPaths(['/repo', '/other', '/missing']);
+    const threads = await service.getThreadsByIds(['older', 'newer', 'other', 'missing']);
 
-    expect(threads.get('/repo')?.sessionId).toBe('newer');
-    expect(threads.get('/repo')?.title).toBe('Newer title');
-    expect(threads.get('/repo')?.firstPrompt).toBe('newer prompt');
-    expect(threads.get('/repo')?.tokensUsed).toBe(250);
-    expect(threads.get('/repo')?.gitBranch).toBe('feat/codex');
-    expect(threads.get('/other')?.sessionId).toBe('other');
-    expect(threads.has('/missing')).toBe(false);
+    expect(threads.get('older')?.sessionId).toBe('older');
+    expect(threads.get('newer')?.title).toBe('Newer title');
+    expect(threads.get('newer')?.firstPrompt).toBe('newer prompt');
+    expect(threads.get('newer')?.tokensUsed).toBe(250);
+    expect(threads.get('newer')?.gitBranch).toBe('feat/codex');
+    expect(threads.get('other')?.sessionId).toBe('other');
+    expect(threads.has('missing')).toBe(false);
   });
 
   test('ignores archived threads', async () => {
@@ -144,7 +144,7 @@ describe('CodexService', () => {
     db.close();
 
     const service = new CodexService(DB_PATH);
-    const threads = await service.getThreadsForPaths(['/repo']);
+    const threads = await service.getThreadsByIds(['archived']);
 
     expect(threads.size).toBe(0);
   });
@@ -207,7 +207,7 @@ describe('CodexService', () => {
     db.close();
 
     const service = new CodexService(DB_PATH);
-    const thread = (await service.getThreadsForPaths(['/repo'])).get('/repo');
+    const thread = (await service.getThreadsByIds(['with-rollout'])).get('with-rollout');
 
     expect(thread?.tokenUsage?.contextTokens).toBe(125);
     expect(thread?.tokenUsage?.contextMaxTokens).toBe(250);

--- a/backend/tests/unit/grok-service.test.ts
+++ b/backend/tests/unit/grok-service.test.ts
@@ -113,11 +113,11 @@ describe('parseGrokChatHistory', () => {
 });
 
 describe('GrokService', () => {
-  test('resolves the latest thread per cwd with token usage', async () => {
+  test('resolves an exact thread by native session id with token usage', async () => {
     const service = new GrokService(new GrokSessionStore(SESSIONS_DIR));
-    const threads = await service.getThreadsForPaths([CWD, '/nonexistent']);
+    const threads = await service.getThreadsByIds([SESSION_ID, 'nonexistent']);
     expect(threads.size).toBe(1);
-    const thread = threads.get(CWD);
+    const thread = threads.get(SESSION_ID);
     expect(thread?.sessionId).toBe(SESSION_ID);
     expect(thread?.title).toBe('Run the shell command: echo hello');
     expect(thread?.firstPrompt).toBe('Run the shell command: echo hello. Then report.');
@@ -127,7 +127,7 @@ describe('GrokService', () => {
 
   test('returns empty map when the sessions dir does not exist', async () => {
     const service = new GrokService(new GrokSessionStore(join(TEST_DIR, 'missing')));
-    expect((await service.getThreadsForPaths([CWD])).size).toBe(0);
+    expect((await service.getThreadsByIds([SESSION_ID])).size).toBe(0);
   });
 });
 

--- a/backend/tests/unit/herdr-service.test.ts
+++ b/backend/tests/unit/herdr-service.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { herdrPaneCommand, indexHerdrAgentPanes } from '../../src/services/herdr';
+
+describe('HerdrService agent identity', () => {
+  test('uses agent.list instead of the foreground process name', () => {
+    const agents = indexHerdrAgentPanes([{
+      pane_id: 'w1:p1',
+      agent: 'codex',
+      agent_status: 'blocked',
+      agent_session: {
+        kind: 'id',
+        value: 'codex-session-id',
+      },
+    }]);
+    const pane = agents.get('w1:p1');
+
+    expect(pane).toMatchObject({
+      agent: 'codex',
+      sessionId: 'codex-session-id',
+      status: 'blocked',
+    });
+    expect(herdrPaneCommand('node-MainThread', pane)).toBe('codex');
+  });
+});

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -13,7 +13,8 @@ Claude Code remains the default agent. Codex is supported as a first-class addit
 - Start the selected agent in the selected working directory.
 - Detect running Claude Code and Codex processes from each pane's foreground process group (herdr `pane.process_info`).
 - Return the detected `agent` in session API responses.
-- Read basic Codex thread metadata from the local Codex state database.
+- Read basic Codex thread metadata from the local Codex state database, keyed
+  by the native session id reported by herdr.
 - Add a Claude/Codex selector to the new session modal.
 - Preserve existing Claude-specific metadata behavior.
 
@@ -66,7 +67,7 @@ The herdr service inspects each pane's foreground processes and detects:
 - Claude Code: `claude` or Claude versioned paths
 - Codex: `codex` or `@openai/codex` paths
 
-When a supported agent is detected on a pane TTY:
+When a supported agent is reported by herdr for a pane:
 
 - session `currentCommand` becomes `claude` or `codex`
 - session `agent` is set to `claude` or `codex`
@@ -86,7 +87,8 @@ Codex session cards use the session name instead of pane title for display, beca
 
 Codex does not expose the same JSONL recap fields that CC Hub reads for Claude Code. Instead, CC Hub reads:
 
-- Local SQLite state at `~/.codex/state_5.sqlite` for: thread ID, title, first user message, token count, git branch, updated time.
+- herdr `agent.list` for the authoritative active thread ID (requires `herdr integration install codex`).
+- Local SQLite state at `~/.codex/state_5.sqlite` for title, first user message, token count, git branch, and updated time, looked up by that ID.
 - Codex conversation transcripts via `CodexConversationService` (`backend/src/services/codex-conversation.ts`).
 - Codex token usage / rate limit state via `CodexUsageService` (`backend/src/services/codex-usage.ts`).
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -823,9 +823,17 @@ export function App() {
 	// Show conversation history for current session
 	const handleShowConversation = useCallback(() => {
 		const activeSession = openSessions.find((s) => s.id === activeSessionId);
-		if (!activeSession?.ccSessionId && !activeSession?.agentSessionId) return;
+		const activePane =
+			activeSession?.panes?.find(
+				(p) => mobileActivePaneId && p.paneId === mobileActivePaneId,
+			) ??
+			activeSession?.panes?.find((p) => p.isActive) ??
+			(activeSession?.panes?.length === 1
+				? activeSession.panes[0]
+				: undefined);
+		if (!activePane?.agent || !activePane.agentSessionId) return;
 		setShowConversation(true);
-	}, [openSessions, activeSessionId]);
+	}, [openSessions, activeSessionId, mobileActivePaneId]);
 
 	// Keep overlay visible (no auto-hide)
 	const startOverlayTimer = useCallback(() => {
@@ -1034,6 +1042,17 @@ export function App() {
 
 	// Get current active session
 	const activeSession = openSessions.find((s) => s.id === activeSessionId);
+	const activeConversationPane =
+		activeSession?.panes?.find(
+			(p) => mobileActivePaneId && p.paneId === mobileActivePaneId,
+		) ??
+		activeSession?.panes?.find((p) => p.isActive) ??
+		(activeSession?.panes?.length === 1
+			? activeSession.panes[0]
+			: undefined);
+	const conversationAvailable = !!(
+		activeConversationPane?.agent && activeConversationPane.agentSessionId
+	);
 
 	// Overlay bar content (shared between positions)
 	const overlayBar = (
@@ -1072,7 +1091,7 @@ export function App() {
 
 			{/* Right: Core actions */}
 			<div className="flex items-center gap-1 shrink-0">
-				{activeSession?.ccSessionId &&
+				{conversationAvailable &&
 					(showConversation ? (
 						<button
 							type="button"
@@ -1170,7 +1189,7 @@ export function App() {
 						// avoiding the black/loading flash on every open.
 						const themeBg =
 							getTerminalThemes()[activeSession.theme || "default"].background;
-						const chatOverlay = activeSession.ccSessionId ? (
+						const chatOverlay = conversationAvailable ? (
 							<div
 								className="h-full flex flex-col"
 								style={{ backgroundColor: themeBg }}
@@ -1223,11 +1242,11 @@ export function App() {
 											/^\/home\/[^/]+\//,
 											"~/",
 										)}
-										inline
-										enabled
-										theme={activeSession.theme}
-										agent={activeSession.agent}
-										agentSessionId={activeSession.agentSessionId}
+									inline
+									enabled
+									theme={activeSession.theme}
+									agent={activeConversationPane?.agent}
+									agentSessionId={activeConversationPane?.agentSessionId}
 										onScrollGesture={() =>
 											mobileTerminalRef.current?.hideKeyboard()
 										}
@@ -1433,9 +1452,7 @@ export function App() {
 					sessionName={activeSession?.name}
 					sessionStatus={activeSession?.state}
 					onShowConversation={
-						activeSession?.ccSessionId || activeSession?.agentSessionId
-							? handleShowConversation
-							: undefined
+						conversationAvailable ? handleShowConversation : undefined
 					}
 					onShowDashboard={() => setShowMobileDashboard(true)}
 				/>

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -7,12 +7,11 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-	type AgentProvider,
-	type PaneInfo,
-	type SessionState,
-	type SessionTheme,
-	isAgentProvider,
+import type {
+	AgentProvider,
+	PaneInfo,
+	SessionState,
+	SessionTheme,
 } from "../../../shared/types";
 import { authFetch } from "../services/api";
 import { openClaudeAppSession } from "../utils/claude-app";
@@ -306,9 +305,13 @@ function TerminalPane({
 	// agent is running on the active pane. Without the loaded check, the very
 	// first render after remount (e.g. after a split) sees panes=undefined and
 	// would wrongly clear chat mode.
-	const activeTmuxPane = session?.panes?.find((p) => p.isActive);
-	const conversationAvailable = isAgentProvider(
-		activeTmuxPane?.currentCommand ?? "",
+	const controlledPaneId = controlModeContext.getControlConfig(paneId)?.paneId;
+	const activeTmuxPane =
+		session?.panes?.find((p) => p.paneId === controlledPaneId) ??
+		session?.panes?.find((p) => p.isActive) ??
+		(session?.panes?.length === 1 ? session.panes[0] : undefined);
+	const conversationAvailable = !!(
+		activeTmuxPane?.agent && activeTmuxPane.agentSessionId
 	);
 	const panesLoaded = !!session?.panes;
 	useEffect(() => {
@@ -688,8 +691,8 @@ function TerminalPane({
 						showComposer={!isTablet}
 						paneId={controlModeContext.getControlConfig(paneId)?.paneId}
 						theme={session?.theme}
-						agent={session?.agent}
-						agentSessionId={session?.agentSessionId}
+						agent={activeTmuxPane?.agent}
+						agentSessionId={activeTmuxPane?.agentSessionId}
 					/>
 				)}
 				{sessionId ? (

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -171,6 +171,10 @@ export interface PaneInfo {
   paneId: string;          // "%0", "%1"
   currentCommand?: string;
   currentPath?: string;
+  /** Agent provider reported by herdr for this pane. */
+  agent?: AgentProvider;
+  /** Native agent session id reported by the pane's herdr integration. */
+  agentSessionId?: string;
   title?: string;          // pane_title set by Claude Code (task description)
   agentName?: string;      // Team agent name from --agent-name process arg
   agentColor?: string;     // Team agent color from --agent-color process arg


### PR DESCRIPTION
## Changes
- use herdr agent.list as the authoritative active agent and native session identity
- remove cwd-based Codex/Grok session guessing
- keep conversation history available for the selected single pane
- consolidate Codex hooks into hooks.json and install Claude/Codex herdr integrations during setup

## Verification
- bun run test (backend 357, frontend 52)
- bun run typecheck
- bun run lint
- browser test with a native Codex session ID