### PR TITLE
Release v0.2.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.41] - 2026-07-25
+
+### Changed
+- **リリースバージョンをフロントエンドバンドルに埋め込むようにした** (#508): バンドル内にバージョンを参照している箇所が無かったため、バックエンドのみのリリースではフロントエンドの成果物がバイト単位で同一になっていた。すると `sw.js` の precache manifest もインストール済みのものと一致し、Service Worker の入れ替えが起きず、クライアントは古いビルドのまま新しいサーバーと通信し続ける。CC Hub は WS プロトコルの型を `shared/types.ts` で frontend / backend 間で共有しているため、このズレは実害になりうる。ルート `package.json` の `version` を vite の `define` で注入し、バンドルハッシュがリリースに連動するよう変更。これにより毎リリースで新しいビルドが precache され、0.2.40 で入れた更新ダイアログが確実に発火する。あわせて起動ログにバージョンが載るようになり、モバイル/タブレットからのデバッグで唯一の手がかりである `/tmp/cc-hub-browser.log` からどのビルドが動いているか判別できる。トレードオフとして、バックエンドのみの修正リリースでも「新しいバージョンがあります」が出るようになるが、protocol skew を防ぐ方を優先している（`frontend/vite.config.ts` / `src/main.tsx`）
+
 ## [0.2.40] - 2026-07-25
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "generated": "2026-07-25",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "generated": "2026-07-25",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes

- **chore**: リリースバージョンをフロントエンドバンドルに埋め込む (#508)

## Notes

0.2.40 で入れた更新ダイアログが**毎リリース確実に発火する**ようにするための変更。これまではバックエンドのみのリリースだとフロントエンドの成果物が同一で、Service Worker の入れ替えが起きなかった。

このリリース自体が、本番環境で更新ダイアログが実際に出るかの検証を兼ねている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZdk3zAu8JodJdeXuooe1F