### PR TITLE
Release v0.2.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.39] - 2026-07-23
+
+### Fixed
+- **systemd user service の PATH 継承漏れで hook が `command not found` になる問題を修正** (#499): 監視サービスの unit は `zsh -lc`（login だが**非対話**）でサーバを起動しており、`zsh -lc` は `.zshenv`/`.zprofile` は読むが **`.zshrc` を読まない**。ユーザーが `.zshrc` で PATH に足す `~/.local/bin`（`rtk`/`herdr`/`claude`）と `~/bin`（`cchub`）が欠落し、herdr サーバが spawn する子プロセス（resume されたエージェントや Claude Code の hook）が `cchub`/`rtk` 等を解決できず `command not found` になっていた（`.cargo/bin` は `.zshenv` 経由で入るのに `.zshrc` 追加分だけ漏れるのが分かりにくかった）。`cchub setup` は対話ターミナルから実行されるため `process.env.PATH` は `.zshrc` 反映済み。これを新設 `buildServicePath()` で取得し、先頭に `~/.local/bin` / `~/bin` を保証した上で cchub / herdr 両 systemd unit の `Environment=PATH=` にベイクするよう修正（重複排除・PATH 空時フォールバック・`%`→`%%` エスケープ）。反映は `cchub setup` の再実行時（`backend/src/commands/setup.ts`、テスト `setup-service-path.test.ts` を追加）
+
+### Changed
+- **G2グラス ehpk を v0.1.19 にビルド** (#503): 0.2.38 の音声入力機能を含む EVEN G2 アプリを `out.ehpk` として再ビルド（`glasses/`）
+
 ## [0.2.38] - 2026-07-23
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "generated": "2026-07-23",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "generated": "2026-07-23",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- **fix(setup): systemd unit の PATH 継承漏れで hook が `command not found` になる問題を修正 (#499)** — `zsh -lc`（非対話 login）が `.zshrc` を読まず `~/.local/bin`・`~/bin` が欠落していたのを、`buildServicePath()` で対話 PATH をベイクして両 unit の `Environment=PATH=` に注入。反映は `cchub setup` 再実行時。
- chore(glasses): ehpk を v0.1.19 にビルド (#503)

## Notes
- 0.2.38 は別 worktree で先行リリース済み。本リリースはその上の未リリース分（#499 修正 + glasses ビルド）を載せる。
- #499 修正は setup 再実行で有効化される（稼働 unit は本リリースでは変更しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSDZbZq2pbhXzDkfTMyJPx