### PR TITLE
refactor(herdr): align HerdrService vocab to herdr workspace (internal)

### DIFF
--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -9,7 +9,7 @@ import type { FileListResponse, FileReadResponse, FileChangesResponse, FileInfo,
 
 const fileService = new FileService();
 const changeTracker = new FileChangeTracker();
-const tmuxService = new HerdrService();
+const herdrService = new HerdrService();
 
 /**
  * The client supplies `sessionWorkingDir` as the base for file access. It MUST
@@ -27,7 +27,7 @@ async function isAllowedSessionDir(sessionWorkingDir: string): Promise<boolean> 
   } catch {
     return false;
   }
-  const sessions = await tmuxService.listSessions();
+  const sessions = await herdrService.listWorkspaces();
   for (const s of sessions) {
     for (const cand of [s.currentPath, ...(s.panes ?? []).map((p) => p.path)]) {
       if (!cand) continue;

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -178,7 +178,7 @@ export const sessions = new Hono();
 
 /** Build the full sessions list (shared by HTTP handler and WS push) */
 export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
-  const herdrSessions = await herdrService.listSessions();
+  const herdrSessions = await herdrService.listWorkspaces();
   const sessionMetadata = await getAllSessionMetadata();
 
   // Enrich thread-based agents by the exact native session ids from herdr.
@@ -431,13 +431,13 @@ sessions.post('/', async (c) => {
   const agent = parsed.success ? parsed.data.agent : DEFAULT_AGENT_PROVIDER;
 
   // Generate session name
-  const herdrSessions = await herdrService.listSessions();
+  const herdrSessions = await herdrService.listWorkspaces();
   const name = parsed.success && parsed.data.name
     ? parsed.data.name
     : `session-${herdrSessions.length + 1}`;
 
   // Check if session already exists
-  const exists = await herdrService.sessionExists(name);
+  const exists = await herdrService.workspaceExists(name);
   if (exists) {
     return c.json({ error: 'Session already exists' }, 400);
   }
@@ -451,7 +451,7 @@ sessions.post('/', async (c) => {
   }
 
   try {
-    const instanceId = await herdrService.createSession(name);
+    const instanceId = await herdrService.createWorkspace(name);
 
     // Start the selected agent if workingDir is specified
     if (parsed.success && parsed.data.workingDir) {
@@ -465,7 +465,7 @@ sessions.post('/', async (c) => {
         (async () => {
           for (let i = 0; i < 30; i++) { // up to 30 seconds
             await new Promise(r => setTimeout(r, 1000));
-            const sessions = await herdrService.listSessions();
+            const sessions = await herdrService.listWorkspaces();
             const session = sessions.find(s => s.name === sessionName);
             if (session?.currentCommand === agent) {
               // Wait a bit more for the TUI to be fully ready, then submit
@@ -695,7 +695,7 @@ sessions.post('/history/resume', async (c) => {
   try {
     // Generate a unique session name based on project
     const projectName = projectPath.split('/').pop() || 'session';
-    const herdrSessions = await herdrService.listSessions();
+    const herdrSessions = await herdrService.listWorkspaces();
 
     // Guard: reject if the same agent is already running in the same directory
     const conflicting = findDuplicateAgentWorkingDirSession(herdrSessions, agent, projectPath);
@@ -709,7 +709,7 @@ sessions.post('/history/resume', async (c) => {
     }
 
     // Create new session
-    await herdrService.createSession(sessionName);
+    await herdrService.createWorkspace(sessionName);
 
     // Change to project directory and run the agent's resume command
     const command = `cd ${shellQuote(expandHome(projectPath))} && ${agentResumeCommand(agent, sessionId)}`;
@@ -717,7 +717,7 @@ sessions.post('/history/resume', async (c) => {
       await sendTextToSession(sessionName, command);
     } catch {
       // Clean up the session if command failed
-      await herdrService.killSession(sessionName);
+      await herdrService.killWorkspace(sessionName);
       return c.json({ error: 'Failed to start agent session' }, 500);
     }
 
@@ -735,7 +735,7 @@ sessions.post('/history/resume', async (c) => {
 // GET /sessions/:id - Get a specific session
 sessions.get('/:id', async (c) => {
   const id = c.req.param('id');
-  const herdrSessions = await herdrService.listSessions();
+  const herdrSessions = await herdrService.listWorkspaces();
   const session = herdrSessions.find(s => s.id === id);
 
   if (!session) {
@@ -759,7 +759,7 @@ sessions.delete('/:id', async (c) => {
   notifySessionChange();
   const id = c.req.param('id');
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     // Already lost — purge from last-known so it disappears from the list.
     await removeLastKnownSession(id).catch(() => {});
@@ -767,7 +767,7 @@ sessions.delete('/:id', async (c) => {
   }
 
   try {
-    await herdrService.killSession(id);
+    await herdrService.killWorkspace(id);
     // Keep the entry in last-known so the session shows up as "Lost" and can
     // be resumed via the Resume button without going to the history tab.
     // To purge entirely, delete the Lost session again.
@@ -783,7 +783,7 @@ sessions.post('/:id/resume', async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const parsed = ResumeSessionSchema.safeParse(body);
 
-  const herdrSessions = await herdrService.listSessions();
+  const herdrSessions = await herdrService.listWorkspaces();
   const session = herdrSessions.find(s => s.id === id);
   if (!session) {
     return c.json({ error: 'Session not found' }, 404);
@@ -817,7 +817,7 @@ sessions.put('/:id/theme', async (c) => {
     return c.json({ error: 'Invalid theme' }, 400);
   }
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -844,7 +844,7 @@ sessions.put('/:id/title', async (c) => {
     return c.json({ error: 'Invalid title' }, 400);
   }
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -868,7 +868,7 @@ sessions.post('/:id/move', async (c) => {
     return c.json({ error: 'Invalid index' }, 400);
   }
   try {
-    const moved = await herdrService.moveSession(id, index);
+    const moved = await herdrService.moveWorkspace(id, index);
     if (!moved) return c.json({ error: 'Session not found' }, 404);
     notifySessionChange();
     return c.json({ success: true });
@@ -923,7 +923,7 @@ sessions.post('/:id/panes/focus', async (c) => {
     return c.json({ error: 'Invalid pane ID' }, 400);
   }
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -948,7 +948,7 @@ sessions.post('/:id/panes/close', async (c) => {
     return c.json({ error: 'Invalid pane ID' }, 400);
   }
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -976,7 +976,7 @@ sessions.post('/:id/panes/split', async (c) => {
     return c.json({ error: 'Invalid request' }, 400);
   }
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -1001,7 +1001,7 @@ sessions.post('/:id/panes/respawn', async (c) => {
     return c.json({ error: 'Invalid request' }, 400);
   }
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -1020,7 +1020,7 @@ sessions.post('/:id/panes/input', async (c) => {
     return c.json({ error: 'Invalid request', issues: parsed.error.issues }, 400);
   }
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -1070,7 +1070,7 @@ sessions.get('/:id/panes/:paneId/viewport', async (c) => {
     return c.json({ error: 'paneId must start with %' }, 400);
   }
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }
@@ -1102,7 +1102,7 @@ sessions.post('/:id/prompt', async (c) => {
     return c.json({ error: 'text is required' }, 400);
   }
 
-  const exists = await herdrService.sessionExists(id);
+  const exists = await herdrService.workspaceExists(id);
   if (!exists) {
     return c.json({ error: 'Session not found' }, 404);
   }

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -266,7 +266,7 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
     return;
   }
 
-  const exists = await herdrService.sessionExists(sessionId);
+  const exists = await herdrService.workspaceExists(sessionId);
   if (!exists) {
     ws.send(JSON.stringify({ type: 'error', message: 'Session not found', sessionId }));
     return;
@@ -504,7 +504,7 @@ async function handleSubscribeConversation(ws: ServerWebSocket<MuxData>, session
 
   let workingDir: string | undefined;
   try {
-    const sessions = await herdrService.listSessions();
+    const sessions = await herdrService.listWorkspaces();
     const session = sessions.find(s => s.id === sessionId);
     workingDir = session?.currentPath;
   } catch (err) {

--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -1,9 +1,11 @@
 /**
- * HerdrService — session-level operations on the herdr backend.
+ * HerdrService — workspace-level operations on the herdr backend.
  *
- * Maps CC Hub sessions onto herdr workspaces (session id = workspace label,
- * falling back to workspace_id). herdr's agent.list response is authoritative
- * for the agent provider and native session identity of each pane.
+ * A CC Hub workspace is a herdr workspace. Its public id is the workspace
+ * label (falling back to workspace_id); the wire still calls this the
+ * "session id" until the API rename lands. herdr's agent.list response is
+ * authoritative for the agent provider and native session identity of each
+ * pane (that "session" is the agent conversation, a different concept).
  */
 
 import { isAgentProvider, type AgentProvider } from '../../../shared/types';
@@ -32,7 +34,7 @@ interface HerdrPaneInfo {
   pid?: number;
 }
 
-interface HerdrSessionInfo {
+interface WorkspaceInfo {
   id: string;
   name: string;
   instanceId?: string;
@@ -98,8 +100,8 @@ function workspaceSessionId(ws: HerdrWorkspace): string {
 }
 
 export class HerdrService {
-  private listSessionsCache: { data: HerdrSessionInfo[]; timestamp: number } | null = null;
-  private static readonly LIST_SESSIONS_CACHE_TTL = 2000;
+  private listWorkspacesCache: { data: WorkspaceInfo[]; timestamp: number } | null = null;
+  private static readonly LIST_WORKSPACES_CACHE_TTL = 2000;
   // pane process info cache (pane_id → foreground process snapshot)
   private processCmdCache = new Map<
     string,
@@ -172,12 +174,12 @@ export class HerdrService {
     return new Map();
   }
 
-  async listSessions(): Promise<HerdrSessionInfo[]> {
+  async listWorkspaces(): Promise<WorkspaceInfo[]> {
     if (
-      this.listSessionsCache &&
-      Date.now() - this.listSessionsCache.timestamp < HerdrService.LIST_SESSIONS_CACHE_TTL
+      this.listWorkspacesCache &&
+      Date.now() - this.listWorkspacesCache.timestamp < HerdrService.LIST_WORKSPACES_CACHE_TTL
     ) {
-      return this.listSessionsCache.data;
+      return this.listWorkspacesCache.data;
     }
 
     try {
@@ -187,7 +189,7 @@ export class HerdrService {
         this.listAgentPanes(),
       ]);
 
-      const result: HerdrSessionInfo[] = await Promise.all(
+      const result: WorkspaceInfo[] = await Promise.all(
         workspaces.map(async (ws) => {
           const wsPanes = allPanes.filter((p) => p.workspace_id === ws.workspace_id);
           const panes: HerdrPaneInfo[] = await Promise.all(
@@ -263,7 +265,7 @@ export class HerdrService {
         }),
       );
 
-      this.listSessionsCache = { data: result, timestamp: Date.now() };
+      this.listWorkspacesCache = { data: result, timestamp: Date.now() };
       return result;
     } catch {
       return [];
@@ -301,11 +303,11 @@ export class HerdrService {
   }
 
   invalidateCache(): void {
-    this.listSessionsCache = null;
+    this.listWorkspacesCache = null;
     this.processCmdCache.clear();
   }
 
-  async createSession(name: string): Promise<string> {
+  async createWorkspace(name: string): Promise<string> {
     this.invalidateCache();
     const existing = await this.resolveWorkspace(name);
     if (existing) {
@@ -330,7 +332,7 @@ export class HerdrService {
    * against herdr 0.7.3/0.7.4: index 13 → insert 0 lands at 0; index 0 →
    * insert 5 lands at 4.
    */
-  async moveSession(sessionId: string, targetIndex: number): Promise<boolean> {
+  async moveWorkspace(sessionId: string, targetIndex: number): Promise<boolean> {
     const workspaces = await listWorkspaces();
     const current = workspaces.findIndex(
       (w) => workspaceSessionId(w) === sessionId || w.workspace_id === sessionId,
@@ -351,7 +353,7 @@ export class HerdrService {
     return true;
   }
 
-  async killSession(sessionId: string): Promise<void> {
+  async killWorkspace(sessionId: string): Promise<void> {
     this.invalidateCache();
     const ws = await this.resolveWorkspace(sessionId);
     if (!ws) {
@@ -364,7 +366,7 @@ export class HerdrService {
     herdrControlSessions.get(sessionId)?.terminate('workspace closed');
   }
 
-  async sessionExists(sessionId: string): Promise<boolean> {
+  async workspaceExists(sessionId: string): Promise<boolean> {
     return (await this.resolveWorkspace(sessionId)) !== null;
   }
 }


### PR DESCRIPTION
## 目的
CC Hub の「Session」= herdr の **workspace**。内部定義を herdr の語彙に合わせる段階移行の **PR1（backend 内部のみ）**。

これは器（workspace）とエージェント会話（session）の用語分離ロードマップの第一歩。ワイヤ/DTO/フロント（`/api/sessions`, `SessionResponse`）は**不変**で外形互換を保つため、単体で安全にマージ可能。

## 変更
- `HerdrSessionInfo` → `WorkspaceInfo`
- `HerdrService` メソッド: `listSessions/createSession/killSession/moveSession/sessionExists` → `listWorkspaces/createWorkspace/killWorkspace/moveWorkspace/workspaceExists`
- `files.ts` の誤称ローカル変数 `tmuxService` → `herdrService`

## 対象外（意図的に不変）
- `GrokSessionStore.listSessions` など**エージェント会話 (B系)** の session
- `agentSessionId` / `ccSessionId` / `bridgeSessionId` / `/api/sessions/history/*` — herdr workspace とは別概念

## 検証（dev backend 3456）
- `bun run typecheck` / `biome lint` クリーン
- `GET /api/sessions` → workspace 12件正常
- create→list→delete の end-to-end（`createWorkspace`/`workspaceExists`/`killWorkspace`）動作確認、検証用 workspace は掃除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL