### PR TITLE
feat(sizing): per-client pane sizing foundation (Phase 1, dormant)

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -413,6 +413,7 @@ function cleanupSubscription(ws: ServerWebSocket<MuxData>, _sessionId: string, s
   sub.pushTimers.clear();
   sub.lastPushAt.clear();
   sub.controlSession.removeClientDeviceType(ws.data.visitorId);
+  sub.controlSession.removeClientDemands(ws.data.visitorId);
   sub.controlSession.removeClient();
 }
 
@@ -679,6 +680,13 @@ async function handleControlMessage(
       }
       case 'client-info': {
         controlSession.setClientDeviceType(ws.data.visitorId, msg.deviceType);
+        break;
+      }
+      case 'pane-demands': {
+        // Record this client's per-pane render sizes (per-client sizing).
+        // Dormant until per-client sizing is enabled — recorded, not yet
+        // consulted for PTY sizing.
+        controlSession.setPaneDemands(ws.data.visitorId, msg.demands);
         break;
       }
     }

--- a/backend/src/services/__tests__/mux-client-schema.test.ts
+++ b/backend/src/services/__tests__/mux-client-schema.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import { MuxClientMessageSchema } from '../../../../shared/types';
+
+/**
+ * Incoming /ws/mux control frames are validated by MuxClientMessageSchema and
+ * SILENTLY DROPPED on failure (terminal-mux.ts). A field the schema doesn't
+ * list is stripped (zod default). Two regressions this locks:
+ *   - `pane-demands` must be a known variant, or per-client sizing reports
+ *     never reach the server.
+ *   - `zoom-pane.zoomed` must be in the schema, or the explicit zoom/unzoom
+ *     intent is stripped and the server silently falls back to toggle.
+ */
+describe('MuxClientMessageSchema — pane-demands', () => {
+  test('accepts pane-demands and keeps the demands', () => {
+    const r = MuxClientMessageSchema.safeParse({
+      type: 'pane-demands',
+      sessionId: 's',
+      demands: { '%1': { cols: 50, rows: 45 } },
+    });
+    expect(r.success).toBe(true);
+    if (r.success && r.data.type === 'pane-demands') {
+      expect(r.data.demands['%1']).toEqual({ cols: 50, rows: 45 });
+    }
+  });
+
+  test('rejects a non-pane key', () => {
+    const r = MuxClientMessageSchema.safeParse({
+      type: 'pane-demands',
+      sessionId: 's',
+      demands: { notapane: { cols: 50, rows: 45 } },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  test('rejects out-of-range dimensions', () => {
+    const r = MuxClientMessageSchema.safeParse({
+      type: 'pane-demands',
+      sessionId: 's',
+      demands: { '%1': { cols: 0, rows: 45 } },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  test('caps the number of demanded panes', () => {
+    const demands: Record<string, { cols: number; rows: number }> = {};
+    for (let i = 0; i < 65; i++) demands[`%${i}`] = { cols: 80, rows: 24 };
+    const r = MuxClientMessageSchema.safeParse({ type: 'pane-demands', sessionId: 's', demands });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('MuxClientMessageSchema — zoom-pane', () => {
+  test('retains the explicit zoomed flag (not stripped)', () => {
+    const r = MuxClientMessageSchema.safeParse({
+      type: 'zoom-pane',
+      sessionId: 's',
+      paneId: '%1',
+      zoomed: true,
+    });
+    expect(r.success).toBe(true);
+    if (r.success && r.data.type === 'zoom-pane') {
+      expect(r.data.zoomed).toBe(true);
+    }
+  });
+
+  test('still valid without zoomed (toggle fallback)', () => {
+    const r = MuxClientMessageSchema.safeParse({ type: 'zoom-pane', sessionId: 's', paneId: '%1' });
+    expect(r.success).toBe(true);
+    if (r.success && r.data.type === 'zoom-pane') {
+      expect(r.data.zoomed).toBeUndefined();
+    }
+  });
+});

--- a/backend/src/services/__tests__/pane-sizing.test.ts
+++ b/backend/src/services/__tests__/pane-sizing.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { type ClientPaneDemands, reconcilePaneSizes } from '../pane-sizing';
+
+/**
+ * A pane has one PTY, so N clients viewing it at different sizes must collapse
+ * to one size. The policy is tmux's per-dimension smallest-wins; a pane no
+ * client reports is simply absent (caller keeps its last size). These lock the
+ * policy so the per-client sizing model can't silently drift.
+ */
+describe('reconcilePaneSizes', () => {
+  test('no clients → empty map', () => {
+    expect(reconcilePaneSizes([]).size).toBe(0);
+  });
+
+  test('single client → its sizes verbatim (single-client equivalence)', () => {
+    const desktop: ClientPaneDemands = { '%1': { cols: 89, rows: 46 }, '%2': { cols: 89, rows: 46 } };
+    const out = reconcilePaneSizes([desktop]);
+    expect(out.get('%1')).toEqual({ cols: 89, rows: 46 });
+    expect(out.get('%2')).toEqual({ cols: 89, rows: 46 });
+  });
+
+  test('smallest-wins per dimension across clients', () => {
+    // Mobile shows %1 full (48 wide); desktop shows %1 in a split (89 wide).
+    const mobile: ClientPaneDemands = { '%1': { cols: 48, rows: 45 } };
+    const desktop: ClientPaneDemands = { '%1': { cols: 89, rows: 46 } };
+    const out = reconcilePaneSizes([mobile, desktop]);
+    // min cols = 48, min rows = 45 — desktop letterboxes, tmux-style.
+    expect(out.get('%1')).toEqual({ cols: 48, rows: 45 });
+  });
+
+  test('dimensions are minimized independently', () => {
+    const a: ClientPaneDemands = { '%1': { cols: 100, rows: 20 } };
+    const b: ClientPaneDemands = { '%1': { cols: 60, rows: 50 } };
+    expect(reconcilePaneSizes([a, b]).get('%1')).toEqual({ cols: 60, rows: 20 });
+  });
+
+  test('a pane only one client shows keeps that client’s size', () => {
+    const mobile: ClientPaneDemands = { '%1': { cols: 48, rows: 45 } };
+    const desktop: ClientPaneDemands = { '%1': { cols: 89, rows: 46 }, '%2': { cols: 89, rows: 46 } };
+    const out = reconcilePaneSizes([mobile, desktop]);
+    expect(out.get('%1')).toEqual({ cols: 48, rows: 45 }); // both → min
+    expect(out.get('%2')).toEqual({ cols: 89, rows: 46 }); // desktop only
+  });
+
+  test('invalid / non-positive dimensions are ignored, never shrink a pane', () => {
+    const good: ClientPaneDemands = { '%1': { cols: 80, rows: 24 } };
+    const bogus: ClientPaneDemands = {
+      '%1': { cols: 0, rows: Number.NaN },
+      '%2': { cols: -5, rows: 10 },
+    };
+    const out = reconcilePaneSizes([good, bogus]);
+    expect(out.get('%1')).toEqual({ cols: 80, rows: 24 }); // bogus %1 skipped
+    expect(out.has('%2')).toBe(false); // %2 had no valid dimension
+  });
+
+  test('fractional sizes are floored', () => {
+    const c: ClientPaneDemands = { '%1': { cols: 80.9, rows: 24.9 } };
+    expect(reconcilePaneSizes([c]).get('%1')).toEqual({ cols: 80, rows: 24 });
+  });
+});

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -19,7 +19,8 @@
  *    poc/herdr/FINDINGS.md).
  */
 
-import type { PaneCursor, PaneModes, PaneViewport, TmuxLayoutNode } from '../../../shared/types';
+import type { PaneCursor, PaneDemand, PaneModes, PaneViewport, TmuxLayoutNode } from '../../../shared/types';
+import { type ClientPaneDemands, reconcilePaneSizes } from './pane-sizing';
 import {
   eventWorkspaceId,
   exportLayout,
@@ -38,6 +39,10 @@ import { herdrLayoutToNode, PaneLayoutTree } from './herdr-layout';
 
 const GRACE_PERIOD_MS = 30_000;
 const RESIZE_DEBOUNCE_MS = 50;
+// Per-client sizing (opt-in, off by default). Phase 1 is diagnostics-only: log
+// whether the clients' reconciled per-pane demands match today's tree/zoom
+// sizing, so single-client equivalence can be proven before any sizing switch.
+const PER_CLIENT_SIZING_DIAG = process.env.CCHUB_PER_CLIENT_SIZING === '1';
 // herdr pane.read hard cap (server-side, not configurable in 0.7.x)
 const HERDR_READ_CAP = 1000;
 
@@ -218,6 +223,11 @@ export class HerdrControlSession {
   private graceTimer: Timer | null = null;
   private destroyed = false;
   private clientDeviceTypes = new Map<string, 'mobile' | 'tablet' | 'desktop'>();
+  // Per-client reported pane render sizes (see PaneDemand). Keyed by clientId
+  // (visitorId), each value keyed by tmux-style pane id. Reconciled into one
+  // PTY size per pane. Recorded now; consulted for sizing only once per-client
+  // sizing is enabled (kept dormant so this is a no-op change on its own).
+  private paneDemands = new Map<string, ClientPaneDemands>();
 
   // Focused pane (tmux-style id). Initialized from herdr's focused flag,
   // updated by selectPane/splitPane and reconciled against herdr state.
@@ -528,8 +538,37 @@ export class HerdrControlSession {
         this.paneSizes.set(paneId, { cols: rect.width, rows: rect.height });
         this.controllerFor(paneId)?.resize(rect.width, rect.height);
       }
+      if (PER_CLIENT_SIZING_DIAG) this.logSizingParity();
     }
     this.emitLayout();
+  }
+
+  /**
+   * Diagnostics for per-client sizing (Phase 1): compare the reconciled
+   * per-pane demands against the size the current tree/zoom path just applied.
+   * For a single client they must match — that's the equivalence gate we need
+   * before ever switching PTY sizing over to the demands. Logs only; changes
+   * nothing.
+   */
+  private logSizingParity(): void {
+    const reconciled = this.reconciledPaneSizes();
+    if (reconciled.size === 0) return;
+    const { cols, rows } = this.clientSize;
+    const rects = this.tree.computeRects(cols, rows);
+    const diffs: string[] = [];
+    for (const [paneId, size] of reconciled) {
+      const rect = rects.get(paneId);
+      if (!rect) {
+        diffs.push(`${paneId}: demand ${size.cols}x${size.rows}, no current rect`);
+      } else if (rect.width !== size.cols || rect.height !== size.rows) {
+        diffs.push(`${paneId}: current ${rect.width}x${rect.height} vs demand ${size.cols}x${size.rows}`);
+      }
+    }
+    console.log(
+      `[per-client-sizing] ${this.sessionId}: ${this.paneDemands.size} client(s), ` +
+        `${reconciled.size} pane demand(s), ${diffs.length} differ` +
+        (diffs.length ? `: ${diffs.join('; ')}` : ' (equivalent)'),
+    );
   }
 
   private emitLayout(): void {
@@ -804,6 +843,25 @@ export class HerdrControlSession {
     this.clientDeviceTypes.set(clientId, deviceType);
   }
 
+  /** Record a client's current per-pane render sizes (per-client sizing). */
+  setPaneDemands(clientId: string, demands: ClientPaneDemands): void {
+    this.paneDemands.set(clientId, demands);
+  }
+
+  /** Drop a client's demands (on disconnect) so its sizes stop constraining panes. */
+  removeClientDemands(clientId: string): void {
+    this.paneDemands.delete(clientId);
+  }
+
+  /**
+   * One reconciled PTY size per pane across all clients' current demands
+   * (smallest-wins). Empty when no client has reported — callers fall back to
+   * the existing tree/zoom sizing. Not yet consulted by applyLayout.
+   */
+  reconciledPaneSizes(): Map<string, PaneDemand> {
+    return reconcilePaneSizes(this.paneDemands.values());
+  }
+
   removeClientDeviceType(clientId: string): void {
     this.clientDeviceTypes.delete(clientId);
   }
@@ -872,6 +930,7 @@ export class HerdrControlSession {
     this.paneDeadListeners.clear();
     this.newSessionListeners.clear();
     this.clientDeviceTypes.clear();
+    this.paneDemands.clear();
     this.paneSizes.clear();
 
     herdrControlSessions.delete(this.sessionId);

--- a/backend/src/services/pane-sizing.ts
+++ b/backend/src/services/pane-sizing.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-client pane sizing: reconcile many clients' reported render sizes into
+ * one PTY size per pane.
+ *
+ * A pane has exactly one PTY (herdr), so its size can only be one value. When
+ * more than one client displays the same pane at different sizes, we pick a
+ * single size per dimension. The default policy is tmux's: the smallest
+ * requested extent wins (the larger client sees unused margin). A pane no
+ * client reports is absent from the result — the caller keeps its last size.
+ *
+ * This is pure and policy-only; it holds no state and talks to nothing.
+ */
+
+import type { PaneDemand } from '../../../shared/types';
+
+/** One client's reported sizes, keyed by tmux-style pane id (`%N`). */
+export type ClientPaneDemands = Record<string, PaneDemand>;
+
+function sanitize(value: number): number | null {
+  if (!Number.isFinite(value)) return null;
+  const floored = Math.floor(value);
+  return floored >= 1 ? floored : null;
+}
+
+/**
+ * Reconcile every client's pane demands into one size per pane.
+ * Default policy: per-dimension smallest-wins (tmux-style). Invalid or
+ * non-positive dimensions are ignored so a bogus report can't shrink a pane
+ * to nothing.
+ */
+export function reconcilePaneSizes(
+  demandsByClient: Iterable<ClientPaneDemands>,
+): Map<string, PaneDemand> {
+  const out = new Map<string, PaneDemand>();
+  for (const demands of demandsByClient) {
+    for (const paneId in demands) {
+      const cols = sanitize(demands[paneId]?.cols);
+      const rows = sanitize(demands[paneId]?.rows);
+      if (cols === null || rows === null) continue;
+      const prev = out.get(paneId);
+      if (!prev) {
+        out.set(paneId, { cols, rows });
+      } else {
+        // Smallest-wins, independently per dimension (matches tmux window sizing).
+        out.set(paneId, {
+          cols: Math.min(prev.cols, cols),
+          rows: Math.min(prev.rows, rows),
+        });
+      }
+    }
+  }
+  return out;
+}

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { PaneViewport, TmuxLayoutNode } from "../../../shared/types";
+import type { PaneDemand, PaneViewport, TmuxLayoutNode } from "../../../shared/types";
 import { authFetch, fetchWithTimeout } from "../services/api";
 import { reportWsLatency } from "../services/latency-store";
 import { appendWsToken } from "../services/peer-ws";
@@ -59,6 +59,10 @@ interface UseMultiplexedTerminalReturn {
 	) => void;
 	equalizePanes: (direction: "horizontal" | "vertical") => void;
 	sendClientInfo: (deviceType: "mobile" | "tablet" | "desktop") => void;
+	// Report the sizes at which this client currently renders each pane it shows
+	// (per-client sizing). Additive to `resize`; the server reconciles one PTY
+	// size per pane across clients.
+	sendPaneDemands: (demands: Record<string, PaneDemand>) => void;
 	// Ask the server for the viewport `offset` rows above the live edge.
 	// offset=0 == live mode; the server will keep pushing unsolicited
 	// updates whenever output arrives. offset>0 silences unsolicited pushes
@@ -687,6 +691,13 @@ export function useMultiplexedTerminal(
 		[],
 	);
 
+	const sendPaneDemands = useCallback(
+		(demands: Record<string, PaneDemand>) => {
+			sendSessionMessage({ type: "pane-demands", demands });
+		},
+		[],
+	);
+
 	const requestViewport = useCallback((paneId: string, offset: number) => {
 		sendSessionMessage({ type: "request-viewport", paneId, offset });
 	}, []);
@@ -748,6 +759,7 @@ export function useMultiplexedTerminal(
 		setSplitRatios,
 		equalizePanes,
 		sendClientInfo,
+		sendPaneDemands,
 		requestViewport,
 		zoomPane,
 		respawnPane,

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -297,9 +297,13 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 					isConnected: controlTerminal.isConnected,
 					onResize: (cols: number, rows: number) => {
 						controlTerminal.resize(cols, rows);
+						// Mobile shows exactly one pane at a time, so its per-client
+						// demand is that pane at the full-screen size (per-client sizing).
+						controlTerminal.sendPaneDemands({ [currentPaneId]: { cols, rows } });
 					},
 					forceResize: (cols: number, rows: number) => {
 						controlTerminal.resize(cols, rows);
+						controlTerminal.sendPaneDemands({ [currentPaneId]: { cols, rows } });
 					},
 					scrollBy: (lines: number) => {
 						// Same sign convention as `term.scrollLines`: positive = toward live

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -755,6 +755,16 @@ export interface PaneModes {
   altScreen: boolean;      // alternate screen buffer active (vim, htop, etc.)
 }
 
+// A client's reported render size for one pane it is currently displaying.
+// Part of the per-client sizing model (see `pane-demands`): instead of one
+// shared session size + a shared zoom, each client reports the size at which
+// it shows each visible pane, and the server reconciles a single PTY size per
+// pane. A client that shows only one pane (mobile) reports just that pane.
+export interface PaneDemand {
+  cols: number;
+  rows: number;
+}
+
 export interface PaneViewport {
   paneId: string;
   cols: number;            // pane width (cells)
@@ -780,6 +790,12 @@ export type ControlClientMessage =
   | { type: 'select-pane'; paneId: string }
   | { type: 'ping'; timestamp: number }
   | { type: 'client-info'; deviceType: 'mobile' | 'tablet' | 'desktop' }
+  // Per-client sizing (see `PaneDemand`): the sizes at which THIS client is
+  // currently rendering each pane it displays. Keyed by tmux-style `%N`. The
+  // server reconciles one PTY size per pane across all clients' demands. A
+  // client sends only the panes it shows (mobile: one; desktop: its split
+  // rects). Additive to `resize`; ignored unless per-client sizing is enabled.
+  | { type: 'pane-demands'; demands: Record<string, PaneDemand> }
   | { type: 'adjust-pane'; paneId: string; direction: 'L' | 'R' | 'U' | 'D'; amount: number }
   // Set the ratios of specific splits in one shot. Each entry identifies a
   // split as the lowest common ancestor of paneA and paneB (expected direction
@@ -866,9 +882,17 @@ const controlClientMessageOptions = [
       .max(32),
   }),
   z.object({ type: z.literal('equalize-panes'), direction: z.enum(['horizontal', 'vertical']) }),
-  z.object({ type: z.literal('zoom-pane'), paneId: PaneIdSchema }),
+  // `zoomed` carries the explicit zoom/unzoom intent; without it here zod
+  // strips the field and the server silently falls back to toggle semantics.
+  z.object({ type: z.literal('zoom-pane'), paneId: PaneIdSchema, zoomed: z.boolean().optional() }),
   z.object({ type: z.literal('respawn-pane'), paneId: PaneIdSchema }),
   z.object({ type: z.literal('request-viewport'), paneId: PaneIdSchema, offset: WsOffset }),
+  z.object({
+    type: z.literal('pane-demands'),
+    demands: z
+      .record(PaneIdSchema, z.object({ cols: WsPaneDim, rows: WsPaneDim }))
+      .refine((d) => Object.keys(d).length <= 64, { message: 'too many pane demands' }),
+  }),
 ] as const;
 
 export const MuxClientMessageSchema = z.discriminatedUnion('type', [


### PR DESCRIPTION
per-client zoom 設計の **Phase 1**。zoom を「セッション共有状態」から「各クライアントのビュー」へ移す土台。**非破壊**（申告は記録のみ、PTY サイズは従来の tree/zoom 経路のまま）。

## 内容
- **`shared/types`**: `PaneDemand` 型 + `pane-demands` クライアントメッセージ。集約は tmux 流の「小さい方に合わせる」（次元ごと min）
- **`pane-sizing.ts`**: 純関数 `reconcilePaneSizes` + ユニットテスト
- **`HerdrControlSession`**: per-client 申告ストア（切断・destroy でクリア）＋ **等価性診断**（`CCHUB_PER_CLIENT_SIZING=1` で opt-in、既定OFF）
- **`terminal-mux`**: `pane-demands` を記録、クリーンアップで破棄
- **モバイル `TerminalPage`**: 表示中1paneのサイズを `sendPaneDemands` で報告

## 併せて修正した潜在バグ
v0.2.19 の `zoom-pane` の Zod スキーマが `zoomed` を含まず、**明示 zoom/unzoom 意図が strip されて常に toggle 扱い**になっていた（クライアント側ガードで症状は隠れていた）。スキーマに追加し、テストで固定。

## 検証（dev + agent-browser）
`CCHUB_PER_CLIENT_SIZING=1` でモバイル複数paneを操作:
```
[per-client-sizing] hakoniwa-city: 1 client(s), 1 pane demand(s), 0 differ (equivalent)
[per-client-sizing] session-8:     1 client(s), 1 pane demand(s), 0 differ (equivalent)
```
→ 単一クライアントで申告集約が現行サイジングと**完全一致**。実サイジング切替（P2以降）の安全弁。

型/lint 通過、backend 全 365 テスト通過（新規 pane-sizing 7 + schema 6）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)