### PR TITLE
fix: 更新ダイアログのボタンをタップしやすいサイズにする

### DIFF
--- a/frontend/src/components/UpdatePrompt.tsx
+++ b/frontend/src/components/UpdatePrompt.tsx
@@ -33,14 +33,14 @@ export function UpdatePrompt() {
 					<button
 						type="button"
 						onClick={dismiss}
-						className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200"
+						className="min-h-11 px-4 text-sm text-zinc-400 hover:text-zinc-200"
 					>
 						{t("update.later")}
 					</button>
 					<button
 						type="button"
 						onClick={reload}
-						className="rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-500"
+						className="min-h-11 rounded bg-blue-600 px-4 text-sm font-medium text-white hover:bg-blue-500"
 					>
 						{t("update.reload")}
 					</button>


### PR DESCRIPTION
## 背景

実機と同じスマホ幅（459x1019）で確認したところ、更新ダイアログのボタンが **42x25 / 74x25 CSS px** しかなく、タッチターゲットの目安 44px を大きく下回っていた。CC Hub は主にスマホ・タブレットから使うアプリなので実害がある。

## 変更

`px-3 py-1.5 text-xs` → `min-h-11 px-4 text-sm`。

アプリのルート `font-size` は UI スケール設定により 14px なので、`min-h-11`（2.75rem）は実測 **39px** になる。rem 基準のままにしてあるので、ユーザーが UI スケールを変えれば他の UI と一緒に追従する。

| | 変更前 | 変更後 |
|---|---|---|
| 後で | 42x25 | 53x39 |
| 再読み込み | 74x25 | 89x39 |

## 検証

ビルド成果物をスマホ幅で表示し、ボタンが最前面にあること（`elementFromPoint`）とタップで実際に新バンドルへ切り替わることを確認済み。ボトムシートのレイアウト崩れも無し。

- `bun run typecheck` / `bun run lint` … pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZdk3zAu8JodJdeXuooe1F