### PR TITLE
feat(sizing): active-client owns the session size (fix dual-view flicker)

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -414,6 +414,7 @@ function cleanupSubscription(ws: ServerWebSocket<MuxData>, _sessionId: string, s
   sub.lastPushAt.clear();
   sub.controlSession.removeClientDeviceType(ws.data.visitorId);
   sub.controlSession.removeClientDemands(ws.data.visitorId);
+  sub.controlSession.removeClientSize(ws.data.visitorId);
   sub.controlSession.removeClient();
 }
 
@@ -577,6 +578,8 @@ async function handleControlMessage(
       case 'input': {
         const data = Buffer.from(msg.data, 'base64');
         console.log(`[mux] input pane=${msg.paneId} bytes=${data.length}`);
+        // Typing on a device makes it the size owner (active-client sizing).
+        controlSession.markClientActive(ws.data.visitorId);
         await controlSession.sendInput(msg.paneId, data);
         // Pre-arm a push: input usually generates output but a silent program
         // (waiting for full line, etc.) wouldn't, and we still want to refresh
@@ -588,17 +591,20 @@ async function handleControlMessage(
       }
       case 'resize': {
         try {
-          if (!sub.firstResizeReceived) {
+          if (msg.active) {
+            // Explicit tap/focus claim: this client takes ownership of the size.
+            controlSession.setClientSize(ws.data.visitorId, msg.cols, msg.rows, true);
+          } else if (!sub.firstResizeReceived) {
             // First resize: force the panes to adopt the new client size
             // synchronously. Subsequent resizes go through the dedup'd path.
-            await controlSession.setClientSizeImmediate(msg.cols, msg.rows);
+            await controlSession.setClientSizeImmediate(ws.data.visitorId, msg.cols, msg.rows);
             sub.firstResizeReceived = true;
             // Brief settle window so the panes reflow before we capture, then
             // push viewports at the new size (the ones we emitted at subscribe
             // time were at whatever size the panes had previously).
             await new Promise(resolve => setTimeout(resolve, 100));
           } else {
-            controlSession.setClientSize(msg.cols, msg.rows);
+            controlSession.setClientSize(ws.data.visitorId, msg.cols, msg.rows);
           }
           for (const paneId of sub.knownPanes) {
             if ((sub.liveOffset.get(paneId) ?? 0) === 0) {

--- a/backend/src/services/__tests__/active-client-size.test.ts
+++ b/backend/src/services/__tests__/active-client-size.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { clientOwnsSessionSize } from '../herdr-control';
+
+/**
+ * Active-client sizing: the device being interacted with owns the shared
+ * session size, so two devices on one session don't thrash it (the dual-view
+ * flicker). This locks the ownership rule; the state transitions (claim on
+ * input/tap, handoff on disconnect) are covered by the mux integration path.
+ */
+describe('clientOwnsSessionSize', () => {
+  test('sole size reporter owns it (single-client = unchanged behavior)', () => {
+    expect(clientOwnsSessionSize('a', 'a', false, 1)).toBe(true);
+    // Even if some other id is nominally active, one reporter still owns.
+    expect(clientOwnsSessionSize('other', 'a', false, 1)).toBe(true);
+  });
+
+  test('with nobody active yet, the first reporter owns', () => {
+    expect(clientOwnsSessionSize(null, 'a', false, 2)).toBe(true);
+  });
+
+  test('the active client keeps ownership', () => {
+    expect(clientOwnsSessionSize('a', 'a', false, 2)).toBe(true);
+  });
+
+  test('a passive second client does NOT own (no flicker)', () => {
+    // b resizes while a is active → recorded only, size stays a's.
+    expect(clientOwnsSessionSize('a', 'b', false, 2)).toBe(false);
+  });
+
+  test('an explicit claim (tap/focus) always takes ownership', () => {
+    expect(clientOwnsSessionSize('a', 'b', true, 2)).toBe(true);
+    expect(clientOwnsSessionSize('a', 'b', true, 5)).toBe(true);
+  });
+
+  test('three clients: only active or claimer owns', () => {
+    expect(clientOwnsSessionSize('a', 'b', false, 3)).toBe(false);
+    expect(clientOwnsSessionSize('a', 'c', false, 3)).toBe(false);
+    expect(clientOwnsSessionSize('a', 'a', false, 3)).toBe(true);
+  });
+});

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -39,13 +39,12 @@ import { herdrLayoutToNode, PaneLayoutTree } from './herdr-layout';
 
 const GRACE_PERIOD_MS = 30_000;
 const RESIZE_DEBOUNCE_MS = 50;
-// Per-client sizing (ON by default; set CCHUB_PER_CLIENT_SIZING=0 to disable).
-// Only intervenes with two or more clients (see resolveTargetSizes): when they
-// view a session at different sizes, a shared pane is shrunk to the smallest
-// demand (tmux-style letterbox) instead of thrashing on the last-writer size.
-// A single client keeps the existing tree/zoom path unchanged. The env var is
-// an escape hatch in case the multi-client path misbehaves in the field.
-const PER_CLIENT_SIZING = process.env.CCHUB_PER_CLIENT_SIZING !== '0';
+// Experimental per-pane smallest-wins override (opt-in via
+// CCHUB_PER_CLIENT_SIZING=1). Superseded for the common case by active-client
+// sizing (the device being used owns the session size), which fixes the
+// dual-view flicker without letterboxing the active device. Kept off by
+// default; may be removed once active-client sizing is proven in the field.
+const PER_CLIENT_SIZING = process.env.CCHUB_PER_CLIENT_SIZING === '1';
 // A client's proposeDimensions and the server's ratio split can disagree by a
 // cell or two from rounding; only a demand this many cells smaller than the
 // tree slot counts as a real cross-client conflict worth shrinking a pane for.
@@ -55,6 +54,24 @@ const SIZING_TOLERANCE = 3;
 const HERDR_READ_CAP = 1000;
 
 const PANE_ID_RE = /^%\d+$/;
+
+/**
+ * Active-client sizing rule: which client drives the shared session size.
+ *
+ * The shared size is owned by whichever client is being interacted with, so two
+ * devices on one session don't fight over it (that flickered). A client owns the
+ * size when it explicitly claims (a tap/focus), when nobody is active yet, when
+ * it is already the active client, or when it is the only one that has reported
+ * a size. Otherwise its resize is recorded but does not move the shared size.
+ */
+export function clientOwnsSessionSize(
+  activeClientId: string | null,
+  clientId: string,
+  claim: boolean,
+  clientCount: number,
+): boolean {
+  return claim || activeClientId === null || activeClientId === clientId || clientCount <= 1;
+}
 
 export function assertPaneId(paneId: string): void {
   if (typeof paneId !== 'string' || !PANE_ID_RE.test(paneId)) {
@@ -205,6 +222,13 @@ export class HerdrControlSession {
   private clientSizeKnown = false;
   private resizeTimer: Timer | null = null;
   private lastClientSize: { cols: number; rows: number } | null = null;
+  // Active-client sizing: the shared session size is owned by whichever client
+  // is currently being interacted with (input or an explicit tap claim). Other
+  // clients' resizes are recorded here but do NOT move the shared size, so two
+  // devices on one session don't fight over it (which flickered). `clientSizes`
+  // remembers each client's last reported size so ownership can hand off.
+  private clientSizes = new Map<string, { cols: number; rows: number }>();
+  private activeClientId: string | null = null;
   // Last known per-pane size: written by applyLayout when we resize, and
   // kept fresh from frame metadata (the renderer's actual geometry).
   private paneSizes = new Map<string, { cols: number; rows: number }>();
@@ -763,11 +787,32 @@ export class HerdrControlSession {
     await this.applyLayout();
   }
 
-  setClientSize(cols: number, rows: number): void {
+  /** Does this client currently own (drive) the shared session size? */
+  private clientOwnsSize(clientId: string, claim: boolean): boolean {
+    return clientOwnsSessionSize(this.activeClientId, clientId, claim, this.clientSizes.size);
+  }
+
+  /**
+   * Record a client's reported size. Only the active client (or one explicitly
+   * claiming via `claim`, or the sole client) actually moves the shared size —
+   * a passive second device's resizes are remembered but ignored, so the two
+   * don't thrash the layout.
+   */
+  setClientSize(clientId: string, cols: number, rows: number, claim = false): void {
+    this.clientSizes.set(clientId, { cols, rows });
+    if (!this.clientOwnsSize(clientId, claim)) return;
     if (this.resizeTimer) clearTimeout(this.resizeTimer);
     this.resizeTimer = setTimeout(() => {
       const last = this.lastClientSize;
-      if (last && last.cols === cols && Math.abs(last.rows - rows) <= 1) return;
+      if (
+        this.activeClientId === clientId &&
+        last &&
+        last.cols === cols &&
+        Math.abs(last.rows - rows) <= 1
+      ) {
+        return;
+      }
+      this.activeClientId = clientId;
       this.lastClientSize = { cols, rows };
       this.clientSize = { cols, rows };
       this.clientSizeKnown = true;
@@ -775,15 +820,61 @@ export class HerdrControlSession {
     }, RESIZE_DEBOUNCE_MS);
   }
 
-  async setClientSizeImmediate(cols: number, rows: number): Promise<void> {
+  async setClientSizeImmediate(clientId: string, cols: number, rows: number): Promise<void> {
+    this.clientSizes.set(clientId, { cols, rows });
+    // A newly-connected second client must not steal the size from the device
+    // the user is on; only apply immediately when this client owns the size.
+    if (!this.clientOwnsSize(clientId, false)) return;
     if (this.resizeTimer) {
       clearTimeout(this.resizeTimer);
       this.resizeTimer = null;
     }
+    this.activeClientId = clientId;
     this.lastClientSize = { cols, rows };
     this.clientSize = { cols, rows };
     this.clientSizeKnown = true;
     await this.applyLayout();
+  }
+
+  /**
+   * Make `clientId` the size owner and resize the session to its last reported
+   * size. Called on input (typing) and on an explicit tap claim, so the device
+   * being used drives the size. No-op if it already owns the size at that size,
+   * or hasn't reported one yet.
+   */
+  markClientActive(clientId: string): void {
+    const size = this.clientSizes.get(clientId);
+    if (!size) return;
+    if (
+      this.activeClientId === clientId &&
+      this.clientSize.cols === size.cols &&
+      this.clientSize.rows === size.rows
+    ) {
+      return;
+    }
+    if (this.resizeTimer) {
+      clearTimeout(this.resizeTimer);
+      this.resizeTimer = null;
+    }
+    this.activeClientId = clientId;
+    this.lastClientSize = size;
+    this.clientSize = size;
+    this.clientSizeKnown = true;
+    void this.applyLayout();
+  }
+
+  /** Drop a disconnected client's size and hand ownership to a remaining one. */
+  removeClientSize(clientId: string): void {
+    this.clientSizes.delete(clientId);
+    if (this.activeClientId !== clientId) return;
+    const next = this.clientSizes.keys().next().value ?? null;
+    this.activeClientId = next;
+    const size = next ? this.clientSizes.get(next) : undefined;
+    if (size) {
+      this.lastClientSize = size;
+      this.clientSize = size;
+      void this.applyLayout();
+    }
   }
 
   async capturePane(paneId: string): Promise<string> {
@@ -950,6 +1041,7 @@ export class HerdrControlSession {
     this.newSessionListeners.clear();
     this.clientDeviceTypes.clear();
     this.paneDemands.clear();
+    this.clientSizes.clear();
     this.paneSizes.clear();
 
     herdrControlSessions.delete(this.sessionId);

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -953,6 +953,9 @@ export function DesktopLayout({
 					};
 				},
 				isConnected: controlTerminal.isConnected,
+				claimActive: () => {
+					controlTerminalRef.current.claimActiveSize();
+				},
 				onResize: () => {
 					// Individual pane resize triggers total container size calculation.
 					// tmux refresh-client -C needs the TOTAL window size, not per-pane.

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -68,6 +68,10 @@ export interface ControlModeConfig {
 	 *  the old `term.scrollToBottom()` in the days of frontend scrollback.
 	 *  No-op if already at the live edge. */
 	scrollToLive?: () => void;
+	/** Claim the session size for this client (tap-to-resize): when the user taps
+	 *  to interact with this device, it takes ownership of the shared size so two
+	 *  devices on one session don't fight over it. */
+	claimActive?: () => void;
 	/** Force-refresh the current viewport (e.g. after a re-connect). */
 	refreshViewport?: () => void;
 	/** Snapshot of the current scroll state for indicator UI. */
@@ -1351,6 +1355,8 @@ export const TerminalComponent = memo(
 
 		const handleShowKeyboard = useCallback(() => {
 			setInputMode("input");
+			// Tapping to interact claims the session size for this device.
+			controlModeRef.current?.claimActive?.();
 			// Snap back to the live edge when the user taps to interact, matching
 			// the pre-server-side-scrollback behavior. `term.scrollToBottom()` is
 			// a no-op now (xterm scrollback is 0); the actual reset goes through

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -39,7 +39,8 @@ interface UseMultiplexedTerminalReturn {
 	connect: () => void;
 	disconnect: () => void;
 	sendInput: (paneId: string, data: string) => void;
-	resize: (cols: number, rows: number) => void;
+	resize: (cols: number, rows: number, active?: boolean) => void;
+	claimActiveSize: () => void;
 	splitPane: (paneId: string, direction: "h" | "v") => void;
 	closePane: (paneId: string) => void;
 	resizePane: (paneId: string, cols: number, rows: number) => void;
@@ -632,8 +633,22 @@ export function useMultiplexedTerminal(
 		if (subscribedSession) dispatchInputEcho(subscribedSession, paneId, data);
 	}, []);
 
-	const resize = useCallback((cols: number, rows: number) => {
-		sendSessionMessage({ type: "resize", cols, rows });
+	// Last size we sent, so a tap can re-claim ownership at the current size.
+	const lastResizeRef = useRef<{ cols: number; rows: number } | null>(null);
+	const resize = useCallback(
+		(cols: number, rows: number, active?: boolean) => {
+			lastResizeRef.current = { cols, rows };
+			sendSessionMessage({ type: "resize", cols, rows, active });
+		},
+		[],
+	);
+
+	// Claim the session size for this client (tap-to-resize): re-send the last
+	// size with `active`, so the device being tapped owns the shared size.
+	const claimActiveSize = useCallback(() => {
+		const last = lastResizeRef.current;
+		if (!last) return;
+		sendSessionMessage({ type: "resize", cols: last.cols, rows: last.rows, active: true });
 	}, []);
 
 	const splitPane = useCallback((paneId: string, direction: "h" | "v") => {
@@ -751,6 +766,7 @@ export function useMultiplexedTerminal(
 		disconnect,
 		sendInput,
 		resize,
+		claimActiveSize,
 		splitPane,
 		closePane,
 		resizePane,

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -295,6 +295,9 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 						};
 					},
 					isConnected: controlTerminal.isConnected,
+					claimActive: () => {
+						controlTerminal.claimActiveSize();
+					},
 					onResize: (cols: number, rows: number) => {
 						controlTerminal.resize(cols, rows);
 						// Mobile shows exactly one pane at a time, so its per-client

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -783,7 +783,11 @@ export interface PaneViewport {
 // Client → Server messages
 export type ControlClientMessage =
   | { type: 'input'; paneId: string; data: string } // base64
-  | { type: 'resize'; cols: number; rows: number }
+  // `active` claims the session size for THIS client (tap-to-resize): the
+  // active client owns the shared size, so two devices on one session don't
+  // fight over it. Sent on a genuine user tap/focus; automatic (layout-driven)
+  // resizes omit it and only take effect if the client is already active.
+  | { type: 'resize'; cols: number; rows: number; active?: boolean }
   | { type: 'split'; paneId: string; direction: 'h' | 'v' }
   | { type: 'close-pane'; paneId: string }
   | { type: 'resize-pane'; paneId: string; cols: number; rows: number }
@@ -859,7 +863,7 @@ const WsOffset = z.number().int().min(0).max(10_000_000);
 
 const controlClientMessageOptions = [
   z.object({ type: z.literal('input'), paneId: PaneIdSchema, data: z.string() }),
-  z.object({ type: z.literal('resize'), cols: WsPaneDim, rows: WsPaneDim }),
+  z.object({ type: z.literal('resize'), cols: WsPaneDim, rows: WsPaneDim, active: z.boolean().optional() }),
   z.object({ type: z.literal('split'), paneId: PaneIdSchema, direction: z.enum(['h', 'v']) }),
   z.object({ type: z.literal('close-pane'), paneId: PaneIdSchema }),
   z.object({ type: z.literal('resize-pane'), paneId: PaneIdSchema, cols: WsPaneDim, rows: WsPaneDim }),


### PR DESCRIPTION
同じセッションを2台で開くと**継続的にちらつく**問題を修正。両端末が自分のコンテナサイズを送り合い、共有セッションサイズが往復していた（last-writer の取り合い。smallest-wins の pane override では直らない層）。

実際の使い方が「1人が端末を行き来する」なので、**操作している端末がサイズの主導権を持つ**方式に:

- **アクティブな端末**（最後に入力した / タップで明示 claim）がサイズを駆動。**非アクティブ端末の resize は記録のみで反映しない** → 取り合いが止まり**ちらつき解消**
- **入力**で active 化、**タップ**で resize を `active` 付き送信（tap-to-resize）→ タップした端末に主導権。切断で委譲
- **単一クライアントは不変**（sole reporter が常に所有）: dev で desktop split 89/89 確認。2クライアントWSテストで passive resize 無視＋input/tap claim を確認

実験的な smallest-wins pane override(P2/P3)は **opt-in に降格**（`CCHUB_PER_CLIENT_SIZING=1`）。active 端末をレターボックス化するため、共通ケースでは active-client 方式が優先。

所有権判定 `clientOwnsSessionSize` を純関数化しユニットテスト追加。型/lint/全382テスト通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)