### PR TITLE
fix: dispose deleted terminal sessions

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -272,6 +272,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     return {
       id: s.id,
       name: s.name,
+      instanceId: s.instanceId,
       createdAt: s.createdAt,
       lastAccessedAt: s.createdAt,
       state: (s.attached ? 'working' : 'idle') as SessionState,
@@ -343,6 +344,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
     results.push({
       id: lost.id,
       name: lost.name,
+      instanceId: undefined,
       createdAt: '',
       lastAccessedAt: '',
       state: 'lost' as SessionState,
@@ -449,7 +451,7 @@ sessions.post('/', async (c) => {
   }
 
   try {
-    await herdrService.createSession(name);
+    const instanceId = await herdrService.createSession(name);
 
     // Start the selected agent if workingDir is specified
     if (parsed.success && parsed.data.workingDir) {
@@ -482,6 +484,7 @@ sessions.post('/', async (c) => {
     return c.json({
       id: name,
       name: name,
+      instanceId,
       createdAt: new Date().toISOString(),
       lastAccessedAt: new Date().toISOString(),
       state: 'idle',

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -245,7 +245,14 @@ export function muxClose(ws: ServerWebSocket<MuxData>, code: number, reason: str
 async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) {
   console.log(`[mux] subscribe: ${sessionId} (current subs: ${ws.data.subscriptions.size})`);
   // Already subscribed — reset state so the next resize re-emits initial viewports.
-  const existing = ws.data.subscriptions.get(sessionId);
+  let existing = ws.data.subscriptions.get(sessionId);
+  // A workspace can be deleted and recreated with the same public session id.
+  // Never re-use the subscription that still points at the destroyed instance.
+  if (existing?.controlSession.isDestroyed) {
+    cleanupSubscription(ws, sessionId, existing);
+    ws.data.subscriptions.delete(sessionId);
+    existing = undefined;
+  }
   if (existing) {
     existing.firstResizeReceived = false;
     existing.liveOffset.clear();
@@ -310,7 +317,7 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
     cleanupFns.push(
       controlSession.onExit((reason) => {
         try {
-          ws.send(JSON.stringify({ type: 'error', message: `Session exited: ${reason}`, sessionId }));
+          ws.send(JSON.stringify({ type: 'session-exited', reason, sessionId }));
         } catch { /* disconnected */ }
         handleUnsubscribe(ws, sessionId);
       })
@@ -404,7 +411,9 @@ function handleUnsubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) {
     cleanupSubscription(ws, sessionId, sub);
     ws.data.subscriptions.delete(sessionId);
   }
-  ws.send(JSON.stringify({ type: 'unsubscribed', sessionId }));
+  try {
+    ws.send(JSON.stringify({ type: 'unsubscribed', sessionId }));
+  } catch { /* disconnected */ }
 }
 
 function cleanupSubscription(ws: ServerWebSocket<MuxData>, _sessionId: string, sub: MuxSubscription) {

--- a/backend/src/services/__tests__/herdr-control-lifecycle.test.ts
+++ b/backend/src/services/__tests__/herdr-control-lifecycle.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { HerdrControlSession, herdrControlSessions } from "../herdr-control";
+
+afterEach(() => {
+	for (const session of herdrControlSessions.values()) session.destroy();
+	herdrControlSessions.clear();
+});
+
+describe("HerdrControlSession lifecycle", () => {
+	test("notifies every subscriber before a deleted session is destroyed", () => {
+		const session = new HerdrControlSession("same-name");
+		herdrControlSessions.set("same-name", session);
+		const reasons: string[] = [];
+
+		let unsubscribeFirst = () => {};
+		unsubscribeFirst = session.onExit((reason) => {
+			reasons.push(`first:${reason}`);
+			unsubscribeFirst();
+		});
+		session.onExit((reason) => reasons.push(`second:${reason}`));
+
+		session.terminate("workspace closed");
+
+		expect(reasons).toEqual([
+			"first:workspace closed",
+			"second:workspace closed",
+		]);
+		expect(session.isDestroyed).toBe(true);
+		expect(herdrControlSessions.has("same-name")).toBe(false);
+	});
+
+	test("an old delayed cleanup cannot remove a same-name replacement", () => {
+		const oldSession = new HerdrControlSession("same-name");
+		const replacement = new HerdrControlSession("same-name");
+		herdrControlSessions.set("same-name", replacement);
+
+		oldSession.destroy();
+
+		expect(herdrControlSessions.get("same-name")).toBe(replacement);
+		expect(replacement.isDestroyed).toBe(false);
+	});
+});

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -637,10 +637,22 @@ export class HerdrControlSession {
   }
 
   private handleExit(reason: string): void {
-    for (const listener of this.exitListeners) {
-      listener(reason);
+    if (this.destroyed) return;
+    // Snapshot the listeners: mux cleanup removes its listener while handling
+    // this callback, and every subscribed client still needs the close event.
+    for (const listener of [...this.exitListeners]) {
+      try {
+        listener(reason);
+      } catch (error) {
+        console.warn(`[herdr-control] exit listener failed for ${this.sessionId}:`, error);
+      }
     }
     this.destroy();
+  }
+
+  /** End this control session and notify every live subscriber first. */
+  terminate(reason: string): void {
+    this.handleExit(reason);
   }
 
   // ==========================================================================
@@ -989,6 +1001,7 @@ export class HerdrControlSession {
   }
 
   addClient(): void {
+    if (this.destroyed) return;
     this.clientCount++;
     if (this.graceTimer) {
       clearTimeout(this.graceTimer);
@@ -997,9 +1010,14 @@ export class HerdrControlSession {
   }
 
   removeClient(): void {
+    if (this.destroyed) return;
     this.clientCount--;
     if (this.clientCount <= 0) {
       this.clientCount = 0;
+      // Several subscriptions can be cleaned up in one exit broadcast. Keep
+      // exactly one reap timer; otherwise an overwritten timer survives
+      // destroy() and fires later against the deleted session instance.
+      if (this.graceTimer) clearTimeout(this.graceTimer);
       this.graceTimer = setTimeout(() => {
         if (this.clientCount <= 0) {
           console.log(`[herdr-control] Grace period expired for session: ${this.sessionId}`);
@@ -1044,7 +1062,11 @@ export class HerdrControlSession {
     this.clientSizes.clear();
     this.paneSizes.clear();
 
-    herdrControlSessions.delete(this.sessionId);
+    // A same-name workspace may already have installed a newer control
+    // session. An old delayed cleanup must never evict that replacement.
+    if (herdrControlSessions.get(this.sessionId) === this) {
+      herdrControlSessions.delete(this.sessionId);
+    }
     console.log(`[herdr-control] Session destroyed: ${this.sessionId}`);
   }
 }

--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -35,6 +35,7 @@ interface HerdrPaneInfo {
 interface HerdrSessionInfo {
   id: string;
   name: string;
+  instanceId?: string;
   createdAt: string;
   attached: boolean;
   currentCommand?: string;
@@ -246,6 +247,7 @@ export class HerdrService {
           return {
             id: workspaceSessionId(ws),
             name: workspaceSessionId(ws),
+            instanceId: ws.workspace_id,
             createdAt: new Date(0).toISOString(),
             attached: ws.focused,
             currentCommand: agent ?? panes[0]?.command,
@@ -313,7 +315,8 @@ export class HerdrService {
       label: name,
       cwd: process.env.HOME || '/tmp',
     });
-    return name;
+    const created = await this.resolveWorkspace(name);
+    return created?.workspace_id ?? name;
   }
 
   /**
@@ -358,7 +361,7 @@ export class HerdrService {
     // Reap the control session immediately. Left in the registry, it would
     // be handed out for a future same-name workspace while still bound to
     // the closed one (blank viewports, dead-pane controller spawn loops).
-    herdrControlSessions.get(sessionId)?.destroy();
+    herdrControlSessions.get(sessionId)?.terminate('workspace closed');
   }
 
   async sessionExists(sessionId: string): Promise<boolean> {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,6 +103,7 @@ function LoadingScreen({
 interface OpenSession {
 	id: string;
 	name: string;
+	instanceId?: string;
 	state: SessionState;
 	currentPath?: string;
 	ccSessionId?: string;
@@ -123,6 +124,7 @@ function apiToOpenSession(s: ExtendedSessionResponse): OpenSession {
 	return {
 		id: s.id,
 		name: s.name,
+		instanceId: s.instanceId,
 		state: s.state,
 		currentPath: s.currentPath,
 		ccSessionId: s.ccSessionId,
@@ -450,6 +452,7 @@ export function App() {
 				if (!apiSession) return session;
 				const next = {
 					...session,
+					instanceId: apiSession.instanceId,
 					theme: apiSession.theme,
 					currentCommand: apiSession.currentCommand,
 					ccSessionId: apiSession.ccSessionId,
@@ -461,6 +464,7 @@ export function App() {
 				};
 				// Skip update if nothing actually changed (avoid extra renders)
 				if (
+					next.instanceId === session.instanceId &&
 					next.theme === session.theme &&
 					next.currentCommand === session.currentCommand &&
 					next.ccSessionId === session.ccSessionId &&
@@ -1261,8 +1265,9 @@ export function App() {
 						return (
 							<TerminalPage
 								ref={mobileTerminalRef}
-								key={activeSessionId}
+								key={`${activeSession.id}:${activeSession.instanceId ?? "legacy"}`}
 								sessionId={activeSession.id}
+								sessionInstanceId={activeSession.instanceId}
 								onStateChange={(state) =>
 									updateSessionState(activeSession.id, state)
 								}

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -43,6 +43,7 @@ const DESKTOP_STATE_KEY = "cchub-desktop-state";
 interface OpenSession {
 	id: string;
 	name: string;
+	instanceId?: string;
 	state: SessionState;
 	currentPath?: string;
 	ccSessionId?: string;
@@ -393,6 +394,7 @@ export function DesktopLayout({
 					return propSession
 						? {
 								...propSession,
+								instanceId: apiSession.instanceId,
 								theme: apiSession.theme,
 								currentCommand: apiSession.currentCommand,
 								ccSessionId: apiSession.ccSessionId,
@@ -405,6 +407,7 @@ export function DesktopLayout({
 						: {
 								id: apiSession.id,
 								name: apiSession.name,
+								instanceId: apiSession.instanceId,
 								state: apiSession.state,
 								currentPath: apiSession.currentPath,
 								ccSessionId: apiSession.ccSessionId,
@@ -579,6 +582,10 @@ export function DesktopLayout({
 	};
 
 	const controlSessionId = getControlSessionId();
+	const controlSessionInstanceId = sessions.find(
+		(session) => session.id === controlSessionId,
+	)?.instanceId;
+	const [terminalGeneration, setTerminalGeneration] = useState(0);
 	const [controlLayout, setControlLayout] = useState<TmuxLayoutNode | null>(
 		null,
 	);
@@ -639,6 +646,7 @@ export function DesktopLayout({
 
 	const controlTerminal = useMultiplexedTerminal({
 		sessionId: controlSessionId || "",
+		sessionInstanceId: controlSessionInstanceId,
 		peerWsBase: peerConn.wsBase,
 		peerApiBase: peerConn.apiBase,
 		token: peerConn.token,
@@ -770,6 +778,17 @@ export function DesktopLayout({
 			updateCachedSessionsByHookEvent(event, sessionId);
 		},
 		onDisconnect: () => {},
+		onSessionExit: () => {
+			setControlLayout(null);
+			setZoomedPaneId(null);
+			lastViewportRef.current.clear();
+			paneOffsetRef.current.clear();
+			paneViewportCacheRef.current.clear();
+			lastSentSizeRef.current = null;
+			// Dispose every xterm surface immediately so a deleted terminal cannot
+			// remain visible while the sessions list catches up.
+			setTerminalGeneration((generation) => generation + 1);
+		},
 		onError: (err) => {
 			console.error("[control-mode] Error:", err);
 		},
@@ -800,7 +819,7 @@ export function DesktopLayout({
 		// viewports with no consumer, rendering a blank terminal until a
 		// full page reload. #history-resume-blank
 		lastSentSizeRef.current = null;
-	}, [controlSessionId]);
+	}, [controlSessionId, controlSessionInstanceId]);
 
 	// Connect/disconnect control mode
 	useEffect(() => {
@@ -811,7 +830,7 @@ export function DesktopLayout({
 			controlTerminal.disconnect();
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [controlSessionId]);
+	}, [controlSessionId, controlSessionInstanceId]);
 
 	// Control mode resize: compute TOTAL window size from layout tree.
 	// tmux refresh-client -C needs cols×rows for the entire window,
@@ -1698,6 +1717,7 @@ export function DesktopLayout({
 						onSplit={handleSplit}
 						sessions={sessions}
 						terminalRefs={terminalRefs}
+						globalReloadKey={terminalGeneration}
 						isTablet={isTablet}
 						controlModeContext={controlModeContext}
 					/>

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -37,6 +37,7 @@ export type PaneNode =
 interface ExtendedSession {
 	id: string;
 	name: string;
+	instanceId?: string;
 	state: SessionState;
 	currentPath?: string;
 	ccSessionId?: string;
@@ -698,7 +699,7 @@ function TerminalPane({
 				{sessionId ? (
 					<div className={showConversation ? "hidden" : "h-full"}>
 						<TerminalComponent
-							key={`${sessionId}-${reloadKey}-${globalReloadKey}`}
+							key={`${sessionId}-${session?.instanceId ?? "legacy"}-${reloadKey}-${globalReloadKey}`}
 							ref={terminalRef}
 							sessionId={sessionId}
 							peerId={session?.peerId}

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -7,6 +7,9 @@ import { getDeviceId } from "../utils/device-id";
 
 interface UseMultiplexedTerminalOptions {
 	sessionId: string;
+	/** Immutable live-session identity (herdr workspace id). Session names can
+	 * be reused after deletion, so this forces a fresh mux subscription. */
+	sessionInstanceId?: string;
 	token?: string | null;
 	// Multi-server: アクティブな peer の WS base URL ("wss://host:port") を指定。
 	// 省略時は Hub (window.location.host) を使う。
@@ -31,6 +34,7 @@ interface UseMultiplexedTerminalOptions {
 	) => void;
 	onConnect?: () => void;
 	onDisconnect?: () => void;
+	onSessionExit?: (reason: string) => void;
 	onError?: (error: string, paneId?: string) => void;
 }
 
@@ -94,6 +98,7 @@ let sharedConnectWatchdog: number | null = null;
 let sharedWsConnectStart = 0;
 let sharedLastPongAt = 0;
 let subscribedSession: string | null = null;
+let subscribedSessionInstance: string | null = null;
 let wsReady = false;
 // Multi-server: 現在の WS 接続が向いている base URL。
 // 接続先が切り替わったら force close して新しい URL に再接続する。
@@ -152,10 +157,12 @@ type MuxCallbacks = {
 	) => void;
 	onConnect?: () => void;
 	onDisconnect?: () => void;
+	onSessionExit?: (reason: string) => void;
 	onError?: (error: string, paneId?: string) => void;
 	setIsConnected?: (v: boolean) => void;
 	setDeadPanes?: (fn: (prev: Set<string>) => Set<string>) => void;
 	sessionId: string;
+	sessionInstanceId?: string;
 	deadPanes: Set<string>;
 };
 
@@ -173,14 +180,22 @@ function sendSessionMessage(msg: Record<string, unknown>) {
 	}
 }
 
-function subscribeToSession(sessionId: string, force = false) {
-	if (subscribedSession === sessionId && !force) return;
+function subscribeToSession(
+	sessionId: string,
+	sessionInstanceId?: string,
+	force = false,
+) {
+	const instanceChanged =
+		subscribedSession === sessionId &&
+		subscribedSessionInstance !== (sessionInstanceId ?? null);
+	if (subscribedSession === sessionId && !instanceChanged && !force) return;
 
-	if (subscribedSession && subscribedSession !== sessionId) {
+	if (subscribedSession && (subscribedSession !== sessionId || instanceChanged)) {
 		sendRaw({ type: "unsubscribe", sessionId: subscribedSession });
 	}
 
 	subscribedSession = sessionId;
+	subscribedSessionInstance = sessionInstanceId ?? null;
 	activeCallbacks?.setIsConnected?.(false);
 	activeCallbacks?.setDeadPanes?.(() => new Set());
 	sendRaw({ type: "subscribe", sessionId });
@@ -203,6 +218,7 @@ function ensureConnection(token?: string | null, wsBase?: string | null) {
 		} catch {}
 		sharedWs = null;
 		subscribedSession = null;
+		subscribedSessionInstance = null;
 		wsReady = false;
 	}
 
@@ -313,7 +329,7 @@ function ensureConnection(token?: string | null, wsBase?: string | null) {
 			case "ready": {
 				wsReady = true;
 				if (currentSession) {
-					subscribeToSession(currentSession, true);
+					subscribeToSession(currentSession, cb?.sessionInstanceId, true);
 				}
 				for (const sid of subscribedConversations) {
 					pendingConversationSubs.add(sid);
@@ -330,6 +346,16 @@ function ensureConnection(token?: string | null, wsBase?: string | null) {
 			}
 			case "unsubscribed":
 				break;
+			case "session-exited": {
+				if (msgSessionId !== currentSession) return;
+				if (subscribedSession === msgSessionId) {
+					subscribedSession = null;
+					subscribedSessionInstance = null;
+				}
+				cb?.setIsConnected?.(false);
+				cb?.onSessionExit?.(msg.reason as string);
+				break;
+			}
 			case "sessions-updated":
 				// Sessions are sourced from `usePeerSessionsWatcher` (one dedicated WS
 				// per peer including the Hub itself), so the terminal sharedWs ignores
@@ -560,7 +586,7 @@ function dispatchInputEcho(
 export function useMultiplexedTerminal(
 	options: UseMultiplexedTerminalOptions,
 ): UseMultiplexedTerminalReturn {
-	const { sessionId, token, peerWsBase, peerApiBase } = options;
+	const { sessionId, sessionInstanceId, token, peerWsBase, peerApiBase } = options;
 	const [isConnected, setIsConnected] = useState(false);
 	const [deadPanes, setDeadPanes] = useState<Set<string>>(new Set());
 
@@ -571,6 +597,7 @@ export function useMultiplexedTerminal(
 	const onHookEventRef = useRef(options.onHookEvent);
 	const onConnectRef = useRef(options.onConnect);
 	const onDisconnectRef = useRef(options.onDisconnect);
+	const onSessionExitRef = useRef(options.onSessionExit);
 	const onErrorRef = useRef(options.onError);
 
 	onPaneViewportRef.current = options.onPaneViewport;
@@ -580,6 +607,7 @@ export function useMultiplexedTerminal(
 	onHookEventRef.current = options.onHookEvent;
 	onConnectRef.current = options.onConnect;
 	onDisconnectRef.current = options.onDisconnect;
+	onSessionExitRef.current = options.onSessionExit;
 	onErrorRef.current = options.onError;
 
 	useEffect(() => {
@@ -591,10 +619,12 @@ export function useMultiplexedTerminal(
 			onHookEvent: (e, c, s, d, m) => onHookEventRef.current?.(e, c, s, d, m),
 			onConnect: () => onConnectRef.current?.(),
 			onDisconnect: () => onDisconnectRef.current?.(),
+			onSessionExit: (reason) => onSessionExitRef.current?.(reason),
 			onError: (e, p) => onErrorRef.current?.(e, p),
 			setIsConnected,
 			setDeadPanes,
 			sessionId,
+			sessionInstanceId,
 			deadPanes,
 		};
 	});
@@ -606,22 +636,23 @@ export function useMultiplexedTerminal(
 			ensureConnection(token, peerWsBase);
 		}
 		if (sharedWs?.readyState === WebSocket.OPEN && wsReady) {
-			subscribeToSession(sessionId);
+			subscribeToSession(sessionId, sessionInstanceId);
 		}
-	}, [sessionId, token, peerWsBase]);
+	}, [sessionId, sessionInstanceId, token, peerWsBase]);
 
 	const connect = useCallback(() => {
 		registerVisibilityListener();
 		ensureConnection(token, peerWsBase);
 		if (sharedWs?.readyState === WebSocket.OPEN && wsReady) {
-			subscribeToSession(sessionId);
+			subscribeToSession(sessionId, sessionInstanceId);
 		}
-	}, [sessionId, token, peerWsBase]);
+	}, [sessionId, sessionInstanceId, token, peerWsBase]);
 
 	const disconnect = useCallback(() => {
 		if (subscribedSession) {
 			sendRaw({ type: "unsubscribe", sessionId: subscribedSession });
 			subscribedSession = null;
+			subscribedSessionInstance = null;
 		}
 		setIsConnected(false);
 	}, []);

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -33,6 +33,7 @@ interface PaneLeafInfo {
 
 interface TerminalPageProps {
 	sessionId: string;
+	sessionInstanceId?: string;
 	token?: string | null;
 	onStateChange?: (state: SessionState) => void;
 	onNewSession?: (sessionId: string, sessionName: string) => void;
@@ -58,6 +59,7 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 	function TerminalPage(
 		{
 			sessionId,
+			sessionInstanceId,
 			token,
 			onStateChange,
 			onNewSession,
@@ -74,6 +76,7 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 		ref,
 	) {
 		const [error, setError] = useState<string | null>(null);
+		const [sessionExited, setSessionExited] = useState(false);
 		const [activePaneId, setActivePaneId] = useState<string | null>(null);
 		const [allPanes, setAllPanes] = useState<PaneLeafInfo[]>([]);
 
@@ -122,6 +125,7 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 
 		const controlTerminal = useMultiplexedTerminal({
 			sessionId,
+			sessionInstanceId,
 			token: peerConn.token ?? token,
 			peerWsBase: peerConn.wsBase,
 			peerApiBase: peerConn.apiBase,
@@ -180,6 +184,7 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 			},
 			onNewSession: onNewSession,
 			onConnect: () => {
+				setSessionExited(false);
 				setError(null);
 				onStateChange?.("idle");
 				controlTerminal.sendClientInfo("mobile");
@@ -199,6 +204,19 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 				);
 			},
 			onDisconnect: () => {
+				onStateChange?.("disconnected");
+			},
+			onSessionExit: () => {
+				setSessionExited(true);
+				setError(null);
+				setActivePaneId(null);
+				setAllPanes([]);
+				cachedPanesRef.current = [];
+				lastViewportRef.current.clear();
+				paneOffsetRef.current.clear();
+				paneViewportCacheRef.current.clear();
+				onPanesChangeRef.current?.([]);
+				onActivePaneChangeRef.current?.(null);
 				onStateChange?.("disconnected");
 			},
 			onError: (err) => {
@@ -384,19 +402,21 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 				{/* Terminal - full screen. mainOverlay (e.g. ChatView) replaces the
           xterm area while the InputBar inside TerminalComponent remains visible. */}
 				<main className="flex-1 relative overflow-hidden min-h-0 select-none">
-					<TerminalComponent
-						ref={ref}
-						sessionId={sessionId}
-						peerId={sessionPeerId}
-						onError={(err) => setError(err)}
-						overlayContent={overlayContent}
-						onOverlayTap={onOverlayTap}
-						showOverlay={showOverlay}
-						theme={theme}
-						controlMode={controlMode}
-						hideTerminalArea={!!mainOverlay && (mainOverlayVisible ?? true)}
-						terminalAreaOverlay={mainOverlay}
-					/>
+					{!sessionExited && (
+						<TerminalComponent
+							ref={ref}
+							sessionId={sessionId}
+							peerId={sessionPeerId}
+							onError={(err) => setError(err)}
+							overlayContent={overlayContent}
+							onOverlayTap={onOverlayTap}
+							showOverlay={showOverlay}
+							theme={theme}
+							controlMode={controlMode}
+							hideTerminalArea={!!mainOverlay && (mainOverlayVisible ?? true)}
+							terminalAreaOverlay={mainOverlay}
+						/>
+					)}
 				</main>
 			</div>
 		);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -131,6 +131,9 @@ export function agentResumeCommand(agent: AgentProvider, sessionId?: string): st
 export interface SessionResponse {
   id: string;
   name: string;
+  /** Immutable identity of this live session instance. A session name can be
+   *  deleted and reused; clients use this value to discard the old terminal. */
+  instanceId?: string;
   createdAt: string;
   lastAccessedAt: string;
   state: SessionState;
@@ -835,6 +838,7 @@ export type ControlServerMessage =
   | { type: 'viewport'; viewport: PaneViewport }
   | { type: 'ready' }
   | { type: 'pong'; timestamp: number }
+  | { type: 'session-exited'; reason: string }
   | { type: 'error'; message: string; paneId?: string }
   | { type: 'new-session'; sessionId: string; sessionName: string }
   | { type: 'pane-dead'; paneId: string }


### PR DESCRIPTION
## Summary
- notify mux clients when a herdr workspace is deleted and dispose stale terminal surfaces immediately
- identify live session instances by immutable herdr workspace id so same-name recreation forces a fresh subscription
- prevent delayed cleanup from evicting a same-name replacement control session

## Testing
- bun run typecheck
- bun run lint
- bun run test (backend 384, frontend 52)
- browser test: create -> output -> delete -> recreate same name -> input; no stale terminal or control-stream error