### PR TITLE
feat(tabs): show recap per pane on multi-pane/tab workspaces

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -326,9 +326,9 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
         } else {
           paneIndicator = 'idle';
         }
-        // Per-pane metrics only for agent panes of a multi workspace (see
-        // isMultiWorkspace); Claude panes get ctx/model from their own .jsonl,
-        // any agent pane gets memory from its pid.
+        // Per-pane metrics + recap only for agent panes of a multi workspace
+        // (see isMultiWorkspace); Claude panes get ctx/model/recap from their
+        // own .jsonl, any agent pane gets memory from its pid.
         const paneMetrics =
           isMultiWorkspace && isSessionAgentOnPane
             ? await computeSessionMetrics({
@@ -337,6 +337,10 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
                 pids: p.pid ? [p.pid] : [],
               })
             : undefined;
+        const paneClaude =
+          isMultiWorkspace && p.agent === 'claude' && p.agentSessionId && p.path
+            ? await claudeCodeService.getSessionById(p.agentSessionId, p.path)
+            : null;
         const pane: PaneInfo = {
           paneId: p.paneId,
           currentCommand: p.command,
@@ -351,6 +355,8 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
             : paneIndicator,
           pid: p.pid,
           metrics: paneMetrics,
+          recap: paneClaude?.lastRecap?.content,
+          recapAt: paneClaude?.lastRecap?.timestamp,
         };
         return pane;
       })) : undefined,

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -1095,8 +1095,10 @@ function SessionItem({
 						)}
 				</div>
 
-				{/* Auto recap (away_summary) — timestamp shown inline at the tail */}
-				{extSession.ccRecap && (
+				{/* Auto recap (away_summary) — timestamp shown inline at the tail.
+				    For a multi-pane/multi-tab workspace it moves to the per-pane
+				    rows (like model/ctx/mem), so hide the header copy there. */}
+				{!isMultiWorkspace && extSession.ccRecap && (
 					<p className="mt-1 text-[12px] text-amber-200 leading-relaxed line-clamp-3">
 						{extSession.ccRecap}
 						{extSession.ccRecapAt && (
@@ -1481,6 +1483,16 @@ function SessionItem({
 												</span>
 											)}
 									</div>
+								)}
+								{pane.recap && (
+									<p className="ml-6 mt-0.5 text-[12px] text-amber-200 leading-relaxed line-clamp-2">
+										{pane.recap}
+										{pane.recapAt && (
+											<span className="ml-2 text-[10px] text-zinc-500">
+												{formatRelativeTime(pane.recapAt, t, i18n.language)}
+											</span>
+										)}
+									</p>
 								)}
 								{pane.paneId === bridgePaneId && (
 									<button

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -205,6 +205,10 @@ export interface PaneInfo {
    *  workspace-level summary would be ambiguous; simple single-pane workspaces
    *  keep the summary on the card header instead. */
   metrics?: SessionMetrics;
+  /** Per-pane Claude recap (away summary), same multi-workspace-only rule as
+   *  `metrics` — the header recap is hidden and each Claude pane shows its own. */
+  recap?: string;
+  recapAt?: string;
 }
 
 export interface SessionMetrics {


### PR DESCRIPTION
## 背景
#463 で model/ctx/mem を per-pane 化したが、**recap（away summary）はヘッダに残っており代表1ペイン分だけ**表示していた。複数エージェントペインがあるとどのペインの recap か曖昧、というご指摘。

## 修正
- **複数ペイン/タブの workspace のみ** recap も各 Claude ペイン行へ移動（metrics と同じルール）。単一ペインはヘッダ recap のまま
- **shared**: `PaneInfo.recap`/`recapAt`
- **backend**: multi workspace の各 Claude ペインの `lastRecap` を取得（`getSessionById` はキャッシュ付きで安価）
- **frontend**: multi 時はヘッダ recap を非表示、各 Claude ペイン行に recap 表示（ヘッダと同じ amber line-clamp）

## dev 検証（3456・実 herdr）
- `cchub-work-1-1`: `%1 claude` に自分の recap が付き、`%8 zsh` は recap 無し
- typecheck(backend/shared/frontend) + biome + frontend build クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL