### PR TITLE
Release v0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.26] - 2026-07-19
+
+### Changed
+- **複数ペイン/タブの workspace で recap もペイン単位表示に** (#466): #463 で model/ctx/mem をペイン単位にしたのに続き、recap（away summary）も同様にした。従来はカードヘッダに代表1ペイン分の recap だけを出しており、複数エージェントペインがあるとどのペインの要約か曖昧だった。複数ペイン/複数タブの時だけ各 Claude ペイン行に自身の recap を表示（`getSessionById` はキャッシュ付きで安価）。単一ペイン単一タブの通常ケースはヘッダ recap のまま維持（`PaneInfo.recap`/`recapAt` を追加）
+
 ## [0.2.25] - 2026-07-19
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- feat(tabs): 複数ペイン/タブの workspace で recap もペイン単位表示に (#466) — #463(model/ctx/mem)に続き recap も各 Claude ペイン行へ。単一ペインはヘッダ維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL