### PR TITLE
Release v0.2.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [0.2.29] - 2026-07-19
 
 ### Added
-- **Kimi Code CLI を第4のエージェントプロバイダとしてサポート**: 新規ワークスペース作成時のエージェント選択に Kimi を追加。herdr が kimi プロセスをランタイム検知し、`cchub setup` が `herdr integration install kimi` も行うため、native session id 連携・ペインインジケータがそのまま動作する。`~/.kimi-code/sessions` の `state.json` / `wire.jsonl` を読み、アクティブセッションのスレッドメタデータ（タイトル・first prompt・トークン使用量）、履歴プロジェクト一覧・検索・会話ビュー、`kimi --session '<id>'` による履歴からの resume に対応。hook 通知は payload が Claude 互換の snake_case のため、`~/.kimi-code/config.toml` の `[[hooks]]` に `cchub notify` を登録するだけで有効
+- **Kimi Code CLI を第4のエージェントプロバイダとしてサポート** (#472): 新規ワークスペース作成時のエージェント選択に Kimi を追加。herdr が kimi プロセスをランタイム検知し、`cchub setup` が `herdr integration install kimi` も行うため、native session id 連携・ペインインジケータがそのまま動作する。`~/.kimi-code/sessions` の `state.json` / `wire.jsonl` を読み、アクティブセッションのスレッドメタデータ（タイトル・first prompt・トークン使用量）、履歴プロジェクト一覧・検索・会話ビュー、`kimi --session '<id>'` による履歴からの resume に対応。hook 通知は payload が Claude 互換の snake_case のため、`~/.kimi-code/config.toml` の `[[hooks]]` に `cchub notify` を登録するだけで有効
 - **ダッシュボードに Kimi タブを追加**: wire.jsonl の `usage.record` を全セッション（サブエージェント分を含む）から集計し、24h/7d のトークン使用量・ターン数・モデル別内訳を表示（ローカルにレート制限窓データはないため合計値のみ）
 
 ## [0.2.28] - 2026-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.29] - 2026-07-19
+
+### Added
+- **Kimi Code CLI を第4のエージェントプロバイダとしてサポート**: 新規ワークスペース作成時のエージェント選択に Kimi を追加。herdr が kimi プロセスをランタイム検知し、`cchub setup` が `herdr integration install kimi` も行うため、native session id 連携・ペインインジケータがそのまま動作する。`~/.kimi-code/sessions` の `state.json` / `wire.jsonl` を読み、アクティブセッションのスレッドメタデータ（タイトル・first prompt・トークン使用量）、履歴プロジェクト一覧・検索・会話ビュー、`kimi --session '<id>'` による履歴からの resume に対応。hook 通知は payload が Claude 互換の snake_case のため、`~/.kimi-code/config.toml` の `[[hooks]]` に `cchub notify` を登録するだけで有効
+- **ダッシュボードに Kimi タブを追加**: wire.jsonl の `usage.record` を全セッション（サブエージェント分を含む）から集計し、24h/7d のトークン使用量・ターン数・モデル別内訳を表示（ローカルにレート制限窓データはないため合計値のみ）
+
 ## [0.2.28] - 2026-07-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,9 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - **GrokService / GrokSessionStore** (`services/grok.ts`) - Grok Build (xAI) integration: scans `~/.grok/sessions/<URL-encoded cwd>/<uuid>/` (`summary.json` metadata, `prompt_history.jsonl` first prompts, `updates.jsonl` `turn_completed` token usage), resolves the latest thread per working directory
 - **GrokHistoryService** (`services/grok-history.ts`) - Grok session history + conversation reader: parses `chat_history.jsonl` (user records with `prompt_index`, assistant `tool_calls`, `tool_result`) into Claude-shaped conversation turns
 - **GrokUsageService** (`services/grok-usage.ts`) - Aggregates Grok token consumption (24h/7d windows, per-model, plan badge) from `turn_completed` records for the dashboard's Grok tab. xAI exposes no rate-limit windows locally, so totals are all it can show
+- **KimiService / KimiSessionStore** (`services/kimi.ts`) - Kimi Code integration: scans `~/.kimi-code/sessions/wd_<name>_<hash>/session_<uuid>/` (`state.json` metadata, main `agents/main/wire.jsonl` first prompt + `usage.record` token usage), resolves exact threads by native session id
+- **KimiHistoryService** (`services/kimi-history.ts`) - Kimi session history + conversation reader: parses `wire.jsonl` (`turn.prompt`, `content.part` text, `tool.call`, `tool.result` loop events) into Claude-shaped conversation turns
+- **KimiUsageService** (`services/kimi-usage.ts`) - Aggregates Kimi token consumption (24h/7d windows, per-model) from `usage.record` records across all agent wires (`agents/main` + sub-agents) for the dashboard's Kimi tab. Kimi exposes no rate-limit windows or plan data locally, so totals are all it can show
 - **ConversationWatcher** (`services/conversation-watcher.ts`) - Watches Claude Code / Codex `.jsonl` files and emits conversation updates to subscribed WebSocket clients
 - **HookStatusService** (`services/hook-status.ts`) - Reports whether the hooks CC Hub still needs are installed (`Stop` for notification text, `PostToolUse`/`AskUserQuestion` for the question's tool name). Indicator transitions come from herdr, not hooks
 - **HerdrAgentStatusWatcher** (`services/herdr-agent-status.ts`) - Subscribes to herdr's per-pane `pane.agent_status_changed` (plus pane lifecycle events, which re-subscribe the pane set) and triggers an immediate sessions push. Decides *when* to rebuild the list, never what's in it — a dropped event costs latency, not correctness
@@ -343,13 +346,15 @@ cchub --version
 - Run `sudo tailscale set --operator=$USER` once to allow cert generation
 - macOS: Install Tailscale via `brew install tailscale` (App Store version lacks CLI)
 - herdr must be installed (`curl -fsSL https://herdr.dev/install.sh | sh` or `brew install herdr`); cchub auto-starts `herdr server` if it isn't running, but a supervised setup (systemd user unit with `Restart=always` + `~/.config/herdr/config.toml` with `resume_agents_on_restore = true`) is strongly recommended so agent sessions survive server restarts
-- For native session identity/restore, install the herdr integrations once: `herdr integration install claude` and `herdr integration install codex` (`cchub setup` installs both)
+- For native session identity/restore, install the herdr integrations once: `herdr integration install claude` / `codex` / `kimi` (`cchub setup` installs all initialized ones)
 
-## Claude Code / Codex / Grok Hook通知連携
+## Claude Code / Codex / Grok / Kimi Hook通知連携
 
-Claude Code・Codex・Grok Build のhookイベント（応答完了、ユーザー入力待ち等）をCC Hub経由でブラウザのOS通知として受け取れる。
+Claude Code・Codex・Grok Build・Kimi Code のhookイベント（応答完了、ユーザー入力待ち等）をCC Hub経由でブラウザのOS通知として受け取れる。
 
 Grok Build は `~/.claude/settings.json` の hooks を互換レイヤでデフォルト読み込みするため、Claude 用の `cchub notify` 設定がそのまま発火する（追加設定不要）。ただし stdin JSON は camelCase 独自形式（`hookEventName: "stop"`, `sessionId`, `transcriptPath`）なので、`/api/notify` 側で Claude 形式に正規化している（`routes/notify.ts` の `normalizeHookBody`）。
+
+Kimi Code は `~/.kimi-code/config.toml` の `[[hooks]]` に設定する（例: `event = "Stop"`, `command = "cchub notify"`）。stdin JSON は Claude 互換の snake_case（`hook_event_name`, `session_id`, ...）なので正規化は不要。
 
 ### 仕組み
 

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "generated": "2026-07-19",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/backend/src/commands/setup.ts
+++ b/backend/src/commands/setup.ts
@@ -194,6 +194,7 @@ type AgentIntegration = {
 const AGENT_INTEGRATIONS: AgentIntegration[] = [
   { name: 'Claude Code', command: 'claude', configDir: join(homedir(), '.claude') },
   { name: 'Codex', command: 'codex', configDir: join(homedir(), '.codex') },
+  { name: 'Kimi Code', command: 'kimi', configDir: join(homedir(), '.kimi-code') },
 ];
 
 function isCommandAvailable(command: string): boolean {

--- a/backend/src/routes/__tests__/notify-transcript-path.test.ts
+++ b/backend/src/routes/__tests__/notify-transcript-path.test.ts
@@ -7,6 +7,8 @@ import { isAllowedTranscriptPath } from '../notify';
 const claudeDir = join(homedir(), '.claude');
 const realFile = join(claudeDir, '.cchub-test-transcript.jsonl');
 const linkFile = join(claudeDir, '.cchub-test-escape-link.jsonl');
+const kimiDir = join(homedir(), '.kimi-code');
+const kimiFile = join(kimiDir, '.cchub-test-transcript.jsonl');
 
 describe('isAllowedTranscriptPath', () => {
   beforeAll(async () => {
@@ -14,15 +16,22 @@ describe('isAllowedTranscriptPath', () => {
     await writeFile(realFile, '{}\n');
     await rm(linkFile, { force: true });
     await symlink('/etc/hosts', linkFile);
+    await mkdir(kimiDir, { recursive: true });
+    await writeFile(kimiFile, '{}\n');
   });
 
   afterAll(async () => {
     await rm(realFile, { force: true });
     await rm(linkFile, { force: true });
+    await rm(kimiFile, { force: true });
   });
 
   test('allows a transcript under ~/.claude', async () => {
     expect(await isAllowedTranscriptPath(realFile)).toBe(true);
+  });
+
+  test('allows a transcript under ~/.kimi-code', async () => {
+    expect(await isAllowedTranscriptPath(kimiFile)).toBe(true);
   });
 
   test('rejects files outside the allowed dirs', async () => {

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -3,6 +3,7 @@ import { StatsService } from '../services/stats-service';
 import { AnthropicUsageService } from '../services/anthropic-usage';
 import { CodexUsageService } from '../services/codex-usage';
 import { GrokUsageService } from '../services/grok-usage';
+import { KimiUsageService } from '../services/kimi-usage';
 import { UsageHistoryService } from '../services/usage-history';
 import { SystemMetricsService } from '../services/system-metrics';
 import { HerdrUpdateService } from '../services/herdr-update';
@@ -14,6 +15,7 @@ const statsService = new StatsService();
 const anthropicUsageService = new AnthropicUsageService();
 const codexUsageService = new CodexUsageService();
 const grokUsageService = new GrokUsageService();
+const kimiUsageService = new KimiUsageService();
 const usageHistoryService = new UsageHistoryService();
 const systemMetricsService = new SystemMetricsService();
 // Shared with the /api/herdr apply route so an apply invalidates this cache.
@@ -40,10 +42,11 @@ async function getDiskUsage(): Promise<{ total: number; used: number; available:
 export async function buildDashboard(): Promise<DashboardResponse> {
   // The herdr skew check rides on this poll instead of its own timer (#393);
   // it is cached, so the extra spawn is far rarer than the request rate.
-  const [usageLimits, codexUsageLimits, grokUsage, dailyActivity, modelUsage, hourlyActivity, usageHistory, systemMetrics, diskUsage, herdrUpdate] = await Promise.all([
+  const [usageLimits, codexUsageLimits, grokUsage, kimiUsage, dailyActivity, modelUsage, hourlyActivity, usageHistory, systemMetrics, diskUsage, herdrUpdate] = await Promise.all([
     anthropicUsageService.getUsageLimits(),
     codexUsageService.getUsageLimits(),
     grokUsageService.getUsageSummary(),
+    kimiUsageService.getUsageSummary(),
     statsService.getDailyActivity(14),
     statsService.getModelUsage(),
     statsService.getHourlyActivity(),
@@ -68,6 +71,7 @@ export async function buildDashboard(): Promise<DashboardResponse> {
     usageLimitsStatus: anthropicUsageService.getStatus(),
     codexUsageLimits,
     grokUsage,
+    kimiUsage,
     usageHistory,
     dailyActivity,
     modelUsage,

--- a/backend/src/routes/notify.ts
+++ b/backend/src/routes/notify.ts
@@ -30,8 +30,8 @@ async function readTrailingLines(path: string, lineCount: number): Promise<strin
 // /api/notify is unauthenticated (local hooks call into it), so the
 // transcript_path in the request body cannot be trusted: generateSmartMessage
 // reads the file and broadcasts text fragments of it to every connected
-// client. Only real transcript locations (the Claude Code / Codex state
-// dirs) may be read. Symlinks are resolved before the prefix check. #347
+// client. Only real transcript locations (the agent CLIs' state dirs) may be
+// read. Symlinks are resolved before the prefix check. #347
 export async function isAllowedTranscriptPath(path: string): Promise<boolean> {
   let resolved: string;
   try {
@@ -39,7 +39,7 @@ export async function isAllowedTranscriptPath(path: string): Promise<boolean> {
   } catch {
     return false;
   }
-  for (const dir of ['.claude', '.codex', '.grok']) {
+  for (const dir of ['.claude', '.codex', '.grok', '.kimi-code']) {
     const root = await realpath(`${homedir()}/${dir}`).catch(() => null);
     if (root && resolved.startsWith(`${root}/`)) return true;
   }

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -15,6 +15,8 @@ import { SessionHistoryService } from '../services/session-history';
 import { CodexHistoryService } from '../services/codex-history';
 import { GrokService } from '../services/grok';
 import { GrokHistoryService } from '../services/grok-history';
+import { KimiService } from '../services/kimi';
+import { KimiHistoryService } from '../services/kimi-history';
 import type { AgentHistoryProvider, AgentThread, AgentThreadService } from '../services/agent-providers';
 import { PromptHistoryService } from '../services/prompt-history';
 import { getAllSessionMetadata, setSessionTheme, setSessionTitle, getLastKnownSessions, saveLastKnownSessions, removeLastKnownSession, type LastKnownSession } from '../services/session-metadata';
@@ -42,10 +44,12 @@ export const sessionHistoryService = new SessionHistoryService();
 const threadServices: Partial<Record<AgentProvider, AgentThreadService>> = {
   codex: new CodexService(),
   grok: new GrokService(),
+  kimi: new KimiService(),
 };
 export const agentHistoryProviders: Partial<Record<AgentProvider, AgentHistoryProvider>> = {
   codex: new CodexHistoryService(undefined, codexConversationService),
   grok: new GrokHistoryService(),
+  kimi: new KimiHistoryService(),
 };
 const promptHistoryService = new PromptHistoryService();
 

--- a/backend/src/services/kimi-history.ts
+++ b/backend/src/services/kimi-history.ts
@@ -1,0 +1,213 @@
+import { readFile } from 'node:fs/promises';
+import type { ConversationMessage, HistorySession, ToolResultInfo, ToolUseInfo } from '../../../shared/types';
+import { claudeProjectDirName } from '../utils/claude-project-path';
+import type { AgentHistoryProvider } from './agent-providers';
+import { KimiSessionStore, kimiWirePath, turnPromptText, type KimiSessionInfo } from './kimi';
+import type { ProjectInfo } from './session-history';
+
+interface KimiWireRecord {
+  type?: string;
+  input?: unknown;
+  origin?: { kind?: unknown };
+  event?: {
+    type?: string;
+    toolCallId?: unknown;
+    name?: unknown;
+    args?: unknown;
+    result?: unknown;
+    part?: { type?: unknown; text?: unknown };
+  };
+}
+
+/** Tool result payloads are `{output, note?, truncated?}` objects (or a plain string). */
+function toolResultOutput(result: unknown): string {
+  if (typeof result === 'string') return result;
+  if (result && typeof result === 'object' && typeof (result as { output?: unknown }).output === 'string') {
+    return (result as { output: string }).output;
+  }
+  return '';
+}
+
+function parseToolArgs(raw: unknown): Record<string, unknown> {
+  return raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+}
+
+/**
+ * Collapse a Kimi Code main `wire.jsonl` into Claude-shaped conversation turns:
+ *  - `turn.prompt` (origin user)        → role=user
+ *  - loop event `content.part` (text)   → role=assistant text (`think` parts
+ *    are dropped)
+ *  - loop event `tool.call`             → ToolUseInfo on the assistant turn
+ *  - loop event `tool.result`           → ToolResultInfo on a user turn
+ *    (toolName resolved from the matching tool.call id)
+ *  - `context.append_message`           → dropped: user payloads duplicate the
+ *    `turn.prompt` records and the rest is injected context
+ *  - metadata / config / step / llm / usage / plan_mode / permission records
+ *    → dropped
+ */
+export function parseKimiWire(text: string): ConversationMessage[] {
+  const messages: ConversationMessage[] = [];
+  let current: ConversationMessage | null = null;
+  const callIdToName = new Map<string, string>();
+
+  const flush = () => {
+    if (!current) return;
+    const hasContent = !!current.content || !!current.toolUse?.length || !!current.toolResult?.length;
+    if (hasContent) messages.push(current);
+    current = null;
+  };
+
+  const ensureRole = (role: 'user' | 'assistant'): ConversationMessage => {
+    if (current?.role !== role) {
+      flush();
+      current = { role, content: '' };
+    }
+    return current as ConversationMessage;
+  };
+
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let record: KimiWireRecord;
+    try {
+      record = JSON.parse(trimmed) as KimiWireRecord;
+    } catch {
+      continue;
+    }
+
+    if (record.type === 'turn.prompt') {
+      const content = turnPromptText(record).trim();
+      if (!content) continue;
+      flush();
+      messages.push({ role: 'user', content });
+      continue;
+    }
+
+    if (record.type !== 'context.append_loop_event') continue;
+    const event = record.event;
+    if (!event) continue;
+
+    if (event.type === 'content.part' && event.part?.type === 'text' && typeof event.part.text === 'string') {
+      const content = event.part.text;
+      if (!content) continue;
+      const turn = ensureRole('assistant');
+      turn.content = turn.content ? `${turn.content}\n\n${content}` : content;
+      continue;
+    }
+
+    if (event.type === 'tool.call') {
+      const id = typeof event.toolCallId === 'string' ? event.toolCallId : '';
+      const name = typeof event.name === 'string' ? event.name : 'tool';
+      if (id) callIdToName.set(id, name);
+      const tool: ToolUseInfo = { id, name, input: parseToolArgs(event.args) };
+      const turn = ensureRole('assistant');
+      turn.toolUse = turn.toolUse ? [...turn.toolUse, tool] : [tool];
+      continue;
+    }
+
+    if (event.type === 'tool.result') {
+      const callId = typeof event.toolCallId === 'string' ? event.toolCallId : '';
+      const turn = ensureRole('user');
+      const result: ToolResultInfo = {
+        toolUseId: callId,
+        toolName: callIdToName.get(callId),
+        output: toolResultOutput(event.result),
+      };
+      turn.toolResult = turn.toolResult ? [...turn.toolResult, result] : [result];
+    }
+  }
+
+  flush();
+  return messages;
+}
+
+/** Reads Kimi Code session history from `~/.kimi-code/sessions`. */
+export class KimiHistoryService implements AgentHistoryProvider {
+  private store: KimiSessionStore;
+
+  constructor(store = new KimiSessionStore()) {
+    this.store = store;
+  }
+
+  async getProjects(): Promise<ProjectInfo[]> {
+    const sessions = await this.store.listSessions();
+    const byDir = new Map<string, ProjectInfo>();
+    for (const s of sessions) {
+      const dirName = claudeProjectDirName(s.cwd);
+      const existing = byDir.get(dirName);
+      if (existing) {
+        existing.sessionCount++;
+        if (!existing.latestModified || s.updatedAt > existing.latestModified) {
+          existing.latestModified = s.updatedAt;
+        }
+      } else {
+        byDir.set(dirName, {
+          dirName,
+          projectPath: s.cwd,
+          projectName: s.cwd.replace(/^\/home\/[^/]+\//, '~/'),
+          sessionCount: 1,
+          latestModified: s.updatedAt,
+        });
+      }
+    }
+    return Array.from(byDir.values());
+  }
+
+  async getProjectSessions(dirName: string): Promise<HistorySession[]> {
+    const sessions = await this.store.listSessions();
+    return sessions
+      .filter((s) => claudeProjectDirName(s.cwd) === dirName)
+      .map((s) => this.toHistorySession(s))
+      .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+  }
+
+  async getRecentSessions(limit = 30): Promise<HistorySession[]> {
+    const sessions = await this.store.listSessions();
+    return sessions
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .slice(0, limit)
+      .map((s) => this.toHistorySession(s));
+  }
+
+  async searchSessions(query: string, limit = 50): Promise<HistorySession[]> {
+    if (!query.trim()) return [];
+    const needle = query.toLowerCase();
+    const sessions = await this.store.listSessions();
+    const matches: HistorySession[] = [];
+    for (const s of sessions) {
+      const haystack = `${s.cwd} ${s.title ?? ''} ${s.firstPrompt ?? ''}`.toLowerCase();
+      if (haystack.includes(needle)) {
+        matches.push(this.toHistorySession(s));
+        if (matches.length >= limit) break;
+      }
+    }
+    matches.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+    return matches;
+  }
+
+  async getConversation(sessionId: string): Promise<ConversationMessage[]> {
+    const session = await this.store.findSession(sessionId);
+    if (!session) return [];
+    try {
+      const text = await readFile(kimiWirePath(session.dir), 'utf8');
+      return parseKimiWire(text);
+    } catch {
+      return [];
+    }
+  }
+
+  private toHistorySession(s: KimiSessionInfo): HistorySession {
+    return {
+      sessionId: s.sessionId,
+      projectPath: s.cwd,
+      projectName: s.cwd.replace(/^\/home\/[^/]+\//, '~/'),
+      firstPrompt: s.firstPrompt,
+      lastPrompt: s.firstPrompt,
+      summary: s.title,
+      // Kimi transcripts have no recap (Claude-only feature).
+      recap: undefined,
+      modified: s.updatedAt,
+      agent: 'kimi',
+    };
+  }
+}

--- a/backend/src/services/kimi-usage.ts
+++ b/backend/src/services/kimi-usage.ts
@@ -1,0 +1,166 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { KimiUsageSummary, KimiUsageWindow } from '../../../shared/types';
+import { KimiSessionStore } from './kimi';
+
+interface UsageRecord {
+  /** Unix ms. */
+  timestamp: number;
+  totalTokens: number;
+  inputTokens: number;
+  cacheReadTokens: number;
+  outputTokens: number;
+  model?: string;
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function emptyWindow(): KimiUsageWindow {
+  return { turns: 0, totalTokens: 0, inputTokens: 0, cacheReadTokens: 0, outputTokens: 0 };
+}
+
+function addToWindow(window: KimiUsageWindow, record: UsageRecord): void {
+  window.turns++;
+  window.totalTokens += record.totalTokens;
+  window.inputTokens += record.inputTokens;
+  window.cacheReadTokens += record.cacheReadTokens;
+  window.outputTokens += record.outputTokens;
+}
+
+/**
+ * Aggregates Kimi Code token consumption from `usage.record` records in each
+ * session's `agents/<agentId>/wire.jsonl` — sub-agent wires included, their tokens
+ * are real consumption. Kimi stores no rate-limit windows or plan data
+ * locally, so consumption totals are all a dashboard can honestly show.
+ */
+export class KimiUsageService {
+  private store: KimiSessionStore;
+  private cache: { timestamp: number; data: KimiUsageSummary | null } | null = null;
+  private static readonly CACHE_TTL = 30_000;
+  private static readonly WINDOW_7D_MS = 7 * 24 * 60 * 60 * 1000;
+  private static readonly WINDOW_24H_MS = 24 * 60 * 60 * 1000;
+
+  constructor(store = new KimiSessionStore()) {
+    this.store = store;
+  }
+
+  async getUsageSummary(): Promise<KimiUsageSummary | null> {
+    if (this.cache && Date.now() - this.cache.timestamp < KimiUsageService.CACHE_TTL) {
+      return this.cache.data;
+    }
+    const data = await this.build();
+    this.cache = { timestamp: Date.now(), data };
+    return data;
+  }
+
+  private async build(): Promise<KimiUsageSummary | null> {
+    const now = Date.now();
+    const cutoff7d = now - KimiUsageService.WINDOW_7D_MS;
+    const sessions = (await this.store.listSessions()).filter(
+      (s) => new Date(s.updatedAt).getTime() >= cutoff7d,
+    );
+    if (sessions.length === 0) return null;
+
+    const records: UsageRecord[] = [];
+    let sessionsWithUsage = 0;
+    await Promise.all(sessions.map(async (s) => {
+      const sessionRecords = await this.readSessionRecords(s.dir, cutoff7d);
+      if (sessionRecords.length > 0) sessionsWithUsage++;
+      records.push(...sessionRecords);
+    }));
+    if (records.length === 0) return null;
+
+    records.sort((a, b) => a.timestamp - b.timestamp);
+    const last24h = emptyWindow();
+    const last7d = emptyWindow();
+    const modelTotals = new Map<string, number>();
+    const cutoff24h = now - KimiUsageService.WINDOW_24H_MS;
+    for (const record of records) {
+      addToWindow(last7d, record);
+      if (record.timestamp >= cutoff24h) addToWindow(last24h, record);
+      if (record.model) {
+        modelTotals.set(record.model, (modelTotals.get(record.model) ?? 0) + record.totalTokens);
+      }
+    }
+
+    const models = Array.from(modelTotals.entries())
+      .map(([model, totalTokens]) => ({ model, totalTokens }))
+      .sort((a, b) => b.totalTokens - a.totalTokens);
+
+    return {
+      last24h,
+      last7d,
+      models,
+      sessions7d: sessionsWithUsage,
+      lastTurnAt: new Date(records[records.length - 1].timestamp).toISOString(),
+    };
+  }
+
+  /** usage.record entries across all agent wires of one session dir. */
+  private async readSessionRecords(sessionDir: string, cutoffMs: number): Promise<UsageRecord[]> {
+    let agentIds: string[];
+    try {
+      agentIds = await readdir(join(sessionDir, 'agents'));
+    } catch {
+      return [];
+    }
+    const records: UsageRecord[] = [];
+    await Promise.all(agentIds.map(async (agentId) => {
+      records.push(...await this.readRecords(join(sessionDir, 'agents', agentId, 'wire.jsonl'), cutoffMs));
+    }));
+    return records;
+  }
+
+  private async readRecords(wirePath: string, cutoffMs: number): Promise<UsageRecord[]> {
+    // Skip files that clearly predate the window before reading them.
+    try {
+      if ((await stat(wirePath)).mtimeMs < cutoffMs) return [];
+    } catch {
+      return [];
+    }
+    let text: string;
+    try {
+      text = await readFile(wirePath, 'utf8');
+    } catch {
+      return [];
+    }
+
+    const records: UsageRecord[] = [];
+    for (const line of text.split('\n')) {
+      if (!line.includes('"usage.record"')) continue;
+      try {
+        const record = JSON.parse(line) as {
+          type?: string;
+          model?: unknown;
+          usage?: {
+            inputOther?: unknown;
+            inputCacheRead?: unknown;
+            inputCacheCreation?: unknown;
+            output?: unknown;
+          };
+          time?: unknown;
+        };
+        if (record.type !== 'usage.record' || !record.usage) continue;
+        const timestamp = typeof record.time === 'number' ? record.time : 0;
+        if (timestamp < cutoffMs) continue;
+        const usage = record.usage;
+        const cacheReadTokens = numberOrZero(usage.inputCacheRead);
+        const inputTokens = numberOrZero(usage.inputOther) + cacheReadTokens + numberOrZero(usage.inputCacheCreation);
+        const outputTokens = numberOrZero(usage.output);
+        records.push({
+          timestamp,
+          totalTokens: inputTokens + outputTokens,
+          inputTokens,
+          cacheReadTokens,
+          outputTokens,
+          model: typeof record.model === 'string' ? record.model : undefined,
+        });
+      } catch {
+        // malformed line
+      }
+    }
+    return records;
+  }
+}

--- a/backend/src/services/kimi.ts
+++ b/backend/src/services/kimi.ts
@@ -1,0 +1,268 @@
+import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs';
+import { readFile, readdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { AgentThread, AgentThreadService, AgentTokenUsage } from './agent-providers';
+
+/** One Kimi Code session as recorded under `~/.kimi-code/sessions`. */
+export interface KimiSessionInfo {
+  sessionId: string;
+  cwd: string;
+  /** Absolute session directory (holds state.json + agents/). */
+  dir: string;
+  title?: string;
+  firstPrompt?: string;
+  createdAt?: string;
+  updatedAt: string;
+}
+
+interface KimiStateJson {
+  createdAt?: string;
+  updatedAt?: string;
+  title?: string;
+  workDir?: string;
+}
+
+/** Minimal shape of a wire.jsonl `turn.prompt` record. */
+interface KimiTurnPromptRecord {
+  input?: unknown;
+  origin?: { kind?: unknown };
+}
+
+/** Path of the main agent's wire log inside a session directory. */
+export function kimiWirePath(sessionDir: string): string {
+  return join(sessionDir, 'agents', 'main', 'wire.jsonl');
+}
+
+/** Joined text of a `turn.prompt` record's text parts (user-origin only). */
+export function turnPromptText(record: KimiTurnPromptRecord): string {
+  if (record.origin?.kind !== 'user') return '';
+  if (!Array.isArray(record.input)) return '';
+  return record.input
+    .map((part) => (part && typeof part === 'object' && typeof (part as { text?: unknown }).text === 'string'
+      ? (part as { text: string }).text
+      : ''))
+    .filter(Boolean)
+    .join('\n');
+}
+
+/**
+ * Kimi Code stores each session under
+ * `~/.kimi-code/sessions/wd_<name>_<hash>/session_<uuid>/` with a `state.json`
+ * (title / workDir / timestamps) and the main agent's wire log in
+ * `agents/main/wire.jsonl`, whose `turn.prompt` records carry the user prompts
+ * and whose `usage.record` records carry per-turn token usage. Sub-agent wires
+ * (`agents/agent-N/`) are ignored.
+ */
+export class KimiSessionStore {
+  private sessionsDir: string;
+  private cache: { timestamp: number; sessions: KimiSessionInfo[] } | null = null;
+  private static readonly CACHE_TTL = 5000;
+
+  constructor(sessionsDir = join(homedir(), '.kimi-code', 'sessions')) {
+    this.sessionsDir = sessionsDir;
+  }
+
+  async listSessions(): Promise<KimiSessionInfo[]> {
+    if (this.cache && Date.now() - this.cache.timestamp < KimiSessionStore.CACHE_TTL) {
+      return this.cache.sessions;
+    }
+    const sessions = await this.scan();
+    this.cache = { timestamp: Date.now(), sessions };
+    return sessions;
+  }
+
+  async findSession(sessionId: string): Promise<KimiSessionInfo | undefined> {
+    const sessions = await this.listSessions();
+    return sessions.find((s) => s.sessionId === sessionId);
+  }
+
+  private async scan(): Promise<KimiSessionInfo[]> {
+    let projectDirs: string[];
+    try {
+      projectDirs = await readdir(this.sessionsDir);
+    } catch {
+      return [];
+    }
+
+    const results: KimiSessionInfo[] = [];
+    await Promise.all(projectDirs.map(async (wdDir) => {
+      if (!wdDir.startsWith('wd_')) return; // stray files next to the project dirs
+      const projectDir = join(this.sessionsDir, wdDir);
+
+      let entries: string[];
+      try {
+        entries = await readdir(projectDir);
+      } catch {
+        return;
+      }
+
+      await Promise.all(entries.map(async (name) => {
+        const sessionDir = join(projectDir, name);
+        const state = await this.readState(join(sessionDir, 'state.json'));
+        if (!state?.updatedAt || !state.workDir) return;
+        results.push({
+          sessionId: name,
+          cwd: state.workDir,
+          dir: sessionDir,
+          title: state.title,
+          firstPrompt: readFirstKimiPrompt(sessionDir),
+          createdAt: state.createdAt,
+          updatedAt: state.updatedAt,
+        });
+      }));
+    }));
+    return results;
+  }
+
+  private async readState(path: string): Promise<KimiStateJson | null> {
+    try {
+      return JSON.parse(await readFile(path, 'utf8')) as KimiStateJson;
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** First real user prompt: the first `turn.prompt` record in the main wire. */
+function readFirstKimiPrompt(sessionDir: string): string | undefined {
+  const wirePath = kimiWirePath(sessionDir);
+  if (!existsSync(wirePath)) return undefined;
+  let text: string;
+  try {
+    const stat = statSync(wirePath);
+    // Bounded head read: the first prompt sits near the top, but config.update
+    // records with the full system prompt can push it back tens of KB.
+    const maxHeadBytes = 1024 * 1024;
+    const size = Math.min(stat.size, maxHeadBytes);
+    const fd = openSync(wirePath, 'r');
+    try {
+      const buffer = Buffer.alloc(size);
+      readSync(fd, buffer, 0, size, 0);
+      text = buffer.toString('utf8');
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return undefined;
+  }
+
+  for (const line of text.split('\n')) {
+    if (!line.includes('"turn.prompt"')) continue;
+    try {
+      const prompt = turnPromptText(JSON.parse(line) as KimiTurnPromptRecord);
+      if (prompt) return prompt;
+    } catch {
+      // partial last line of the head slice, or a malformed record
+    }
+  }
+  return undefined;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Tail-read the main wire.jsonl and return the usage block of the last
+ * `usage.record` record. Bounded read (like the Grok reader) so multi-MB
+ * streams don't get re-parsed on every sessions push.
+ */
+export function readLatestKimiTokenUsage(sessionDir: string): AgentTokenUsage | undefined {
+  const wirePath = kimiWirePath(sessionDir);
+  if (!existsSync(wirePath)) return undefined;
+  let text: string;
+  try {
+    const stat = statSync(wirePath);
+    const maxTailBytes = 1024 * 1024;
+    if (stat.size <= maxTailBytes) {
+      const fd = openSync(wirePath, 'r');
+      try {
+        const buffer = Buffer.alloc(stat.size);
+        readSync(fd, buffer, 0, stat.size, 0);
+        text = buffer.toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+    } else {
+      const fd = openSync(wirePath, 'r');
+      try {
+        const buffer = Buffer.alloc(maxTailBytes);
+        readSync(fd, buffer, 0, maxTailBytes, stat.size - maxTailBytes);
+        text = buffer.toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  const lines = text.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line?.includes('"usage.record"')) continue;
+    try {
+      const record = JSON.parse(line) as {
+        type?: string;
+        model?: unknown;
+        usage?: {
+          inputOther?: unknown;
+          inputCacheRead?: unknown;
+          inputCacheCreation?: unknown;
+          output?: unknown;
+        };
+      };
+      if (record.type !== 'usage.record' || !record.usage) continue;
+      const usage = record.usage;
+      const cacheRead = numberOrUndefined(usage.inputCacheRead);
+      const inputParts = [usage.inputOther, usage.inputCacheRead, usage.inputCacheCreation]
+        .map(numberOrUndefined)
+        .filter((n): n is number => n !== undefined);
+      const totalInputTokens = inputParts.length > 0 ? inputParts.reduce((a, b) => a + b, 0) : undefined;
+      const output = numberOrUndefined(usage.output);
+      return {
+        model: typeof record.model === 'string' ? record.model : undefined,
+        totalInputTokens,
+        totalCacheReadTokens: cacheRead,
+        totalOutputTokens: output,
+        totalTokens: totalInputTokens !== undefined || output !== undefined
+          ? (totalInputTokens ?? 0) + (output ?? 0)
+          : undefined,
+      };
+    } catch {
+      // partial first line of the tail slice, or a malformed record
+    }
+  }
+  return undefined;
+}
+
+/** Exact Kimi Code sessions by native session id, for the active-sessions list. */
+export class KimiService implements AgentThreadService {
+  private store: KimiSessionStore;
+
+  constructor(store = new KimiSessionStore()) {
+    this.store = store;
+  }
+
+  async getThreadsByIds(sessionIds: string[]): Promise<Map<string, AgentThread>> {
+    const uniqueIds = new Set(sessionIds.filter(Boolean));
+    if (uniqueIds.size === 0) return new Map();
+
+    const sessions = await this.store.listSessions();
+    const result = new Map<string, AgentThread>();
+    for (const s of sessions) {
+      if (!uniqueIds.has(s.sessionId)) continue;
+      result.set(s.sessionId, {
+        sessionId: s.sessionId,
+        title: s.title,
+        firstPrompt: s.firstPrompt,
+        tokenUsage: readLatestKimiTokenUsage(s.dir),
+        cwd: s.cwd,
+        createdAt: s.createdAt,
+        updatedAt: s.updatedAt,
+      });
+    }
+    return result;
+  }
+}

--- a/backend/tests/unit/agent-providers.test.ts
+++ b/backend/tests/unit/agent-providers.test.ts
@@ -36,6 +36,12 @@ describe('Agent provider registry', () => {
     expect(parsed.agent).toBe('grok');
   });
 
+  test('accepts Kimi as a create-session agent', () => {
+    const parsed = CreateSessionSchema.parse({ name: 'example', agent: 'kimi' });
+
+    expect(parsed.agent).toBe('kimi');
+  });
+
   test('rejects unsupported create-session agents', () => {
     const parsed = CreateSessionSchema.safeParse({ name: 'example', agent: 'gemini' });
 
@@ -50,6 +56,8 @@ describe('Agent provider registry', () => {
     expect(detectAgentProviderFromArgs('/home/user/.bun/install/global/node_modules/@openai/codex/bin/codex.js')).toBe('codex');
     expect(detectAgentProviderFromArgs('grok')).toBe('grok');
     expect(detectAgentProviderFromArgs('/home/user/.grok/bin/grok -p prompt')).toBe('grok');
+    expect(detectAgentProviderFromArgs('kimi')).toBe('kimi');
+    expect(detectAgentProviderFromArgs('/home/user/.kimi-code/bin/kimi --session session_abc')).toBe('kimi');
   });
 
   test('does not detect provider names inside unrelated paths', () => {
@@ -61,6 +69,7 @@ describe('Agent provider registry', () => {
   test('threadAgentOf identifies thread-based agents only', () => {
     expect(threadAgentOf('codex')).toBe('codex');
     expect(threadAgentOf('grok')).toBe('grok');
+    expect(threadAgentOf('kimi')).toBe('kimi');
     expect(threadAgentOf('claude')).toBeUndefined();
     expect(threadAgentOf('bash')).toBeUndefined();
     expect(threadAgentOf(undefined)).toBeUndefined();
@@ -112,5 +121,7 @@ describe('Agent provider registry', () => {
     expect(agentResumeCommand('codex', 'thread-xyz')).toBe("codex resume 'thread-xyz'");
     expect(agentResumeCommand('grok')).toBe('grok --resume');
     expect(agentResumeCommand('grok', 'session-abc')).toBe("grok --resume 'session-abc'");
+    expect(agentResumeCommand('kimi')).toBe('kimi --session');
+    expect(agentResumeCommand('kimi', 'session-abc')).toBe("kimi --session 'session-abc'");
   });
 });

--- a/backend/tests/unit/kimi-service.test.ts
+++ b/backend/tests/unit/kimi-service.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { KimiService, KimiSessionStore, readLatestKimiTokenUsage } from '../../src/services/kimi';
+import { KimiHistoryService, parseKimiWire } from '../../src/services/kimi-history';
+import { claudeProjectDirName } from '../../src/utils/claude-project-path';
+
+const TEST_DIR = join(tmpdir(), `cchub-kimi-service-${Date.now()}`);
+const SESSIONS_DIR = join(TEST_DIR, 'sessions');
+
+const CWD = '/home/user/my-project';
+// Kimi names project dirs `wd_<basename>_<hexhash>`; the hash is opaque to us.
+const WD_DIR = 'wd_my-project_58f1d424d923';
+const SESSION_ID = 'session_019f7599-9759-78b1-9141-e8f187717ba5';
+
+function stateJson(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    createdAt: '2026-07-19T12:01:01.293Z',
+    updatedAt: '2026-07-19T12:01:01.332Z',
+    title: 'Run the shell command: echo hello',
+    isCustomTitle: false,
+    agents: { main: { type: 'main', parentAgentId: null } },
+    workDir: CWD,
+    lastPrompt: 'Run the shell command: echo hello',
+    ...overrides,
+  });
+}
+
+// Verbatim record shapes from a real kimi 0.27.0 wire.jsonl.
+const WIRE_JSONL = [
+  JSON.stringify({ type: 'metadata', protocol_version: '1.4', created_at: 1784463029095 }),
+  JSON.stringify({ type: 'config.update', modelAlias: 'k3', thinkingEffort: 'off', time: 1784463029095 }),
+  JSON.stringify({ type: 'turn.prompt', input: [{ type: 'text', text: 'Run the shell command: echo hello' }], origin: { kind: 'user' }, time: 1784463056815 }),
+  // Duplicates the turn.prompt payload — must not produce a second user turn.
+  JSON.stringify({ type: 'context.append_message', message: { role: 'user', content: [{ type: 'text', text: 'Run the shell command: echo hello' }], toolCalls: [], origin: { kind: 'user' } }, time: 1784463056816 }),
+  // Injected context — not conversation.
+  JSON.stringify({ type: 'context.append_message', message: { role: 'user', content: [{ type: 'text', text: '<system-reminder>auto mode</system-reminder>' }], toolCalls: [], origin: { kind: 'injection' } }, time: 1784463056817 }),
+  JSON.stringify({ type: 'context.append_loop_event', event: { type: 'step.begin', uuid: 's-1', turnId: '0', step: 1 }, time: 1784463056819 }),
+  JSON.stringify({ type: 'context.append_loop_event', event: { type: 'content.part', uuid: 'p-1', turnId: '0', step: 1, part: { type: 'think', think: 'The user wants echo hello.' } }, time: 1784463057000 }),
+  JSON.stringify({ type: 'context.append_loop_event', event: { type: 'content.part', uuid: 'p-2', turnId: '0', step: 1, part: { type: 'text', text: "I'll run that." } }, time: 1784463057001 }),
+  JSON.stringify({ type: 'context.append_loop_event', event: { type: 'tool.call', uuid: 'Bash_0', turnId: '0', step: 1, toolCallId: 'Bash_0', name: 'Bash', args: { command: 'echo hello' }, description: 'Running echo hello' }, time: 1784463057002 }),
+  JSON.stringify({ type: 'context.append_loop_event', event: { type: 'tool.result', parentUuid: 'Bash_0', toolCallId: 'Bash_0', result: { output: 'exit: 0\nhello\n' } }, time: 1784463057100 }),
+  JSON.stringify({ type: 'context.append_loop_event', event: { type: 'content.part', uuid: 'p-3', turnId: '0', step: 1, part: { type: 'text', text: 'It printed `hello`.' } }, time: 1784463057200 }),
+  JSON.stringify({ type: 'context.append_loop_event', event: { type: 'step.end', uuid: 's-1', turnId: '0', step: 1, usage: { inputOther: 2559, output: 1085, inputCacheRead: 52480, inputCacheCreation: 0 }, finishReason: 'end_turn' }, time: 1784463057300 }),
+  JSON.stringify({ type: 'usage.record', model: 'k3', usage: { inputOther: 2559, output: 1085, inputCacheRead: 52480, inputCacheCreation: 0 }, usageScope: 'turn', time: 1784463057301 }),
+].join('\n');
+
+beforeEach(async () => {
+  const sessionDir = join(SESSIONS_DIR, WD_DIR, SESSION_ID);
+  await mkdir(join(sessionDir, 'agents', 'main'), { recursive: true });
+  await writeFile(join(sessionDir, 'state.json'), stateJson());
+  await writeFile(join(sessionDir, 'agents', 'main', 'wire.jsonl'), WIRE_JSONL);
+  // Sub-agent wires are not part of the conversation and must be ignored.
+  await mkdir(join(sessionDir, 'agents', 'agent-0'), { recursive: true });
+  await writeFile(join(sessionDir, 'agents', 'agent-0', 'wire.jsonl'), '{"type":"turn.prompt"}\n');
+  // Non-project files that live alongside the wd_* dirs must be skipped.
+  await writeFile(join(SESSIONS_DIR, 'session_index.jsonl'), `${JSON.stringify({ sessionId: SESSION_ID, sessionDir, workDir: CWD })}\n`);
+});
+
+afterEach(async () => {
+  await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('parseKimiWire', () => {
+  test('collapses records into Claude-shaped turns', () => {
+    const messages = parseKimiWire(WIRE_JSONL);
+    expect(messages).toHaveLength(4);
+
+    // Real prompt only; the append_message duplicate / injection is dropped.
+    expect(messages[0]).toEqual({ role: 'user', content: 'Run the shell command: echo hello' });
+
+    expect(messages[1]?.role).toBe('assistant');
+    expect(messages[1]?.content).toBe("I'll run that.");
+    expect(messages[1]?.toolUse).toEqual([
+      { id: 'Bash_0', name: 'Bash', input: { command: 'echo hello' } },
+    ]);
+
+    expect(messages[2]?.role).toBe('user');
+    expect(messages[2]?.toolResult).toEqual([
+      { toolUseId: 'Bash_0', toolName: 'Bash', output: 'exit: 0\nhello\n' },
+    ]);
+
+    expect(messages[3]).toEqual({ role: 'assistant', content: 'It printed `hello`.' });
+  });
+
+  test('returns empty for garbage input', () => {
+    expect(parseKimiWire('not json\n{"type":"metadata"}')).toEqual([]);
+  });
+});
+
+describe('KimiSessionStore', () => {
+  test('lists sessions with metadata from state.json and first prompt from the wire', async () => {
+    const store = new KimiSessionStore(SESSIONS_DIR);
+    const sessions = await store.listSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.sessionId).toBe(SESSION_ID);
+    expect(sessions[0]?.cwd).toBe(CWD);
+    expect(sessions[0]?.title).toBe('Run the shell command: echo hello');
+    expect(sessions[0]?.firstPrompt).toBe('Run the shell command: echo hello');
+    expect(sessions[0]?.updatedAt).toBe('2026-07-19T12:01:01.332Z');
+  });
+
+  test('findSession resolves by the session_<uuid> dir name', async () => {
+    const store = new KimiSessionStore(SESSIONS_DIR);
+    expect((await store.findSession(SESSION_ID))?.cwd).toBe(CWD);
+    expect(await store.findSession('session_missing')).toBeUndefined();
+  });
+
+  test('returns empty when the sessions dir does not exist', async () => {
+    const store = new KimiSessionStore(join(TEST_DIR, 'missing'));
+    expect(await store.listSessions()).toEqual([]);
+  });
+});
+
+describe('KimiService', () => {
+  test('resolves an exact thread by native session id with token usage', async () => {
+    const service = new KimiService(new KimiSessionStore(SESSIONS_DIR));
+    const threads = await service.getThreadsByIds([SESSION_ID, 'nonexistent']);
+    expect(threads.size).toBe(1);
+    const thread = threads.get(SESSION_ID);
+    expect(thread?.sessionId).toBe(SESSION_ID);
+    expect(thread?.title).toBe('Run the shell command: echo hello');
+    expect(thread?.firstPrompt).toBe('Run the shell command: echo hello');
+    expect(thread?.cwd).toBe(CWD);
+    expect(thread?.tokenUsage?.model).toBe('k3');
+    expect(thread?.tokenUsage?.totalTokens).toBe(56124);
+    expect(thread?.tokenUsage?.totalOutputTokens).toBe(1085);
+  });
+
+  test('returns empty map when the sessions dir does not exist', async () => {
+    const service = new KimiService(new KimiSessionStore(join(TEST_DIR, 'missing')));
+    expect((await service.getThreadsByIds([SESSION_ID])).size).toBe(0);
+  });
+});
+
+describe('readLatestKimiTokenUsage', () => {
+  test('reads usage from the last usage.record record', () => {
+    const usage = readLatestKimiTokenUsage(join(SESSIONS_DIR, WD_DIR, SESSION_ID));
+    expect(usage).toEqual({
+      model: 'k3',
+      totalInputTokens: 55039,
+      totalCacheReadTokens: 52480,
+      totalOutputTokens: 1085,
+      totalTokens: 56124,
+    });
+  });
+});
+
+describe('KimiHistoryService', () => {
+  test('groups sessions into Claude-encoded project buckets', async () => {
+    const service = new KimiHistoryService(new KimiSessionStore(SESSIONS_DIR));
+    const projects = await service.getProjects();
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.dirName).toBe(claudeProjectDirName(CWD));
+    expect(projects[0]?.projectPath).toBe(CWD);
+    expect(projects[0]?.sessionCount).toBe(1);
+  });
+
+  test('lists project sessions tagged agent=kimi', async () => {
+    const service = new KimiHistoryService(new KimiSessionStore(SESSIONS_DIR));
+    const sessions = await service.getProjectSessions(claudeProjectDirName(CWD));
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.sessionId).toBe(SESSION_ID);
+    expect(sessions[0]?.agent).toBe('kimi');
+    expect(sessions[0]?.firstPrompt).toBe('Run the shell command: echo hello');
+  });
+
+  test('search matches cwd and prompts', async () => {
+    const service = new KimiHistoryService(new KimiSessionStore(SESSIONS_DIR));
+    expect(await service.searchSessions('echo hello')).toHaveLength(1);
+    expect(await service.searchSessions('no-such-text')).toHaveLength(0);
+  });
+
+  test('reads a conversation by session id', async () => {
+    const service = new KimiHistoryService(new KimiSessionStore(SESSIONS_DIR));
+    const messages = await service.getConversation(SESSION_ID);
+    expect(messages).toHaveLength(4);
+    expect(await service.getConversation('unknown-id')).toEqual([]);
+  });
+});

--- a/backend/tests/unit/kimi-usage.test.ts
+++ b/backend/tests/unit/kimi-usage.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { KimiSessionStore } from '../../src/services/kimi';
+import { KimiUsageService } from '../../src/services/kimi-usage';
+
+const TEST_DIR = join(tmpdir(), `cchub-kimi-usage-${Date.now()}`);
+const SESSIONS_DIR = join(TEST_DIR, 'sessions');
+const CWD = '/home/user/proj';
+const WD_DIR = 'wd_proj_58f1d424d923';
+const SESSION_ID = 'session_019f0000-0000-7000-8000-000000000001';
+
+function usageRecord(timeMs: number, model: string, usage: Record<string, number>): string {
+  return JSON.stringify({ type: 'usage.record', model, usage, usageScope: 'turn', time: timeMs });
+}
+
+function stateJson(): string {
+  const nowIso = new Date().toISOString();
+  return JSON.stringify({
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    title: 'test',
+    workDir: CWD,
+  });
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+let latestMs = 0;
+
+beforeEach(async () => {
+  const now = Date.now();
+  latestMs = now - 30 * 60_000;
+
+  const sessionDir = join(SESSIONS_DIR, WD_DIR, SESSION_ID);
+  await mkdir(join(sessionDir, 'agents', 'main'), { recursive: true });
+  await mkdir(join(sessionDir, 'agents', 'agent-0'), { recursive: true });
+  await writeFile(join(sessionDir, 'state.json'), stateJson());
+  await writeFile(join(sessionDir, 'agents', 'main', 'wire.jsonl'), [
+    JSON.stringify({ type: 'metadata', protocol_version: '1.4', created_at: now - 2 * DAY_MS }),
+    // 2 days ago → 7d only. input = 1000 + 2000 + 0 = 3000, total = 3100
+    usageRecord(now - 2 * DAY_MS, 'k2', { inputOther: 1000, output: 100, inputCacheRead: 2000, inputCacheCreation: 0 }),
+    // 1h ago → both windows. input = 500 + 0 + 250 = 750, total = 800
+    usageRecord(now - HOUR_MS, 'k3', { inputOther: 500, output: 50, inputCacheRead: 0, inputCacheCreation: 250 }),
+    // 10 days ago → excluded from the 7d window
+    usageRecord(now - 10 * DAY_MS, 'k2', { inputOther: 99_999, output: 1, inputCacheRead: 0, inputCacheCreation: 0 }),
+  ].join('\n'));
+  // Sub-agent wire: real consumption, must be summed in. input = 100 + 375 + 0 = 475, total = 500
+  await writeFile(join(sessionDir, 'agents', 'agent-0', 'wire.jsonl'), [
+    usageRecord(latestMs, 'k3', { inputOther: 100, output: 25, inputCacheRead: 375, inputCacheCreation: 0 }),
+  ].join('\n'));
+
+  // A second session with no usage records must not count towards sessions7d.
+  const idleDir = join(SESSIONS_DIR, WD_DIR, 'session_019f0000-0000-7000-8000-000000000002');
+  await mkdir(join(idleDir, 'agents', 'main'), { recursive: true });
+  await writeFile(join(idleDir, 'state.json'), stateJson());
+  await writeFile(join(idleDir, 'agents', 'main', 'wire.jsonl'), `${JSON.stringify({ type: 'metadata' })}\n`);
+});
+
+afterEach(async () => {
+  await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('KimiUsageService', () => {
+  test('aggregates 24h / 7d windows from usage.record records, sub-agents included', async () => {
+    const service = new KimiUsageService(new KimiSessionStore(SESSIONS_DIR));
+    const summary = await service.getUsageSummary();
+    expect(summary).not.toBeNull();
+    expect(summary?.last7d).toEqual({
+      turns: 3,
+      totalTokens: 4400,
+      inputTokens: 4225,
+      cacheReadTokens: 2375,
+      outputTokens: 175,
+    });
+    expect(summary?.last24h).toEqual({
+      turns: 2,
+      totalTokens: 1300,
+      inputTokens: 1225,
+      cacheReadTokens: 375,
+      outputTokens: 75,
+    });
+    expect(summary?.models).toEqual([
+      { model: 'k2', totalTokens: 3100 },
+      { model: 'k3', totalTokens: 1300 },
+    ]);
+    expect(summary?.sessions7d).toBe(1);
+    expect(summary?.lastTurnAt).toBe(new Date(latestMs).toISOString());
+  });
+
+  test('returns null when there are no sessions', async () => {
+    const service = new KimiUsageService(new KimiSessionStore(join(TEST_DIR, 'missing')));
+    expect(await service.getUsageSummary()).toBeNull();
+  });
+});

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -475,7 +475,7 @@ function CreateSessionModal({
 					<div className="text-xs text-th-text-secondary mb-1">
 						{t("session.agent")}
 					</div>
-					<div className="grid grid-cols-3 gap-2">
+					<div className="grid grid-cols-4 gap-2">
 						{AGENT_PROVIDER_IDS.map((option) => (
 							<button
 								key={option}

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -24,7 +24,7 @@ interface DashboardProps {
 	compact?: boolean; // true when in narrow side panel
 }
 
-type AgentTab = "claude" | "codex" | "grok";
+type AgentTab = "claude" | "codex" | "grok" | "kimi";
 
 export function Dashboard({ className = "", compact = false }: DashboardProps) {
 	const { t, i18n } = useTranslation();
@@ -45,6 +45,7 @@ export function Dashboard({ className = "", compact = false }: DashboardProps) {
 	const [agentTab, setAgentTab] = useState<AgentTab>("claude");
 	const codexLimits = data?.codexUsageLimits;
 	const grokUsage = data?.grokUsage;
+	const kimiUsage = data?.kimiUsage;
 	// Claude is "available" when we have any actionable Claude data. The endpoint
 	// returns empty arrays / no-credentials errors on a Codex-only machine.
 	const claudeAvailable =
@@ -58,6 +59,7 @@ export function Dashboard({ className = "", compact = false }: DashboardProps) {
 		...(claudeAvailable ? (["claude"] as const) : []),
 		...(codexLimits ? (["codex"] as const) : []),
 		...(grokUsage ? (["grok"] as const) : []),
+		...(kimiUsage ? (["kimi"] as const) : []),
 	];
 	const showAgentTabs = availableTabs.length > 1;
 	const effectiveTab: AgentTab = availableTabs.includes(agentTab)
@@ -207,6 +209,64 @@ export function Dashboard({ className = "", compact = false }: DashboardProps) {
 						</div>
 						<div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06] md:col-span-2 text-th-text-muted text-xs">
 							{t("dashboard.grokNoRateLimitInfo")}
+						</div>
+					</div>
+				) : effectiveTab === "kimi" ? (
+					<div
+						className={
+							compact
+								? "space-y-3"
+								: "md:grid md:grid-cols-2 md:gap-4 space-y-3 md:space-y-0"
+						}
+					>
+						<div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06] md:col-span-2">
+							<div className="flex items-center justify-between mb-3">
+								<h3 className="text-xs font-medium text-th-text-secondary">
+									{t("dashboard.kimiUsage")}
+								</h3>
+							</div>
+							<div className="grid grid-cols-2 gap-3">
+								{(
+									[
+										["kimiLast24h", kimiUsage?.last24h],
+										["kimiLast7d", kimiUsage?.last7d],
+									] as const
+								).map(([labelKey, window]) => (
+									<div
+										key={labelKey}
+										className="bg-white/[0.03] rounded-md p-3 border border-white/[0.06]"
+									>
+										<div className="text-[11px] text-th-text-muted mb-1">
+											{t(`dashboard.${labelKey}`)}
+										</div>
+										<div className="text-lg font-semibold text-th-text">
+											{formatTokens(window?.totalTokens ?? 0)}
+										</div>
+										<div className="text-[11px] text-th-text-muted mt-0.5">
+											{t("dashboard.kimiTurns", { count: window?.turns ?? 0 })}
+										</div>
+									</div>
+								))}
+							</div>
+							{(kimiUsage?.models.length ?? 0) > 0 && (
+								<div className="mt-3 space-y-1">
+									<div className="text-[11px] text-th-text-muted">
+										{t("dashboard.kimiModelBreakdown")}
+									</div>
+									{kimiUsage?.models.map((m) => (
+										<div
+											key={m.model}
+											className="flex justify-between text-xs text-th-text-secondary"
+										>
+											<span>{m.model}</span>
+											<span>{formatTokens(m.totalTokens)}</span>
+										</div>
+									))}
+								</div>
+							)}
+						</div>
+						<div className="bg-white/[0.03] rounded-lg p-4 border border-white/[0.06] md:col-span-2 text-th-text-muted text-xs">
+							{t("dashboard.kimiNoRateLimitInfo")}
 						</div>
 					</div>
 				) : effectiveTab === "codex" ? (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -59,7 +59,8 @@
 		"agentProvider": {
 			"claude": "Claude",
 			"codex": "Codex",
-			"grok": "Grok"
+			"grok": "Grok",
+			"kimi": "Kimi"
 		},
 		"workingDirectory": "Working Directory",
 		"newFolder": "New Folder",
@@ -179,7 +180,13 @@
 		"grokLast7d": "Last 7 days",
 		"grokTurns": "{{count}} turns",
 		"grokModelBreakdown": "By model (7 days)",
-		"grokNoRateLimitInfo": "xAI does not expose rate-limit windows locally, so token totals are aggregated from Grok session logs instead of showing cycle utilization."
+		"grokNoRateLimitInfo": "xAI does not expose rate-limit windows locally, so token totals are aggregated from Grok session logs instead of showing cycle utilization.",
+		"kimiUsage": "Kimi Usage",
+		"kimiLast24h": "Last 24 hours",
+		"kimiLast7d": "Last 7 days",
+		"kimiTurns": "{{count}} turns",
+		"kimiModelBreakdown": "By model (7 days)",
+		"kimiNoRateLimitInfo": "Kimi Code does not expose rate-limit windows locally, so token totals are aggregated from Kimi session logs (sub-agent usage included) instead of showing cycle utilization."
 	},
 	"files": {
 		"title": "File Browser",
@@ -228,6 +235,7 @@
 		"claude": "Claude",
 		"codex": "Codex",
 		"grok": "Grok",
+		"kimi": "Kimi",
 		"system": "System",
 		"errorTitle": "Conversation unavailable",
 		"errorMissingAgent": "Session has no agent information. Try refreshing the session list.",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -59,7 +59,8 @@
 		"agentProvider": {
 			"claude": "Claude",
 			"codex": "Codex",
-			"grok": "Grok"
+			"grok": "Grok",
+			"kimi": "Kimi"
 		},
 		"workingDirectory": "作業ディレクトリ",
 		"newFolder": "新規フォルダ",
@@ -179,7 +180,13 @@
 		"grokLast7d": "過去7日間",
 		"grokTurns": "{{count}} ターン",
 		"grokModelBreakdown": "モデル別（7日間）",
-		"grokNoRateLimitInfo": "xAI はレート制限情報をローカルに公開していないため、サイクル使用率の代わりに Grok セッションログから集計したトークン消費量を表示しています。"
+		"grokNoRateLimitInfo": "xAI はレート制限情報をローカルに公開していないため、サイクル使用率の代わりに Grok セッションログから集計したトークン消費量を表示しています。",
+		"kimiUsage": "Kimi 使用量",
+		"kimiLast24h": "過去24時間",
+		"kimiLast7d": "過去7日間",
+		"kimiTurns": "{{count}} ターン",
+		"kimiModelBreakdown": "モデル別（7日間）",
+		"kimiNoRateLimitInfo": "Kimi Code はレート制限情報をローカルに公開していないため、サイクル使用率の代わりに Kimi セッションログ（サブエージェント分を含む）から集計したトークン消費量を表示しています。"
 	},
 	"files": {
 		"title": "ファイルブラウザ",
@@ -228,6 +235,7 @@
 		"claude": "Claude",
 		"codex": "Codex",
 		"grok": "Grok",
+		"kimi": "Kimi",
 		"system": "System",
 		"errorTitle": "会話を表示できません",
 		"errorMissingAgent": "セッションのエージェント情報が取得できませんでした。セッション一覧を再読み込みしてください。",

--- a/frontend/src/utils/agentDisplay.ts
+++ b/frontend/src/utils/agentDisplay.ts
@@ -38,6 +38,12 @@ const AGENT_BADGES: Record<AgentProvider, AgentBadgeStyle> = {
 		barClassName: "bg-emerald-400/70",
 		labelClassName: "text-emerald-300",
 	},
+	kimi: {
+		label: AGENT_PROVIDERS.kimi.displayName,
+		badgeClassName: "text-amber-300 bg-amber-400/10 border-amber-400/20",
+		barClassName: "bg-amber-400/70",
+		labelClassName: "text-amber-300",
+	},
 };
 
 /** Badge style for a provider; unknown/undefined falls back to Claude. */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -76,6 +76,15 @@ export const AGENT_PROVIDERS = {
     processPatterns: [/(?:^|\/)grok(?:\s|$)/],
     supportsConversationMetadata: false,
   },
+  kimi: {
+    id: 'kimi',
+    command: 'kimi',
+    resumeCommand: 'kimi --session',
+    labelKey: 'session.agentProvider.kimi',
+    displayName: 'Kimi',
+    processPatterns: [/(?:^|\/)kimi(?:\s|$)/],
+    supportsConversationMetadata: false,
+  },
 } as const;
 
 export type AgentProvider = keyof typeof AGENT_PROVIDERS;
@@ -546,6 +555,31 @@ export interface GrokUsageSummary {
   lastTurnAt?: string;
 }
 
+/**
+ * Aggregated Kimi Code token usage. Kimi exposes no rate-limit windows or plan
+ * data in its local session data, so the dashboard shows consumption totals
+ * aggregated from `usage.record` records instead of cycle utilization bars.
+ */
+export interface KimiUsageWindow {
+  /** usage.record entries in the window. */
+  turns: number;
+  totalTokens: number;
+  inputTokens: number;
+  cacheReadTokens: number;
+  outputTokens: number;
+}
+
+export interface KimiUsageSummary {
+  last24h: KimiUsageWindow;
+  last7d: KimiUsageWindow;
+  /** Per-model totals over the 7-day window, largest first. */
+  models: Array<{ model: string; totalTokens: number }>;
+  /** Sessions with usage in the 7-day window. */
+  sessions7d: number;
+  /** ISO timestamp of the most recent usage record seen. */
+  lastTurnAt?: string;
+}
+
 // Usage history snapshot for line chart
 export interface UsageSnapshot {
   timestamp: string; // ISO 8601
@@ -616,6 +650,7 @@ export interface DashboardResponse {
   usageLimitsStatus?: UsageLimitsStatus; // Error/state info for UI
   codexUsageLimits?: CodexUsageLimits | null; // From Codex rollouts
   grokUsage?: GrokUsageSummary | null; // From Grok updates.jsonl turn_completed records
+  kimiUsage?: KimiUsageSummary | null; // From Kimi wire.jsonl usage.record records
   usageHistory: UsageSnapshot[]; // Usage history for line chart
   dailyActivity: DailyActivity[];
   modelUsage: ModelUsage[];


### PR DESCRIPTION
## Changes
- feat(agent): Kimi Code CLI を第4のエージェントプロバイダとしてサポート（検知・起動・履歴・会話表示・resume・通知・usage タブ）
- chore: bump version to 0.2.29

## Notes
- herdr が kimi をランタイム検知するため herdr 側の変更不要。native session id は `herdr integration install kimi`（`cchub setup` に同梱）で有効化
- hook 通知は `~/.kimi-code/config.toml` の `[[hooks]]` に `event = "Stop"`, `command = "cchub notify"` を登録（payload は Claude 互換 snake_case）