### PR TITLE
Release v0.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.20] - 2026-07-19
+
+### Fixed
+- **開いている Codex セッションの会話履歴を表示できない問題を修正** (#439): 実行プロセス名が `node-MainThread` になるケースや、同じ作業ディレクトリに複数の履歴があるケースで、cwd から最新スレッドを推測して誤った Session ID を選ぶ可能性があった。herdr の `agent.list` が報告するエージェント種別と native Session ID を唯一の識別元に変更し、Codex/Grok の cwd フォールバックを削除。非フォーカス中の単一paneでも対象paneを選択できるようにし、native ID が未報告の場合は履歴ボタンを安全に無効化する
+
+### Changed
+- **Codex hooks を `~/.codex/hooks.json` に一本化** (#439): herdr の `SessionStart` と CC Hub の `Stop` / `PostToolUse:AskUserQuestion` を同じ JSON に保持し、重複していた `config.toml` の hook 定義を移行時に削除する。`cchub setup` は Claude/Codex 両方の herdr integration を導入し、既存の未知の hook と `[hooks.state]` は保持する
+
 ## [0.2.19] - 2026-07-19
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- fix: use herdr native agent/session identity for active conversation history
- fix: remove cwd-based Codex/Grok session fallback
- fix: keep history available for selected single panes
- chore: consolidate Codex hooks in hooks.json and install herdr integrations during setup

## Verification
- bun run test (backend 357, frontend 52)
- bun run typecheck
- bun run lint
- browser history test with a native Codex session ID