### PR TITLE
fix(tabs): make "new tab" reachable on a single-tab workspace

### DIFF
--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -259,13 +259,14 @@ export class HerdrService {
             ? 'blocked'
             : agentPane?.agentStatus;
 
-          // Tab list only matters for multi-tab workspaces (the single-tab
-          // case renders no tab UI), so the extra tab.list RPC is skipped for
-          // the common one-tab workspace.
+          // Tabs: a multi-tab workspace needs tab.list for real labels/counts;
+          // the common single-tab case is derived from active_tab_id with no
+          // extra RPC. Always populated (even for one tab) so the UI can offer
+          // "new tab" and show the active tab without a chicken-and-egg gate.
           let tabs: TabInfo[] | undefined;
           if ((ws.tab_count ?? 1) > 1) {
             const herdrTabs = await listTabs(ws.workspace_id);
-            if (herdrTabs.length > 1) {
+            if (herdrTabs.length > 0) {
               tabs = herdrTabs
                 .slice()
                 .sort((a, b) => a.number - b.number)
@@ -276,6 +277,11 @@ export class HerdrService {
                   active: t.tab_id === ws.active_tab_id,
                 }));
             }
+          } else if (ws.active_tab_id) {
+            const num = ws.active_tab_id.match(/:t(\d+)$/)?.[1] ?? '1';
+            tabs = [
+              { id: ws.active_tab_id, label: num, paneCount: wsPanes.length, active: true },
+            ];
           }
 
           return {

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -162,12 +162,14 @@ function SessionMenuDialog({
 	session,
 	onChangeTheme,
 	onChangeTitle,
+	onCreateTab,
 	onDelete,
 	onCancel,
 }: {
 	session: SessionResponse;
 	onChangeTheme: (theme: SessionTheme | null) => void;
 	onChangeTitle?: (title: string | null) => void;
+	onCreateTab?: () => void;
 	onDelete: () => void;
 	onCancel: () => void;
 }) {
@@ -279,6 +281,20 @@ function SessionMenuDialog({
 								{t("common.save")}
 							</button>
 						</div>
+					</div>
+				)}
+
+				{/* New tab — always available so a single-tab workspace can grow one */}
+				{onCreateTab && (
+					<div className="mb-4">
+						<button
+							type="button"
+							onClick={onCreateTab}
+							className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-md bg-th-surface-active hover:bg-white/[0.08] text-th-text text-sm font-medium transition-colors"
+						>
+							<Plus className="w-4 h-4" />
+							{t("session.newTab")}
+						</button>
 					</div>
 				)}
 
@@ -1211,7 +1227,7 @@ function SessionItem({
 
 			{/* Tab list (expandable): switch / create / close the workspace's tabs.
 			    Long-press a tab to close it (never the last one). */}
-			{panesExpanded && extSession.tabs && extSession.tabs.length > 1 && (
+			{panesExpanded && extSession.tabs && extSession.tabs.length >= 1 && (
 				<div
 					className="mx-4 mb-2 pt-2 border-t border-white/[0.06] space-y-1"
 					onClick={(e) => e.stopPropagation()}
@@ -2260,6 +2276,10 @@ export function WorkspaceList({
 					session={sessionForMenu}
 					onChangeTheme={handleMenuChangeTheme}
 					onChangeTitle={handleMenuChangeTitle}
+					onCreateTab={() => {
+						handleTabAction(sessionForMenu.id, "create");
+						handleMenuClose();
+					}}
 					onDelete={handleMenuDelete}
 					onCancel={handleMenuClose}
 				/>


### PR DESCRIPTION
## 問題
タブUIの「+ 新規タブ」ボタンは workspace が**すでに2タブ以上ある時だけ**表示され、backend も `tab_count > 1` の時だけ `tabs[]` を返していた。→ 通常の**単一タブ workspace では2つ目のタブを作る導線が無い**（鶏卵問題）。`POST /tabs/create` 自体は動くが UI から呼べなかった。

## 修正
- **backend**: `tabs[]`/`activeTabId` を**常に**返す。単一タブは `active_tab_id` から導出（`tab.list` RPC を増やさない、multi-tab は従来通り）
- **frontend**: 展開時に **1タブ以上**でインラインのタブ欄（「+ 新規タブ」含む）を描画（従来は >1）。加えて workspace の**長押しメニューに「新規タブ」を追加** — 展開できない単一ペイン単一タブ workspace でも作成可能

## dev 検証（3456）
- 単一タブ workspace が `tabs:[{label:"1",active:true}]` を返すようになった
- REST create でタブが増える（`[t1] → [t1, t2*]`）確認
- typecheck(backend/frontend) + biome + frontend build クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL