### PR TITLE
feat: リリースバージョンをフロントエンドバンドルに埋め込む

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,7 +14,9 @@ applyUiScale(getStoredUiScale());
 initRemoteLogger();
 
 // Log app version and device info for debugging
-console.log(`[CC Hub] App loaded - ${new Date().toISOString()}`);
+console.log(
+	`[CC Hub] App loaded v${__APP_VERSION__} - ${new Date().toISOString()}`,
+);
 console.log(`[CC Hub] UA: ${navigator.userAgent}`);
 console.log(
 	`[CC Hub] Screen: ${screen.width}x${screen.height} DPR:${devicePixelRatio}`,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,9 @@
 
 declare module "*.css";
 
+/** Release version from the root package.json, injected by vite at build time. */
+declare const __APP_VERSION__: string;
+
 interface Window {
 	__cchub_ws_bytes_per_sec?: number;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,14 @@ import path from 'path';
 import { execSync } from 'child_process';
 import os from 'os';
 
+// The release version lives in the root package.json. Baking it into the bundle
+// keeps the frontend in step with the backend it talks to: every release changes
+// the bundle hash, so the service worker precaches a new build and the update
+// prompt fires even when only the backend changed.
+const APP_VERSION = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+).version as string;
+
 // Get Tailscale certificate for HTTPS
 function getTailscaleCert(): { key: Buffer; cert: Buffer } | undefined {
   try {
@@ -79,6 +87,9 @@ function getTailscaleCert(): { key: Buffer; cert: Buffer } | undefined {
 const httpsConfig = getTailscaleCert();
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(APP_VERSION),
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## 背景

バンドル内にバージョンを参照している箇所が無いため、**バックエンドのみのリリースではフロントエンドの成果物がバイト単位で同一**になっていた。すると `sw.js` の precache manifest もインストール済みのものと一致し、Service Worker の入れ替えが起きず、クライアントは古いビルドのまま新しいサーバーと通信し続ける。

CC Hub は WS プロトコルの型を `shared/types.ts` で frontend / backend 間で共有しているため、このズレは実害になりうる。

## 変更

ルート `package.json` の `version` を vite の `define` でバンドルに注入する。

- バンドルハッシュがリリースに連動するため、**毎リリースで新しいビルドが precache され、更新ダイアログ（#506）が確実に発火する**
- 起動ログにバージョンが載る。モバイル/タブレットからのデバッグでは `/tmp/cc-hub-browser.log` が唯一の手がかりなので、どのビルドが動いているか判別できるようになる

```
[CC Hub] App loaded v0.2.40 - 2026-07-25T...
```

## トレードオフ

バックエンドのみの修正リリースでも「新しいバージョンがあります」が出るようになる。ただし frontend/backend のバージョンを揃える方が protocol skew を防げるため、意図的にこちらを選択している。ユーザーは「後で」で無視できる。

## 検証

- `bun run typecheck` / `bun run lint` … pass
- `bun run test` … backend 426 pass / frontend 74 pass / 0 fail
- ビルド成果物に `App loaded v0.2.40` が埋め込まれていることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZdk3zAu8JodJdeXuooe1F