### PR TITLE
Release v0.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.24] - 2026-07-19
+
+### Added
+- **ワークスペースの「タブ」対応（herdr の workspace > tab > pane を3階層で扱う）** (#455, #456, #457): これまで CC Hub は tab の概念を持たず、`herdr tab` で複数タブを作った workspace は全タブの pane を1画面にフラット混在させ、各タブの縦横比・ズームを失って表示が崩れていた。制御セッションを **「アクティブなタブだけを描画」** に変更し、`workspace.get` の `active_tab_id` を権威にタブ切替へ追従（別タブの pane を混ぜない／アクティブタブが空でも他タブが残ればセッションを終了しない）。**セッション一覧の各ワークスペース配下にタブを入れ子表示**し、タップで切替・「+ 新規タブ」・長押しで閉じる（desktop / tablet / mobile 共通）。`SessionResponse.tabs[]` / `activeTabId` を露出し、WebSocket（`select-tab` / `create-tab` / `close-tab`）と REST（`POST /:id/tabs/{select,create,close}`）を追加
+
+### Changed
+- **内部・API・フロントの命名を「Session」→「Workspace」に整合** (#454, #458, #460): CC Hub の1セッションは herdr の1ワークスペースそのもの。backend の型・メソッドを workspace 語彙へ寄せ、`/api/workspaces` を正典パスとして追加（旧 `/api/sessions` は**エイリアスで維持**するため CLI `cchub send`/`peek`・peer・glasses は無変更で動作）。フロントを `/api/workspaces` へ移行し、一覧のヘッダ／作成ボタンなどのラベルを「ワークスペース」に変更。エージェント会話履歴（`/api/sessions/history`）は別概念のため据え置き
+  - 注意: 更新済みのフロントは peer 宛にも `/api/workspaces` を叩くため、まだ更新していない古い peer は一時的に 404 になり得る（fleet を更新すればエイリアスにより解消）
+
 ## [0.2.23] - 2026-07-19
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- feat(tabs): ワークスペースの「タブ」対応（herdr の workspace > tab > pane を3階層で扱う）(#455, #456, #457) — アクティブタブのみ描画で multi-tab の表示崩壊を解消、タブ切替追従、セッション一覧に入れ子タブ UI（切替/新規/閉じる、desktop/tablet/mobile）、`SessionResponse.tabs[]` + WS/REST タブ操作
- refactor(naming): 内部・API・フロントの命名を「Session」→「Workspace」に整合 (#454, #458, #460) — `/api/workspaces` を正典パス化（旧 `/api/sessions` はエイリアス維持、CLI/peer/glasses 無変更）

## Notes
- 未リリースの6 PR（#454-#460）をまとめる patch リリース
- peer version-skew: 更新済みフロントは peer 宛にも `/api/workspaces` を叩くため、未更新の古い peer は一時 404 になり得る（fleet 更新で解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL