### PR TITLE
fix: ペインindicatorで古いhookオーバーライドがherdrの生きた状態に勝つのを修正（偽の許可待ちバッジ）

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -186,6 +186,30 @@ export function herdrStatusToIndicator(status?: string): IndicatorState | null {
   }
 }
 
+/**
+ * Per-pane indicator, same priority as the session level: herdr's per-pane
+ * status is the source of truth and hook state only fills in what herdr can't
+ * see. A hook override can sit stale for most of a turn — nothing fires
+ * between an answered AskUserQuestion and the turn's Stop — so it must never
+ * outrank a live herdr status (a stale `waiting_input` here becomes a false
+ * 許可待ち badge on the workspace card). Thread agents keep hooks first,
+ * mirroring the session-level rule (#390: herdr's accuracy there is
+ * unverified).
+ */
+export function paneIndicatorState(opts: {
+  paneAgent?: AgentProvider;
+  paneAgentStatus?: string;
+  sessionIndicator: IndicatorState;
+  hookState: IndicatorState | null;
+}): IndicatorState {
+  if (!opts.paneAgent) return 'idle';
+  const herdrState = herdrStatusToIndicator(opts.paneAgentStatus);
+  if (agentSupportsConversationMetadata(opts.paneAgent)) {
+    return herdrState ?? opts.sessionIndicator;
+  }
+  return opts.hookState ?? herdrState ?? 'idle';
+}
+
 export const sessions = new Hono();
 
 /** Build the full sessions list (shared by HTTP handler and WS push) */
@@ -317,16 +341,12 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
       metrics: sessionMetrics,
       panes: s.panes ? await Promise.all(s.panes.map(async (p) => {
         const isSessionAgentOnPane = !!p.agent;
-        const isClaudeOnPane = isSessionAgentOnPane && includeClaudeInfo;
-        let paneIndicator: IndicatorState | undefined;
-        if (isClaudeOnPane) {
-          // Use session-level indicator for Claude panes (hook/jsonl based)
-          paneIndicator = indicatorState === 'completed' ? 'waiting_input' : indicatorState;
-        } else if (includeThreadInfo && isSessionAgentOnPane) {
-          paneIndicator = hookState ?? 'idle';
-        } else {
-          paneIndicator = 'idle';
-        }
+        const paneIndicator = paneIndicatorState({
+          paneAgent: p.agent,
+          paneAgentStatus: p.agentStatus,
+          sessionIndicator: indicatorState,
+          hookState,
+        });
         // Per-pane metrics + recap only for agent panes of a multi workspace
         // (see isMultiWorkspace); Claude panes get ctx/model/recap from their
         // own .jsonl, any agent pane gets memory from its pid.
@@ -349,7 +369,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
           agent: p.agent,
           agentSessionId: p.agentSessionId,
           isActive: p.isActive,
-          indicatorState: isSessionAgentOnPane ? (hookState ?? paneIndicator) : paneIndicator,
+          indicatorState: paneIndicator,
           pid: p.pid,
           metrics: paneMetrics,
           recap: paneClaude?.lastRecap?.content,

--- a/backend/src/services/__tests__/herdr-agent-indicator.test.ts
+++ b/backend/src/services/__tests__/herdr-agent-indicator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { herdrStatusToIndicator } from '../../routes/sessions';
+import { herdrStatusToIndicator, paneIndicatorState } from '../../routes/sessions';
 import { parseHookJson, parseHookToml } from '../hook-status';
 
 /**
@@ -23,6 +23,99 @@ describe('herdrStatusToIndicator', () => {
     expect(herdrStatusToIndicator('unknown')).toBeNull();
     expect(herdrStatusToIndicator(undefined)).toBeNull();
     expect(herdrStatusToIndicator('thinking_very_hard')).toBeNull();
+  });
+});
+
+describe('paneIndicatorState', () => {
+  it('never lets a stale hook override outrank a live herdr status', () => {
+    // Repro of the false 許可待ち badge: PostToolUse/AskUserQuestion set a
+    // waiting_input override (24h TTL), the user answered, and Claude kept
+    // working — nothing fires to clear the override until Stop, but herdr
+    // already reports `working`.
+    expect(
+      paneIndicatorState({
+        paneAgent: 'claude',
+        paneAgentStatus: 'working',
+        sessionIndicator: 'processing',
+        hookState: 'waiting_input',
+      }),
+    ).toBe('processing');
+  });
+
+  it('shows waiting_input when herdr itself reports blocked', () => {
+    expect(
+      paneIndicatorState({
+        paneAgent: 'claude',
+        paneAgentStatus: 'blocked',
+        sessionIndicator: 'waiting_input',
+        hookState: null,
+      }),
+    ).toBe('waiting_input');
+  });
+
+  it('does not remap a completed Claude pane to waiting_input', () => {
+    // The tmux-era pane list showed idle-at-prompt as waiting_input; today
+    // that state pulses yellow and derives the card's 許可待ち badge, so a
+    // finished turn must stay `completed` even while a stale override lives.
+    expect(
+      paneIndicatorState({
+        paneAgent: 'claude',
+        paneAgentStatus: 'done',
+        sessionIndicator: 'completed',
+        hookState: 'waiting_input',
+      }),
+    ).toBe('completed');
+  });
+
+  it('falls back to the session indicator when herdr has no status for a Claude pane', () => {
+    expect(
+      paneIndicatorState({
+        paneAgent: 'claude',
+        paneAgentStatus: undefined,
+        sessionIndicator: 'processing',
+        hookState: null,
+      }),
+    ).toBe('processing');
+  });
+
+  it('keeps hooks first for thread agents, then herdr, then idle', () => {
+    // Mirrors the session-level rule: herdr's status accuracy for thread
+    // agents is unverified (#390).
+    expect(
+      paneIndicatorState({
+        paneAgent: 'codex',
+        paneAgentStatus: 'working',
+        sessionIndicator: 'processing',
+        hookState: 'completed',
+      }),
+    ).toBe('completed');
+    expect(
+      paneIndicatorState({
+        paneAgent: 'kimi',
+        paneAgentStatus: 'idle',
+        sessionIndicator: 'completed',
+        hookState: null,
+      }),
+    ).toBe('completed');
+    expect(
+      paneIndicatorState({
+        paneAgent: 'codex',
+        paneAgentStatus: undefined,
+        sessionIndicator: 'completed',
+        hookState: null,
+      }),
+    ).toBe('idle');
+  });
+
+  it('reports idle for panes with no agent', () => {
+    expect(
+      paneIndicatorState({
+        paneAgent: undefined,
+        paneAgentStatus: 'working',
+        sessionIndicator: 'processing',
+        hookState: 'processing',
+      }),
+    ).toBe('idle');
   });
 });
 


### PR DESCRIPTION
## 問題

ワークスペースカードに「許可待ち」バッジが出るが、実際には許可プロンプトは出ておらず Claude は普通に実行中だった（herdr `agent_status` = `working`）。

## 原因

3つの連鎖:

1. **古い hook オーバーライド**: `PostToolUse`/`AskUserQuestion` hook が `waiting_input` オーバーライド（TTL 24時間）をセットする。質問に回答してもそれを消すイベントがない（`UserPromptSubmit`/`PreToolUse` は v0.2.2 以降発火せず、`Stop` はターン終了まで来ない）ため、長いターンの残り全部で `waiting_input` が残る。
2. **ペインだけ優先順位が逆**: セッションレベルは `herdrState ?? hookState`（#390 の「herdr が source of truth」）なのに、ペインは `hookState ?? paneIndicator` で hook が herdr に勝っていた（tmux 時代の名残）。
3. **カードバッジはペイン由来**: `WorkspaceList` はペインのどれかが `waiting_input` ならバッジを出すため、ペインの古い状態がそのまま「許可待ち」表示になる。

## 修正

- ペイン indicator をセッションレベルと同じ優先順位に統一する純関数 `paneIndicatorState()` を追加: herdr の per-pane status（`herdr.ts` が既に返している）が最優先、hook は herdr が見えないペインの補完のみ。thread agent（codex/grok/kimi）はセッションレベル同様 hook 優先を維持（#390: herdr 精度未検証）。
- tmux 時代の「completed → waiting_input」ペイン再マップを削除。現 UI ではこの状態は黄色パルス + カードバッジに繋がるため、hook 未設置時にも同種の偽バッジを生んでいた。

## 検証

- ユニットテスト追加（報告シナリオの再現含む）: backend 428 pass / frontend 74 pass / lint clean
- dev 検証（port 3457、修正版バックエンド）: 実行中セッション（herdr=`working`）に `AskUserQuestion` の古いオーバーライドを注入 → ペインは `processing` を維持（旧コードでは `waiting_input` になっていた。本番で実測済み）。ターン完了済みセッションへの注入でも `completed` を維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjXwsv7QKW7DCAeW5KwFSM