### PR TITLE
docs: complete v0.2.20 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.20] - 2026-07-19
 
+### Added
+- **クライアント別pane sizing の基盤を追加（Phase 1、既定OFF）** (#441): モバイルクライアントが表示中paneのサイズ需要を申告し、サーバーがクライアント単位で保持・集約できる土台を追加。`CCHUB_PER_CLIENT_SIZING=1` の診断モードでは現行サイジングとの等価性だけを検証し、実際のPTYサイズ制御は従来経路を維持する非破壊な変更
+
 ### Fixed
 - **開いている Codex セッションの会話履歴を表示できない問題を修正** (#439): 実行プロセス名が `node-MainThread` になるケースや、同じ作業ディレクトリに複数の履歴があるケースで、cwd から最新スレッドを推測して誤った Session ID を選ぶ可能性があった。herdr の `agent.list` が報告するエージェント種別と native Session ID を唯一の識別元に変更し、Codex/Grok の cwd フォールバックを削除。非フォーカス中の単一paneでも対象paneを選択できるようにし、native ID が未報告の場合は履歴ボタンを安全に無効化する
+- **明示的なzoom/unzoom指定がtoggleとして処理される問題を修正** (#441): `zoom-pane` の Zod schema に `zoomed` を追加し、クライアントから送った冪等なzoom意図がstripされないようにした
 
 ### Changed
 - **Codex hooks を `~/.codex/hooks.json` に一本化** (#439): herdr の `SessionStart` と CC Hub の `Stop` / `PostToolUse:AskUserQuestion` を同じ JSON に保持し、重複していた `config.toml` の hook 定義を移行時に削除する。`cchub setup` は Claude/Codex 両方の herdr integration を導入し、既存の未知の hook と `[hooks.state]` は保持する


### PR DESCRIPTION
## Changes
- document PR #441, which merged into main before the v0.2.20 release merge
- include the dormant per-client pane sizing foundation and zoom schema fix

## Notes
Documentation-only follow-up before creating the v0.2.20 tag.