### PR TITLE
fix: 待機中の Service Worker を明示的に activate して更新を反映する

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "typescript": "^5.7.0",
         "vite": "^8.0.0",
         "vite-plugin-pwa": "^1.2.0",
+        "workbox-window": "^7.4.1",
       },
     },
     "glasses": {
@@ -1339,7 +1340,7 @@
 
     "workbox-cacheable-response": ["workbox-cacheable-response@7.4.0", "", { "dependencies": { "workbox-core": "7.4.0" } }, "sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ=="],
 
-    "workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+    "workbox-core": ["workbox-core@7.4.1", "", {}, "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ=="],
 
     "workbox-expiration": ["workbox-expiration@7.4.0", "", { "dependencies": { "idb": "^7.0.1", "workbox-core": "7.4.0" } }, "sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw=="],
 
@@ -1361,7 +1362,7 @@
 
     "workbox-sw": ["workbox-sw@7.4.0", "", {}, "sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw=="],
 
-    "workbox-window": ["workbox-window@7.4.0", "", { "dependencies": { "@types/trusted-types": "^2.0.2", "workbox-core": "7.4.0" } }, "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw=="],
+    "workbox-window": ["workbox-window@7.4.1", "", { "dependencies": { "@types/trusted-types": "^2.0.2", "workbox-core": "7.4.1" } }, "sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A=="],
 
     "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
@@ -1431,9 +1432,39 @@
 
     "vite-plugin-pwa/vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
+    "vite-plugin-pwa/workbox-window": ["workbox-window@7.4.0", "", { "dependencies": { "@types/trusted-types": "^2.0.2", "workbox-core": "7.4.0" } }, "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw=="],
+
+    "workbox-background-sync/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-broadcast-update/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
     "workbox-build/rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
+
+    "workbox-build/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-build/workbox-window": ["workbox-window@7.4.0", "", { "dependencies": { "@types/trusted-types": "^2.0.2", "workbox-core": "7.4.0" } }, "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw=="],
+
+    "workbox-cacheable-response/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-expiration/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-google-analytics/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-navigation-preload/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-precaching/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-range-requests/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-recipes/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-routing/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-strategies/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
+
+    "workbox-streams/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -1476,6 +1507,8 @@
     "vite-plugin-pwa/vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vite-plugin-pwa/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "vite-plugin-pwa/workbox-window/workbox-core": ["workbox-core@7.4.0", "", {}, "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ=="],
 
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -93,14 +93,8 @@
         });
       }
     </script>
-    <!-- Force SW update check on every page load -->
-    <script>
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.getRegistrations().then(function(regs) {
-          regs.forEach(function(reg) { reg.update(); });
-        });
-      }
-    </script>
+    <!-- The SW is registered by useServiceWorkerUpdate; registering already
+         re-fetches sw.js, so no separate update check is needed here. -->
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,14 +34,15 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "@types/bun": "^1.3.10",
     "@tailwindcss/vite": "^4.2.1",
+    "@types/bun": "^1.3.10",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "tailwindcss": "^4.2.1",
     "typescript": "^5.7.0",
     "vite": "^8.0.0",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "workbox-window": "^7.4.1"
   }
 }

--- a/frontend/src/hooks/useServiceWorkerUpdate.ts
+++ b/frontend/src/hooks/useServiceWorkerUpdate.ts
@@ -1,82 +1,69 @@
 import { useCallback, useEffect, useState } from "react";
-
-const supported = "serviceWorker" in navigator;
-
-// Is the page under service-worker control? On a first-ever visit it is not:
-// registration happens on `load` and the worker then claims the page, firing a
-// `controllerchange` that means "now controlled", not "new release". Swallow
-// that one — but only that one, so a genuine swap later in the same page
-// session still prompts.
-let hasController = supported && navigator.serviceWorker.controller !== null;
+import { registerSW } from "virtual:pwa-register";
 
 // How often to re-check sw.js while a tab stays open. Tablets are often left on
 // the same page for hours, so a release would otherwise go unnoticed until the
 // next manual reload.
 const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000;
 
-// The worker can take over before React has mounted — index.html kicks off a
-// `registration.update()` on load, and this bundle is large enough that the
-// event can land first. So subscribe at module scope (main.tsx imports this
-// before it renders) and replay the result into whichever hook mounts later.
+// Registration happens at module scope (main.tsx imports this before it renders)
+// so the worker is picked up whether or not React has mounted yet, and a worker
+// that is already waiting from a previous visit is reported immediately.
 let updateDetected = false;
 const listeners = new Set<() => void>();
 
-if (supported) {
-	navigator.serviceWorker.addEventListener("controllerchange", () => {
-		if (!hasController) {
-			hasController = true;
-			return;
-		}
-		console.log("[CC Hub] SW: new version activated, prompting for reload");
+const updateServiceWorker = registerSW({
+	onNeedRefresh() {
+		console.log("[CC Hub] SW: new version waiting, prompting for reload");
 		updateDetected = true;
 		for (const listener of listeners) listener();
-	});
-}
+	},
+	onRegisterError(error) {
+		// Without this the registration failure is swallowed and the app silently
+		// loses update detection.
+		console.error("[CC Hub] SW: registration failed", error);
+	},
+	onRegisteredSW(_swUrl, registration) {
+		if (!registration) return;
+		const check = () => {
+			if (document.visibilityState !== "visible") return;
+			registration.update().catch(() => {
+				// Offline or the worker is gone — the next check retries.
+			});
+		};
+		document.addEventListener("visibilitychange", check);
+		window.setInterval(check, UPDATE_CHECK_INTERVAL_MS);
+	},
+});
 
 interface ServiceWorkerUpdate {
-	/** A newer build has been precached and its worker has taken over. */
+	/** A newer build has been precached and its worker is waiting to take over. */
 	updateAvailable: boolean;
 	/** Hide the prompt; it reappears only if another release is detected. */
 	dismiss: () => void;
-	/** Reload so the page is served from the new worker's precache. */
+	/** Activate the waiting worker and reload onto the new build. */
 	reload: () => void;
 }
 
 /**
- * Reports that a new release's service worker has taken control.
+ * Reports that a new release's service worker is installed and waiting.
  *
- * The generated worker uses `skipWaiting()` + `clientsClaim()` (vite-plugin-pwa
- * `registerType: 'autoUpdate'`), so it swaps itself in as soon as the new build
- * is precached. The page keeps running the old bundle until it reloads — and
- * reloading a terminal out from under the user is hostile, so we ask first.
+ * The worker is generated in `prompt` mode, so it never activates on its own —
+ * `registerSW`'s returned callback posts SKIP_WAITING and reloads once the user
+ * accepts. That matters because a worker relying on `skipWaiting()` was
+ * observed to stay in `waiting` indefinitely while a tab was open, which left
+ * the page on the old build forever.
  */
 export function useServiceWorkerUpdate(): ServiceWorkerUpdate {
 	const [updateAvailable, setUpdateAvailable] = useState(updateDetected);
 
 	useEffect(() => {
-		if (!supported) return;
-
 		const onUpdate = () => setUpdateAvailable(true);
 		listeners.add(onUpdate);
-		// The worker may have taken over between render and this effect.
+		// The worker may have started waiting between render and this effect.
 		if (updateDetected) setUpdateAvailable(true);
-
-		const checkForUpdate = () => {
-			if (document.visibilityState !== "visible") return;
-			navigator.serviceWorker
-				.getRegistration()
-				.then((reg) => reg?.update())
-				.catch(() => {
-					// Offline or the worker is gone — the next check retries.
-				});
-		};
-		document.addEventListener("visibilitychange", checkForUpdate);
-		const timer = window.setInterval(checkForUpdate, UPDATE_CHECK_INTERVAL_MS);
-
 		return () => {
 			listeners.delete(onUpdate);
-			document.removeEventListener("visibilitychange", checkForUpdate);
-			window.clearInterval(timer);
 		};
 	}, []);
 
@@ -84,7 +71,9 @@ export function useServiceWorkerUpdate(): ServiceWorkerUpdate {
 		updateDetected = false;
 		setUpdateAvailable(false);
 	}, []);
-	const reload = useCallback(() => window.location.reload(), []);
+	const reload = useCallback(() => {
+		void updateServiceWorker(true);
+	}, []);
 
 	return { updateAvailable, dismiss, reload };
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 declare module "*.css";
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -97,7 +97,15 @@ export default defineConfig({
       devOptions: {
         enabled: false,
       },
-      registerType: 'autoUpdate',
+      // `autoUpdate` bakes skipWaiting() into the worker, but in practice the
+      // new worker still sat in `waiting` for as long as a tab stayed open, so
+      // nothing ever swapped. Prompt mode keeps it waiting on purpose and hands
+      // the trigger to useServiceWorkerUpdate, which posts SKIP_WAITING once the
+      // user accepts the reload.
+      registerType: 'prompt',
+      // registerSW() is called from useServiceWorkerUpdate, so vite must not
+      // also inject its own registration script.
+      injectRegister: null,
       includeAssets: ['favicon.svg', 'icon-192.png', 'icon-512.png'],
       manifest: {
         name: 'CC Hub',


### PR DESCRIPTION
## 背景

v0.2.41 を実際にリリースして本番で検証したところ、**更新ダイアログが出なかった**。

調査結果:

- 新しい worker は正常にインストールされ、新ビルドを precache まで済ませていた
- しかしタブが開いている限り **`waiting` のまま activate しなかった**
- `about:blank` へ移動してクライアントを消すと即座に activate し、再訪で新バンドルが読み込まれた

つまり `registerType: 'autoUpdate'` が worker に埋め込む `skipWaiting()` が、**クライアントが制御下にある間は効いていなかった**。0.2.40 で入れた検知は `controllerchange` を待つ実装だったため、入れ替わりが起きない以上ダイアログは永久に出ない。

さらに調査の過程で、**Service Worker がそもそも登録されていない**ケースも判明した（下記）。

## 変更

### 1. `registerType: 'prompt'` へ切り替え

prompt モードは worker を意図的に `waiting` に留め、`SKIP_WAITING` メッセージハンドラを持つ SW を生成する。自動 activate に頼らず、**ユーザーが承認した時点で明示的に activate させる**。

フックは vite-plugin-pwa 純正の `registerSW` を使う形に置き換えた:

- `onNeedRefresh` が waiting 中の worker を検知（前回訪問から waiting のまま残っているものも拾う）
- 承認時に `updateServiceWorker(true)` が `SKIP_WAITING` を送り、`controllerchange` を待ってリロード

登録がアプリ側の責務になったため `injectRegister: null` とし、`index.html` の更新チェックスクリプトは冗長になったので削除した（`register()` 自体が毎回 `sw.js` を取りに行くため）。

### 2. `workbox-window` を依存に追加（silent failure の修正）

`virtual:pwa-register` は `workbox-window` を動的インポートするが、依存に無かったため **bare specifier が解決できずバンドルに残り**、登録が丸ごと失敗していた。

```
TypeError: Failed to resolve module specifier 'workbox-window'
```

さらに悪いことに、vite-plugin-pwa は `onRegisterError` を渡さない限り**このエラーを握り潰す**ため、コンソールには何も出ず「SW が1つも登録されていない」状態に静かになっていた。`onRegisterError` を配線して二度と無言で失敗しないようにした。

（従来の `autoUpdate` + 注入スクリプトは素の `navigator.serviceWorker.register` を使うため `workbox-window` を必要とせず、この問題は表面化していなかった）

## 検証

実ビルド成果物を、バイナリと同じ `Cache-Control` を返す静的サーバーで配信し、バージョンを上げて再ビルドしながら確認:

| 検証項目 | 結果 |
|---|---|
| SW が登録される | ✅ `active: activated` |
| 再訪でページが制御下に入る | ✅ `controller: true` |
| 新ビルド配置 → タブを開いたまま検知 | ✅ ダイアログ表示（`waiting: installed`） |
| 「後で」→ リロードせず旧バンドル継続 | ✅ worker は waiting のまま保持 |
| 「再読み込み」→ **タブを閉じずに**新バンドルへ | ✅ `waiting: null` / 新ハッシュのバンドル |

最後の行が今回の本題で、**本番で永久に詰まっていた `waiting` 状態からユーザー操作だけで復帰できる**ことを確認した。

- `bun run lint` … backend / frontend ともに pass
- `bun run test` … backend 426 pass / frontend 74 pass / 0 fail

## 移行時の注意

現在配布中の v0.2.41 は autoUpdate 版 SW で、その worker が既に `waiting` で固まっている端末がある。このリリースの SW を拾うには**一度全タブを閉じる**（またはページから離れて戻る）操作が一度だけ必要。以降は本 PR の仕組みでタブを開いたまま更新できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZdk3zAu8JodJdeXuooe1F