### PR TITLE
fix(peers): 同名セッションがあると peer のターミナルを開けない問題を修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import {
 	type AgentProvider,
 	type ExtendedSessionResponse,
 	type IndicatorState,
+	LOCAL_PEER_ID,
 	type PaneInfo,
 	type SessionState,
 	type SessionTheme,
@@ -448,7 +449,12 @@ export function App() {
 		if (deviceType !== "mobile" || apiSessions.length === 0) return;
 		setOpenSessions((prev) =>
 			prev.map((session) => {
-				const apiSession = apiSessions.find((s) => s.id === session.id);
+				// id は peer 間で重複し得るので、同じ peer のセッションから更新する
+				const apiSession = apiSessions.find(
+					(s) =>
+						s.id === session.id &&
+						isSameNotificationPeer(s.peerId, session.peerId),
+				);
 				if (!apiSession) return session;
 				const next = {
 					...session,
@@ -711,12 +717,26 @@ export function App() {
 				return;
 			}
 
-			// Check if already open
-			const existing = openSessions.find((s) => s.id === session.id);
+			// Check if already open. Session ids (workspace labels) can collide
+			// across peers: an entry with the same id but a different peer is
+			// REPLACED so the id maps to the peer the user just picked — the pane
+			// tree keys panes by bare id, so both can't be shown at once anyway.
+			const existing = openSessions.find(
+				(s) =>
+					s.id === session.id && isSameNotificationPeer(s.peerId, session.peerId),
+			);
 			if (existing) {
 				setActiveSessionId(session.id);
 			} else {
-				setOpenSessions((prev) => [...prev, apiToOpenSession(session)]);
+				setOpenSessions((prev) => {
+					const idx = prev.findIndex((s) => s.id === session.id);
+					if (idx >= 0) {
+						const next = [...prev];
+						next[idx] = apiToOpenSession(session);
+						return next;
+					}
+					return [...prev, apiToOpenSession(session)];
+				});
 				setActiveSessionId(session.id);
 			}
 			// Update FileViewer active dir to follow session
@@ -733,9 +753,20 @@ export function App() {
 	const handleSelectPane = useCallback(
 		(session: ExtendedSessionResponse, paneId: string) => {
 			// Open session without resetting paneId (handleSelectSession sets it to null)
-			const existing = openSessions.find((s) => s.id === session.id);
+			const existing = openSessions.find(
+				(s) =>
+					s.id === session.id && isSameNotificationPeer(s.peerId, session.peerId),
+			);
 			if (!existing) {
-				setOpenSessions((prev) => [...prev, apiToOpenSession(session)]);
+				setOpenSessions((prev) => {
+					const idx = prev.findIndex((s) => s.id === session.id);
+					if (idx >= 0) {
+						const next = [...prev];
+						next[idx] = apiToOpenSession(session);
+						return next;
+					}
+					return [...prev, apiToOpenSession(session)];
+				});
 			}
 			setActiveSessionId(session.id);
 			setShowSessionList(false);
@@ -1265,9 +1296,10 @@ export function App() {
 						return (
 							<TerminalPage
 								ref={mobileTerminalRef}
-								key={`${activeSession.id}:${activeSession.instanceId ?? "legacy"}`}
+								key={`${activeSession.peerId ?? "local"}:${activeSession.id}:${activeSession.instanceId ?? "legacy"}`}
 								sessionId={activeSession.id}
 								sessionInstanceId={activeSession.instanceId}
+								peerId={activeSession.peerId ?? LOCAL_PEER_ID}
 								onStateChange={(state) =>
 									updateSessionState(activeSession.id, state)
 								}
@@ -1301,9 +1333,12 @@ export function App() {
 					{/* Pane tab bar - only shown when multiple panes exist */}
 					{mobilePanes.length > 1 &&
 						(() => {
-							// Get pane command info from API sessions data
+							// Get pane command info from API sessions data (same peer —
+							// ids can collide across peers)
 							const apiSession = apiSessions.find(
-								(s) => s.id === activeSessionId,
+								(s) =>
+									s.id === activeSessionId &&
+									isSameNotificationPeer(s.peerId, activeSession?.peerId),
 							);
 							const apiPanes = apiSession?.panes;
 							// Agent color to Tailwind text class

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -11,11 +11,13 @@ import {
 	Unplug,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type {
-	PaneViewport,
-	SessionState,
-	SessionTheme,
-	TmuxLayoutNode,
+import {
+	LOCAL_PEER_ID,
+	type PaneViewport,
+	samePeerId,
+	type SessionState,
+	type SessionTheme,
+	type TmuxLayoutNode,
 } from "../../../shared/types";
 import {
 	sendTerminalInputRest,
@@ -25,6 +27,10 @@ import { usePeerConnection } from "../hooks/usePeerConnection";
 import { useRemoteControlMode } from "../hooks/useRemoteControlMode";
 import { sessionFetch } from "../services/peer-fetch";
 import { nukeClientCache } from "../utils/nuke-cache";
+import {
+	resolveSessionPeer,
+	type SessionPeerIntent,
+} from "../utils/sessionPeer";
 import { usePeers } from "../hooks/usePeers";
 import {
 	updateCachedSessionsByHookEvent,
@@ -45,6 +51,22 @@ import { SessionModal } from "./SessionModal";
 import type { ControlModeConfig, TerminalRef } from "./Terminal";
 
 const DESKTOP_STATE_KEY = "cchub-desktop-state";
+// The peer the user last picked a session from (persisted so a reload
+// reconnects the restored pane tree to the same peer's session).
+const SESSION_PEER_KEY = "cchub-desktop-session-peer";
+
+function loadSessionPeerIntent(): SessionPeerIntent | null {
+	try {
+		const raw = localStorage.getItem(SESSION_PEER_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw);
+		if (parsed && typeof parsed.id === "string" && typeof parsed.peerId === "string")
+			return parsed;
+	} catch {
+		// ignore
+	}
+	return null;
+}
 
 interface OpenSession {
 	id: string;
@@ -397,7 +419,11 @@ export function DesktopLayout({
 	const sessions =
 		apiSessions.length > 0
 			? apiSessions.map((apiSession) => {
-					const propSession = propSessions.find((p) => p.id === apiSession.id);
+					// id (workspace 名) は peer 間で重複し得るので peer も一致させる
+					const propSession = propSessions.find(
+						(p) =>
+							p.id === apiSession.id && samePeerId(p.peerId, apiSession.peerId),
+					);
 					return propSession
 						? {
 								...propSession,
@@ -570,6 +596,13 @@ export function DesktopLayout({
 			return;
 		}
 		appliedSessionSwitchRequestRef.current = sessionSwitchRequest.requestId;
+		// App が openSessions に対象セッションを（peer 込みで）登録済みなので、
+		// そこから intent を更新する。古い intent（同名別 peer の選択）を上書き
+		// しないと通知先の peer に繋がらない。
+		const target = propSessionsRef.current.find(
+			(s) => s.id === sessionSwitchRequest.sessionId,
+		);
+		recordSessionPeerIntent(sessionSwitchRequest.sessionId, target?.peerId);
 		setDesktopState((previous) => ({
 			...previous,
 			root: updateAllSessionIds(
@@ -597,8 +630,37 @@ export function DesktopLayout({
 	};
 
 	const controlSessionId = getControlSessionId();
-	const controlSessionInstanceId = sessions.find(
-		(session) => session.id === controlSessionId,
+	// The pane tree stores bare session ids, so the owning peer is re-resolved
+	// here — preferring the user's explicit pick over the merged list, where a
+	// same-name local session would win.
+	const [sessionPeerIntent, setSessionPeerIntent] =
+		useState<SessionPeerIntent | null>(loadSessionPeerIntent);
+	const sessionPeerIntentRef = useRef(sessionPeerIntent);
+	sessionPeerIntentRef.current = sessionPeerIntent;
+	const recordSessionPeerIntent = useCallback(
+		(id: string, peerId?: string) => {
+			const intent = { id, peerId: peerId ?? LOCAL_PEER_ID };
+			setSessionPeerIntent(intent);
+			try {
+				localStorage.setItem(SESSION_PEER_KEY, JSON.stringify(intent));
+			} catch {
+				// ignore quota errors
+			}
+		},
+		[],
+	);
+	const controlPeerId = resolveSessionPeer(
+		controlSessionId,
+		sessionPeerIntent,
+		propSessions,
+		sessions,
+	);
+	const controlSessionInstanceId = (
+		sessions.find(
+			(session) =>
+				session.id === controlSessionId &&
+				samePeerId(session.peerId, controlPeerId),
+		) ?? sessions.find((session) => session.id === controlSessionId)
 	)?.instanceId;
 	const [terminalGeneration, setTerminalGeneration] = useState(0);
 	const [controlLayout, setControlLayout] = useState<TmuxLayoutNode | null>(
@@ -607,7 +669,12 @@ export function DesktopLayout({
 
 	// Multi-server: アクティブセッションが remote peer の場合、そっちの WS に切り替える
 	const { peers } = usePeers();
-	const peerConn = usePeerConnection(controlSessionId || "", apiSessions, peers);
+	const peerConn = usePeerConnection(
+		controlSessionId || "",
+		apiSessions,
+		peers,
+		controlPeerId,
+	);
 
 	// Refs for remote-control REST operations (avoid re-creating callbacks)
 	const controlSessionIdRef = useRef(controlSessionId);
@@ -646,6 +713,9 @@ export function DesktopLayout({
 	const sessionsRef = useRef(sessions);
 	sessionsRef.current = sessions;
 
+	const propSessionsRef = useRef(propSessions);
+	propSessionsRef.current = propSessions;
+
 	// Resolve the peer that owns the currently-active pane's session, so
 	// image uploads land on the host whose Claude Code will read them.
 	const getActivePeerId = useCallback((): string | undefined => {
@@ -654,8 +724,12 @@ export function DesktopLayout({
 			activePaneRef.current,
 		);
 		const sid = pane?.type === "terminal" ? pane.sessionId : null;
-		if (!sid) return undefined;
-		return sessionsRef.current.find((s) => s.id === sid)?.peerId;
+		return resolveSessionPeer(
+			sid,
+			sessionPeerIntentRef.current,
+			propSessionsRef.current,
+			sessionsRef.current,
+		);
 	}, []);
 
 	// Timer for applying the server layout's exact pane sizes after a layout message
@@ -827,7 +901,16 @@ export function DesktopLayout({
 		(op: "focus" | "split" | "close", body: Record<string, unknown>) => {
 			const sid = controlSessionIdRef.current;
 			if (!sid) return;
-			const session = sessionsRef.current.find((s) => s.id === sid);
+			// sessionFetch は peerId しか見ない。同名衝突で local に化けないよう
+			// intent 優先で解決した peer を渡す。
+			const session = {
+				peerId: resolveSessionPeer(
+					sid,
+					sessionPeerIntentRef.current,
+					propSessionsRef.current,
+					sessionsRef.current,
+				),
+			};
 			sessionFetch(
 				session,
 				peersRef.current,
@@ -1627,25 +1710,39 @@ export function DesktopLayout({
 		return desktopState.root;
 	}, [desktopState.root, zoomedPaneId]);
 
-	// Get active session for file viewer
+	// Get active session for file viewer (same peer as the pane's intent —
+	// ids can collide across peers)
 	const activePane = findPaneById(desktopState.root, desktopState.activePane);
-	const activeSession =
-		activePane?.type === "terminal" && activePane.sessionId
-			? sessions.find((s) => s.id === activePane.sessionId)
-			: null;
+	const activePaneSessionId =
+		activePane?.type === "terminal" ? activePane.sessionId : null;
+	const activePanePeerId = resolveSessionPeer(
+		activePaneSessionId,
+		sessionPeerIntent,
+		propSessions,
+		sessions,
+	);
+	const activeSession = activePaneSessionId
+		? (sessions.find(
+				(s) =>
+					s.id === activePaneSessionId &&
+					samePeerId(s.peerId, activePanePeerId),
+			) ?? sessions.find((s) => s.id === activePaneSessionId))
+		: null;
 
 	// Handle session selection from modal
 	const handleModalSelectSession = useCallback(
-		(session: { id: string }) => {
+		(session: { id: string; peerId?: string; currentPath?: string }) => {
 			const paneId = activePaneRef.current;
+			// 選択した peer を記録してから pane を切り替える（同名の local
+			// セッションに接続してしまわないように）
+			recordSessionPeerIntent(session.id, session.peerId);
 			handleSelectSessionForPane(paneId, session.id);
 			// Update FileViewer active dir to follow session
-			const s = sessions.find((s) => s.id === session.id);
-			if (s?.currentPath) {
-				setActiveFileViewerDir(s.currentPath);
+			if (session.currentPath) {
+				setActiveFileViewerDir(session.currentPath);
 			}
 		},
-		[handleSelectSessionForPane, sessions],
+		[handleSelectSessionForPane, recordSessionPeerIntent],
 	);
 
 	return (

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -738,7 +738,7 @@ function SessionItem({
 	onSelectPane?: (session: ExtendedSessionResponse, paneId: string) => void;
 	onShowMenu: (session: ExtendedSessionResponse) => void;
 	onResume?: (sessionId: string, ccSessionId?: string) => void;
-	onDelete?: (sessionId: string) => void;
+	onDelete?: (sessionId: string, peerId?: string) => void;
 	onShowConversation?: (
 		ccSessionId: string,
 		title: string,
@@ -980,7 +980,7 @@ function SessionItem({
 						</button>
 						<button
 							type="button"
-							onClick={() => onDelete?.(session.id)}
+							onClick={() => onDelete?.(session.id, extSession.peerId)}
 							className="inline-flex items-center gap-1.5 px-3 py-1 rounded-md text-[12px] font-medium bg-zinc-600/20 text-zinc-400 hover:bg-red-600/20 hover:text-red-400 transition-colors"
 						>
 							<X className="w-3 h-3" />
@@ -1837,14 +1837,21 @@ export function WorkspaceList({
 
 	const handleMenuDelete = async () => {
 		if (sessionForMenu) {
-			await deleteSession(sessionForMenu.id);
+			await deleteSession(
+				sessionForMenu.id,
+				(sessionForMenu as ExtendedSessionResponse).peerId ?? LOCAL_PEER_ID,
+			);
 			setSessionForMenu(null);
 		}
 	};
 
 	const handleMenuChangeTheme = async (theme: SessionTheme | null) => {
 		if (sessionForMenu) {
-			await updateSessionTheme(sessionForMenu.id, theme);
+			await updateSessionTheme(
+				sessionForMenu.id,
+				theme,
+				(sessionForMenu as ExtendedSessionResponse).peerId ?? LOCAL_PEER_ID,
+			);
 			setSessionForMenu(null);
 		}
 	};
@@ -2122,7 +2129,9 @@ export function WorkspaceList({
 															onSelectPane={onSelectPane}
 															onShowMenu={handleShowMenu}
 															onResume={handleResume}
-															onDelete={(id) => deleteSession(id)}
+															onDelete={(id, peerId) =>
+																deleteSession(id, peerId ?? LOCAL_PEER_ID)
+															}
 															onShowConversation={handleShowConversation}
 															onPaneAction={handlePaneAction}
 															onClosePane={(sid, pid, name) =>

--- a/frontend/src/hooks/usePeerConnection.ts
+++ b/frontend/src/hooks/usePeerConnection.ts
@@ -17,11 +17,15 @@ export interface PeerConnectionInfo {
  * 指定したセッションが属する peer の WS接続情報を返す。
  * - sessionId が見つからない / peerId が local / 不明: Hub の接続情報を返す
  * - peerId が remote: peer.url から wsBase + apiBase を導出
+ * - preferredPeerId: セッション id は peer 間で重複し得る（herdr workspace 名）
+ *   ので、呼び出し側がユーザーの選択した peer を知っている場合はそれを渡す。
+ *   指定時は sessions からの id 検索（最初の一致 = local 優先）を行わない。
  */
 export function usePeerConnection(
 	sessionId: string,
 	sessions: ExtendedSessionResponse[],
 	peers: PeerClientView[],
+	preferredPeerId?: string,
 ): PeerConnectionInfo {
 	return useMemo(() => {
 		const hubInfo: PeerConnectionInfo = {
@@ -33,8 +37,8 @@ export function usePeerConnection(
 
 		if (!sessionId) return hubInfo;
 
-		const session = sessions.find((s) => s.id === sessionId);
-		const peerId = session?.peerId;
+		const peerId =
+			preferredPeerId ?? sessions.find((s) => s.id === sessionId)?.peerId;
 		if (!peerId || peerId === LOCAL_PEER_ID) return hubInfo;
 
 		const peer = peers.find((p) => p.id === peerId);
@@ -46,5 +50,5 @@ export function usePeerConnection(
 			token: peer.wsToken ?? null,
 			apiBase: peer.url.replace(/\/+$/, ""),
 		};
-	}, [sessionId, sessions, peers]);
+	}, [sessionId, sessions, peers, preferredPeerId]);
 }

--- a/frontend/src/hooks/useWorkspaces.ts
+++ b/frontend/src/hooks/useWorkspaces.ts
@@ -5,6 +5,7 @@ import {
 	type ExtendedSessionResponse,
 	type IndicatorState,
 	type PeerSession,
+	samePeerId,
 	type SessionResponse,
 	type SessionTheme,
 } from "../../../shared/types";
@@ -72,10 +73,13 @@ interface UseWorkspacesReturn {
 		// 省略時 or local 指定で Hub に作る。
 		peerId?: string,
 	) => Promise<ExtendedSessionResponse | null>;
-	deleteSession: (id: string) => Promise<boolean>;
+	// peerId: session ids (workspace labels) can collide across peers — pass the
+	// owning peer so the request doesn't resolve to the local same-name session.
+	deleteSession: (id: string, peerId?: string) => Promise<boolean>;
 	updateSessionTheme: (
 		id: string,
 		theme: SessionTheme | null,
+		peerId?: string,
 	) => Promise<boolean>;
 }
 
@@ -183,31 +187,53 @@ export function useWorkspaces(): UseWorkspacesReturn {
 		[peers],
 	);
 
-	const deleteSession = useCallback(async (id: string): Promise<boolean> => {
-		setError(null);
-		try {
-			const session = sessions.find((s) => s.id === id);
-			const response = await sessionFetch(session, peers, `/api/workspaces/${id}`, {
-				method: "DELETE",
-			});
-
-			if (!response.ok) throw new Error("Failed to delete session");
-
-			setSessions((prev) => prev.filter((s) => s.id !== id));
-			return true;
-		} catch (err) {
-			if (!isTransientNetworkError(err)) {
-				setError(err instanceof Error ? err.message : "Unknown error");
-			}
-			return false;
-		}
-	}, [sessions, peers]);
-
-	const updateSessionTheme = useCallback(
-		async (id: string, theme: SessionTheme | null): Promise<boolean> => {
+	const deleteSession = useCallback(
+		async (id: string, peerId?: string): Promise<boolean> => {
 			setError(null);
 			try {
-				const session = sessions.find((s) => s.id === id);
+				const session =
+					peerId !== undefined
+						? { peerId }
+						: sessions.find((s) => s.id === id);
+				const response = await sessionFetch(
+					session,
+					peers,
+					`/api/workspaces/${id}`,
+					{ method: "DELETE" },
+				);
+
+				if (!response.ok) throw new Error("Failed to delete session");
+
+				setSessions((prev) =>
+					prev.filter(
+						(s) =>
+							s.id !== id ||
+							(peerId !== undefined && !samePeerId(s.peerId, peerId)),
+					),
+				);
+				return true;
+			} catch (err) {
+				if (!isTransientNetworkError(err)) {
+					setError(err instanceof Error ? err.message : "Unknown error");
+				}
+				return false;
+			}
+		},
+		[sessions, peers],
+	);
+
+	const updateSessionTheme = useCallback(
+		async (
+			id: string,
+			theme: SessionTheme | null,
+			peerId?: string,
+		): Promise<boolean> => {
+			setError(null);
+			try {
+				const session =
+					peerId !== undefined
+						? { peerId }
+						: sessions.find((s) => s.id === id);
 				const response = await sessionFetch(
 					session,
 					peers,
@@ -223,7 +249,10 @@ export function useWorkspaces(): UseWorkspacesReturn {
 
 				setSessions((prev) =>
 					prev.map((s) =>
-						s.id === id ? { ...s, theme: theme ?? undefined } : s,
+						s.id === id &&
+						(peerId === undefined || samePeerId(s.peerId, peerId))
+							? { ...s, theme: theme ?? undefined }
+							: s,
 					),
 				);
 				return true;

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -34,6 +34,10 @@ interface PaneLeafInfo {
 interface TerminalPageProps {
 	sessionId: string;
 	sessionInstanceId?: string;
+	/** Peer that owns this session. Session ids (workspace labels) can collide
+	 *  across peers, so the caller's intent must be passed instead of being
+	 *  re-derived from an id lookup (which resolves to the local session). */
+	peerId?: string;
 	token?: string | null;
 	onStateChange?: (state: SessionState) => void;
 	overlayContent?: ReactNode;
@@ -59,6 +63,7 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 		{
 			sessionId,
 			sessionInstanceId,
+			peerId,
 			token,
 			onStateChange,
 			overlayContent,
@@ -117,9 +122,10 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 		// Multi-server: sessionId が remote peer のものなら、その peer の WS に接続する
 		const { peers } = usePeers();
 		const { sessions: apiSessions } = useWorkspaces();
-		const peerConn = usePeerConnection(sessionId, apiSessions, peers);
+		const peerConn = usePeerConnection(sessionId, apiSessions, peers, peerId);
 		// peerId of the session we're rendering; used to route image uploads.
-		const sessionPeerId = apiSessions.find((s) => s.id === sessionId)?.peerId;
+		const sessionPeerId =
+			peerId ?? apiSessions.find((s) => s.id === sessionId)?.peerId;
 
 		const controlTerminal = useMultiplexedTerminal({
 			sessionId,

--- a/frontend/src/utils/sessionPeer.test.ts
+++ b/frontend/src/utils/sessionPeer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSessionPeer } from "./sessionPeer";
+
+describe("resolveSessionPeer", () => {
+	// Same workspace label on both hosts — the collision this resolver exists for.
+	const merged = [
+		{ id: "cchub", peerId: undefined }, // local, first in display order
+		{ id: "cchub", peerId: "mac" },
+		{ id: "only-mac", peerId: "mac" },
+	];
+
+	test("no sid returns undefined", () => {
+		expect(resolveSessionPeer(null, null, [], merged)).toBeUndefined();
+	});
+
+	test("intent wins over open sessions and merged order", () => {
+		expect(
+			resolveSessionPeer(
+				"cchub",
+				{ id: "cchub", peerId: "mac" },
+				[{ id: "cchub", peerId: undefined }],
+				merged,
+			),
+		).toBe("mac");
+	});
+
+	test("intent for a different session is ignored", () => {
+		expect(
+			resolveSessionPeer("cchub", { id: "other", peerId: "mac" }, [], merged),
+		).toBeUndefined();
+	});
+
+	test("open session entry pins local explicitly when peerId is unset", () => {
+		expect(
+			resolveSessionPeer("cchub", null, [{ id: "cchub" }], merged),
+		).toBe("local");
+	});
+
+	test("open session entry carries its remote peer", () => {
+		expect(
+			resolveSessionPeer("cchub", null, [{ id: "cchub", peerId: "mac" }], merged),
+		).toBe("mac");
+	});
+
+	test("falls back to the merged list (first match) when no intent is known", () => {
+		expect(resolveSessionPeer("only-mac", null, [], merged)).toBe("mac");
+		// Collision without intent keeps the historical local-first behavior.
+		expect(resolveSessionPeer("cchub", null, [], merged)).toBeUndefined();
+	});
+});

--- a/frontend/src/utils/sessionPeer.ts
+++ b/frontend/src/utils/sessionPeer.ts
@@ -1,0 +1,27 @@
+import { LOCAL_PEER_ID } from "../../../shared/types";
+
+/** The peer the user last explicitly picked a session from. */
+export interface SessionPeerIntent {
+	id: string;
+	peerId: string;
+}
+
+/**
+ * Resolve which peer owns session `sid`. Session ids are herdr workspace
+ * labels and can collide across peers, so an id lookup in the merged list
+ * (local peer first) would silently pick the local session. Order of trust:
+ * the user's last explicit pick (intent), then the App-opened session entry,
+ * then the merged list.
+ */
+export function resolveSessionPeer(
+	sid: string | null | undefined,
+	intent: SessionPeerIntent | null,
+	openSessions: { id: string; peerId?: string }[],
+	mergedSessions: { id: string; peerId?: string }[],
+): string | undefined {
+	if (!sid) return undefined;
+	if (intent?.id === sid) return intent.peerId;
+	const open = openSessions.find((s) => s.id === sid);
+	if (open) return open.peerId ?? LOCAL_PEER_ID;
+	return mergedSessions.find((s) => s.id === sid)?.peerId;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -265,6 +265,13 @@ export type ResizeTerminalInput = z.infer<typeof ResizeTerminalSchema>;
 export const SELF_PEER_URL = 'self' as const;
 export const LOCAL_PEER_ID = 'local' as const;
 
+/** Compare peer ids treating unset / 'local' as the same (the local Hub).
+ *  Session ids are herdr workspace labels and can collide across peers, so
+ *  any session lookup by id must also match on the owning peer. */
+export function samePeerId(a?: string | null, b?: string | null): boolean {
+  return (a ?? LOCAL_PEER_ID) === (b ?? LOCAL_PEER_ID);
+}
+
 export type PeerStatus = 'online' | 'offline' | 'unauthorized' | 'unknown';
 
 export interface Peer {


### PR DESCRIPTION
## 問題

mac peer のセッションを開こうとしても、local に同名セッション（例: `wine-softdenchi`）があると必ず local 側のターミナルが開いてしまう。

## 原因

セッション id は herdr の workspace 名で、peer 間で衝突する。フロントの至る所で bare id だけで検索していた（`usePeerConnection`・DesktopLayout のマージ・リモコンモードの REST 操作・削除/テーマ変更・モバイルのライブ更新）ため、マージ済み一覧の先頭一致 = local セッションに解決されていた。

## 修正

選択時の「どの peer を選んだか」という意図を通す方式:

- **DesktopLayout**: session→peer の intent を保持（localStorage 永続化、セッションモーダル選択・通知遷移で更新）し、control WS 接続・REST ペイン操作・画像アップロード先・ファイルビューアの解決を `resolveSessionPeer`（intent → App の openSessions → マージ一覧の順）に一本化
- **usePeerConnection**: 呼び出し側が peer を知っている場合の `preferredPeerId` を追加
- **App**: openSessions を (id, peer) で照合し、同 id 別 peer は差し替え。モバイルの TerminalPage に peerId を伝搬、ライブ更新も peer 一致で照合
- **useWorkspaces**: 削除・テーマ変更に明示的な peerId を追加（同名の local workspace を誤って削除しない）

## 検証（dev + agent-browser、実際の mac peer 使用）

- 衝突状態を再現: `wine-softdenchi` が local (Codex) と mac (Claude) の両方に存在
- 修正後、mac 側カードをクリックすると `[MUX] target changed (wss://localhost:5173 → wss://makotomacbook-pro.tail4459c9.ts.net:5923); reconnecting` → 接続成功、mac 側の内容（Wine ビルド作業）が表示されることを確認
- `bun test frontend/src/` 62 pass（resolveSessionPeer のテスト追加）/ `bunx tsc --noEmit` / `bun run lint` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZvZCXfurraXBuTdfSABj7