### PR TITLE
feat(glasses): voice input — glasses mic → Groq STT → prompt

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import { dashboard } from './routes/dashboard';
 import { notify } from './routes/notify';
 import { peers } from './routes/peers';
 import { herdr } from './routes/herdr';
+import { glasses } from './routes/glasses';
 import { muxOpen, muxMessage, muxClose, type MuxData } from './routes/terminal-mux';
 import { parseArgs, runCli, VERSION } from './cli';
 import { conditionalAuthMiddleware, isAuthRequired, getJwtSecret, initJwtSecret } from './middleware/auth';
@@ -164,6 +165,7 @@ app.use('/api/dashboard', conditionalAuthMiddleware);
 app.use('/api/peers', conditionalAuthMiddleware);
 app.use('/api/peers/*', conditionalAuthMiddleware);
 app.use('/api/herdr/*', conditionalAuthMiddleware);
+app.use('/api/glasses/*', conditionalAuthMiddleware);
 
 app.route('/api/logs', logs);
 app.route('/api/sessions', sessions);
@@ -175,6 +177,7 @@ app.route('/api/dashboard', dashboard);
 app.route('/api/notify', notify);
 app.route('/api/peers', peers);
 app.route('/api/herdr', herdr);
+app.route('/api/glasses', glasses);
 
 // Static files handling
 const staticRoot = process.env.STATIC_ROOT || '../frontend/dist';

--- a/backend/src/routes/glasses.ts
+++ b/backend/src/routes/glasses.ts
@@ -1,0 +1,101 @@
+import { Hono } from 'hono';
+
+const glasses = new Hono();
+
+const GROQ_STT_URL = 'https://api.groq.com/openai/v1/audio/transcriptions';
+const GROQ_MODEL = 'whisper-large-v3-turbo';
+const MAX_AUDIO_BYTES = 25 * 1024 * 1024; // Groq's file limit
+
+/**
+ * Wrap raw little-endian 16-bit PCM into a minimal WAV container so Groq's
+ * transcription endpoint (which wants a real audio file) accepts it.
+ */
+function pcmToWav(pcm: Uint8Array, sampleRate: number, channels = 1, bitsPerSample = 16): Uint8Array {
+  const blockAlign = (channels * bitsPerSample) / 8;
+  const byteRate = sampleRate * blockAlign;
+  const header = Buffer.alloc(44);
+  header.write('RIFF', 0);
+  header.writeUInt32LE(36 + pcm.length, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16); // fmt chunk size
+  header.writeUInt16LE(1, 20); // audio format = PCM
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write('data', 36);
+  header.writeUInt32LE(pcm.length, 40);
+  return Buffer.concat([header, Buffer.from(pcm)]);
+}
+
+/**
+ * POST /api/glasses/stt — transcribe audio via Groq whisper-large-v3-turbo.
+ *
+ * Body: raw audio bytes (application/octet-stream).
+ *   - Default: little-endian 16-bit mono PCM at `?sampleRate=` (default 16000);
+ *     the server wraps it into a WAV before forwarding to Groq.
+ *   - `?format=wav`: body is already a complete WAV/other audio file — forwarded as-is.
+ * Query: `?sampleRate=<n>` (PCM only), `?lang=<code>` (default `ja`).
+ * Response: `{ text }`.
+ *
+ * Used by the G2 glasses voice-input flow (SDK gives raw mic PCM only, so STT
+ * is done server-side; the key never leaves this host).
+ */
+glasses.post('/stt', async (c) => {
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) {
+    return c.json({ error: 'GROQ_API_KEY not set on the server' }, 503);
+  }
+
+  const format = c.req.query('format') || 'pcm';
+  const sampleRate = Number(c.req.query('sampleRate')) || 16000;
+  const lang = c.req.query('lang') || 'ja';
+
+  const raw = new Uint8Array(await c.req.arrayBuffer());
+  if (raw.length === 0) {
+    return c.json({ error: 'empty audio body' }, 400);
+  }
+  if (raw.length > MAX_AUDIO_BYTES) {
+    return c.json({ error: 'audio too large' }, 413);
+  }
+
+  const wav = format === 'wav' ? raw : pcmToWav(raw, sampleRate);
+
+  try {
+    // Copy into a freshly-allocated ArrayBuffer-backed view so the Blob part
+    // types cleanly (Bun's Uint8Array is ArrayBufferLike, not ArrayBuffer).
+    const wavBytes = new Uint8Array(wav.length);
+    wavBytes.set(wav);
+
+    const form = new FormData();
+    form.append('file', new Blob([wavBytes.buffer], { type: 'audio/wav' }), 'audio.wav');
+    form.append('model', GROQ_MODEL);
+    form.append('language', lang);
+    form.append('response_format', 'json');
+    // Greedy decoding keeps short commands fast and deterministic.
+    form.append('temperature', '0');
+
+    const res = await fetch(GROQ_STT_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: form,
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      console.error(`[glasses/stt] Groq ${res.status}: ${detail.slice(0, 300)}`);
+      return c.json({ error: `STT provider error (${res.status})` }, 502);
+    }
+
+    const data = (await res.json()) as { text?: string };
+    const text = (data.text || '').trim();
+    return c.json({ text });
+  } catch (err) {
+    console.error('[glasses/stt] transcription failed:', err);
+    return c.json({ error: 'transcription failed' }, 500);
+  }
+});
+
+export { glasses };

--- a/bun.lock
+++ b/bun.lock
@@ -61,10 +61,10 @@
       "name": "glasses",
       "version": "0.1.0",
       "dependencies": {
-        "@evenrealities/even_hub_sdk": "^0.0.9",
+        "@evenrealities/even_hub_sdk": "^0.0.12",
       },
       "devDependencies": {
-        "@evenrealities/evenhub-cli": "^0.1.11",
+        "@evenrealities/evenhub-cli": "^0.1.13",
         "typescript": "~5.9.3",
         "vite": "^8.0.1",
       },
@@ -329,9 +329,9 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "@evenrealities/even_hub_sdk": ["@evenrealities/even_hub_sdk@0.0.9", "", {}, "sha512-LlqqX1sp3sgBs86DSZs5J4nzTnoAV0ZHwcEo1xtOB9cGSrrgNv+6wMiVmR4CfynVeT5NJs/xE3hwO0Hvep17mg=="],
+    "@evenrealities/even_hub_sdk": ["@evenrealities/even_hub_sdk@0.0.12", "", {}, "sha512-PXAeuPl7dMIlSWlctDeQAodIr7iuNROaH9GvRrZ86xzRh33DkMJYY1hSxy6BTk+TLkDA0tYlVi4bOsSIJngINA=="],
 
-    "@evenrealities/evenhub-cli": ["@evenrealities/evenhub-cli@0.1.11", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^14.0.2", "inquirer": "^13.1.0", "js-yaml": "^4.1.1", "open": "^11.0.0", "qrcode": "^1.5.4", "zod": "^4.3.2" }, "peerDependencies": { "typescript": "^5" }, "bin": { "evenhub": "main.js", "eh": "main.js" } }, "sha512-NDbku18NzYH15g+OxB/6FtMW2m+ySneG87GXOxsWoTdCFgpobVTYNJjjZMoUdyTy4NwfMElziDRBVmaCZE2eMg=="],
+    "@evenrealities/evenhub-cli": ["@evenrealities/evenhub-cli@0.1.13", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^14.0.2", "inquirer": "^13.1.0", "js-yaml": "^4.1.1", "open": "^11.0.0", "qr-image": "^3.2.0", "qrcode-terminal": "^0.12.0", "zod": "^4.3.2" }, "peerDependencies": { "typescript": "^5" }, "bin": { "evenhub": "main.js", "eh": "main.js" } }, "sha512-glkkGfImds8ceh1YTbVvwuw7jlcSAKnI6Q7ATrDynKSvODs9/FV/R+0CliyCog3JJRTON0+EXBLW3lxU4x8NBQ=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
 
@@ -587,9 +587,9 @@
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -635,8 +635,6 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
-
     "caniuse-lite": ["caniuse-lite@1.0.30001766", "", {}, "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
@@ -654,8 +652,6 @@
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
-
-    "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -685,8 +681,6 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
-
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
@@ -707,8 +701,6 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
-
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
@@ -717,7 +709,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.278", "", {}, "sha512-dQ0tM1svDRQOwxnXxm+twlGTjr9Upvt8UFWAgmLsxEzFQxhbti4VwxmMjsDxVC51Zo84swW7FVCXEV+VAkhuPw=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
@@ -763,8 +755,6 @@
 
     "filelist": ["filelist@1.0.4", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q=="],
 
-    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
@@ -784,8 +774,6 @@
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
-
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -967,8 +955,6 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
@@ -1095,17 +1081,9 @@
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
-    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
-    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
-
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
-
-    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1121,8 +1099,6 @@
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
-    "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
-
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
@@ -1135,7 +1111,9 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
+    "qr-image": ["qr-image@3.2.0", "", {}, "sha512-rXKDS5Sx3YipVsqmlMJsJsk6jXylEpiHRC2+nJy66fxA5ExYyGa4PqwteW69SaVmAb2OQ18HbYriT7cGQMbduw=="],
+
+    "qrcode-terminal": ["qrcode-terminal@0.12.0", "", { "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="],
 
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
 
@@ -1169,11 +1147,7 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
-
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -1202,8 +1176,6 @@
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
-
-    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -1241,7 +1213,7 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1257,7 +1229,7 @@
 
     "stringify-object": ["stringify-object@3.3.0", "", { "dependencies": { "get-own-enumerable-property-symbols": "^3.0.0", "is-obj": "^1.0.1", "is-regexp": "^1.0.0" } }, "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1357,8 +1329,6 @@
 
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
 
-    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
-
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
     "workbox-background-sync": ["workbox-background-sync@7.4.0", "", { "dependencies": { "idb": "^7.0.1", "workbox-core": "7.4.0" } }, "sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w=="],
@@ -1393,29 +1363,17 @@
 
     "workbox-window": ["workbox-window@7.4.0", "", { "dependencies": { "@types/trusted-types": "^2.0.2", "workbox-core": "7.4.0" } }, "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw=="],
 
-    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
-    "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
-
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
-    "yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
-
-    "yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@rollup/plugin-babel/rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
 
@@ -1461,6 +1419,12 @@
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -1471,11 +1435,11 @@
 
     "workbox-build/rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
 
-    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@rollup/plugin-node-resolve/@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -1507,8 +1471,14 @@
 
     "@tailwindcss/vite/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "vite-plugin-pwa/vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vite-plugin-pwa/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/glasses/package.json
+++ b/glasses/package.json
@@ -14,10 +14,10 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@evenrealities/even_hub_sdk": "^0.0.9"
+    "@evenrealities/even_hub_sdk": "^0.0.12"
   },
   "devDependencies": {
-    "@evenrealities/evenhub-cli": "^0.1.11",
+    "@evenrealities/evenhub-cli": "^0.1.13",
     "typescript": "~5.9.3",
     "vite": "^8.0.1"
   }

--- a/glasses/src/api.ts
+++ b/glasses/src/api.ts
@@ -34,3 +34,28 @@ export async function getConversation(ccSessionId: string, last = 10): Promise<C
     return []
   }
 }
+
+/** Send raw 16-bit mono PCM to the server for Groq transcription. Returns the recognized text. */
+export async function transcribe(pcm: Uint8Array, sampleRate = 16000): Promise<string> {
+  // Copy into a tightly-sized ArrayBuffer so the fetch body types cleanly.
+  const body = new Uint8Array(pcm.length)
+  body.set(pcm)
+  const res = await fetch(`${baseUrl}/api/glasses/stt?sampleRate=${sampleRate}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: body.buffer,
+  })
+  if (!res.ok) throw new Error(`STT ${res.status}`)
+  const data = (await res.json()) as { text?: string }
+  return (data.text || '').trim()
+}
+
+/** Send a free-text prompt to a session (bracketed paste + Enter server-side = submit). */
+export async function sendPrompt(sessionId: string, text: string): Promise<void> {
+  const res = await fetch(`${baseUrl}/api/sessions/${encodeURIComponent(sessionId)}/prompt`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  })
+  if (!res.ok) throw new Error(`prompt ${res.status}`)
+}

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -5,6 +5,7 @@ import {
   RebuildPageContainer,
   TextContainerUpgrade,
   OsEventTypeList,
+  AudioInputSource,
 } from '@evenrealities/even_hub_sdk'
 import { formatMessage } from './types.ts'
 import type { Session, ConversationMessage } from './types.ts'
@@ -13,7 +14,8 @@ const W = 576
 const H = 288
 
 export type Bridge = Awaited<ReturnType<typeof waitForEvenAppBridge>>
-type Mode = 'session_list' | 'conversation' | 'choice'
+type Mode = 'session_list' | 'conversation' | 'choice' | 'voice'
+export type VoicePhase = 'recording' | 'transcribing' | 'confirm'
 
 // Display metrics (measured on actual G2 hardware)
 // Body container: 568x210, border=0, padding=6 → effective 556x198
@@ -167,6 +169,26 @@ export interface AppState {
   choiceOptions: string[]
   apiUsagePercent: string
   debugEvent?: string
+  voicePhase?: VoicePhase
+  voiceText?: string
+}
+
+// ─── Microphone control (glasses mic → raw PCM via onEvenHubEvent) ───
+
+export async function startMic(bridge: Bridge | null): Promise<boolean> {
+  if (!bridge) return false
+  try {
+    return await bridge.audioControl(true, AudioInputSource.Glasses)
+  } catch {
+    return false
+  }
+}
+
+export async function stopMic(bridge: Bridge | null): Promise<void> {
+  if (!bridge) return
+  try {
+    await bridge.audioControl(false)
+  } catch { /* ignore */ }
 }
 
 function sName(s: Session): string {
@@ -231,6 +253,31 @@ function choiceBody(state: AppState): string {
     const cursor = i === state.choiceIndex ? '>>>' : '   '
     return `${cursor} ${opt}`
   }).join('\n')
+}
+
+function voiceContent(state: AppState): { headerText: string; bodyText: string; footerText: string } {
+  const session = state.sessions[state.sessionIndex]
+  const name = session ? sName(session) : '---'
+  switch (state.voicePhase) {
+    case 'recording':
+      return {
+        headerText: `${name}  [録音中]`,
+        bodyText: '● 録音中\n\nマイクに向かって話してください',
+        footerText: 'tap:停止して認識  dbl:キャンセル',
+      }
+    case 'transcribing':
+      return {
+        headerText: `${name}  [認識中]`,
+        bodyText: '認識中…',
+        footerText: 'dbl:キャンセル',
+      }
+    default: // 'confirm'
+      return {
+        headerText: `${name}  [確認]`,
+        bodyText: state.voiceText ? state.voiceText : '(認識できませんでした)',
+        footerText: state.voiceText ? 'tap:送信  dbl:キャンセル' : 'dbl:戻る',
+      }
+  }
 }
 
 // ─── Page builders ───
@@ -355,6 +402,45 @@ function buildChoice(state: AppState): RebuildPageContainer {
   })
 }
 
+function buildVoice(state: AppState): RebuildPageContainer {
+  const { headerText, bodyText, footerText } = voiceContent(state)
+
+  const header = new TextContainerProperty({
+    xPosition: 0, yPosition: 0,
+    width: W, height: 36,
+    borderWidth: 0,
+    paddingLength: 4,
+    containerID: 1, containerName: 'header',
+    isEventCapture: 0,
+    content: headerText,
+  })
+
+  const body = new TextContainerProperty({
+    xPosition: 4, yPosition: 36,
+    width: W - 8, height: H - 36 - 36,
+    borderWidth: 0,
+    paddingLength: 6,
+    containerID: 2, containerName: 'body',
+    isEventCapture: 0,
+    content: bodyText,
+  })
+
+  const footer = new TextContainerProperty({
+    xPosition: 0, yPosition: H - 36,
+    width: W, height: 36,
+    borderWidth: 0,
+    paddingLength: 4,
+    containerID: 3, containerName: 'footer',
+    isEventCapture: 1,
+    content: footerText,
+  })
+
+  return new RebuildPageContainer({
+    containerTotalNum: 3,
+    textObject: [header, body, footer],
+  })
+}
+
 export function buildSetupGuide(): RebuildPageContainer {
   const header = new TextContainerProperty({
     xPosition: 0, yPosition: 0,
@@ -450,6 +536,7 @@ export async function updateDisplay(bridge: Bridge | null, state: AppState): Pro
       case 'session_list': container = buildSessionList(state); break
       case 'conversation': container = buildConversation(state); break
       case 'choice': container = buildChoice(state); break
+      case 'voice': container = buildVoice(state); break
     }
     await bridge.rebuildPageContainer(container)
     return
@@ -495,6 +582,24 @@ export async function updateDisplay(bridge: Bridge | null, state: AppState): Pro
       }))
       break
     }
+    case 'voice': {
+      const { headerText, bodyText, footerText } = voiceContent(state)
+      await Promise.all([
+        bridge.textContainerUpgrade(new TextContainerUpgrade({
+          containerID: 1, containerName: 'header',
+          content: headerText,
+        })),
+        bridge.textContainerUpgrade(new TextContainerUpgrade({
+          containerID: 2, containerName: 'body',
+          content: bodyText,
+        })),
+        bridge.textContainerUpgrade(new TextContainerUpgrade({
+          containerID: 3, containerName: 'footer',
+          content: footerText,
+        })),
+      ])
+      break
+    }
   }
 }
 
@@ -508,6 +613,7 @@ export function setupEvents(
     onTap: () => void
     onDoubleTap: () => void
     onRawEvent?: (raw: string) => void
+    onAudioData?: (pcm: Uint8Array) => void
   },
 ): void {
   if (!bridge) return
@@ -515,6 +621,23 @@ export function setupEvents(
   const EVENT_DEBOUNCE = 300
 
   bridge.onEvenHubEvent((event) => {
+    // Mic PCM arrives on the same event channel; route it out before ring handling.
+    // Runtime shape may be Uint8Array, number[], or base64 string (host/JSON dependent).
+    const audio = event.audioEvent?.audioPcm as unknown
+    if (audio) {
+      let bytes: Uint8Array | null = null
+      if (audio instanceof Uint8Array) bytes = audio
+      else if (Array.isArray(audio)) bytes = new Uint8Array(audio as number[])
+      else if (typeof audio === 'string') {
+        const bin = atob(audio)
+        const u = new Uint8Array(bin.length)
+        for (let i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i)
+        bytes = u
+      }
+      if (bytes && bytes.length) callbacks.onAudioData?.(bytes)
+      return
+    }
+
     const raw = JSON.stringify(event).slice(0, 80)
     callbacks.onRawEvent?.(raw)
 

--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -1,5 +1,5 @@
-import { getDashboard, getConversation, setBaseUrl } from './api.ts'
-import { initDisplay, updateDisplay, setupEvents, buildSetupGuide, getMultiCountAt, getTotalPagesAt } from './display.ts'
+import { getDashboard, getConversation, setBaseUrl, transcribe, sendPrompt } from './api.ts'
+import { initDisplay, updateDisplay, setupEvents, buildSetupGuide, getMultiCountAt, getTotalPagesAt, startMic, stopMic } from './display.ts'
 import type { AppState } from './display.ts'
 import { startPhoneUI } from './phone-ui.ts'
 import { CcHubWsClient } from './ws-client.ts'
@@ -10,6 +10,20 @@ const LS_KEY = 'cchub-url'
 const POLL_INTERVAL = 5000
 const INITIAL_LOAD_COUNT = 20
 const LOAD_MORE_INCREMENT = 20
+const MIC_SAMPLE_RATE = 16000
+
+/** Concatenate collected PCM chunks into one contiguous buffer. */
+function concatPcm(chunks: Uint8Array[]): Uint8Array {
+  let len = 0
+  for (const c of chunks) len += c.length
+  const out = new Uint8Array(len)
+  let off = 0
+  for (const c of chunks) {
+    out.set(c, off)
+    off += c.length
+  }
+  return out
+}
 
 const state: AppState = {
   mode: 'session_list',
@@ -189,6 +203,63 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
   })
   wsClient.connect()
 
+  // ── Voice input: glasses mic → PCM → Groq STT → prompt ──
+  let audioChunks: Uint8Array[] = []
+  let recording = false
+
+  async function startVoice() {
+    if (!currentSession()) return
+    audioChunks = []
+    state.mode = 'voice'
+    state.voicePhase = 'recording'
+    state.voiceText = ''
+    updateDisplay(bridge, state)
+    recording = true
+    const ok = await startMic(bridge)
+    if (!ok) {
+      recording = false
+      state.voicePhase = 'confirm'
+      state.voiceText = ''
+      updateDisplay(bridge, state)
+    }
+  }
+
+  async function stopAndTranscribe() {
+    if (!recording) return
+    recording = false
+    await stopMic(bridge)
+    state.voicePhase = 'transcribing'
+    updateDisplay(bridge, state)
+    try {
+      const pcm = concatPcm(audioChunks)
+      state.voiceText = pcm.length > 0 ? await transcribe(pcm, MIC_SAMPLE_RATE) : ''
+    } catch {
+      state.voiceText = ''
+    }
+    state.voicePhase = 'confirm'
+    updateDisplay(bridge, state)
+  }
+
+  async function sendVoice() {
+    const s = currentSession()
+    const text = state.voiceText?.trim()
+    if (s && text) {
+      try { await sendPrompt(s.id, text) } catch { /* ignore */ }
+    }
+    state.mode = 'conversation'
+    updateDisplay(bridge, state)
+    loadConversation().then(() => updateDisplay(bridge, state))
+  }
+
+  async function cancelVoice() {
+    if (recording) {
+      recording = false
+      await stopMic(bridge)
+    }
+    state.mode = 'conversation'
+    updateDisplay(bridge, state)
+  }
+
   const handlers = {
     async swipeUp() {
       switch (state.mode) {
@@ -279,10 +350,9 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
               state.choiceIndex = 0
             }
           } else {
-            // Refresh conversation + reconnect WS if needed
-            if (wsClient.getState() !== 'OPEN') wsClient.connect()
-            if (s) wsClient.subscribe(s.id)
-            await loadConversation()
+            // Non-waiting session → start a free-text voice reply
+            await startVoice()
+            return
           }
         }
           break
@@ -295,10 +365,19 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
           state.mode = 'conversation'
           break
         }
+        case 'voice': {
+          if (state.voicePhase === 'recording') await stopAndTranscribe()
+          else if (state.voicePhase === 'confirm' && state.voiceText) await sendVoice()
+          return
+        }
       }
       updateDisplay(bridge, state)
     },
     async doubleTap() {
+      if (state.mode === 'voice') {
+        await cancelVoice()
+        return
+      }
       if (state.mode === 'conversation' || state.mode === 'choice') {
         // If viewing a waiting session, jump to next waiting session
         const waitingSessions = state.sessions
@@ -332,6 +411,9 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
     onSwipeUp: handlers.swipeUp,
     onTap: handlers.tap,
     onDoubleTap: handlers.doubleTap,
+    onAudioData: (pcm) => {
+      if (recording) audioChunks.push(pcm)
+    },
   })
 
   // Poll dashboard for API usage


### PR DESCRIPTION
G2グラスからハンズフリー音声入力でセッションに返信/プロンプト送信する機能。

## 実装
- **backend**: `POST /api/glasses/stt` — 生PCM(16k mono s16le)をWAV化して **Groq whisper-large-v3-turbo (language=ja)** に転送→`{text}`。鍵はサーバ側から出ない(SDKは生PCMしか渡さないため)。
- **glasses**: 新 voice モード(録音→認識→確認→送信)。`audioControl(true, Glasses)` + `onEvenHubEvent` のPCM取得、結果を `/sessions/:id/prompt`(bracketed paste+Enter=submit)へ。
- **SDK bump**: EvenHub SDK 0.0.9→0.0.12、evenhub-cli 0.1.11→0.1.13。

## 検証
- Groq経路を実測: sample日本語WAV(6s)で「新しいタスクを作成してください 明日の予定を教えて」を **0.35s** で正しく認識。
- dev backend 経由の `POST /api/glasses/stt`(生PCM) も 200/0.36s で同結果。
- glasses: typecheck / build 通過。
- サービスへの `GROQ_API_KEY` 供給は `~/.zshenv` 方式(herdrと同経路)で設定済み。

## 実機に残るタスク(本PR後)
- ehpk 再ビルド→EVEN Hub アップロード→Beta(`/glasses-upload`)。
- 実機でマイクPCM形式の確認(16kHz/mono/s16le 仮定)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)