### PR TITLE
feat(frontend): リモコンモード (PC専用) — pane 乗っ取りゼロで操作だけ提供

### DIFF
--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -8,6 +8,7 @@ import {
 	RefreshCw,
 	SplitSquareHorizontal,
 	SplitSquareVertical,
+	Unplug,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
@@ -16,8 +17,13 @@ import type {
 	SessionTheme,
 	TmuxLayoutNode,
 } from "../../../shared/types";
-import { useMultiplexedTerminal } from "../hooks/useMultiplexedTerminal";
+import {
+	sendTerminalInputRest,
+	useMultiplexedTerminal,
+} from "../hooks/useMultiplexedTerminal";
 import { usePeerConnection } from "../hooks/usePeerConnection";
+import { useRemoteControlMode } from "../hooks/useRemoteControlMode";
+import { sessionFetch } from "../services/peer-fetch";
 import { nukeClientCache } from "../utils/nuke-cache";
 import { usePeers } from "../hooks/usePeers";
 import {
@@ -451,6 +457,14 @@ export function DesktopLayout({
 	const [showSessionModal, setShowSessionModal] = useState(false);
 	const [showDashboard, setShowDashboard] = useState(false);
 
+	// Remote-control mode (PC only): stop the live terminal render so the local
+	// herdr client keeps ownership of the panes. Tablet keeps normal terminals.
+	const { remoteControl: remoteControlFlag, toggleRemoteControl } =
+		useRemoteControlMode();
+	const remoteControl = !isTablet && remoteControlFlag;
+	const remoteControlRef = useRef(remoteControl);
+	remoteControlRef.current = remoteControl;
+
 	// Floating keyboard state (for tablet mode)
 	const [showKeyboard, setShowKeyboard] = useState(() => {
 		if (!isTablet) return false;
@@ -594,6 +608,12 @@ export function DesktopLayout({
 	const { peers } = usePeers();
 	const peerConn = usePeerConnection(controlSessionId || "", apiSessions, peers);
 
+	// Refs for remote-control REST operations (avoid re-creating callbacks)
+	const controlSessionIdRef = useRef(controlSessionId);
+	controlSessionIdRef.current = controlSessionId;
+	const peersRef = useRef(peers);
+	peersRef.current = peers;
+
 	// Zoom state: when a pane is zoomed, show only that pane full-screen
 	const [zoomedPaneId, setZoomedPaneId] = useState<string | null>(null);
 	const zoomedPaneIdRef = useRef<string | null>(null);
@@ -650,6 +670,7 @@ export function DesktopLayout({
 		peerWsBase: peerConn.wsBase,
 		peerApiBase: peerConn.apiBase,
 		token: peerConn.token,
+		live: !remoteControl,
 		onPaneViewport: (paneId, viewport) => {
 			lastViewportRef.current.set(paneId, viewport);
 			let perPane = paneViewportCacheRef.current.get(paneId);
@@ -798,6 +819,30 @@ export function DesktopLayout({
 	const controlTerminalRef = useRef(controlTerminal);
 	controlTerminalRef.current = controlTerminal;
 
+	// Remote-control mode: pane operations go over REST (pure RPC — no control
+	// stream, no PaneController). The WS path requires an active subscription,
+	// which remote-control mode deliberately never opens.
+	const restPaneOp = useCallback(
+		(op: "focus" | "split" | "close", body: Record<string, unknown>) => {
+			const sid = controlSessionIdRef.current;
+			if (!sid) return;
+			const session = sessionsRef.current.find((s) => s.id === sid);
+			sessionFetch(
+				session,
+				peersRef.current,
+				`/api/workspaces/${encodeURIComponent(sid)}/panes/${op}`,
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(body),
+				},
+			).catch((err) => {
+				console.error(`[remote-control] panes/${op} failed:`, err);
+			});
+		},
+		[],
+	);
+
 	// Reset control mode state when session changes (but NOT on initial mount).
 	// On initial mount, child Terminal components register callbacks before this
 	// parent effect runs (React runs child effects first). Clearing on initial mount
@@ -821,16 +866,23 @@ export function DesktopLayout({
 		lastSentSizeRef.current = null;
 	}, [controlSessionId, controlSessionInstanceId]);
 
-	// Connect/disconnect control mode
+	// Connect/disconnect control mode.
+	// Remote-control mode: drop the live subscription (disconnect sends only an
+	// unsubscribe — sessionId is preserved) but still run connect() so the shared
+	// WS stays up for hook events / conversation streams; subscribeToSession is
+	// gated by `live: false`, so no PaneController is ever spawned.
 	useEffect(() => {
 		if (controlSessionId) {
+			if (remoteControl) {
+				controlTerminal.disconnect();
+			}
 			controlTerminal.connect();
 		}
 		return () => {
 			controlTerminal.disconnect();
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [controlSessionId, controlSessionInstanceId]);
+	}, [controlSessionId, controlSessionInstanceId, remoteControl]);
 
 	// Control mode resize: compute TOTAL window size from layout tree.
 	// tmux refresh-client -C needs cols×rows for the entire window,
@@ -1046,12 +1098,24 @@ export function DesktopLayout({
 			};
 		},
 		splitPane: (paneId: string, direction: "h" | "v") => {
+			if (remoteControl) {
+				restPaneOp("split", { paneId, direction });
+				return;
+			}
 			controlTerminalRef.current.splitPane(paneId, direction);
 		},
 		closePane: (paneId: string) => {
+			if (remoteControl) {
+				restPaneOp("close", { paneId });
+				return;
+			}
 			controlTerminalRef.current.closePane(paneId);
 		},
-		zoomPane: (paneId: string) => {
+		// Zoom is meaningless while the xterm area shows the remote-control
+		// placeholder — leaving the handler unset also hides the zoom button.
+		zoomPane: remoteControl
+			? undefined
+			: (paneId: string) => {
 			console.log(`[zoom] ${paneId} (current=${zoomedPaneId})`);
 			const isUnzooming = zoomedPaneId === paneId;
 			if (isUnzooming) {
@@ -1093,19 +1157,38 @@ export function DesktopLayout({
 		},
 		onShowSessions: () => setShowSessionModal(true),
 		onOpenFileViewer: openFileViewer,
+		remoteControl,
+		// Chat composer fallback: the mux WS rejects input for unsubscribed
+		// sessions, so remote-control mode sends over REST (peer-aware).
+		sendInputRest: remoteControl
+			? (paneId: string, data: string) =>
+					sendTerminalInputRest(
+						peerConn.apiBase,
+						peerConn.token,
+						controlSessionIdRef.current ?? "",
+						paneId,
+						data,
+					)
+			: undefined,
 	};
 
 	const handleSplit = useCallback((direction: "horizontal" | "vertical") => {
 		const activeId = activePaneRef.current;
-		controlTerminalRef.current.splitPane(
-			activeId,
-			direction === "horizontal" ? "h" : "v",
-		);
+		const dir = direction === "horizontal" ? "h" : "v";
+		if (remoteControlRef.current) {
+			restPaneOp("split", { paneId: activeId, direction: dir });
+			return;
+		}
+		controlTerminalRef.current.splitPane(activeId, dir);
 		// Wait for tmux layout update via %layout-change
 	}, []);
 
 	const handleClosePane = useCallback((paneId?: string) => {
 		const targetId = paneId || activePaneRef.current;
+		if (remoteControlRef.current) {
+			restPaneOp("close", { paneId: targetId });
+			return;
+		}
 		controlTerminalRef.current.closePane(targetId);
 		// Wait for tmux layout update via %layout-change
 	}, []);
@@ -1286,6 +1369,8 @@ export function DesktopLayout({
 			}
 
 			// Ctrl/Cmd + Shift + Arrow: Resize active pane
+			// (no-op in remote-control mode — pane sizes are owned by the local
+			// herdr client and the WS path would reject the unsubscribed session)
 			if (
 				e.shiftKey &&
 				!e.altKey &&
@@ -1295,6 +1380,7 @@ export function DesktopLayout({
 					e.key === "ArrowDown")
 			) {
 				e.preventDefault();
+				if (remoteControlRef.current) return;
 				const paneId = activePaneRef.current;
 				const dirMap: Record<string, "L" | "R" | "U" | "D"> = {
 					ArrowLeft: "L",
@@ -1310,6 +1396,7 @@ export function DesktopLayout({
 			// Ctrl/Cmd + Shift + =: Equalize pane sizes
 			if (e.shiftKey && !e.altKey && (e.key === "+" || e.key === "=")) {
 				e.preventDefault();
+				if (remoteControlRef.current) return;
 				const root = desktopStateRef.current.root;
 				const dir =
 					root.type === "split"
@@ -1434,7 +1521,11 @@ export function DesktopLayout({
 			ref?.clearSelection();
 		}
 		setDesktopState((prev) => ({ ...prev, activePane: paneId }));
-		controlTerminalRef.current.selectPane(paneId);
+		if (remoteControlRef.current) {
+			restPaneOp("focus", { paneId });
+		} else {
+			controlTerminalRef.current.selectPane(paneId);
+		}
 	}, []);
 
 	const handleSelectSessionForPane = useCallback(
@@ -1585,6 +1676,22 @@ export function DesktopLayout({
 								title="Dashboard (Ctrl+Shift+B)"
 							>
 								<BarChart3 className="w-[18px] h-[18px]" />
+							</button>
+							<button
+								type="button"
+								onClick={toggleRemoteControl}
+								className={`p-1.5 rounded-md transition-colors ${
+									remoteControl
+										? "text-amber-400 bg-amber-500/20"
+										: "text-zinc-600 hover:text-zinc-400"
+								}`}
+								title={
+									remoteControl
+										? "Remote control mode ON — terminal rendered by local herdr"
+										: "Remote control mode OFF"
+								}
+							>
+								<Unplug className="w-[18px] h-[18px]" />
 							</button>
 						</div>
 					</div>

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -4,6 +4,7 @@ import {
 	ExternalLink,
 	MessageSquare,
 	Terminal as TerminalIcon,
+	Unplug,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -66,6 +67,12 @@ export interface ControlModeContext {
 	setKeyboardVisible?: (visible: boolean) => void;
 	onShowSessions?: () => void;
 	onOpenFileViewer?: (dir: string, peerId?: string) => void;
+	/** Remote-control mode (PC only): the xterm area shows a placeholder and
+	 * the local herdr client owns the terminal. */
+	remoteControl?: boolean;
+	/** REST input sender for remote-control mode (the mux WS rejects input for
+	 * unsubscribed sessions). Used by the Chat composer. */
+	sendInputRest?: (paneId: string, data: string) => Promise<boolean>;
 }
 
 interface PaneContainerProps {
@@ -694,6 +701,7 @@ function TerminalPane({
 						theme={session?.theme}
 						agent={activeTmuxPane?.agent}
 						agentSessionId={activeTmuxPane?.agentSessionId}
+						sendInputOverRest={controlModeContext.sendInputRest}
 					/>
 				)}
 				{sessionId ? (
@@ -708,6 +716,29 @@ function TerminalPane({
 							onDisconnect={handleDisconnect}
 							theme={session?.theme}
 							controlMode={controlModeContext.getControlConfig(paneId)}
+							hideTerminalArea={!!controlModeContext.remoteControl}
+							terminalAreaOverlay={
+								controlModeContext.remoteControl ? (
+									<div className="h-full flex flex-col items-center justify-center gap-2 p-4 text-center select-none">
+										<Unplug className="w-8 h-8 text-zinc-600" aria-hidden />
+										<p className="text-th-text-secondary text-sm font-medium">
+											{t("remoteControl.active")}
+										</p>
+										<p className="text-th-text-muted text-xs max-w-[280px]">
+											{t("remoteControl.hint")}
+										</p>
+										{conversationAvailable && (
+											<button
+												type="button"
+												onClick={() => setShowConversation(true)}
+												className="mt-2 px-3 py-1.5 bg-white/[0.06] hover:bg-white/[0.1] text-th-text-secondary hover:text-th-text rounded-md text-xs transition-colors"
+											>
+												{t("remoteControl.openChat")}
+											</button>
+										)}
+									</div>
+								) : undefined
+							}
 						/>
 					</div>
 				) : (

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1416,7 +1416,9 @@ export const TerminalComponent = memo(
 						className="absolute inset-0 z-10 pointer-events-none"
 						style={{ touchAction: "none" }}
 					/>
-					{(!isInitialized || !isConnected) && (
+					{/* Hidden while an overlay replaces the xterm area (remote-control
+					    mode keeps isConnected=false by design — no live subscription). */}
+					{!hideTerminalArea && (!isInitialized || !isConnected) && (
 						<div className="absolute top-2 left-2 z-30 pointer-events-none">
 							<div className="flex items-center gap-2 bg-yellow-900/80 text-yellow-200 text-xs px-2.5 py-1 rounded-lg shadow">
 								<div className="w-3 h-3 border-2 border-yellow-400 border-t-transparent rounded-full animate-spin" />

--- a/frontend/src/components/chat/ChatComposer.tsx
+++ b/frontend/src/components/chat/ChatComposer.tsx
@@ -8,6 +8,9 @@ interface ChatComposerProps {
 	paneId: string | undefined;
 	disabled?: boolean;
 	placeholder?: string;
+	/** Remote-control mode: send over REST instead of the mux WS (which rejects
+	 *  input for sessions this client is not subscribed to). */
+	sendOverRest?: (paneId: string, data: string) => Promise<boolean>;
 }
 
 export function ChatComposer({
@@ -15,6 +18,7 @@ export function ChatComposer({
 	paneId,
 	disabled,
 	placeholder,
+	sendOverRest,
 }: ChatComposerProps) {
 	const [value, setValue] = useState("");
 	const taRef = useRef<HTMLTextAreaElement>(null);
@@ -29,16 +33,25 @@ export function ChatComposer({
 	const send = useCallback(() => {
 		const text = value;
 		if (!text.trim() || !paneId) return;
+		const wrapped = text.includes("\n")
+			? `\x1b[200~${text}\x1b[201~`
+			: text;
+		if (sendOverRest) {
+			// One REST call carries text + trailing \r; clear only on success so a
+			// failed request never silently drops the user's message.
+			void sendOverRest(paneId, `${wrapped}\r`).then((ok) => {
+				if (ok) setValue("");
+			});
+			return;
+		}
 		// During reconnect / disconnect sendTerminalInput returns false without
 		// throwing. Clearing the textarea regardless would silently drop the
 		// user's message. Only clear when both the text and the trailing \r
 		// landed on the WS. #263
-		const textOk = text.includes("\n")
-			? sendTerminalInput(sessionId, paneId, `\x1b[200~${text}\x1b[201~`)
-			: sendTerminalInput(sessionId, paneId, text);
+		const textOk = sendTerminalInput(sessionId, paneId, wrapped);
 		const enterOk = textOk && sendTerminalInput(sessionId, paneId, "\r");
 		if (textOk && enterOk) setValue("");
-	}, [sessionId, paneId, value]);
+	}, [sessionId, paneId, value, sendOverRest]);
 
 	const onKeyDown = useCallback(
 		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -30,6 +30,9 @@ interface ChatViewProps {
 	agent?: AgentProvider;
 	/** Codex thread id, used as the conversation key when agent=codex. */
 	agentSessionId?: string | null;
+	/** Remote-control mode: send composer input over REST instead of the mux WS
+	 *  (which rejects input for sessions this client is not subscribed to). */
+	sendInputOverRest?: (paneId: string, data: string) => Promise<boolean>;
 }
 
 export function ChatView({
@@ -46,6 +49,7 @@ export function ChatView({
 	theme,
 	agent,
 	agentSessionId,
+	sendInputOverRest,
 }: ChatViewProps) {
 	const { t } = useTranslation();
 	const { messages, isReady, conversationId, error } = useAgentConversation({
@@ -94,7 +98,11 @@ export function ChatView({
 	}
 
 	const composer = showComposer ? (
-		<ChatComposer sessionId={sessionId} paneId={paneId} />
+		<ChatComposer
+			sessionId={sessionId}
+			paneId={paneId}
+			sendOverRest={sendInputOverRest}
+		/>
 	) : null;
 
 	// Prompt-style line at the bottom of the conversation showing what the user

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -11,6 +11,10 @@ interface UseMultiplexedTerminalOptions {
 	 * be reused after deletion, so this forces a fresh mux subscription. */
 	sessionInstanceId?: string;
 	token?: string | null;
+	/** When false, suppress the live terminal subscription (remote-control mode,
+	 * PC-only): CC Hub never opens a control stream, so the local herdr client
+	 * keeps ownership of the terminal. Other operations are unaffected. */
+	live?: boolean;
 	// Multi-server: アクティブな peer の WS base URL ("wss://host:port") を指定。
 	// 省略時は Hub (window.location.host) を使う。
 	peerWsBase?: string | null;
@@ -164,6 +168,8 @@ type MuxCallbacks = {
 	sessionId: string;
 	sessionInstanceId?: string;
 	deadPanes: Set<string>;
+	/** When false, subscribeToSession is a no-op (remote-control mode). */
+	live?: boolean;
 };
 
 let activeCallbacks: MuxCallbacks | null = null;
@@ -185,6 +191,10 @@ function subscribeToSession(
 	sessionInstanceId?: string,
 	force = false,
 ) {
+	// Remote-control mode: never open a live subscription. This gates all three
+	// call sites (ready handler / subscribe effect / connect) at once, so no
+	// PaneController is spawned and the local herdr client keeps the terminal.
+	if (activeCallbacks?.live === false) return;
 	const instanceChanged =
 		subscribedSession === sessionId &&
 		subscribedSessionInstance !== (sessionInstanceId ?? null);
@@ -567,6 +577,52 @@ export function sendTerminalInput(
 	return true;
 }
 
+/**
+ * REST variant of sendTerminalInput for remote-control mode: the mux WS rejects
+ * input for sessions this client is not subscribed to, so route through
+ * POST /panes/input instead (same peer-aware base+token pattern as the
+ * respawnPane fallback). Resolves true only when the server accepted the input.
+ */
+export async function sendTerminalInputRest(
+	peerApiBase: string | null | undefined,
+	token: string | null | undefined,
+	sessionId: string,
+	paneId: string,
+	data: string,
+): Promise<boolean> {
+	const path = `/api/workspaces/${encodeURIComponent(sessionId)}/panes/input`;
+	const bytes = new TextEncoder().encode(data);
+	const body = JSON.stringify({
+		paneId,
+		data: uint8ArrayToBase64(bytes),
+		encoding: "base64",
+	});
+	const headers: HeadersInit = { "Content-Type": "application/json" };
+	try {
+		let res: Response;
+		if (peerApiBase && peerApiBase.length > 0) {
+			const peerHeaders = new Headers(headers);
+			if (token) peerHeaders.set("Authorization", `Bearer ${token}`);
+			res = await fetchWithTimeout(`${peerApiBase}${path}`, {
+				method: "POST",
+				headers: peerHeaders,
+				body,
+			});
+		} else {
+			res = await authFetch(`${import.meta.env.VITE_API_URL || ""}${path}`, {
+				method: "POST",
+				headers,
+				body,
+			});
+		}
+		if (!res.ok) return false;
+		dispatchInputEcho(sessionId, paneId, data);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function dispatchInputEcho(
 	sessionId: string,
 	paneId: string,
@@ -626,6 +682,7 @@ export function useMultiplexedTerminal(
 			sessionId,
 			sessionInstanceId,
 			deadPanes,
+			live: options.live ?? true,
 		};
 	});
 

--- a/frontend/src/hooks/useRemoteControlMode.ts
+++ b/frontend/src/hooks/useRemoteControlMode.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "cchub-remote-control";
+
+function readFlag(): boolean {
+	try {
+		// Default OFF: remote-control mode is opt-in. Only an explicit "true"
+		// enables it (PC-only "let the local herdr client own the terminal" mode).
+		return localStorage.getItem(STORAGE_KEY) === "true";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Remote-control mode flag (PC/desktop only).
+ *
+ * When enabled, CC Hub stops the live terminal render (WS `subscribe` →
+ * PaneController) so it never takes over the pane — the running local herdr
+ * client keeps ownership of the terminal. Everything else (workspace/pane list,
+ * focus, split/close, new session, tab ops, prompt, Files, Dashboard, Chat)
+ * still works because those paths don't need a control stream.
+ *
+ * Persisted in `cchub-remote-control` (default OFF). Listens for the storage
+ * event so toggling in another tab updates this one live. Mirrors the
+ * `useTheme` (getter init + `setItem` on change) / `useHistoryV2Flag`
+ * (storage-event sync) conventions.
+ */
+export function useRemoteControlMode(): {
+	remoteControl: boolean;
+	toggleRemoteControl: () => void;
+	setRemoteControl: (value: boolean) => void;
+} {
+	const [remoteControl, setRemoteControl] = useState<boolean>(() => readFlag());
+
+	useEffect(() => {
+		try {
+			localStorage.setItem(STORAGE_KEY, remoteControl ? "true" : "false");
+		} catch {
+			// ignore
+		}
+	}, [remoteControl]);
+
+	useEffect(() => {
+		function onStorage(e: StorageEvent) {
+			if (e.key === STORAGE_KEY || e.key === null) {
+				setRemoteControl(readFlag());
+			}
+		}
+		window.addEventListener("storage", onStorage);
+		return () => {
+			window.removeEventListener("storage", onStorage);
+		};
+	}, []);
+
+	const toggleRemoteControl = useCallback(() => {
+		setRemoteControl((prev) => !prev);
+	}, []);
+
+	return { remoteControl, toggleRemoteControl, setRemoteControl };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -353,5 +353,10 @@
 		"hookNotConfiguredDismiss": "Dismiss",
 		"hookSetupAction": "Setup",
 		"hookSetupPrompt": "Please add `cchub notify` to your Claude Code or Codex hook settings in your home directory. Add it to all four events: Stop, PreToolUse, UserPromptSubmit, and PostToolUse (matcher: AskUserQuestion). The hook command is: cchub notify\nClaude Code example:\n{\"hooks\":{\"Stop\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"cchub notify\"}]}],\"PreToolUse\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"cchub notify\"}]}],\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"cchub notify\"}]}],\"PostToolUse\":[{\"matcher\":\"AskUserQuestion\",\"hooks\":[{\"type\":\"command\",\"command\":\"cchub notify\"}]}]}}\nCodex example:\n[[hooks.Stop]]\n[[hooks.Stop.hooks]]\ntype = \"command\"\ncommand = \"cchub notify\"\n\n[[hooks.PreToolUse]]\n[[hooks.PreToolUse.hooks]]\ntype = \"command\"\ncommand = \"cchub notify\"\n\n[[hooks.UserPromptSubmit]]\n[[hooks.UserPromptSubmit.hooks]]\ntype = \"command\"\ncommand = \"cchub notify\"\n\n[[hooks.PostToolUse]]\nmatcher = \"AskUserQuestion\"\n[[hooks.PostToolUse.hooks]]\ntype = \"command\"\ncommand = \"cchub notify\"\nMerge this into the existing settings.json or config.toml in your home directory, preserving any existing hooks. Add cchub notify as a new entry or append to the existing hooks array — do not overwrite other settings."
+	},
+	"remoteControl": {
+		"active": "Remote control mode",
+		"hint": "The terminal is rendered by your local herdr client. Pane operations and prompts still work from here.",
+		"openChat": "View conversation in Chat"
 	}
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -353,5 +353,10 @@
 		"hookNotConfiguredDismiss": "閉じる",
 		"hookSetupAction": "設定する",
 		"hookSetupPrompt": "Claude Code か Codex の hook 設定をホームディレクトリ側で整えて `cchub notify` を追加してください。次の4つのイベントすべてに追加します: Stop / PreToolUse / UserPromptSubmit / PostToolUse（matcher: AskUserQuestion）。hookコマンドは: cchub notify\nClaude Code 例:\n{\"hooks\":{\"Stop\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"cchub notify\"}]}],\"PreToolUse\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"cchub notify\"}]}],\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"cchub notify\"}]}],\"PostToolUse\":[{\"matcher\":\"AskUserQuestion\",\"hooks\":[{\"type\":\"command\",\"command\":\"cchub notify\"}]}]}}\nCodex 例:\n[[hooks.Stop]]\n[[hooks.Stop.hooks]]\ntype = \"command\"\ncommand = \"cchub notify\"\n\n[[hooks.PreToolUse]]\n[[hooks.PreToolUse.hooks]]\ntype = \"command\"\ncommand = \"cchub notify\"\n\n[[hooks.UserPromptSubmit]]\n[[hooks.UserPromptSubmit.hooks]]\ntype = \"command\"\ncommand = \"cchub notify\"\n\n[[hooks.PostToolUse]]\nmatcher = \"AskUserQuestion\"\n[[hooks.PostToolUse.hooks]]\ntype = \"command\"\ncommand = \"cchub notify\"\n既存のsettings.json / config.toml にマージしてください。既存のhooksエントリや他の設定は上書きせず、cchub notify を新しいエントリとして追加するか、既存の hooks 配列の末尾に追加してください。"
+	},
+	"remoteControl": {
+		"active": "リモコンモード中",
+		"hint": "ターミナルはローカルの herdr クライアントに表示されています。ペイン操作やプロンプト送信はここから可能です。",
+		"openChat": "会話を Chat で見る"
 	}
 }


### PR DESCRIPTION
## 概要

PC でローカルの herdr クライアント(TUI)を使いながら CC Hub を開くと、ライブ描画のための PaneController がペインを排他的に乗っ取り、制御を奪い合う問題（`project_dual_server_pane_takeover`）への対策。

ヘッダーの新トグル（Unplug アイコン）で**リモコンモード**を ON にすると、xterm のライブ描画（WS subscribe → PaneController）を完全に止め、ローカル herdr がターミナルの所有権を保持したまま、CC Hub は「一覧 + フォーカス + ペイン操作 + prompt + Files + Dashboard + Chat」のリモコンとして機能する。

## 実装

- **useRemoteControlMode** (新規): `cchub-remote-control` localStorage フラグ（デフォルト OFF）、storage イベントで他タブ即反映
- **useMultiplexedTerminal**: `live: false` で `subscribeToSession` を3経路（ready/effect/connect）一括ゲート。共有 WS 自体は維持（hook 通知・会話ストリーム用）。`sendTerminalInputRest` ヘルパー追加（peer 対応 `POST /panes/input`）
- **DesktopLayout**: ON 中の focus/split/close は REST 経由（mux WS は未 subscribe セッションの操作を "Not subscribed" で拒否するため）。zoom / Ctrl+Shift+Arrow / equalize は ON 中無効。トグルは `!isTablet` のみ表示
- **PaneContainer / Terminal**: xterm 領域にプレースホルダ（Chat 切替導線付き）。オーバーレイ中は Connecting バッジ非表示
- **ChatComposer**: ON 中は REST 送信（成功時のみクリア）

tablet / mobile は一切変更なし。**バックエンド変更なし**。

## 検証（dev 環境・agent-browser）

- OFF: 従来どおりライブ描画
- ON: プレースホルダ表示、`unsubscribe` 送信、**dev backend の `herdr terminal session control` 子プロセスが grace period 後に消滅**（乗っ取りゼロを実証）
- ON 中: セッション切替（subscribe されない）、focus/split/close REST 200 で herdr に反映、Chat 送信 REST 200 → claude 応答・ライブ更新表示
- storage イベント経由の OFF 切替 → subscribe 復帰・ライブ描画復帰
- リロード後も ON 維持
- `bun run lint` / `bun run test` (backend 384 / frontend 52) / `tsc --noEmit` すべてクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZvZCXfurraXBuTdfSABj7