### PR TITLE
Release v0.2.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.38] - 2026-07-23
+
+### Added
+- **G2グラスの音声入力** (#500): グラス内蔵マイクからハンズフリーで Claude Code セッションへ返信/プロンプト送信できる voice モードを追加。EvenHub SDK はマイクの生 PCM しか渡さないため STT はサーバ側で行う: 新エンドポイント `POST /api/glasses/stt` が 16kHz mono PCM を WAV 化して **Groq `whisper-large-v3-turbo`**（`language=ja`）に転送し、認識テキストを返す。API キーはサーバから出ない。グラス側は `audioControl(true, Glasses)` + `onEvenHubEvent` の PCM を蓄積し、会話画面の非 waiting セッションで tap → 録音 → 停止で認識 → 確認 → 送信（`/sessions/:id/prompt` のブラケットペースト + Enter で submit）。実測で日本語コマンドを ~0.35s で認識。EvenHub SDK を 0.0.9→0.0.12、evenhub-cli を 0.1.11→0.1.13 に更新（`backend/src/routes/glasses.ts` / `glasses/src/{api,display,main}.ts`）
+
 ## [0.2.37] - 2026-07-21
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.37",
-  "generated": "2026-07-21",
+  "version": "0.2.38",
+  "generated": "2026-07-23",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.2.37",
-  "generated": "2026-07-21",
+  "version": "0.2.38",
+  "generated": "2026-07-23",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- feat(glasses): G2グラスの音声入力 (#500) — グラスマイク → Groq STT (`whisper-large-v3-turbo`, ja) → セッションへプロンプト送信。新エンドポイント `POST /api/glasses/stt`、voice モード追加。SDK 0.0.12 / cli 0.1.13 へ更新。

## Notes
- 実機で使うには別途 ehpk 再ビルド→EVEN Hub アップロード（`/glasses-upload`）が必要。
- サーバの `GROQ_API_KEY` は `~/.zshenv` 経由で供給（herdr と同経路）。