### PR TITLE
feat(tabs): show model/ctx/mem per pane on multi-pane/tab workspaces

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -277,6 +277,11 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         }
       : metrics;
 
+    // A multi-pane / multi-tab workspace shows per-pane metrics instead of one
+    // ambiguous card-header summary; simple single-pane workspaces keep the
+    // header summary and skip the extra per-pane metric computation.
+    const isMultiWorkspace = (s.panes?.length ?? 0) > 1 || (s.tabs?.length ?? 0) > 1;
+
     return {
       id: s.id,
       name: s.name,
@@ -307,7 +312,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       theme: sessionMetadata[s.id]?.theme,
       customTitle: sessionMetadata[s.id]?.title,
       metrics: sessionMetrics,
-      panes: s.panes ? s.panes.map((p) => {
+      panes: s.panes ? await Promise.all(s.panes.map(async (p) => {
         const isSessionAgentOnPane = !p.isDead && !!p.agent;
         const isClaudeOnPane = isSessionAgentOnPane && includeClaudeInfo;
         let paneIndicator: IndicatorState | undefined;
@@ -321,6 +326,17 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         } else {
           paneIndicator = 'idle';
         }
+        // Per-pane metrics only for agent panes of a multi workspace (see
+        // isMultiWorkspace); Claude panes get ctx/model from their own .jsonl,
+        // any agent pane gets memory from its pid.
+        const paneMetrics =
+          isMultiWorkspace && isSessionAgentOnPane
+            ? await computeSessionMetrics({
+                ccSessionId: p.agent === 'claude' ? p.agentSessionId : undefined,
+                workingDir: p.path,
+                pids: p.pid ? [p.pid] : [],
+              })
+            : undefined;
         const pane: PaneInfo = {
           paneId: p.paneId,
           currentCommand: p.command,
@@ -334,9 +350,10 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
             ? (hookState === 'processing' && p.title?.startsWith('✳') ? paneIndicator : (hookState ?? paneIndicator))
             : paneIndicator,
           pid: p.pid,
+          metrics: paneMetrics,
         };
         return pane;
-      }) : undefined,
+      })) : undefined,
       tabs: s.tabs,
       activeTabId: s.activeTabId,
     };

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -867,6 +867,10 @@ function SessionItem({
 		agent && isAgentProvider(agent)
 			? t(AGENT_PROVIDERS[agent].labelKey)
 			: undefined;
+	// Multi-pane / multi-tab workspace: a single card-header summary of
+	// model/ctx/mem would be ambiguous, so those move to the per-pane rows.
+	const isMultiWorkspace =
+		(extSession.panes?.length ?? 0) > 1 || (extSession.tabs?.length ?? 0) > 1;
 	// Derive card-level indicatorState from panes (priority: waiting_input > processing > idle)
 	const cardIndicator: IndicatorState | undefined = (() => {
 		if (extSession.panes && extSession.panes.length > 0) {
@@ -1111,8 +1115,10 @@ function SessionItem({
 						</p>
 					)}
 
-				{/* Metadata row: agent / context / memory / tokens */}
-				{(agentLabel || extSession.metrics || peerBadge) && (
+				{/* Metadata row: agent / context / memory / tokens.
+				    For a multi-pane/multi-tab workspace, model/ctx/mem move to the
+				    per-pane rows (below), so only the peer badge stays here. */}
+				{(peerBadge || (!isMultiWorkspace && (agentLabel || extSession.metrics))) && (
 					<div className="mt-1.5 flex items-center gap-3 flex-wrap text-[11px] text-zinc-500">
 						{peerBadge && (
 							<span
@@ -1129,7 +1135,7 @@ function SessionItem({
 								{peerBadge.nickname}
 							</span>
 						)}
-						{agentLabel && (
+						{!isMultiWorkspace && agentLabel && (
 							<span className="inline-flex items-center px-2 py-0.5 rounded-full font-medium bg-zinc-500/15 text-zinc-400">
 								{agentLabel}
 								{extSession.metrics?.model && (
@@ -1142,7 +1148,7 @@ function SessionItem({
 								)}
 							</span>
 						)}
-						{typeof extSession.metrics?.contextPercent === "number" && (
+						{!isMultiWorkspace && typeof extSession.metrics?.contextPercent === "number" && (
 							<div
 								className="inline-flex items-center gap-1.5"
 								title={`${formatTokenCount(extSession.metrics.contextTokens ?? 0)} / ${formatTokenCount(extSession.metrics.contextMaxTokens ?? 0)}`}
@@ -1167,7 +1173,8 @@ function SessionItem({
 								</span>
 							</div>
 						)}
-						{typeof extSession.metrics?.memoryRssBytes === "number" &&
+						{!isMultiWorkspace &&
+							typeof extSession.metrics?.memoryRssBytes === "number" &&
 							extSession.metrics.memoryRssBytes > 0 && (
 								<span
 									className="font-mono tabular-nums"
@@ -1314,8 +1321,8 @@ function SessionItem({
 				</div>
 			)}
 
-			{/* Pane list (expandable, shows per-pane status indicators) */}
-			{panesExpanded && extSession.panes && extSession.panes.length > 1 && (
+			{/* Pane list (expandable, shows per-pane status indicators + metrics) */}
+			{panesExpanded && extSession.panes && isMultiWorkspace && (
 				<div
 					className="mx-4 mb-3 pt-2 border-t border-white/[0.06] space-y-1"
 					onClick={(e) => e.stopPropagation()}
@@ -1431,6 +1438,50 @@ function SessionItem({
 								)}
 									<ChevronRight className="w-3.5 h-3.5 text-zinc-700 shrink-0" />
 								</button>
+								{pane.metrics && (
+									<div className="ml-6 mt-0.5 flex items-center gap-3 flex-wrap text-[11px] text-zinc-500">
+										{pane.metrics.model && (
+											<span className="text-zinc-500" title={pane.metrics.model}>
+												{formatModelName(pane.metrics.model)}
+											</span>
+										)}
+										{typeof pane.metrics.contextPercent === "number" && (
+											<div
+												className="inline-flex items-center gap-1.5"
+												title={`${formatTokenCount(pane.metrics.contextTokens ?? 0)} / ${formatTokenCount(pane.metrics.contextMaxTokens ?? 0)}`}
+											>
+												<span className="text-zinc-600">ctx</span>
+												<div className="w-14 h-1 bg-white/10 rounded-full overflow-hidden">
+													<div
+														className={`h-full ${
+															pane.metrics.contextPercent >= 80
+																? "bg-red-500"
+																: pane.metrics.contextPercent >= 60
+																	? "bg-amber-500"
+																	: "bg-emerald-500"
+														}`}
+														style={{
+															width: `${Math.max(2, pane.metrics.contextPercent)}%`,
+														}}
+													/>
+												</div>
+												<span className="font-mono tabular-nums">
+													{pane.metrics.contextPercent.toFixed(1)}%
+												</span>
+											</div>
+										)}
+										{typeof pane.metrics.memoryRssBytes === "number" &&
+											pane.metrics.memoryRssBytes > 0 && (
+												<span
+													className="font-mono tabular-nums"
+													title={`${pane.metrics.memoryRssBytes} bytes`}
+												>
+													<span className="text-zinc-600">mem</span>{" "}
+													{formatBytes(pane.metrics.memoryRssBytes)}
+												</span>
+											)}
+									</div>
+								)}
 								{pane.paneId === bridgePaneId && (
 									<button
 										type="button"

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -200,6 +200,11 @@ export interface PaneInfo {
   isDead?: boolean;
   indicatorState?: IndicatorState;
   pid?: number;            // shell/subprocess PID of the pane's foreground group
+  /** Per-pane agent metrics (model / context% / memory). Populated only for
+   *  agent panes of a multi-pane/multi-tab workspace, where a single
+   *  workspace-level summary would be ambiguous; simple single-pane workspaces
+   *  keep the summary on the card header instead. */
+  metrics?: SessionMetrics;
 }
 
 export interface SessionMetrics {


### PR DESCRIPTION
## 背景
カードヘッダの model/ctx%/mem は「代表1ペイン分」を出しており、複数ペイン/タブがあると**どのペインの値か曖昧**（例: ctx 55% はどのペイン？）というご指摘。

## 修正
- **複数ペイン/複数タブの workspace のみ** model/ctx/mem を**各エージェントペイン行へ移動**。単一ペイン単一タブの通常ケースは**ヘッダ表示のまま**（回帰なし・折りたたみ時のグランス性維持）
- recap と peer バッジは workspace 単位なのでヘッダに残す
- **shared**: `PaneInfo.metrics?: SessionMetrics`
- **backend**: multi workspace の各エージェントペインで per-pane metrics を算出（Claude は自 .jsonl から ctx/model、任意のエージェントペインは pid から mem）。単一ペインはスキップ
- **frontend**: multi 時はヘッダの model/ctx/mem を隠しペイン行に表示。active タブが単一ペインの multi-tab workspace でもペインリストを開く

## dev 検証（3456・実 herdr、読み取りのみ）
- `cchub-work-1-1`（2ペイン）: `%1 claude` に model/ctx**55.5%**/mem が付き、`%8 zsh` は metrics 無し
- typecheck(backend/shared/frontend) + biome + frontend build クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL