### PR TITLE
Release v0.2.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.42] - 2026-07-25
+
+### Fixed
+- **待機中の Service Worker が activate せず更新ダイアログが出なかった問題を修正** (#510): v0.2.41 を実際にリリースして本番で検証したところ、新しい worker は正常にインストールされ新ビルドを precache まで済ませていたのに、**タブが開いている限り `waiting` のまま activate しなかった**。`about:blank` へ移動してクライアントを消すと即座に activate したことから、`registerType: 'autoUpdate'` が worker に埋め込む `skipWaiting()` がクライアント制御下では効いていないと判明。0.2.40 の検知は `controllerchange` を待つ実装だったため、入れ替わりが起きない以上ダイアログは永久に出ない。worker を意図的に `waiting` に留めて `SKIP_WAITING` メッセージハンドラを持たせる `registerType: 'prompt'` に切り替え、vite-plugin-pwa 純正の `registerSW` を使う形へ置き換えた。`onNeedRefresh` が waiting 中の worker（前回訪問から残っているものも含む）を検知し、承認時に `updateServiceWorker(true)` が `SKIP_WAITING` を送って activate させリロードする。登録がアプリ側の責務になったため `injectRegister: null` とし、`index.html` の更新チェックスクリプトは冗長になったので削除（`register()` 自体が毎回 `sw.js` を取りに行くため）（`frontend/vite.config.ts` / `src/hooks/useServiceWorkerUpdate.ts` / `index.html`）
+- **Service Worker が一切登録されていなかった問題を修正** (#510): `virtual:pwa-register` は `workbox-window` を動的インポートするが依存に無く、bare specifier が解決できないまま残って登録が丸ごと失敗していた（`TypeError: Failed to resolve module specifier 'workbox-window'`）。しかも vite-plugin-pwa は `onRegisterError` を渡さない限りこのエラーを握り潰すため、コンソールに何も出ないまま「SW が1つも無い」状態に静かになっていた。`workbox-window` を依存に追加し、`onRegisterError` を配線して二度と無言で失敗しないようにした。従来の `autoUpdate` + 注入スクリプトは素の `navigator.serviceWorker.register` を使うため `workbox-window` を必要とせず、この問題は表面化していなかった（`frontend/package.json`）
+
 ## [0.2.41] - 2026-07-25
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "generated": "2026-07-25",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "generated": "2026-07-25",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes

- **fix**: 待機中の Service Worker を明示的に activate して更新を反映する (#510)
- **fix**: `workbox-window` 欠落で Service Worker が一切登録されていなかった問題を修正 (#510)

## Notes

v0.2.41 を本番で検証して発覚した2件の修正。新 worker が `waiting` のまま永久に activate しなかったため、0.2.40 で入れた更新ダイアログが出なかった。`registerType: 'prompt'` へ切り替え、承認時に `SKIP_WAITING` を送って明示的に activate させる方式にした。

**移行時の注意**: 現在 v0.2.41 の autoUpdate 版 worker が `waiting` で固まっている端末は、このリリースを拾うのに一度だけ全タブを閉じる操作が必要。以降はタブを開いたまま更新できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZdk3zAu8JodJdeXuooe1F