### PR TITLE
Release v0.2.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.28] - 2026-07-19
+
+### Added
+- **リモコンモード（PC専用）** (#470): ヘッダーの Unplug トグルで xterm のライブ描画（WS subscribe → PaneController）を止め、ローカル herdr クライアントがターミナルの所有権を保持したまま、CC Hub をワークスペース一覧＋フォーカス／split／close／prompt／Files／Dashboard／Chat のリモコンとして使えるモード。ON 中の pane 操作と Chat 送信は REST 経由（mux WS は未 subscribe セッションの操作を拒否するため）。xterm 領域はプレースホルダ（Chat 切替導線付き）に置き換わる。`cchub-remote-control` localStorage に永続化（デフォルト OFF）、storage イベントで他タブ即反映。tablet / mobile は対象外、バックエンド変更なし
+
 ## [0.2.27] - 2026-07-19
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- feat: リモコンモード（PC専用） (#470) — ライブ描画を止めてローカル herdr にターミナルを譲り、CC Hub は操作リモコンに徹するトグル

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZvZCXfurraXBuTdfSABj7