### PR TITLE
fix: 期限切れで CI を恒久的に落とすテストを修正

### DIFF
--- a/backend/src/services/__tests__/usage-history-legacy.test.ts
+++ b/backend/src/services/__tests__/usage-history-legacy.test.ts
@@ -90,7 +90,11 @@ describe('UsageHistoryService.recordSnapshot scoped limits', () => {
   });
 
   test('appends to history that predates scoped tracking', async () => {
-    await writeFile(HISTORY_FILE, JSON.stringify([snap('2026-07-17T00:00:00.000Z')]));
+    // Relative, not a literal date: recordSnapshot prunes anything older than
+    // 8 days, so a hardcoded timestamp silently turns into "history is empty"
+    // once it ages out — and then this asserts the wrong thing forever.
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    await writeFile(HISTORY_FILE, JSON.stringify([snap(yesterday)]));
     await new UsageHistoryService().recordSnapshot(cycle, cycle, [fable]);
     const written = await readSnapshots();
     expect(written).toHaveLength(2);


### PR DESCRIPTION
## 問題

`UsageHistoryService.recordSnapshot scoped limits > appends to history that predates scoped tracking` が **2026-07-25 以降すべての CI で失敗する**状態になっていた（PR #513 の CI 失敗で発覚。変更内容とは無関係）。

## 原因

テストが履歴のシードに**リテラルの日付** `2026-07-17T00:00:00.000Z` を使っていた。

`recordSnapshot` は 8日より古いスナップショットを剪定する（`MAX_AGE_MS = 8 * 24 * 60 * 60 * 1000`）。2026-07-25 00:00 UTC を過ぎた時点でシードが剪定対象になり、append の前に消えるため `toHaveLength(2)` が落ちる。

時間の経過だけで壊れるため、**diff を見ても原因が分からない**タイプの故障になる。実際 v0.2.43 のリリース CI（07-24 20:38 UTC = 7.86日）までは通っており、その数時間後から落ち始めた。

## 修正

シードを現在時刻からの相対（1日前）にする。これがテストの本来の意図（「scoped 以前の履歴があっても追記される」）と一致する。

## 検証

```
bun test src/services/__tests__/usage-history-legacy.test.ts
 9 pass  0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZdk3zAu8JodJdeXuooe1F