### PR TITLE
fix(setup): bake PATH into systemd units so hooks resolve (#499)

### DIFF
--- a/backend/src/commands/__tests__/setup-service-path.test.ts
+++ b/backend/src/commands/__tests__/setup-service-path.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { buildServicePath } from '../setup';
+
+/**
+ * #499: supervised systemd units launch via `zsh -lc` (login, non-interactive),
+ * which does NOT source `.zshrc`. Users add `~/.local/bin` / `~/bin` to PATH
+ * there, so the server and its spawned hooks lose those dirs and fail with
+ * `command not found`. buildServicePath() bakes a complete PATH for the unit,
+ * guaranteeing the two home bin dirs are present regardless of inherited PATH.
+ */
+
+const ORIGINAL_PATH = process.env.PATH;
+
+afterEach(() => {
+  process.env.PATH = ORIGINAL_PATH;
+});
+
+describe('buildServicePath', () => {
+  const home = homedir();
+  const localBin = join(home, '.local', 'bin');
+  const homeBin = join(home, 'bin');
+
+  test('prepends ~/.local/bin and ~/bin even when the inherited PATH omits them', () => {
+    process.env.PATH = '/usr/local/bin:/usr/bin';
+    const dirs = buildServicePath().split(':');
+    expect(dirs[0]).toBe(localBin);
+    expect(dirs[1]).toBe(homeBin);
+    expect(dirs).toContain('/usr/bin');
+  });
+
+  test('does not duplicate the home bin dirs already present in PATH', () => {
+    process.env.PATH = `${homeBin}:${localBin}:/usr/bin`;
+    const dirs = buildServicePath().split(':');
+    expect(dirs.filter((d) => d === localBin)).toHaveLength(1);
+    expect(dirs.filter((d) => d === homeBin)).toHaveLength(1);
+  });
+
+  test('falls back to standard dirs when PATH is empty', () => {
+    process.env.PATH = '';
+    const dirs = buildServicePath().split(':');
+    expect(dirs).toEqual([localBin, homeBin, '/usr/local/bin', '/usr/bin', '/bin']);
+  });
+
+  test('escapes % so systemd does not treat it as a unit specifier', () => {
+    process.env.PATH = '/opt/we%rd/bin';
+    expect(buildServicePath()).toContain('/opt/we%%rd/bin');
+  });
+});

--- a/backend/src/commands/setup.ts
+++ b/backend/src/commands/setup.ts
@@ -9,6 +9,37 @@ import { herdrBinaryPath } from '../services/herdr-client';
 import { migrateCodexHooksToJson } from '../services/codex-hook-config';
 import { storePassword as storePasswordInKeychain } from '../utils/keychain';
 
+/**
+ * PATH to bake into the systemd units (`Environment=PATH=`).
+ *
+ * #499: the supervised units launch via `zsh -lc`, a *login but non-interactive*
+ * shell that sources `.zshenv`/`.zprofile` but NOT `.zshrc`. Users commonly add
+ * `~/.local/bin` / `~/bin` to PATH in `.zshrc`, so the supervised server (and
+ * everything it spawns — resumed agents and their Claude Code hooks) can't find
+ * `cchub` / `herdr` / `rtk` / `claude` and hooks fail with `command not found`.
+ *
+ * `cchub setup` is run from the user's interactive terminal, so `process.env.PATH`
+ * here already includes their `.zshrc` additions. Bake that in, guaranteeing the
+ * two home bin dirs are present up front regardless of what the inherited PATH
+ * looks like. `%` is doubled because systemd treats it as a specifier in units.
+ */
+export function buildServicePath(): string {
+  const home = homedir();
+  const inherited = (process.env.PATH ?? '').split(':').filter(Boolean);
+  // If PATH is somehow empty, still guarantee the standard system dirs so the
+  // service can find `/usr/bin/env` etc.
+  const base = inherited.length > 0 ? inherited : ['/usr/local/bin', '/usr/bin', '/bin'];
+  const seen = new Set<string>();
+  const dirs: string[] = [];
+  for (const dir of [join(home, '.local', 'bin'), join(home, 'bin'), ...base]) {
+    if (!seen.has(dir)) {
+      seen.add(dir);
+      dirs.push(dir);
+    }
+  }
+  return dirs.join(':').replace(/%/g, '%%');
+}
+
 /** Escape special characters for safe inclusion in XML/plist content. */
 function escapeXml(s: string): string {
   return s
@@ -29,6 +60,7 @@ After=network.target tailscaled.service
 Type=simple
 ExecStart=__SHELL__ -lc 'exec __EXEC_PATH__ -p __PORT__'
 EnvironmentFile=%h/.config/cchub/env
+Environment=PATH=__PATH__
 KillMode=process
 Restart=always
 RestartSec=3
@@ -135,6 +167,7 @@ ExecStart=__HERDR_PATH__ server
 Restart=always
 RestartSec=2
 Environment=LANG=en_US.UTF-8
+Environment=PATH=__PATH__
 
 [Install]
 WantedBy=default.target
@@ -289,7 +322,10 @@ async function provisionHerdr(): Promise<void> {
     const systemdDir = join(homedir(), '.config', 'systemd', 'user');
     await mkdir(systemdDir, { recursive: true });
     const unitPath = join(systemdDir, 'herdr.service');
-    await writeFile(unitPath, HERDR_SYSTEMD_SERVICE.replace(/__HERDR_PATH__/g, herdrPath));
+    await writeFile(
+      unitPath,
+      HERDR_SYSTEMD_SERVICE.replace(/__HERDR_PATH__/g, herdrPath).replace(/__PATH__/g, buildServicePath()),
+    );
     console.log(t('setup.herdrServiceFile', { path: unitPath }));
     Bun.spawnSync(['systemctl', '--user', 'daemon-reload']);
     if (wasRunning && !isHerdrSystemdActive()) {
@@ -435,7 +471,8 @@ async function setupSystemd(port: number, password?: string): Promise<void> {
   const serviceContent = SYSTEMD_SERVICE
     .replace(/__SHELL__/g, shell)
     .replace(/__EXEC_PATH__/g, execPath)
-    .replace(/__PORT__/g, String(port));
+    .replace(/__PORT__/g, String(port))
+    .replace(/__PATH__/g, buildServicePath());
   const servicePath = join(systemdDir, 'cchub.service');
   await writeFile(servicePath, serviceContent);
   console.log(t('setup.serviceFile', { path: servicePath }));


### PR DESCRIPTION
## 問題 (#499)

herdr を systemd user service で起動すると、hook（`rtk` / `cchub` 等）が `command not found` になる。

## 真因

監視 unit の `ExecStart` が `zsh -lc`（**login だが非対話**）で起動する。`zsh -lc` は `.zshenv` / `.zprofile` は読むが **`.zshrc` は読まない**。多くのユーザーは `~/.local/bin` / `~/bin` を `.zshrc` で PATH 追加しているため、これらが漏れる。

```
systemd --user (最小 PATH)
  └─ zsh -lc 'exec herdr server'   ← .zshrc 未読 → ~/.local/bin, ~/bin が無い PATH
       └─ resume した agent / claude
            └─ hook: rtk, cchub    ← command not found
```

実機確認: 稼働中 herdr server の `/proc/<pid>/environ` の PATH に `~/.local/bin`（rtk/herdr/claude）・`~/bin`（cchub）が無いことを確認。`.cargo/bin` は `.zshenv`（常に読まれる）にあるので入るが、`.zshrc` 追加分だけが漏れる。

## 修正

`backend/src/commands/setup.ts`:

- `buildServicePath()` を新設 — `cchub setup` は対話ターミナルから実行されるので `process.env.PATH` は `.zshrc` 反映済み。それを取得し、先頭に `~/.local/bin` / `~/bin` を保証（重複排除、`%`→`%%` エスケープ、PATH 空時は標準ディレクトリにフォールバック）
- **cchub / herdr 両 unit** に `Environment=PATH=__PATH__` を追加（両方 `zsh -lc` 起因の同根なので一括対応）
- 新規テスト `setup-service-path.test.ts`（prepend / dedupe / empty-fallback / `%` escape の4件）

## 検証

- ✅ unit テスト 4/4 pass、`biome lint` クリーン
- ✅ 生成される herdr unit の `Environment=PATH=` 先頭に `~/.local/bin`・`~/bin` を確認
- ✅ その PATH で transient systemd unit (`systemd-run --user -p Environment=PATH=...`) を起こし、`cchub`/`rtk`/`herdr`/`claude` すべて解決を実証（非破壊）

## 反映タイミング

この修正は **`cchub setup` を再実行して初めて live unit に反映**される（稼働中の unit は本 PR では触らない）。実運用ではビルド → リリース → `cchub update` → `cchub setup` の後に有効化される。

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSDZbZq2pbhXzDkfTMyJPx