### PR TITLE
Release v0.2.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.34] - 2026-07-20
+
+### Changed
+- **フロントのセッション識別を `peerId:id` 複合キーに全面移行** (#487): セッション id は herdr の workspace 名で peer 間で衝突するため、0.2.33 では「選択時の peer intent を記録して id 検索のたびに再解決する」応急処置になっていた。識別子自体を複合キー化し、pane ツリー (`PaneNode.sessionKey`)・アクティブセッション・開いているセッション一覧・localStorage 永続化をすべて `peerId:id` で持つように変更。WS subscribe / REST パスに乗せる直前に bare id へ分解するためサーバー側プロトコルは無変更。これにより同名の local / peer セッションを**同時に開ける**ようになり、`resolveSessionPeer` と intent 永続化 (`cchub-desktop-session-peer`) を削除。既存の localStorage は初回ロード時に一度だけ自動移行する
+
 ## [0.2.33] - 2026-07-20
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "generated": "2026-07-20",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "generated": "2026-07-20",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes

- refactor(peers): フロントのセッション識別を `peerId:id` 複合キーに全面移行 (#487, PR #489)

## Notes

セッション id（herdr workspace 名）の peer 間衝突に対する構造的な修正です。v0.2.33 の intent 方式（`resolveSessionPeer` + `cchub-desktop-session-peer`）を廃止し、pane ツリー・アクティブセッション・localStorage をすべて複合キーで持つようにしました。

- サーバー側プロトコルは無変更（WS subscribe / REST パス直前に bare id へ分解）
- 同名の local / peer セッションを同時に開けるようになりました
- 既存の localStorage は初回ロード時に一度だけ自動移行されます（旧 intent キーは削除）
- 検証: `bun test` 70 pass / lint / tsc / build クリーン、dev + agent-browser で実 peer（mac）のターミナル表示・リロード復元まで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZvZCXfurraXBuTdfSABj7