### PR TITLE
test: モバイル/タブレット幅の e2e を CI で回してレイアウト漏れを検出する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,37 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  # Mobile renders a different component tree from desktop and tablet, and until
+  # this job existed no viewport other than desktop was ever exercised. These
+  # specs stub every /api call, so they need neither a backend nor herdr.
+  responsive:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install Playwright chromium
+        run: bunx playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: Run responsive e2e (desktop / tablet / mobile)
+        run: bun run test:e2e:responsive
+        working-directory: frontend
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "test": "TZ=UTC bun test src/",
     "test:e2e": "playwright test",
+    "test:e2e:responsive": "playwright test --project=responsive-desktop --project=responsive-tablet --project=responsive-mobile",
     "lint": "bunx @biomejs/biome lint src/",
     "typecheck": "tsgo --noEmit"
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// The dev server serves over HTTPS when a Tailscale cert is present (see
+// vite.config.ts), which is the normal local setup but never the case in CI.
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:5173';
+
+const RESPONSIVE = /responsive\/.*\.spec\.ts/;
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
@@ -8,18 +14,45 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: BASE_URL,
     trace: 'on-first-retry',
+    ignoreHTTPSErrors: true,
   },
   projects: [
+    // Existing specs drive a live backend with real herdr sessions, so they
+    // stay desktop-only and local-only.
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      testIgnore: RESPONSIVE,
+    },
+    // The responsive specs stub the backend, so they run anywhere — including
+    // CI. Mobile renders a different component tree from desktop and tablet,
+    // and until these existed no width other than desktop was ever exercised.
+    {
+      name: 'responsive-desktop',
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: RESPONSIVE,
+    },
+    {
+      name: 'responsive-tablet',
+      // Chromium rather than the descriptor's WebKit: this is a layout check,
+      // not an engine-compatibility one, and CI only installs chromium.
+      use: { ...devices['iPad (gen 7)'], browserName: 'chromium' },
+      testMatch: RESPONSIVE,
+    },
+    {
+      name: 'responsive-mobile',
+      use: { ...devices['Pixel 5'] },
+      testMatch: RESPONSIVE,
     },
   ],
   webServer: {
     command: 'bun run dev',
-    url: 'http://localhost:5173',
+    url: BASE_URL,
     reuseExistingServer: !process.env.CI,
+    // The local dev server presents a Tailscale cert for a different hostname.
+    ignoreHTTPSErrors: true,
+    timeout: 120_000,
   },
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1215,7 +1215,7 @@ export function App() {
 
 	// Mobile: Show terminal with overlay (position depends on keyboard state)
 	return (
-		<div className="h-screen flex flex-col bg-th-bg relative">
+		<div className="h-screen flex flex-col bg-th-bg relative" data-layout="mobile">
 			{/* Terminal - full screen */}
 			{activeSession ? (
 				<div

--- a/frontend/src/components/DesktopLayout.tsx
+++ b/frontend/src/components/DesktopLayout.tsx
@@ -1717,8 +1717,14 @@ export function DesktopLayout({
 		[handleSelectSessionForPane],
 	);
 
+	// data-layout pins which of the three layout trees rendered; the responsive
+	// e2e matrix asserts on it so a viewport can't silently fall through to the
+	// wrong one.
 	return (
-		<div className="h-screen flex bg-th-bg">
+		<div
+			className="h-screen flex bg-th-bg"
+			data-layout={isTablet ? "tablet" : "desktop"}
+		>
 			{/* Main content */}
 			<div className="flex-1 flex flex-col min-w-0">
 				{/* Header - desktop: minimal icons, tablet: full toolbar */}

--- a/frontend/tests/e2e/responsive/fixtures.ts
+++ b/frontend/tests/e2e/responsive/fixtures.ts
@@ -1,0 +1,68 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Boots the SPA with a stubbed backend.
+ *
+ * These specs exist to catch layout regressions across viewports, so they must
+ * run anywhere — including CI, where there is no backend and no herdr. Every
+ * /api call is answered from here instead; the terminal WebSocket is left to
+ * fail, which the app already tolerates.
+ */
+
+const SESSIONS = [
+  {
+    id: 'demo',
+    name: 'demo',
+    instanceId: 'demo-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastAccessedAt: '2026-01-01T00:00:00.000Z',
+    state: 'idle',
+    currentPath: '/home/dev/project',
+    agent: 'claude',
+    theme: 'default',
+  },
+  {
+    id: 'notes',
+    name: 'notes',
+    instanceId: 'notes-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastAccessedAt: '2026-01-01T00:00:00.000Z',
+    state: 'idle',
+    currentPath: '/home/dev/notes',
+    agent: 'codex',
+    theme: 'ocean',
+  },
+];
+
+/** Endpoint suffix -> JSON body. Anything unmatched falls back to `{}`. */
+const ROUTES: Array<[RegExp, unknown]> = [
+  [/\/api\/auth\/required$/, { required: false }],
+  [/\/api\/auth\/me$/, { authenticated: true }],
+  [/\/api\/workspaces$/, { sessions: SESSIONS }],
+  [/\/api\/sessions$/, { sessions: SESSIONS }],
+  [/\/api\/peers$/, { peers: [] }],
+  [/\/api\/notify\/hook-status$/, { missing: [] }],
+];
+
+export async function bootApp(page: Page): Promise<void> {
+  // Onboarding is a full-screen overlay; skipping it exposes the real UI, which
+  // is what these specs are measuring.
+  await page.addInitScript(() => {
+    localStorage.setItem('cchub-onboarding-completed', 'true');
+    localStorage.setItem('cchub-onboarding-sessionlist-completed', 'true');
+  });
+
+  await page.route('**/api/**', async (route) => {
+    const url = route.request().url();
+    const match = ROUTES.find(([pattern]) => pattern.test(url));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(match ? match[1] : {}),
+    });
+  });
+
+  await page.goto('/');
+  // The bundle is large; wait for React to have painted something real.
+  await page.locator('#root > *').first().waitFor({ state: 'attached' });
+}

--- a/frontend/tests/e2e/responsive/layout-parity.spec.ts
+++ b/frontend/tests/e2e/responsive/layout-parity.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+import { bootApp } from './fixtures';
+
+// Runs once per viewport project (desktop / tablet / mobile). Mobile renders a
+// different component tree from desktop and tablet, so "it booted at one width"
+// has never implied the others work.
+
+/** Which layout tree each viewport project is expected to land on. */
+const EXPECTED_LAYOUT: Record<string, string> = {
+  'responsive-desktop': 'desktop',
+  'responsive-tablet': 'tablet',
+  'responsive-mobile': 'mobile',
+};
+
+test.describe('layout parity', () => {
+  test('boots and renders the app shell', async ({ page }) => {
+    await bootApp(page);
+
+    // Something beyond the fallback markup must be on screen.
+    await expect(page.locator('#root')).not.toBeEmpty();
+    // index.html reveals this only when React fails to mount within 4s.
+    await expect(page.locator('#fallback')).toBeHidden();
+  });
+
+  test('renders the layout tree this viewport is meant to use', async ({
+    page,
+  }) => {
+    await bootApp(page);
+
+    const expected = EXPECTED_LAYOUT[test.info().project.name];
+    // Without this the matrix can quietly test one layout three times — the
+    // device heuristic keys off screen size and touch, not just viewport width.
+    await expect(page.locator(`[data-layout="${expected}"]`)).toBeVisible();
+  });
+
+  test('does not scroll horizontally', async ({ page }) => {
+    await bootApp(page);
+
+    const overflow = await page.evaluate(() => {
+      const el = document.documentElement;
+      return { scrollWidth: el.scrollWidth, clientWidth: el.clientWidth };
+    });
+
+    // 1px of slack for sub-pixel rounding at fractional device scale factors.
+    expect(
+      overflow.scrollWidth,
+      `page scrolls horizontally: ${overflow.scrollWidth}px of content in a ${overflow.clientWidth}px viewport`,
+    ).toBeLessThanOrEqual(overflow.clientWidth + 1);
+  });
+});

--- a/frontend/tests/e2e/responsive/touch-targets.spec.ts
+++ b/frontend/tests/e2e/responsive/touch-targets.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test';
+import { bootApp } from './fixtures';
+
+/**
+ * Guards the class of bug that shipped in the update prompt: a control that
+ * looks fine on a desktop viewport but is too small to hit on a phone.
+ *
+ * The bar is deliberately below the 44px platform guideline — the app scales
+ * its own spacing off a 14px root font, so 44px would flag most of the existing
+ * chrome. This catches "obviously untappable", not "not ideal".
+ */
+const MIN_TOUCH_PX = 32;
+
+/**
+ * Controls that were already under the bar when this check landed. They are
+ * recorded rather than silently tolerated: the point of this spec is to stop
+ * *new* ones, and fixing these three means reflowing session bars that need
+ * their own visual pass at every width.
+ *
+ * Tracked in #514. Delete entries as they are fixed; never add one.
+ */
+const KNOWN_TOO_SMALL = [
+  // mobile: session switcher in the bottom bar
+  'div.h-full.w-full > div.fixed.bottom-0 > div.flex.items-center > button.flex.flex-1',
+  // tablet: session selector in the header
+  'div.flex-1.flex > div.shrink-0.select-none > div.flex.items-center > button.flex.items-center',
+  // tablet: chat/terminal toggle in the pane header
+  'div.h-full.flex > div.flex.items-center > div.flex.items-center > button.p-2.rounded',
+];
+
+test.describe('touch targets', () => {
+  test.skip(
+    () => !test.info().project.use.hasTouch,
+    'only meaningful on touch viewports',
+  );
+
+  test('interactive controls are big enough to tap', async ({ page }) => {
+    await bootApp(page);
+
+    const tooSmall = await page.evaluate((min) => {
+      const controls = document.querySelectorAll<HTMLElement>(
+        'button, a[href], [role="button"]',
+      );
+      const violations: Array<{
+        label: string;
+        w: number;
+        h: number;
+        path: string;
+      }> = [];
+
+      for (const el of controls) {
+        const rect = el.getBoundingClientRect();
+        // Skip anything not actually on screen — hidden menus, offscreen
+        // drawers, and zero-size wrappers are not tap targets.
+        if (rect.width === 0 || rect.height === 0) continue;
+        if (getComputedStyle(el).visibility === 'hidden') continue;
+        if (rect.bottom < 0 || rect.top > innerHeight) continue;
+        if (rect.right < 0 || rect.left > innerWidth) continue;
+
+        if (rect.height < min) {
+          // A DOM path makes the failure actionable — the label alone is often
+          // dynamic data that appears nowhere in the source.
+          const path: string[] = [];
+          for (let node: HTMLElement | null = el, i = 0; node && i < 4; i++) {
+            const cls = node.className
+              ?.toString()
+              .split(/\s+/)
+              .filter(Boolean)
+              .slice(0, 2)
+              .join('.');
+            path.unshift(node.tagName.toLowerCase() + (cls ? `.${cls}` : ''));
+            node = node.parentElement;
+          }
+          violations.push({
+            label:
+              el.getAttribute('aria-label') ||
+              el.getAttribute('title') ||
+              el.textContent?.trim().slice(0, 30) ||
+              el.tagName.toLowerCase(),
+            w: Math.round(rect.width),
+            h: Math.round(rect.height),
+            path: path.join(' > '),
+          });
+        }
+      }
+      return violations;
+    }, MIN_TOUCH_PX);
+
+    const regressions = tooSmall.filter(
+      (v) => !KNOWN_TOO_SMALL.includes(v.path),
+    );
+
+    expect(
+      regressions,
+      `controls under ${MIN_TOUCH_PX}px tall:\n${regressions
+        .map((v) => `  - "${v.label}" ${v.w}x${v.h}  @ ${v.path}`)
+        .join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 背景

スマホ・タブレット・デスクトップ間で対応漏れが繰り返し発生していたため、実態を調べた。漏れは3種類ある。

**① 構造的分岐（mobile）** — `App.tsx` の mobile 分岐は **305行の独立した JSX ツリー**で、使うコンポーネント自体が別系統。

| 用途 | mobile | desktop / tablet |
|---|---|---|
| ターミナル | `pages/TerminalPage` | `PaneContainer` → `TerminalPane` |
| セッション一覧 | `WorkspaceList` を直接 | `SessionModal` |
| ダッシュボード | `Dashboard` | `DashboardPanel` |
| キーボード | `Keyboard` | `FloatingKeyboard` |

**② パラメトリック分岐（tablet）** — `isTablet ?` が `PaneContainer` に30箇所、`DesktopLayout` に18箇所。

**③ ビューポート起因** — コンポーネントは共有なのに、その幅で見ていない。

そして③は仕組みで防げるのに防いでいなかった。`playwright.config.ts` の projects は **Desktop Chrome ひとつだけ**で、しかも **CI は playwright を一度も実行していない**（`test.yml` は lint / typecheck / unit test / build のみ）。

この PR は ③ を機械化し、①②の一部も捕まえる。①②の根本対応は #515 / #516 に切り出した。

## 変更

### ビューポートマトリクス

`responsive-desktop` / `responsive-tablet` / `responsive-mobile` の3 project を追加。タブレットは記述子が WebKit を要求するが、目的はレイアウト検証でありエンジン互換性ではないので Chromium に固定した（CI も chromium だけ入れれば済む）。

### CI 実行可能な spec ディレクトリ

既存 spec は実 herdr セッションを前提としており CI で動かない。新しい `tests/e2e/responsive/` は `page.route` で **/api を全てスタブ**するため、バックエンドも herdr も要らない。既存 spec は `testIgnore` でデスクトップ・ローカル専用のまま据え置いた。

検証内容:

| 検証 | 目的 |
|---|---|
| アプリシェルが mount し `#fallback` が出ない | 起動時クラッシュ |
| **意図したレイアウトツリーが描画される**（新 `data-layout` 属性） | マトリクスが実は同じレイアウトを3回踏んでいた、を防ぐ |
| 横スクロールが発生しない | レスポンシブ崩れ |
| タップ領域が最小高さを満たす（タッチ幅のみ） | #513 で作り込んだ 25px バグの再発防止 |

`data-layout` が要る理由: デバイス判定は `screen` の短辺とタッチ有無で行っており、ビューポート幅だけでは決まらない。実際この属性を入れて初めて3系統を確実に踏んでいると確認できた。

### CI ジョブ

`responsive` ジョブを追加。chromium だけインストールし、失敗時は playwright レポートを artifact に上げる。

## 既知の違反

タップ領域チェックは導入時点で3件を検出した。いずれも既存のもので、`KNOWN_TOO_SMALL` に **DOM パス付きで明示的に記録**した上で #514 に切り出している（許可リストは「黙って見逃す」ではなく「記録して追跡する」ための仕組み）。

| レイアウト | コントロール | 実測 |
|---|---|---|
| mobile | ボトムバーのセッション切替 | 243x27 |
| tablet | ヘッダーのセッションセレクタ | 78x27 |
| tablet | ペインヘッダーの Chat 切替 | 28x28 |

修正すると縦方向のレイアウトが動くため3幅での目視確認が要り、ガード導入と混ぜると範囲が膨らむので分離した。

## 検証

```
11 passed, 1 skipped   (desktop / tablet / mobile)
```

skip はデスクトップのタップ領域チェック（非タッチのため意図的）。

`bun run lint` / `bun run typecheck` ともに pass。

## 関連

- #514 タップ領域の既存負債
- #515 UI操作の単一定義化（①の根本対応）
- #516 モバイルツリーの統合（①の構造的根絶）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZdk3zAu8JodJdeXuooe1F