### PR TITLE
Release v0.2.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.37] - 2026-07-21
+
+### Added
+- **ワークスペース一覧にダッシュボードトグルを追加** (#497): 全画面のワークスペース一覧（`SessionModal`）のヘッダーにダッシュボードボタンを追加。押すと `DashboardPanel` が右サイドパネルとして開き、ワークスペース一覧は `flex-1` で残り幅に縮んで左に寄り、ダッシュボードに隠れず横並びで表示される。再クリックでトグルオフし一覧が全幅に戻る。`WorkspaceList` に `onToggleDashboard` / `dashboardOpen` props を追加し、渡された時だけボタンを表示するため props 未指定のモバイル直接オーバーレイ経路は従来通り変化なし。zoom は各カラム独立適用でパネルの二重ズームを回避。dev で「ボタン表示 → 一覧が2カラムのまま左に寄る → トグルオフで全幅復帰」を検証済み（`frontend/src/components/SessionModal.tsx` / `WorkspaceList.tsx`）
+
 ## [0.2.36] - 2026-07-21
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "generated": "2026-07-21",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "generated": "2026-07-21",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- feat: ワークスペース一覧にダッシュボードトグルを追加 (#497) — 一覧ヘッダーのボタンでダッシュボードを右サイドパネルとして開き、一覧は左に寄って隠れずに横並び表示。再クリックでトグルオフ

## Notes
- モバイル直接オーバーレイ経路は props 未指定のため従来通り変化なし
- dev / agent-browser で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)