### PR TITLE
feat(workspace): ワークスペース一覧にダッシュボードトグルを追加

### DIFF
--- a/frontend/src/components/SessionModal.tsx
+++ b/frontend/src/components/SessionModal.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { SessionResponse } from "../../../shared/types";
+import { DashboardPanel } from "./DashboardPanel";
 import { WorkspaceList } from "./WorkspaceList";
 
 interface SessionModalProps {
@@ -15,6 +16,8 @@ export function SessionModal({
 	onSelectSession,
 	isTablet,
 }: SessionModalProps) {
+	const [showDashboard, setShowDashboard] = useState(false);
+
 	// Close on Escape
 	useEffect(() => {
 		if (!isOpen) return;
@@ -40,21 +43,36 @@ export function SessionModal({
 	if (!isOpen) return null;
 
 	// Desktop only: scale up. Tablet keeps native size so touch targets are
-	// unchanged.
+	// unchanged. Applied per-column so the dashboard panel (which self-zooms via
+	// its own isTablet) isn't double-scaled.
 	const desktopZoom = isTablet ? undefined : { zoom: 1.25 };
 
 	return (
-		<div
-			className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0a]"
-			style={desktopZoom}
-		>
-			<div className="flex-1 min-h-0 overflow-hidden w-full h-full">
+		<div className="fixed inset-0 z-50 flex bg-[#0a0a0a]">
+			{/* Workspace list: takes the free space and shrinks to the left when the
+			    dashboard opens, so it stays fully visible beside the panel instead
+			    of being covered by it. */}
+			<div
+				className="flex-1 min-w-0 min-h-0 overflow-hidden h-full"
+				style={desktopZoom}
+			>
 				<WorkspaceList
 					onSelectSession={handleSelectSession}
 					inline={true}
 					onClose={onClose}
+					onToggleDashboard={() => setShowDashboard((v) => !v)}
+					dashboardOpen={showDashboard}
 				/>
 			</div>
+
+			{/* Dashboard side panel (right) */}
+			{showDashboard && (
+				<DashboardPanel
+					isOpen={true}
+					onClose={() => setShowDashboard(false)}
+					isTablet={isTablet}
+				/>
+			)}
 		</div>
 	);
 }

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -8,6 +8,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import {
 	ArrowRight,
+	BarChart3,
 	ChevronLeft,
 	ChevronRight,
 	ExternalLink,
@@ -155,6 +156,8 @@ interface SessionListProps {
 	inline?: boolean; // true for side panel, false for fullscreen
 	contentScale?: number; // Scale factor for content (tabs remain fixed)
 	isOnboarding?: boolean; // Show dummy session for onboarding
+	onToggleDashboard?: () => void; // Show a dashboard toggle in the header when provided
+	dashboardOpen?: boolean; // Active state for the dashboard toggle button
 }
 
 // Session menu dialog (color change + title edit + delete)
@@ -1490,6 +1493,8 @@ export function WorkspaceList({
 	inline = false,
 	contentScale,
 	isOnboarding = false,
+	onToggleDashboard,
+	dashboardOpen = false,
 }: SessionListProps) {
 	const { t } = useTranslation();
 	const {
@@ -1962,6 +1967,20 @@ export function WorkspaceList({
 							</div>
 						</div>
 						<div className="flex items-center gap-1 shrink-0">
+							{onToggleDashboard && (
+								<button
+									type="button"
+									onClick={onToggleDashboard}
+									className={`p-2 rounded-lg transition-colors ${
+										dashboardOpen
+											? "text-blue-400 bg-blue-500/20"
+											: "text-zinc-500 hover:text-zinc-300 hover:bg-white/[0.06]"
+									}`}
+									title={t("dashboard.title")}
+								>
+									<BarChart3 className="w-[18px] h-[18px]" />
+								</button>
+							)}
 							<button
 								type="button"
 								onClick={() => setShowSearch(!showSearch)}


### PR DESCRIPTION
## 概要

ワークスペース一覧（フルスクリーンの `SessionModal`）のヘッダーにダッシュボードボタンを追加。押すとダッシュボードが右サイドパネルとして開き、ワークスペース一覧は左に寄って隠れずに横並び表示される。

## 変更点

- **WorkspaceList.tsx**: `onToggleDashboard` / `dashboardOpen` props を追加。渡された時だけヘッダー（検索の左隣）にダッシュボードトグルボタンを表示。開いている間はアクティブ表示。props 未指定のモバイル直接オーバーレイ経路は従来通り変化なし。
- **SessionModal.tsx**: 全画面の縦フレックスから横フレックスに変更し、一覧を `flex-1`、`DashboardPanel` を右サイドパネルとして横並び配置。ダッシュボード表示時は一覧が残り幅に縮んで左に寄る。zoom は各カラム独立適用でパネルの二重ズームを回避。

## 動作確認（dev / agent-browser）

- ✅ 一覧ヘッダーにダッシュボードボタン表示
- ✅ クリックで右にダッシュボード、一覧は2カラムのまま左に寄って全て見える
- ✅ 再クリックでトグルオフ、一覧が全幅に戻る
- ✅ lint / tsc / コンソール・devログともエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)