### PR TITLE
refactor: remove tmux-era respawn/break-pane UX and the pane-dead event (#478)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,6 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 - `POST /:id/panes/focus` - Focus a pane (`{ paneId }`)
 - `POST /:id/panes/close` - Close a pane (`{ paneId }`, rejects last pane)
 - `POST /:id/panes/split` - Split a pane (`{ paneId, direction: 'h'|'v' }`)
-- `POST /:id/panes/respawn` - Respawn a dead pane
 - `POST /:id/panes/input` - Send input to a pane over REST (used by `cchub send` / peers)
 - `GET /:id/panes/:paneId/viewport` - Capture a pane viewport over REST (used by `cchub peek` / `--wait`)
 - `POST /:id/tabs/select` - Switch the workspace's active tab (`{ tabId }`)
@@ -146,8 +145,8 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 **Terminal WebSocket** (`/ws/mux`):
 - Multiplexed WebSocket — single connection serves all sessions
 - Client subscribes/unsubscribes per session via JSON messages
-- Client messages (`MuxClientMessage`): `subscribe`, `unsubscribe`, `subscribe-conversation`, `unsubscribe-conversation`, then per-session (`ControlClientMessage`): `input`, `resize`, `split`, `close-pane`, `resize-pane`, `select-pane`, `adjust-pane`, `equalize-panes`, `zoom-pane`, `respawn-pane`, `request-viewport`, `select-tab`, `create-tab`, `close-tab`, `ping`, `client-info`
-- Server messages (`MuxServerMessage`): `subscribed`, `unsubscribed`, `sessions-updated`, `conversation-subscribed`, `conversation-unsubscribed`, `initial-conversation`, `conversation-update`, then per-session (`ControlServerMessage`): `layout`, `viewport`, `ready`, `pong`, `error`, `pane-dead`, `hook-event`
+- Client messages (`MuxClientMessage`): `subscribe`, `unsubscribe`, `subscribe-conversation`, `unsubscribe-conversation`, then per-session (`ControlClientMessage`): `input`, `resize`, `split`, `close-pane`, `resize-pane`, `select-pane`, `adjust-pane`, `equalize-panes`, `zoom-pane`, `request-viewport`, `select-tab`, `create-tab`, `close-tab`, `ping`, `client-info`
+- Server messages (`MuxServerMessage`): `subscribed`, `unsubscribed`, `sessions-updated`, `conversation-subscribed`, `conversation-unsubscribed`, `initial-conversation`, `conversation-update`, then per-session (`ControlServerMessage`): `layout`, `viewport`, `ready`, `pong`, `error`, `hook-event`
 - Server periodically pushes `sessions-updated` (5s interval) with full session list
 
 **Other**:
@@ -228,7 +227,7 @@ glasses/     # EVEN G2 smart glasses app (EvenHub SDK, built to out.ehpk)
 
 ### Frontend Hooks
 
-- **useMultiplexedTerminal.ts** - WebSocket connection to `/ws/mux` for multiplexed terminal I/O. Handles auto-reconnect, keepalive pings, session subscribe/unsubscribe, base64 I/O encoding, viewport dispatch (`onPaneViewport` callback). Returns `sendInput`, `resize`, `splitPane`, `closePane`, `selectPane`, `zoomPane`, `respawnPane`, `adjustPane`, `equalizePanes`, `requestViewport`, `sendClientInfo`
+- **useMultiplexedTerminal.ts** - WebSocket connection to `/ws/mux` for multiplexed terminal I/O. Handles auto-reconnect, keepalive pings, session subscribe/unsubscribe, base64 I/O encoding, viewport dispatch (`onPaneViewport` callback). Returns `sendInput`, `resize`, `splitPane`, `closePane`, `selectPane`, `zoomPane`, `adjustPane`, `equalizePanes`, `requestViewport`, `sendClientInfo`
 - **useSessions.ts** - Active sessions state management
 - **useSessionHistory.ts** - Session history browsing
 - **useDashboard.ts** - Dashboard data fetching

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -928,10 +928,6 @@ const PaneSplitSchema = z.object({
   direction: z.enum(['h', 'v']),
 });
 
-const PaneRespawnSchema = z.object({
-  paneId: PaneIdSchema,
-});
-
 const TabSelectSchema = z.object({
   tabId: TabIdSchema,
 });
@@ -1028,25 +1024,6 @@ sessions.post('/:id/panes/split', async (c) => {
   } catch (_error) {
     return c.json({ error: 'Failed to split pane' }, 500);
   }
-});
-
-// POST /sessions/:id/panes/respawn - Respawn a dead pane
-sessions.post('/:id/panes/respawn', async (c) => {
-  const id = c.req.param('id');
-  const body = await c.req.json().catch(() => ({}));
-  const parsed = PaneRespawnSchema.safeParse(body);
-
-  if (!parsed.success) {
-    return c.json({ error: 'Invalid request' }, 400);
-  }
-
-  const exists = await herdrService.workspaceExists(id);
-  if (!exists) {
-    return c.json({ error: 'Session not found' }, 404);
-  }
-
-  // herdr has no dead-pane/respawn concept; exited panes are closed.
-  return c.json({ error: 'respawn-pane is not supported' }, 501);
 });
 
 // POST /sessions/:id/tabs/select - Switch the workspace's active tab

--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -323,14 +323,6 @@ async function handleSubscribe(ws: ServerWebSocket<MuxData>, sessionId: string) 
       })
     );
 
-    cleanupFns.push(
-      controlSession.onPaneDead((paneId) => {
-        try {
-          ws.send(JSON.stringify({ type: 'pane-dead', paneId, sessionId }));
-        } catch { /* disconnected */ }
-      })
-    );
-
     // The client can disconnect while the awaits above are in flight. muxClose
     // has already run at that point and didn't see this subscription, so the
     // listeners and addClient() would leak (the grace period would never
@@ -664,19 +656,6 @@ async function handleControlMessage(
           }
         } catch (err) {
           console.warn(`[mux] zoom-pane failed for ${msg.paneId}:`, err);
-        }
-        break;
-      }
-      case 'respawn-pane': {
-        try {
-          await controlSession.respawnPane(msg.paneId);
-        } catch (e) {
-          ws.send(JSON.stringify({
-            type: 'error',
-            message: e instanceof Error ? e.message : 'Failed to respawn pane',
-            paneId: msg.paneId,
-            sessionId,
-          }));
         }
         break;
       }

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -89,7 +89,6 @@ export function assertPaneId(paneId: string): void {
 
 type LayoutListener = (layout: TmuxLayoutNode, zoomedPaneId: string | null) => void;
 type ExitListener = (reason: string) => void;
-type PaneDeadListener = (paneId: string) => void;
 
 /** Live terminal state tracked from a pane's frame stream. */
 export interface PaneRuntimeState {
@@ -261,7 +260,6 @@ export class HerdrControlSession {
   private globalOutputListeners = new Set<(paneId: string, data: Buffer) => void>();
   private layoutListeners = new Set<LayoutListener>();
   private exitListeners = new Set<ExitListener>();
-  private paneDeadListeners = new Set<PaneDeadListener>();
 
   private clientCount = 0;
   private graceTimer: Timer | null = null;
@@ -578,7 +576,6 @@ export class HerdrControlSession {
         this.stopController(this.toHerdr(tmuxId));
         this.paneSizes.delete(tmuxId);
         this.runtimeStates.delete(tmuxId);
-        for (const listener of this.paneDeadListeners) listener(tmuxId);
         changed = true;
       }
     }
@@ -618,9 +615,9 @@ export class HerdrControlSession {
       .map((p) => toTmuxPaneId(p.pane_id))
       .filter((id): id is string => id !== null);
 
-    // Tear down the outgoing tab's controllers / runtime state; those panes are
-    // not dead, just off-screen, so no pane-dead events — the new layout tells
-    // the client which panes exist now.
+    // Tear down the outgoing tab's controllers / runtime state; those panes
+    // are just off-screen — the new layout tells the client which panes exist
+    // now.
     for (const tmuxId of previousPaneIds) {
       this.stopController(this.toHerdr(tmuxId));
       this.paneSizes.delete(tmuxId);
@@ -827,11 +824,6 @@ export class HerdrControlSession {
       this.activePaneId = this.tree.paneIds()[0] ?? null;
     }
     await this.applyLayout();
-  }
-
-  async respawnPane(paneId: string): Promise<void> {
-    assertPaneId(paneId);
-    throw new Error('respawn-pane is not supported in herdr mode');
   }
 
   async resizePane(paneId: string, cols: number, rows: number): Promise<void> {
@@ -1046,10 +1038,6 @@ export class HerdrControlSession {
     });
   }
 
-  async breakPaneToNewSession(_paneId: string, _newSessionName: string): Promise<void> {
-    throw new Error('break-pane is not supported in herdr mode');
-  }
-
   // ==========================================================================
   // Public API - Listeners
   // ==========================================================================
@@ -1072,13 +1060,6 @@ export class HerdrControlSession {
     this.exitListeners.add(listener);
     return () => {
       this.exitListeners.delete(listener);
-    };
-  }
-
-  onPaneDead(listener: PaneDeadListener): () => void {
-    this.paneDeadListeners.add(listener);
-    return () => {
-      this.paneDeadListeners.delete(listener);
     };
   }
 
@@ -1180,7 +1161,6 @@ export class HerdrControlSession {
     this.globalOutputListeners.clear();
     this.layoutListeners.clear();
     this.exitListeners.clear();
-    this.paneDeadListeners.clear();
     this.clientDeviceTypes.clear();
     this.paneDemands.clear();
     this.clientSizes.clear();

--- a/backend/tests/unit/ws-message-validation.test.ts
+++ b/backend/tests/unit/ws-message-validation.test.ts
@@ -22,7 +22,6 @@ describe('MuxClientMessageSchema', () => {
       { type: 'adjust-pane', sessionId: 's1', paneId: '%0', direction: 'L', amount: 5 },
       { type: 'equalize-panes', sessionId: 's1', direction: 'horizontal' },
       { type: 'zoom-pane', sessionId: 's1', paneId: '%0' },
-      { type: 'respawn-pane', sessionId: 's1', paneId: '%0' },
       { type: 'request-viewport', sessionId: 's1', paneId: '%0', offset: 0 },
       { type: 'ping', sessionId: '', timestamp: 123 },
       { type: 'client-info', sessionId: 's1', deviceType: 'tablet' },

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -720,7 +720,6 @@ export function DesktopLayout({
 		sessionId: controlSessionId || "",
 		sessionInstanceId: controlSessionInstanceId,
 		peerWsBase: peerConn.wsBase,
-		peerApiBase: peerConn.apiBase,
 		token: peerConn.token,
 		live: !remoteControl,
 		onPaneViewport: (paneId, viewport) => {
@@ -1202,10 +1201,6 @@ export function DesktopLayout({
 					controlTerminalRef.current.zoomPane(paneId, zoomedPaneId !== paneId);
 				},
 		isZoomed: zoomedPaneId !== null,
-		respawnPane: (paneId: string) => {
-			controlTerminalRef.current.respawnPane(paneId);
-		},
-		deadPanes: controlTerminal.deadPanes,
 		setKeyboardVisible: isTablet
 			? (visible: boolean) => setShowKeyboard(visible)
 			: undefined,

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -15,15 +15,12 @@ import {
 	type SessionState,
 	type SessionTheme,
 } from "../../../shared/types";
-import { authFetch } from "../services/api";
 import { openClaudeAppSession } from "../utils/claude-app";
 import { makeSessionKey, parseSessionKey } from "../utils/sessionKey";
 import { toHomeShortPath } from "../utils/path";
 import { ChatView } from "./chat/ChatView";
 import type { ControlModeConfig } from "./Terminal";
 import { TerminalComponent, type TerminalRef } from "./Terminal";
-
-const API_BASE = import.meta.env.VITE_API_URL || "";
 
 // ペインノード型定義。
 // sessionKey は `peerId:id` の複合キー (utils/sessionKey.ts) — セッション id
@@ -65,8 +62,6 @@ export interface ControlModeContext {
 	closePane: (paneId: string) => void;
 	zoomPane?: (paneId: string) => void;
 	isZoomed?: boolean;
-	respawnPane?: (paneId: string) => void;
-	deadPanes?: Set<string>;
 	onCopyPrompt?: (text: string) => void;
 	setKeyboardVisible?: (visible: boolean) => void;
 	onShowSessions?: () => void;
@@ -196,7 +191,6 @@ function TerminalPane({
 	isTablet = false,
 	controlModeContext,
 }: TerminalPaneProps) {
-	const isDead = controlModeContext.deadPanes?.has(paneId) ?? false;
 	const { t } = useTranslation();
 	const terminalRef = useRef<TerminalRef>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -635,68 +629,6 @@ function TerminalPane({
 					)}
 				</div>
 			</div>
-
-			{/* Dead pane overlay */}
-			{isDead && (
-				<div className="absolute inset-0 z-40 flex items-center justify-center bg-black/60 backdrop-blur-[2px]">
-					<div className="flex flex-col items-center gap-4 px-8 py-6 bg-th-surface/95 border border-th-border rounded-xl shadow-2xl max-w-xs">
-						<div className="w-10 h-10 rounded-full bg-red-500/20 flex items-center justify-center">
-							<svg
-								aria-hidden="true"
-								className="w-5 h-5 text-red-400"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-							>
-								<path
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									strokeWidth={2}
-									d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"
-								/>
-							</svg>
-						</div>
-						<p className="text-th-text text-sm font-medium">
-							{t("pane.processExited")}
-						</p>
-						<div className="flex gap-2 w-full">
-							<button
-								type="button"
-								onClick={(e) => {
-									e.stopPropagation();
-									controlModeContext.respawnPane?.(paneId);
-								}}
-								className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors"
-							>
-								{t("pane.restart")}
-							</button>
-							<button
-								type="button"
-								onClick={(e) => {
-									e.stopPropagation();
-									if (sessionTarget) {
-										authFetch(
-											`${API_BASE}/api/workspaces/${encodeURIComponent(sessionTarget.id)}`,
-											{
-												method: "DELETE",
-											},
-										)
-											.then(() => {
-												window.location.reload();
-											})
-											.catch(() => {
-												window.location.reload();
-											});
-									}
-								}}
-								className="flex-1 px-4 py-2 bg-th-surface-hover hover:bg-th-border text-th-text-secondary rounded-lg text-sm font-medium transition-colors"
-							>
-								{t("common.close")}
-							</button>
-						</div>
-					</div>
-				</div>
-			)}
 
 			{/* Terminal, conversation, or session selector */}
 			<div className="flex-1 min-h-0">

--- a/frontend/src/hooks/useMultiplexedTerminal.ts
+++ b/frontend/src/hooks/useMultiplexedTerminal.ts
@@ -18,16 +18,11 @@ interface UseMultiplexedTerminalOptions {
 	// Multi-server: アクティブな peer の WS base URL ("wss://host:port") を指定。
 	// 省略時は Hub (window.location.host) を使う。
 	peerWsBase?: string | null;
-	// REST API base URL for the peer that owns this session ("" for Hub, e.g.
-	// "https://peer:port" for a remote peer). Used by REST fallbacks when the
-	// mux WebSocket is closed. #256
-	peerApiBase?: string | null;
 	onPaneViewport?: (paneId: string, viewport: PaneViewport) => void;
 	onLayoutChange?: (
 		layout: TmuxLayoutNode,
 		zoomedPaneId: string | null,
 	) => void;
-	onPaneDead?: (paneId: string) => void;
 	onHookEvent?: (
 		event: string,
 		cwd?: string,
@@ -77,8 +72,6 @@ interface UseMultiplexedTerminalReturn {
 	// until the next request-viewport.
 	requestViewport: (paneId: string, offset: number) => void;
 	zoomPane: (paneId: string, zoomed?: boolean) => void;
-	respawnPane: (paneId: string) => void;
-	deadPanes: Set<string>;
 }
 
 // =============================================================================
@@ -149,7 +142,6 @@ type MuxCallbacks = {
 		layout: TmuxLayoutNode,
 		zoomedPaneId: string | null,
 	) => void;
-	onPaneDead?: (paneId: string) => void;
 	onHookEvent?: (
 		event: string,
 		cwd?: string,
@@ -162,10 +154,8 @@ type MuxCallbacks = {
 	onSessionExit?: (reason: string) => void;
 	onError?: (error: string, paneId?: string) => void;
 	setIsConnected?: (v: boolean) => void;
-	setDeadPanes?: (fn: (prev: Set<string>) => Set<string>) => void;
 	sessionId: string;
 	sessionInstanceId?: string;
-	deadPanes: Set<string>;
 	/** When false, subscribeToSession is a no-op (remote-control mode). */
 	live?: boolean;
 };
@@ -205,7 +195,6 @@ function subscribeToSession(
 	subscribedSession = sessionId;
 	subscribedSessionInstance = sessionInstanceId ?? null;
 	activeCallbacks?.setIsConnected?.(false);
-	activeCallbacks?.setDeadPanes?.(() => new Set());
 	sendRaw({ type: "subscribe", sessionId });
 }
 
@@ -394,14 +383,6 @@ function ensureConnection(token?: string | null, wsBase?: string | null) {
 				cb?.onError?.(msg.message as string, msg.paneId as string | undefined);
 				break;
 			}
-			case "pane-dead": {
-				if (msgSessionId !== currentSession) return;
-				cb?.setDeadPanes?.((prev: Set<string>) =>
-					new Set(prev).add(msg.paneId as string),
-				);
-				cb?.onPaneDead?.(msg.paneId as string);
-				break;
-			}
 			case "hook-event": {
 				cb?.onHookEvent?.(
 					msg.event as string,
@@ -574,8 +555,8 @@ export function sendTerminalInput(
 /**
  * REST variant of sendTerminalInput for remote-control mode: the mux WS rejects
  * input for sessions this client is not subscribed to, so route through
- * POST /panes/input instead (same peer-aware base+token pattern as the
- * respawnPane fallback). Resolves true only when the server accepted the input.
+ * POST /panes/input instead (peer-aware base+token, see #256). Resolves true
+ * only when the server accepted the input.
  */
 export async function sendTerminalInputRest(
 	peerApiBase: string | null | undefined,
@@ -636,13 +617,11 @@ function dispatchInputEcho(
 export function useMultiplexedTerminal(
 	options: UseMultiplexedTerminalOptions,
 ): UseMultiplexedTerminalReturn {
-	const { sessionId, sessionInstanceId, token, peerWsBase, peerApiBase } = options;
+	const { sessionId, sessionInstanceId, token, peerWsBase } = options;
 	const [isConnected, setIsConnected] = useState(false);
-	const [deadPanes, setDeadPanes] = useState<Set<string>>(new Set());
 
 	const onPaneViewportRef = useRef(options.onPaneViewport);
 	const onLayoutChangeRef = useRef(options.onLayoutChange);
-	const onPaneDeadRef = useRef(options.onPaneDead);
 	const onHookEventRef = useRef(options.onHookEvent);
 	const onConnectRef = useRef(options.onConnect);
 	const onDisconnectRef = useRef(options.onDisconnect);
@@ -651,7 +630,6 @@ export function useMultiplexedTerminal(
 
 	onPaneViewportRef.current = options.onPaneViewport;
 	onLayoutChangeRef.current = options.onLayoutChange;
-	onPaneDeadRef.current = options.onPaneDead;
 	onHookEventRef.current = options.onHookEvent;
 	onConnectRef.current = options.onConnect;
 	onDisconnectRef.current = options.onDisconnect;
@@ -662,17 +640,14 @@ export function useMultiplexedTerminal(
 		activeCallbacks = {
 			onPaneViewport: (p, v) => onPaneViewportRef.current?.(p, v),
 			onLayoutChange: (l, z) => onLayoutChangeRef.current?.(l, z),
-			onPaneDead: (p) => onPaneDeadRef.current?.(p),
 			onHookEvent: (e, c, s, d, m) => onHookEventRef.current?.(e, c, s, d, m),
 			onConnect: () => onConnectRef.current?.(),
 			onDisconnect: () => onDisconnectRef.current?.(),
 			onSessionExit: (reason) => onSessionExitRef.current?.(reason),
 			onError: (e, p) => onErrorRef.current?.(e, p),
 			setIsConnected,
-			setDeadPanes,
 			sessionId,
 			sessionInstanceId,
-			deadPanes,
 			live: options.live ?? true,
 		};
 	});
@@ -800,45 +775,6 @@ export function useMultiplexedTerminal(
 		sendSessionMessage({ type: "zoom-pane", paneId, zoomed });
 	}, []);
 
-	const respawnPane = useCallback(
-		(paneId: string) => {
-			setDeadPanes((prev) => {
-				const next = new Set(prev);
-				next.delete(paneId);
-				return next;
-			});
-			if (sharedWs?.readyState === WebSocket.OPEN) {
-				sendSessionMessage({ type: "respawn-pane", paneId });
-				return;
-			}
-			// WS is down — fall back to REST. The old fallback used plain fetch()
-			// against the Hub origin: it 401'd under password auth (no Bearer
-			// header) and POSTed to the wrong server for peer sessions. Route
-			// through authFetch for local and the peer base+token for remote. #256
-			const path = `/api/workspaces/${encodeURIComponent(sessionId)}/panes/respawn`;
-			const body = JSON.stringify({ paneId });
-			const headers: HeadersInit = { "Content-Type": "application/json" };
-			const isRemotePeer = peerApiBase && peerApiBase.length > 0;
-			const request = isRemotePeer
-				? (() => {
-						const peerHeaders = new Headers(headers);
-						if (token) peerHeaders.set("Authorization", `Bearer ${token}`);
-						return fetchWithTimeout(`${peerApiBase}${path}`, {
-							method: "POST",
-							headers: peerHeaders,
-							body,
-						});
-					})()
-				: authFetch(
-						`${import.meta.env.VITE_API_URL || ""}${path}`,
-						{ method: "POST", headers, body },
-					);
-			const reconnect = () => setTimeout(() => ensureConnection(), 500);
-			request.then(reconnect).catch(reconnect);
-		},
-		[sessionId, token, peerApiBase],
-	);
-
 	return {
 		isConnected,
 		connect,
@@ -857,8 +793,6 @@ export function useMultiplexedTerminal(
 		sendPaneDemands,
 		requestViewport,
 		zoomPane,
-		respawnPane,
-		deadPanes,
 	};
 }
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -283,9 +283,7 @@
 		"active": "Active",
 		"confirmClose": "Close?",
 		"cannotCloseLast": "Cannot close the last pane",
-		"paneTab": "Pane {{id}}",
-		"processExited": "Process exited",
-		"restart": "Restart"
+		"paneTab": "Pane {{id}}"
 	},
 	"url": {
 		"noUrls": "No URLs found",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -283,9 +283,7 @@
 		"active": "アクティブ",
 		"confirmClose": "閉じる?",
 		"cannotCloseLast": "最後のペインは閉じられません",
-		"paneTab": "ペイン {{id}}",
-		"processExited": "プロセスが終了しました",
-		"restart": "再起動"
+		"paneTab": "ペイン {{id}}"
 	},
 	"url": {
 		"noUrls": "URLが見つかりません",

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -132,7 +132,6 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 			sessionInstanceId,
 			token: peerConn.token ?? token,
 			peerWsBase: peerConn.wsBase,
-			peerApiBase: peerConn.apiBase,
 			onPaneViewport: (paneId, viewport) => {
 				lastViewportRef.current.set(paneId, viewport);
 				let perPane = paneViewportCacheRef.current.get(paneId);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -884,7 +884,6 @@ export type ControlClientMessage =
   // older clients / the glasses app). Mobile always sends an explicit value so
   // that re-issuing zoom on reconnect is idempotent rather than a toggle.
   | { type: 'zoom-pane'; paneId: string; zoomed?: boolean }
-  | { type: 'respawn-pane'; paneId: string }
   // Ask the server for a viewport `offset` rows above the live edge.
   // offset=0 means live mode; the server will also push fresh viewports
   // unsolicited when new output arrives.
@@ -911,7 +910,6 @@ export type ControlServerMessage =
   | { type: 'pong'; timestamp: number }
   | { type: 'session-exited'; reason: string }
   | { type: 'error'; message: string; paneId?: string }
-  | { type: 'pane-dead'; paneId: string }
   | { type: 'hook-event'; event: string; cwd?: string; sessionId?: string; message?: string; data?: Record<string, unknown> };
 
 // =============================================================================
@@ -963,7 +961,6 @@ const controlClientMessageOptions = [
   // `zoomed` carries the explicit zoom/unzoom intent; without it here zod
   // strips the field and the server silently falls back to toggle semantics.
   z.object({ type: z.literal('zoom-pane'), paneId: PaneIdSchema, zoomed: z.boolean().optional() }),
-  z.object({ type: z.literal('respawn-pane'), paneId: PaneIdSchema }),
   z.object({ type: z.literal('request-viewport'), paneId: PaneIdSchema, offset: WsOffset }),
   z.object({ type: z.literal('select-tab'), tabId: TabIdSchema }),
   z.object({ type: z.literal('create-tab') }),


### PR DESCRIPTION
## 概要

#478 の対応（B案: 撤去。方針は AskUserQuestion で確認済み）。

tmux の `remain-on-exit` 前提で設計された respawn UX と pane-dead イベントは、herdr にその概念が無いため破綻していた:

- **herdr に dead pane は存在しない** — herdr 0.7.4 で実測: pane 内プロセスの exit で pane は `pane.list` から即座に消え、最後の pane なら workspace ごと消える。CLI/socket API に respawn 相当の操作も無い（`pane run` は生きた shell へのコマンド投入、`agent start` は新規 pane 作成）
- `respawnPane` / `breakPaneToNewSession` は無条件 throw なのに、WS スキーマ・mux dispatch・REST(501)・dead-pane オーバーレイの Restart ボタンまで全経路が配線済みだった
- `pane-dead` は意味が反転: 「pane が pane.list から消えた」= 正常な外部 close で発火し、本来駆動するはずのオーバーレイは表示され得ない（同じ更新で pane が layout から消えるため）

## 変更内容

機能を end-to-end で撤去（-224 行）:

- shared: `respawn-pane`(client) / `pane-dead`(server) メッセージ型と zod スキーマ
- backend: mux dispatch、`POST /:id/panes/respawn`、`HerdrControlSession` の respawn/breakPane/paneDead リスナー機構
- frontend: `deadPanes` state、dead-pane オーバーレイ、respawn 配線、未使用化した `peerApiBase` オプション、locale キー (`pane.processExited` / `pane.restart`)
- CLAUDE.md のプロトコル記述を追随

エージェント復活は既存の resume 経路（`POST /:id/resume`、履歴 resume、herdr の `resume_agents_on_restore`）がカバー。glasses/ はこれらのメッセージを参照していないため ehpk 再ビルド不要。

## 検証 (dev, Vite https://localhost:5173)

- ✅ 2 pane 構成で片方の shell を exit → pane がオーバーレイなしで自然に消え、残 pane がフル幅にレイアウト（誤報の解消）
- ✅ split / close / zoom の通常操作は無傷
- ✅ lint / tsc (frontend+backend) / 全テスト緑（respawn-pane を valid frame として期待していたスキーマテストは追随修正）

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjXwsv7QKW7DCAeW5KwFSM