### PR TITLE
feat(herdr): render the active tab, not a flattened merge of all tabs

### DIFF
--- a/backend/src/services/herdr-client.ts
+++ b/backend/src/services/herdr-client.ts
@@ -247,10 +247,13 @@ export function eventWorkspaceId(ev: Record<string, unknown>): string | null {
   if (!data || typeof data !== 'object') return null;
   const d = data as Record<string, unknown>;
   if (typeof d.workspace_id === 'string') return d.workspace_id;
-  const pane = d.pane;
-  if (pane && typeof pane === 'object') {
-    const p = pane as Record<string, unknown>;
-    if (typeof p.workspace_id === 'string') return p.workspace_id;
+  // pane.* nest it under `pane`, tab.* under `tab` (verified against 0.7.4).
+  for (const key of ['pane', 'tab'] as const) {
+    const nested = d[key];
+    if (nested && typeof nested === 'object') {
+      const n = nested as Record<string, unknown>;
+      if (typeof n.workspace_id === 'string') return n.workspace_id;
+    }
   }
   return null;
 }
@@ -269,6 +272,22 @@ export function toHerdrPaneId(workspaceId: string, tmuxPaneId: string): string {
 export async function listWorkspaces(): Promise<HerdrWorkspace[]> {
   const res = await herdrRpc<{ workspaces: HerdrWorkspace[] }>('workspace.list', {});
   return res.workspaces ?? [];
+}
+
+/**
+ * Fetch one workspace (for its authoritative `active_tab_id`). herdr updates
+ * `active_tab_id` immediately on `tab.focus`, so this is how the control
+ * session follows tab switches. Null on any failure.
+ */
+export async function getWorkspace(workspaceId: string): Promise<HerdrWorkspace | null> {
+  try {
+    const res = await herdrRpc<{ workspace?: HerdrWorkspace }>('workspace.get', {
+      workspace_id: workspaceId,
+    });
+    return res.workspace ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export async function listPanes(workspaceId?: string): Promise<HerdrPane[]> {

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -25,6 +25,7 @@ import {
   eventWorkspaceId,
   exportLayout,
   getPane,
+  getWorkspace,
   type HerdrPane,
   herdrRpc,
   herdrSubscribe,
@@ -212,6 +213,11 @@ export function scanFrameForState(state: PaneRuntimeState, bytes: Buffer): void 
 export class HerdrControlSession {
   private sessionId: string;
   private workspaceId: string | null = null;
+  // A herdr workspace holds one or more tabs; CC Hub renders a single tab at a
+  // time (its split tree is one tab's geometry). This tracks which tab is live,
+  // following herdr's `active_tab_id`. null = pre-init or herdr too old to
+  // report tabs, in which case every pane is treated as one flat tab.
+  private activeTabId: string | null = null;
   private tree = new PaneLayoutTree();
 
   // Client size as reported by the browser (drives pane PTY sizes).
@@ -286,8 +292,10 @@ export class HerdrControlSession {
       throw new Error(`herdr workspace not found for session: ${this.sessionId}`);
     }
     this.workspaceId = ws.workspace_id;
+    this.activeTabId = ws.active_tab_id ?? null;
 
-    const panes = await listPanes(ws.workspace_id);
+    const allPanes = await listPanes(ws.workspace_id);
+    const panes = this.filterActiveTab(allPanes);
     const tmuxIds = panes
       .map((p) => toTmuxPaneId(p.pane_id))
       .filter((id): id is string => id !== null);
@@ -316,9 +324,18 @@ export class HerdrControlSession {
     // other workspaces (previews, throwaway workspaces, other sessions) does
     // not fan out into a pane.list reconcile per session. An event with no
     // recognizable workspace still reconciles — a wasted reconcile is
-    // harmless, a missed one would cost correctness.
+    // harmless, a missed one would cost correctness. tab.* events drive the
+    // active-tab switch (reconcile re-reads active_tab_id authoritatively).
     this.unsubscribeEvents = herdrSubscribe(
-      [{ type: 'pane.created' }, { type: 'pane.closed' }, { type: 'pane.exited' }],
+      [
+        { type: 'pane.created' },
+        { type: 'pane.closed' },
+        { type: 'pane.exited' },
+        { type: 'tab.focused' },
+        { type: 'tab.created' },
+        { type: 'tab.closed' },
+        { type: 'tab.moved' },
+      ],
       (ev) => {
         const wsId = eventWorkspaceId(ev);
         if (wsId === null || wsId === this.workspaceId) {
@@ -331,8 +348,14 @@ export class HerdrControlSession {
     );
 
     console.log(
-      `[herdr-control] Session ready: ${this.sessionId} (workspace=${ws.workspace_id}, panes=${tmuxIds.length})`,
+      `[herdr-control] Session ready: ${this.sessionId} (workspace=${ws.workspace_id}, tab=${this.activeTabId ?? 'n/a'}, panes=${tmuxIds.length})`,
     );
+  }
+
+  /** Panes belonging to the live tab (all panes when tabs aren't reported). */
+  private filterActiveTab(panes: HerdrPane[]): HerdrPane[] {
+    if (!this.activeTabId) return panes;
+    return panes.filter((p) => p.tab_id === this.activeTabId);
   }
 
   /**
@@ -484,9 +507,9 @@ export class HerdrControlSession {
 
   private async reconcilePanes(): Promise<void> {
     if (this.destroyed || !this.workspaceId) return;
-    let panes: Awaited<ReturnType<typeof listPanes>>;
+    let allPanes: Awaited<ReturnType<typeof listPanes>>;
     try {
-      panes = await listPanes(this.workspaceId);
+      allPanes = await listPanes(this.workspaceId);
     } catch {
       // Distinguish "workspace is gone" (terminal) from a transient RPC
       // failure. Swallowing the former leaves this session in the registry
@@ -504,6 +527,19 @@ export class HerdrControlSession {
       }
       return;
     }
+
+    // Follow herdr's active tab. workspace.get reports active_tab_id
+    // authoritatively (it updates the instant a tab is focused), so a tab.*
+    // event that brought us here re-points the session at the new tab's
+    // geometry rather than merging tabs into one flat tree.
+    const ws = await getWorkspace(this.workspaceId);
+    const activeTab = ws?.active_tab_id ?? this.activeTabId;
+    if (activeTab && activeTab !== this.activeTabId && allPanes.some((p) => p.tab_id === activeTab)) {
+      await this.switchActiveTab(activeTab, allPanes);
+      return;
+    }
+
+    const panes = this.filterActiveTab(allPanes);
     const live = new Set<string>();
     let changed = false;
 
@@ -546,12 +582,73 @@ export class HerdrControlSession {
     }
 
     if (this.tree.paneIds().length === 0) {
-      this.handleExit('all panes closed');
+      // The active tab is empty. Only an empty *workspace* means the session is
+      // gone; if other tabs still hold panes, the active tab was just closed —
+      // switch to a surviving tab instead of tearing the session down.
+      if (allPanes.length === 0) {
+        this.handleExit('all panes closed');
+        return;
+      }
+      await this.switchActiveTab(allPanes[0].tab_id, allPanes);
       return;
     }
     if (changed) {
       await this.applyLayout();
     }
+  }
+
+  /**
+   * Re-point the control session at a different tab of the same workspace:
+   * rebuild the split tree from that tab's panes and swap the per-pane control
+   * streams over. Used when herdr's active tab changes (tab focus / the active
+   * tab being closed). Mirrors start()'s per-tab setup.
+   */
+  private async switchActiveTab(tabId: string, allPanes: HerdrPane[]): Promise<void> {
+    if (this.destroyed) return;
+    const previousPaneIds = this.tree.paneIds();
+    this.activeTabId = tabId;
+    const panes = this.filterActiveTab(allPanes);
+    const tmuxIds = panes
+      .map((p) => toTmuxPaneId(p.pane_id))
+      .filter((id): id is string => id !== null);
+
+    // Tear down the outgoing tab's controllers / runtime state; those panes are
+    // not dead, just off-screen, so no pane-dead events — the new layout tells
+    // the client which panes exist now.
+    for (const tmuxId of previousPaneIds) {
+      this.stopController(this.toHerdr(tmuxId));
+      this.paneSizes.delete(tmuxId);
+      this.runtimeStates.delete(tmuxId);
+    }
+
+    await this.hydrateLayout(panes, tmuxIds);
+
+    const focused = panes.find((p) => p.focused);
+    this.activePaneId = (focused ? toTmuxPaneId(focused.pane_id) : null) ?? tmuxIds[0] ?? null;
+
+    for (const pane of panes) {
+      const tmuxId = toTmuxPaneId(pane.pane_id);
+      if (tmuxId) {
+        this.paneSizes.set(tmuxId, {
+          cols: this.clientSize.cols,
+          rows: paneViewportRows(pane, this.clientSize.rows),
+        });
+      }
+    }
+
+    if (this.controllersEnabled) {
+      for (const tmuxId of this.tree.paneIds()) {
+        this.startController(
+          this.toHerdr(tmuxId),
+          this.clientSizeKnown ? (this.paneSizes.get(tmuxId) ?? null) : null,
+        );
+      }
+    }
+
+    console.log(
+      `[herdr-control] Active tab → ${tabId} (session=${this.sessionId}, panes=${tmuxIds.length})`,
+    );
+    await this.applyLayout();
   }
 
   // ==========================================================================

--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -191,7 +191,15 @@ export class HerdrService {
 
       const result: WorkspaceInfo[] = await Promise.all(
         workspaces.map(async (ws) => {
-          const wsPanes = allPanes.filter((p) => p.workspace_id === ws.workspace_id);
+          // Only the active tab's panes represent the session: herdr stacks
+          // multiple tabs' panes under one workspace, but the terminal view
+          // (HerdrControlSession) renders a single tab, so the list must agree
+          // or the pane count / preview would count panes the user can't see.
+          const wsPanes = allPanes.filter(
+            (p) =>
+              p.workspace_id === ws.workspace_id &&
+              (!ws.active_tab_id || p.tab_id === ws.active_tab_id),
+          );
           const panes: HerdrPaneInfo[] = await Promise.all(
             wsPanes.map(async (p) => {
               const tmuxId = toTmuxPaneId(p.pane_id) ?? p.pane_id;


### PR DESCRIPTION
## 背景
herdr は **workspace → tab → pane** の3階層。CC Hub は tab 次元を無視し、workspace 内の**全 tab の pane を1本のフラット split tree に混ぜて**いた（`tab_id` は型でパースされるだけで未消費）。

単一 tab では無害だが、`herdr tab` で tab を足した瞬間に:
- `hydrateLayout` の `matches` ガードが必ず false → フラット chain へ退行（各 tab の縦横比・ズームを喪失）
- 別 tab の pane が同一画面に混在

これはロードマップ **PR2（tab を第一級機能にする前段の、制御層の tab 対応）**。

## 変更（`HerdrControlSession` を「1 tab をレンダリング」に）
- `start` / `reconcilePanes` を **active tab の pane** に絞る（`workspace.get` の `active_tab_id` が権威）
- `tab.focused/created/closed/moved` を購読 → active tab 切替を**追従して再 hydrate**（`switchActiveTab`）
- active tab が空でも他 tab に pane が残るなら**セッションを終了せず生存 tab へ切替**（誤終了防止）
- 一覧側 `HerdrService.listWorkspaces` も active tab の pane だけを数える（ターミナル表示と一致）
- `getWorkspace()` を herdr-client に追加、`eventWorkspaceId` を tab イベント対応に拡張

## 検証済みの前提（実測）
- pane 番号は **workspace 内で一意**（tab をまたいでも `w:p1/p2/p3...` と連番、衝突なし）→ `%N ↔ wK:pN` マッピングは**不変**
- `workspace.get` の `active_tab_id` は `tab focus` 直後に即更新される

## dev 検証（backend 3456 + raw WS client）
2 tab（tab1=1 pane, tab2=2 pane split）の workspace で:
- WS `layout`: `[%1]`（tab1）→ tab2 focus で `[%2,%3]`（**tab2のみ、%1と混ざらない**）→ tab1 focus で `[%1]` に復帰
- `GET /api/sessions`: 1 → 2（workspace 全3枚中 active tab の2枚のみ）→ 1
- `bun test src/services/__tests__/` **185 pass / 0 fail**、typecheck / biome クリーン
- 単一 tab（通常ケース）は `filterActiveTab` が全 pane を返すため従来と同一（回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL