### PR TITLE
Release v0.2.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.27] - 2026-07-19
+
+### Changed
+- **セッションモーダルの冗長な「Sessions」見出しを削除** (#468): ワークスペース/履歴タブが既に見出しの役割をしていたため、上部の「Sessions」タイトル行を削除し、セグメントタブ（ワークスペース／履歴）と検索/＋/× を1行に統合。上部が詰まり、一覧の表示エリアが上へ広がる。`WorkspaceList` は desktop / tablet / mobile 共有のため3つとも適用
+
 ## [0.2.26] - 2026-07-19
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- feat(ui): セッションモーダルの冗長な「Sessions」見出しを削除、タブと検索/＋/× を1行に統合 (#468) — 一覧の表示エリアが上へ広がる。desktop/tablet/mobile 共通

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE2XKTXaSJ7iDUy6qTwkyL