### PR TITLE
feat(api): add /api/workspaces as the canonical alias of /api/sessions

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -52,8 +52,13 @@ const app = new Hono();
 
 // Middleware - custom logger that skips noisy polling endpoints
 app.use('*', logger((message, ...rest) => {
-  // Skip GET /api/sessions polling logs (fired every 5s per client)
-  if (message.includes('GET') && message.includes('/api/sessions') && !message.includes('/api/sessions/')) {
+  // Skip GET /api/sessions|/api/workspaces polling logs (fired every 5s per client)
+  if (
+    message.includes('GET') &&
+    (message.includes('/api/sessions') || message.includes('/api/workspaces')) &&
+    !message.includes('/api/sessions/') &&
+    !message.includes('/api/workspaces/')
+  ) {
     return;
   }
   // Skip POST /api/notify hook traffic — fires on every Claude/Codex hook
@@ -149,6 +154,10 @@ app.get('/api/images/:filename', async (c) => {
 app.use('/api/logs/*', conditionalAuthMiddleware);
 app.use('/api/sessions/*', conditionalAuthMiddleware);
 app.use('/api/sessions', conditionalAuthMiddleware);
+// `/api/workspaces` is the canonical name (a CC Hub session IS a herdr
+// workspace); `/api/sessions` stays as an alias for CLI / peers / glasses.
+app.use('/api/workspaces/*', conditionalAuthMiddleware);
+app.use('/api/workspaces', conditionalAuthMiddleware);
 app.use('/api/upload/*', conditionalAuthMiddleware);
 app.use('/api/files/*', conditionalAuthMiddleware);
 app.use('/api/dashboard', conditionalAuthMiddleware);
@@ -158,6 +167,8 @@ app.use('/api/herdr/*', conditionalAuthMiddleware);
 
 app.route('/api/logs', logs);
 app.route('/api/sessions', sessions);
+// Alias mount: same router, canonical `workspace` name (see auth note above).
+app.route('/api/workspaces', sessions);
 app.route('/api/upload', upload);
 app.route('/api/files', files);
 app.route('/api/dashboard', dashboard);


### PR DESCRIPTION
## 目的
CC Hub の session は herdr の **workspace** そのもの。ドメインに合う `/api/workspaces` を正典パスとして追加し、`/api/sessions` は**エイリアス**として残す（ロードマップ PR4 の第一段=バックエンド）。

ユーザー選択の方針「**API+フロント改名、旧パスはエイリアス維持**」に沿う: フロントは次の PR で `/api/workspaces` へ移行、**CLI(`cchub send`/`peek`)・peer proxy・glasses は無変更**で `/api/sessions` を使い続けられる。

## 変更
- `sessions` ルーターを `/api/workspaces` にも二重マウント（同一ハンドラ）+ auth ミドルウェア
- ポーリングログ抑制を `/api/workspaces` にも適用

## dev 検証（backend 3456）
- `/api/workspaces` と `/api/sessions` が**同一レスポンス**（200、13件一致）
- `/api/workspaces/history/projects` 200（history サブルートも alias 反映）
- alias 経由 `POST /api/workspaces`(201) / `DELETE`(200) — ミューテーションも正常
- backend typecheck クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL