### PR TITLE
feat(history): 期間ファセットを最上部に移動し、他ファセットを期間で絞り込み

### DIFF
--- a/frontend/src/components/history/HistoryFacetSidebar.tsx
+++ b/frontend/src/components/history/HistoryFacetSidebar.tsx
@@ -103,9 +103,10 @@ function MultiGroup({
 }
 
 /**
- * Faceted filter sidebar (desktop left rail / drawer body). Project / Agent /
- * Branch / Peer are multi-select; Period is single-select. Counts are totals
- * across the loaded set.
+ * Faceted filter sidebar (desktop left rail / drawer body). Period is
+ * single-select and sits on top: the Project / Agent / Branch / Peer
+ * multi-select groups below it are scoped (options and counts) to the
+ * selected date range.
  */
 export function HistoryFacetSidebar({
 	data,
@@ -123,6 +124,32 @@ export function HistoryFacetSidebar({
 
 	return (
 		<div className="text-[12.5px]">
+			{/* Period first: it scopes the option lists / counts of every group
+			    below, so it reads as the outermost filter. */}
+			<div className="mb-4">
+				<div className="text-[10.5px] uppercase tracking-wider text-zinc-500 mb-1">
+					{t("history.facetPeriod")}
+				</div>
+				{periods.map((p) => (
+					<label
+						key={p.value ?? "all"}
+						className="flex items-center gap-2 py-1 cursor-pointer group"
+					>
+						<input
+							type="radio"
+							name="history-period"
+							checked={state.period === p.value}
+							onChange={() => onChange({ ...state, period: p.value })}
+							className="w-3.5 h-3.5 accent-blue-500 shrink-0"
+						/>
+						<span
+							className={`text-[12.5px] ${state.period === p.value ? "text-zinc-100" : "text-zinc-400 group-hover:text-zinc-300"}`}
+						>
+							{p.label}
+						</span>
+					</label>
+				))}
+			</div>
 			<MultiGroup
 				title={t("history.facetProject")}
 				values={data.projects}
@@ -149,30 +176,6 @@ export function HistoryFacetSidebar({
 					onToggle={(v) => onChange(toggleFacet(state, "peers", v))}
 				/>
 			)}
-			<div className="mb-2">
-				<div className="text-[10.5px] uppercase tracking-wider text-zinc-500 mb-1">
-					{t("history.facetPeriod")}
-				</div>
-				{periods.map((p) => (
-					<label
-						key={p.value ?? "all"}
-						className="flex items-center gap-2 py-1 cursor-pointer group"
-					>
-						<input
-							type="radio"
-							name="history-period"
-							checked={state.period === p.value}
-							onChange={() => onChange({ ...state, period: p.value })}
-							className="w-3.5 h-3.5 accent-blue-500 shrink-0"
-						/>
-						<span
-							className={`text-[12.5px] ${state.period === p.value ? "text-zinc-100" : "text-zinc-400 group-hover:text-zinc-300"}`}
-						>
-							{p.label}
-						</span>
-					</label>
-				))}
-			</div>
 		</div>
 	);
 }

--- a/frontend/src/components/history/SessionHistoryV2.tsx
+++ b/frontend/src/components/history/SessionHistoryV2.tsx
@@ -13,6 +13,7 @@ import {
 	type ActiveChip,
 	activeChips,
 	applyFacets,
+	applyPeriodFilter,
 	computeFacetData,
 	emptyFacetState,
 	type FacetState,
@@ -195,8 +196,13 @@ export function SessionHistoryV2({
 	const isSearchMode = searchQuery.trim().length > 0;
 	const sourceItems = isSearchMode ? searchResults : items;
 
-	// Facet value lists + counts are derived from the full loaded set.
-	const facetData = useMemo(() => computeFacetData(items, t), [items, t]);
+	// Facet value lists + counts are scoped to the selected period, so the
+	// other axes only offer (and count) values inside the date range. Selected
+	// values are pinned at count 0 so they can still be unchecked.
+	const facetData = useMemo(
+		() => computeFacetData(applyPeriodFilter(items, facet.period, Date.now()), t, facet),
+		[items, facet, t],
+	);
 	const chips: ActiveChip[] = useMemo(
 		() => activeChips(facet, facetData, t),
 		[facet, facetData, t],

--- a/frontend/src/utils/historyFacets.test.ts
+++ b/frontend/src/utils/historyFacets.test.ts
@@ -3,6 +3,7 @@ import type { HistorySession } from "../../../shared/types";
 import {
 	activeChips,
 	applyFacets,
+	applyPeriodFilter,
 	computeFacetData,
 	emptyFacetState,
 	isFacetActive,
@@ -105,6 +106,48 @@ describe("computeFacetData", () => {
 		const data = computeFacetData(items, t);
 		expect(data.peers.length).toBe(2);
 		expect(data.peers.find((v) => v.value === "mac")?.label).toBe("m0a-mac");
+	});
+
+	test("selected values are pinned at count 0 when absent from the scoped set", () => {
+		const items = [snap("a", { projectName: "~/p1", agent: "claude" })];
+		const s = {
+			...emptyFacetState(),
+			projects: new Set(["~/gone"]),
+			agents: new Set(["codex"]),
+			branches: new Set([UNKNOWN_BRANCH]),
+		};
+		const data = computeFacetData(items, t, s);
+		expect(data.projects.find((v) => v.value === "~/gone")).toMatchObject({
+			count: 0,
+			label: "gone",
+		});
+		expect(data.agents.find((v) => v.value === "codex")?.count).toBe(0);
+		// "a" has no branch, so the unknown sentinel is genuinely present (1).
+		expect(data.branches.find((v) => v.value === UNKNOWN_BRANCH)?.count).toBe(1);
+		// pinned zero-count entries sort below real ones
+		expect(data.projects[0].value).toBe("~/p1");
+	});
+});
+
+describe("applyPeriodFilter", () => {
+	const items = [
+		snap("recent", { modifiedMs: NOW - HOUR }),
+		snap("old", { modifiedMs: NOW - 10 * DAY }),
+	];
+
+	test("null period returns items unchanged", () => {
+		expect(applyPeriodFilter(items, null, NOW)).toBe(items);
+	});
+
+	test("scopes to the range, ignoring other axes", () => {
+		expect(applyPeriodFilter(items, "7d", NOW).map((x) => x.sessionId)).toEqual([
+			"recent",
+		]);
+	});
+
+	test("excludes unparseable dates", () => {
+		const bad = { ...snap("z"), modified: "" };
+		expect(applyPeriodFilter([bad], "24h", NOW)).toHaveLength(0);
 	});
 });
 

--- a/frontend/src/utils/historyFacets.ts
+++ b/frontend/src/utils/historyFacets.ts
@@ -42,6 +42,30 @@ const PERIOD_MS: Record<NonNullable<HistoryPeriod>, number> = {
 	"30d": 30 * 24 * 60 * 60 * 1000,
 };
 
+function inPeriod(
+	it: HistorySession,
+	period: NonNullable<HistoryPeriod>,
+	now: number,
+): boolean {
+	const ts = new Date(it.modified).getTime();
+	// Unparseable dates are excluded from time-bounded views rather than
+	// slipping through.
+	return !Number.isNaN(ts) && now - ts <= PERIOD_MS[period];
+}
+
+/**
+ * Filter by the period axis alone. Facet option lists are scoped with this so
+ * the other axes only offer values that exist inside the selected date range.
+ */
+export function applyPeriodFilter(
+	items: HistorySession[],
+	period: HistoryPeriod,
+	now: number,
+): HistorySession[] {
+	if (!period) return items;
+	return items.filter((it) => inPeriod(it, period, now));
+}
+
 function agentOf(s: HistorySession): string {
 	return s.agent ?? "claude";
 }
@@ -67,12 +91,7 @@ export function applyFacets(
 		if (s.agents.size && !s.agents.has(agentOf(it))) return false;
 		if (s.branches.size && !s.branches.has(branchOf(it))) return false;
 		if (s.peers.size && !s.peers.has(peerOf(it))) return false;
-		if (s.period) {
-			const ts = new Date(it.modified).getTime();
-			// Exclude unparseable dates from time-bounded views rather than letting
-			// them slip through.
-			if (Number.isNaN(ts) || now - ts > PERIOD_MS[s.period]) return false;
-		}
+		if (s.period && !inPeriod(it, s.period, now)) return false;
 		return true;
 	});
 }
@@ -124,13 +143,28 @@ function projectLabel(projectName: string): string {
 	return projectName.replace(/^~\//, "");
 }
 
+/** Ensure every selected value stays listed (count 0) even when the scoped
+ * item set no longer contains it, so it can still be unchecked in place. */
+function pinSelected(
+	counts: Map<string, number>,
+	selected?: Set<string>,
+): Map<string, number> {
+	if (selected) {
+		for (const v of selected) if (!counts.has(v)) counts.set(v, 0);
+	}
+	return counts;
+}
+
 /**
- * Build the facet value lists (with total counts) for the sidebar. Counts are
- * totals across the loaded set (not disjunctive) — simple and stable.
+ * Build the facet value lists (with counts) for the sidebar. `items` is
+ * expected to be pre-scoped to the selected period, so counts reflect the date
+ * range; within that the counts are totals (not disjunctive) — simple and
+ * stable. Pass `selected` so checked values survive dropping out of range.
  */
 export function computeFacetData(
 	items: HistorySession[],
 	t: TFunction,
+	selected?: FacetState,
 ): FacetData {
 	const peerNick = new Map<string, string>();
 	const peerColor = new Map<string, string>();
@@ -140,7 +174,7 @@ export function computeFacetData(
 		if (it.peerColor) peerColor.set(p, it.peerColor);
 	}
 
-	const peerCounts = tally(items, peerOf);
+	const peerCounts = pinSelected(tally(items, peerOf), selected?.peers);
 	const peers =
 		peerCounts.size > 1
 			? sortedValues(
@@ -151,10 +185,17 @@ export function computeFacetData(
 			: [];
 
 	return {
-		projects: sortedValues(tally(items, (s) => s.projectName), projectLabel),
-		agents: sortedValues(tally(items, agentOf), agentDisplayName),
-		branches: sortedValues(tally(items, branchOf), (v) =>
-			v === UNKNOWN_BRANCH ? t("history.facetBranchUnknown") : v,
+		projects: sortedValues(
+			pinSelected(tally(items, (s) => s.projectName), selected?.projects),
+			projectLabel,
+		),
+		agents: sortedValues(
+			pinSelected(tally(items, agentOf), selected?.agents),
+			agentDisplayName,
+		),
+		branches: sortedValues(
+			pinSelected(tally(items, branchOf), selected?.branches),
+			(v) => (v === UNKNOWN_BRANCH ? t("history.facetBranchUnknown") : v),
 		),
 		peers,
 	};


### PR DESCRIPTION
## 概要

履歴検索（History V2）のファセットサイドバーを改善:

- **期間フィルタを最上部に移動** — 期間が他の全グループのスコープを決める最外殻フィルタとして機能するため
- **プロジェクト / エージェント / ブランチ / peer の選択肢と件数を、選択中の期間で絞り込んだセッション集合から算出** — 「今日」を選ぶと、今日のセッションに存在する値だけが表示され、件数も期間内カウントになる
- 選択中の値が期間外になった場合は 0 件でリストに残し、その場でチェック解除できるようにした（チップからも解除可能）

## 検証

- `bun test frontend/src/` 56 pass / `bun run lint` クリーン（テスト追加: applyPeriodFilter, ピン留め）
- dev 環境 + agent-browser で確認:
  - 期間グループが最上部に表示される
  - 「今日」選択でプロジェクト一覧が 26→13 値・期間内カウントに絞り込み、エージェントから Grok が消える（今日の実績なし）
  - すべて→Grok 選択→今日 に切り替えると Grok が 0 件でピン留め表示され、解除可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZvZCXfurraXBuTdfSABj7