### PR TITLE
Release v0.2.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.46] - 2026-07-25
+
+### Fixed
+- **グラス連絡チャンネル: エージェント自筆 waiting item のライフサイクルを修正** (#504, #524): `cchub glasses --kind waiting` で投稿した自筆の判断依頼が、2つの経路で正しく扱われていなかった。(1) backend の `exitBlocked` が **paneId を持たない waiting item を、同一セッションの無関係な pane が blocked 解除しただけで削除**していた（`--session` 指定投稿は paneId が付かないため、未回答の「デプロイしていい?」が黙って消え得た）。auto 検知の item だけが herdr の blocked epoch に従うよう限定し、agent 自筆 item は独自ライフサイクル（answered→dismissed）に委ねるよう修正（`backend/src/services/glasses-relay.ts`）。(2) glasses アプリ側で、回答済みの自筆 item が banner に残り続けていた（auto item は pane の blocked 解除で自動消去されるが、自筆 item は blocked epoch を持たないため消去契機が無かった）。choice/voice 回答成功時に該当 item を明示削除（楽観的ローカル remove + サーバー dismiss で再接続時の復活も防止）するよう修正（`glasses/src/controller.ts`、ehpk v0.1.24）。回帰テスト追加
+
 ## [0.2.45] - 2026-07-25
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "generated": "2026-07-25",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "generated": "2026-07-25",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- fix(glasses-relay): エージェント自筆 waiting item のライフサイクル修正 (#504, #524)
  - backend: `exitBlocked` を auto item 限定に → 無関係 pane 解除で自筆 item が消えない
  - glasses: 回答済み自筆 item を明示削除 → banner に残らない（ehpk v0.1.24）
  - 回帰テスト追加

## Notes
グラス側は v0.1.24 として EVEN Hub Beta 昇格済み。backend 修正はこのリリースで本番反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJX3pQcb1QfypbJwcP8gka