### PR TITLE
feat(tabs): expose workspace tabs in the API + WS tab operations

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -24,6 +24,14 @@ import { pushSessionsNow } from './terminal-mux';
 import { detectPaneState, stripAnsi, type DetectedPaneState } from '../services/pane-state';
 
 const herdrService = new HerdrService();
+
+/** Drop the workspace-list cache so the next buildSessionsList() re-reads herdr.
+ *  Called after a mutation (e.g. a tab op) that must reflect in the pushed list
+ *  immediately rather than after the 2s cache TTL. */
+export function invalidateWorkspacesCache(): void {
+  herdrService.invalidateCache();
+}
+
 const claudeCodeService = new ClaudeCodeService();
 const codexConversationService = new CodexConversationService();
 // peers.ts からも参照するため export
@@ -329,6 +337,8 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         };
         return pane;
       }) : undefined,
+      tabs: s.tabs,
+      activeTabId: s.activeTabId,
     };
   }));
 
@@ -369,6 +379,8 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       agent: lost.agent,
       metrics: undefined,
       panes: undefined,
+      tabs: undefined,
+      activeTabId: undefined,
     });
   }
 

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -13,7 +13,7 @@ import type {
   ConversationMessage,
 } from '../../../shared/types';
 import { MuxClientMessageSchema } from '../../../shared/types';
-import { buildSessionsList } from './sessions';
+import { buildSessionsList, invalidateWorkspacesCache } from './sessions';
 
 // Output → push debounce. Wait this long after the last %output for a pane
 // before recapturing. Shorter = lower latency; longer = fewer captures.
@@ -702,6 +702,26 @@ async function handleControlMessage(
         // Dormant until per-client sizing is enabled — recorded, not yet
         // consulted for PTY sizing.
         controlSession.setPaneDemands(ws.data.visitorId, msg.demands);
+        break;
+      }
+      case 'select-tab':
+      case 'create-tab':
+      case 'close-tab': {
+        try {
+          if (msg.type === 'select-tab') await controlSession.selectTab(msg.tabId);
+          else if (msg.type === 'create-tab') await controlSession.createTab();
+          else await controlSession.closeTab(msg.tabId);
+          // Reflect the new tab set / active tab in the pushed session list now,
+          // not after the 2s cache TTL (the layout already switched via reconcile).
+          invalidateWorkspacesCache();
+          pushSessionsNow();
+        } catch (e) {
+          ws.send(JSON.stringify({
+            type: 'error',
+            message: e instanceof Error ? e.message : 'Tab operation failed',
+            sessionId,
+          }));
+        }
         break;
       }
     }

--- a/backend/src/services/herdr-client.ts
+++ b/backend/src/services/herdr-client.ts
@@ -102,6 +102,16 @@ export interface HerdrWorkspace {
   tab_count?: number;
 }
 
+export interface HerdrTab {
+  tab_id: string;
+  workspace_id: string;
+  number: number;
+  label: string;
+  focused: boolean;
+  pane_count?: number;
+  agent_status?: HerdrAgentStatus;
+}
+
 const RPC_TIMEOUT_MS = 10_000;
 let reqCounter = 0;
 
@@ -294,6 +304,35 @@ export async function listPanes(workspaceId?: string): Promise<HerdrPane[]> {
   const params: Record<string, unknown> = workspaceId ? { workspace_id: workspaceId } : {};
   const res = await herdrRpc<{ panes: HerdrPane[] }>('pane.list', params);
   return res.panes ?? [];
+}
+
+/** Tabs of a workspace (herdr workspace > tab > pane), with labels + counts. */
+export async function listTabs(workspaceId: string): Promise<HerdrTab[]> {
+  try {
+    const res = await herdrRpc<{ tabs?: HerdrTab[] }>('tab.list', { workspace_id: workspaceId });
+    return res.tabs ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/** Focus (switch to) a tab. */
+export async function focusTab(tabId: string): Promise<void> {
+  await herdrRpc('tab.focus', { tab_id: tabId });
+}
+
+/** Create a new tab in a workspace, optionally focusing it. Returns its id. */
+export async function createTab(workspaceId: string, focus = true): Promise<string | null> {
+  const res = await herdrRpc<{ tab?: { tab_id?: string } }>('tab.create', {
+    workspace_id: workspaceId,
+    focus,
+  });
+  return res.tab?.tab_id ?? null;
+}
+
+/** Close a tab (and every pane in it). */
+export async function closeTab(tabId: string): Promise<void> {
+  await herdrRpc('tab.close', { tab_id: tabId });
 }
 
 export async function getPane(herdrPaneId: string): Promise<HerdrPane | null> {

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -22,8 +22,11 @@
 import type { PaneCursor, PaneDemand, PaneModes, PaneViewport, TmuxLayoutNode } from '../../../shared/types';
 import { type ClientPaneDemands, reconcilePaneSizes, resolveTargetSizes } from './pane-sizing';
 import {
+  closeTab as herdrCloseTab,
+  createTab as herdrCreateTab,
   eventWorkspaceId,
   exportLayout,
+  focusTab as herdrFocusTab,
   getPane,
   getWorkspace,
   type HerdrPane,
@@ -878,6 +881,35 @@ export class HerdrControlSession {
     } catch {
       // focus is best-effort
     }
+  }
+
+  // ==========================================================================
+  // Tab operations (herdr workspace > tab > pane)
+  // ==========================================================================
+
+  /**
+   * Switch the workspace's active tab. reconcilePanes then re-points the split
+   * tree at the new tab (also driven independently by the tab.focused event).
+   */
+  async selectTab(tabId: string): Promise<void> {
+    await herdrFocusTab(tabId);
+    await this.reconcilePanes();
+  }
+
+  /** Create a new focused tab in this workspace and switch to it. */
+  async createTab(): Promise<void> {
+    if (!this.workspaceId) throw new Error('Control session not active');
+    await herdrCreateTab(this.workspaceId, true);
+    await this.reconcilePanes();
+  }
+
+  /**
+   * Close a tab (and its panes). If it was the active tab, reconcile switches
+   * to a surviving tab; the workspace is torn down only when its last tab goes.
+   */
+  async closeTab(tabId: string): Promise<void> {
+    await herdrCloseTab(tabId);
+    await this.reconcilePanes();
   }
 
   /**

--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -8,10 +8,11 @@
  * pane (that "session" is the agent conversation, a different concept).
  */
 
-import { isAgentProvider, type AgentProvider } from '../../../shared/types';
+import { isAgentProvider, type AgentProvider, type TabInfo } from '../../../shared/types';
 import {
   herdrRpc,
   listPanes,
+  listTabs,
   listWorkspaces,
   readPaneText,
   toTmuxPaneId,
@@ -57,6 +58,9 @@ interface WorkspaceInfo {
    *  one, `unknown` when no agent is on the pane. Drives the indicator, so
    *  hooks no longer have to report every state transition. */
   agentStatus?: HerdrAgentStatus;
+  /** Tabs of this workspace, present only when it has more than one tab. */
+  tabs?: TabInfo[];
+  activeTabId?: string;
 }
 
 export interface HerdrAgentRecord {
@@ -254,6 +258,26 @@ export class HerdrService {
           )
             ? 'blocked'
             : agentPane?.agentStatus;
+
+          // Tab list only matters for multi-tab workspaces (the single-tab
+          // case renders no tab UI), so the extra tab.list RPC is skipped for
+          // the common one-tab workspace.
+          let tabs: TabInfo[] | undefined;
+          if ((ws.tab_count ?? 1) > 1) {
+            const herdrTabs = await listTabs(ws.workspace_id);
+            if (herdrTabs.length > 1) {
+              tabs = herdrTabs
+                .slice()
+                .sort((a, b) => a.number - b.number)
+                .map((t) => ({
+                  id: t.tab_id,
+                  label: t.label || String(t.number),
+                  paneCount: t.pane_count ?? 0,
+                  active: t.tab_id === ws.active_tab_id,
+                }));
+            }
+          }
+
           return {
             id: workspaceSessionId(ws),
             name: workspaceSessionId(ws),
@@ -269,6 +293,8 @@ export class HerdrService {
             panes,
             agentSessionId,
             agentStatus,
+            tabs,
+            activeTabId: ws.active_tab_id,
           };
         }),
       );

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -147,6 +147,17 @@ export interface SessionListResponse {
   sessions: SessionResponse[];
 }
 
+/** One tab of a workspace (herdr workspace > tab > pane). Surfaced so the UI
+ *  can list a multi-tab workspace's tabs and switch between them. */
+export interface TabInfo {
+  /** herdr tab id (e.g. "w1:t2"); echoed back to select/close the tab. */
+  id: string;
+  /** Display label — herdr's tab number by default, or a custom rename. */
+  label: string;
+  paneCount: number;
+  active: boolean;
+}
+
 export interface ErrorResponse {
   error: string;
   code?: string;
@@ -164,6 +175,10 @@ export const LoginSchema = z.object({
 
 // Pane ID validation (e.g., "%0", "%1")
 export const PaneIdSchema = z.string().regex(/^%\d+$/, 'Invalid pane ID');
+
+// herdr tab id validation (e.g. "w1:t2", "w1W:t3"). Server-provided and echoed
+// back by the client to select/close a tab; bounded to the herdr id shape.
+export const TabIdSchema = z.string().regex(/^[A-Za-z0-9]+:t\d+$/, 'Invalid tab ID');
 
 // Agent session id validation. Claude/Codex session ids are UUID-like; this
 // also bounds them to shell-safe characters because the id is typed into an
@@ -622,6 +637,10 @@ export interface ExtendedSessionResponse extends SessionResponse {
   ccRecapAt?: string;
   waitingToolName?: string;
   panes?: PaneInfo[];
+  /** Tabs of this workspace. Only present when it has more than one tab — a
+   *  single-tab workspace renders no tab list. `panes` reflects the active tab. */
+  tabs?: TabInfo[];
+  activeTabId?: string;
   messageCount?: number;
   gitBranch?: string;
   durationMinutes?: number;
@@ -823,7 +842,13 @@ export type ControlClientMessage =
   // Ask the server for a viewport `offset` rows above the live edge.
   // offset=0 means live mode; the server will also push fresh viewports
   // unsolicited when new output arrives.
-  | { type: 'request-viewport'; paneId: string; offset: number };
+  | { type: 'request-viewport'; paneId: string; offset: number }
+  // Tab operations (herdr workspace > tab > pane). CC Hub renders one tab at a
+  // time; these switch/create/close the workspace's tabs. `tabId` is a herdr
+  // tab id echoed back from `SessionResponse.tabs`.
+  | { type: 'select-tab'; tabId: string }
+  | { type: 'create-tab' }
+  | { type: 'close-tab'; tabId: string };
 
 // Server → Client messages
 export type ControlServerMessage =
@@ -895,6 +920,9 @@ const controlClientMessageOptions = [
   z.object({ type: z.literal('zoom-pane'), paneId: PaneIdSchema, zoomed: z.boolean().optional() }),
   z.object({ type: z.literal('respawn-pane'), paneId: PaneIdSchema }),
   z.object({ type: z.literal('request-viewport'), paneId: PaneIdSchema, offset: WsOffset }),
+  z.object({ type: z.literal('select-tab'), tabId: TabIdSchema }),
+  z.object({ type: z.literal('create-tab') }),
+  z.object({ type: z.literal('close-tab'), tabId: TabIdSchema }),
   z.object({
     type: z.literal('pane-demands'),
     demands: z


### PR DESCRIPTION
## 背景
PR2 で制御セッションは「1 tab をレンダリング」するようになった。本 PR は **tab セット全体をクライアントに露出**し、**切替/作成/閉じる**操作を可能にする（ロードマップ PR3）。ワイヤは**追加のみ**（DTO の optional フィールド + 新 WS メッセージ型）で後方互換。

tab バー UI（PR5）は「セッション一覧に入れ子」方針のため、`SessionResponse.tabs[]` を SessionModal が消費する。

## 変更
- **shared/types**: `TabInfo`（id/label/paneCount/active）+ `SessionResponse.tabs?`/`activeTabId?`。WS 制御メッセージ `select-tab`/`create-tab`/`close-tab`（+ `TabIdSchema`、zod オプション）
- **herdr-client**: `HerdrTab` 型、`listTabs`/`focusTab`/`createTab`/`closeTab`。RPC パラメータは socket 直叩きで実測確認（`tab.create {workspace_id, focus}`, `tab.focus/close {tab_id}`, `tab.list {workspace_id}`）
- **HerdrService.listWorkspaces**: `tabs`/`activeTabId` を付与。`tab.list` は **`tab_count > 1` の時だけ**呼ぶ（単一 tab の通常ケースは追加 RPC なし）
- **HerdrControlSession**: `selectTab`/`createTab`/`closeTab`（RPC + reconcile。active tab 切替自体は PR2 の `switchActiveTab`）
- **terminal-mux**: tab メッセージを dispatch。workspace-list キャッシュを無効化 + `pushSessionsNow` で tab リストを即時反映

## dev 検証（backend 3456 + raw WS client）
2-tab workspace（tab1=1 pane, tab2=2 pane、tab2 active）で:
- `GET /api/sessions`: `tabs=[{"1",1,active:false},{"2",2,active:true}]`, `activeTabId=t2`, panes=2 ✅
- WS `select-tab t1` → `layout [%1]` + list `[1*(1),2(2)]` に即時切替
- WS `create-tab` → `layout [%4]` + list `[1(1),2(2),3*(1)]`（新tab+focus）
- WS `close-tab t1` → list `[1(2),2*(1)]`（除去、active 維持）
- 反映レイテンシ ~200-400ms、error なし
- **185 unit tests pass**、typecheck（backend/shared/frontend）+ biome クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL