### PR TITLE
feat(sizing): enable per-client sizing by default

### DIFF
--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -39,12 +39,13 @@ import { herdrLayoutToNode, PaneLayoutTree } from './herdr-layout';
 
 const GRACE_PERIOD_MS = 30_000;
 const RESIZE_DEBOUNCE_MS = 50;
-// Per-client sizing (opt-in, off by default). When on, a pane any client
-// actually displays is sized to the reconciled (smallest-wins) demand instead
-// of the shared tree/zoom guess. Single-client demands equal the tree/zoom
-// size (proven in Phase 1), so this is behavior-neutral until two clients
-// disagree — then the smaller wins (tmux-style) rather than last-writer thrash.
-const PER_CLIENT_SIZING = process.env.CCHUB_PER_CLIENT_SIZING === '1';
+// Per-client sizing (ON by default; set CCHUB_PER_CLIENT_SIZING=0 to disable).
+// Only intervenes with two or more clients (see resolveTargetSizes): when they
+// view a session at different sizes, a shared pane is shrunk to the smallest
+// demand (tmux-style letterbox) instead of thrashing on the last-writer size.
+// A single client keeps the existing tree/zoom path unchanged. The env var is
+// an escape hatch in case the multi-client path misbehaves in the field.
+const PER_CLIENT_SIZING = process.env.CCHUB_PER_CLIENT_SIZING !== '0';
 // A client's proposeDimensions and the server's ratio split can disagree by a
 // cell or two from rounding; only a demand this many cells smaller than the
 // tree slot counts as a real cross-client conflict worth shrinking a pane for.


### PR DESCRIPTION
per-client サイジングを**既定ON**にする（`CCHUB_PER_CLIENT_SIZING=0` で無効化できる逃げ道つき）。

- 単一クライアントは挙動不変（override は2クライアント以上のときだけ）
- dual-view（tablet+phone 等で同一セッションを別サイズ表示）で、共有 pane を last-writer 取り合いでなく **smallest-wins レターボックス**に

dev検証: 既定ONで単一 desktop の split 89/89 維持、conflict ログ 0。型/lint/テスト通過。実機 dual-view 検証のためリリースする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)