### PR TITLE
Release v0.2.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.44] - 2026-07-25
+
+### Fixed
+- **更新ダイアログのボタンがタップしづらかった問題を修正** (#513): 実機と同じスマホ幅（459x1019）で確認したところ、ボタンが 42x25 / 74x25 CSS px しかなく、タッチターゲットの目安 44px を大きく下回っていた。`px-3 py-1.5 text-xs` → `min-h-11 px-4 text-sm` に変更し、53x39 / 89x39 に拡大。rem 基準のままなので UI スケール設定に追従する（`frontend/src/components/UpdatePrompt.tsx`）
+- **時間経過だけで CI が恒久的に落ちるテストを修正** (#517): `UsageHistoryService` のテストが履歴のシードにリテラル日付 `2026-07-17T00:00:00.000Z` を使っていた。`recordSnapshot` は8日より古いスナップショットを剪定するため、2026-07-25 00:00 UTC を過ぎた時点でシードが append の前に消え、以後すべての PR で失敗するようになっていた（v0.2.43 のリリース CI は 7.86 日時点で通っており、その数時間後から発症）。diff を見ても原因が分からない類の故障なので、シードを現在時刻からの相対（1日前）に変更（`backend/src/services/__tests__/usage-history-legacy.test.ts`）
+
+### Added
+- **モバイル/タブレット幅の e2e を CI で実行するようにした** (#518): スマホ・タブレット・デスクトップ間の対応漏れが繰り返し発生していた原因を調査したところ、(1) `App.tsx` の mobile 分岐が305行の独立 JSX ツリーで、ターミナル / セッション一覧 / ダッシュボード / キーボードすべて desktop と別コンポーネントであること、(2) `isTablet ?` の三項が PaneContainer に30箇所・DesktopLayout に18箇所あること、(3) 共有コンポーネントでもその幅で目視していないこと、の3種類に分類できた。加えて **CI が playwright を一度も実行しておらず**（`test.yml` は lint / typecheck / unit test / build のみ）、`playwright.config.ts` の projects も Desktop Chrome ひとつだけで、モバイル幅は一度も検証されていなかった。`responsive-desktop` / `responsive-tablet` / `responsive-mobile` の3 project と、`page.route` で `/api` を全スタブしてバックエンドも herdr も不要にした `tests/e2e/responsive/` を追加し、CI に `responsive` ジョブを新設。検証内容はアプリシェルの mount、**意図したレイアウトツリーが描画されていること**（新設 `data-layout` 属性。デバイス判定は `screen` の短辺とタッチ有無で決まりビューポート幅だけでは決まらないため、これが無いとマトリクスが同じレイアウトを3回踏みうる）、横スクロールが発生しないこと、タッチ幅でのタップ領域の最小高さ。既存 spec は実 herdr セッション前提のため `testIgnore` でデスクトップ・ローカル専用のまま据え置いた。タップ領域チェックは導入時点で既存3件を検出しており、DOM パス付きで `KNOWN_TOO_SMALL` に記録した上で #514 に分離している（`frontend/playwright.config.ts` / `tests/e2e/responsive/` / `.github/workflows/test.yml`）
+
 ## [0.2.43] - 2026-07-25
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "generated": "2026-07-25",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "generated": "2026-07-25",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes

- **fix**: 更新ダイアログのボタンをタップしやすいサイズにする (#513)
- **fix**: 時間経過だけで CI を恒久的に落とすテストを修正 (#517)
- **feat**: モバイル/タブレット幅の e2e を CI で実行してレイアウト漏れを検出する (#518)

## Notes

スマホ・タブレット・デスクトップ間の対応漏れの再発防止が主題。CI が playwright を一度も実行しておらず、モバイル幅は一度も検証されていなかったため、3幅のマトリクスをバックエンド不要の形で CI に載せた。

#517 は調査中に発覚した別件で、テストがリテラル日付を持っていたため 2026-07-25 以降すべての PR が落ちる状態になっていた。先行してマージ済み。

残タスクは #514（タップ領域の既存負債）/ #515（UI操作の単一定義化）/ #516（モバイルツリーの統合）に分離してある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZdk3zAu8JodJdeXuooe1F