### PR TITLE
feat(mobile): ワークスペース一覧にダッシュボードボタンを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1036,6 +1036,8 @@ export function App() {
 				onSelectPane={handleSelectPane}
 				onBack={openSessions.length > 0 ? handleBackFromList : undefined}
 				isOnboarding={showSessionListOnboarding}
+				onToggleDashboard={() => setShowMobileDashboard((v) => !v)}
+				dashboardOpen={showMobileDashboard}
 			/>
 			{showSessionListOnboarding && (
 				<Onboarding
@@ -1425,9 +1427,12 @@ export function App() {
 				/>
 			)}
 
-			{/* Mobile Dashboard Overlay */}
+			{/* Mobile Dashboard Overlay.
+			    z-[70] so it also covers the workspace list overlay (z-[60]) — the
+			    list header now has its own dashboard button, and closing the
+			    dashboard drops the user back onto the list. */}
 			{showMobileDashboard && (
-				<div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0a] animate-modal-in">
+				<div className="fixed inset-0 z-[70] flex flex-col bg-[#0a0a0a] animate-modal-in">
 					<div className="shrink-0 px-4 pt-3 pb-3 border-b border-white/[0.06]">
 						<div className="flex items-center justify-between gap-2">
 							<div className="flex items-center gap-1 bg-white/[0.04] rounded-lg p-0.5">


### PR DESCRIPTION
## 背景

スマホではダッシュボードへの入口が「ターミナル画面の上部バー」と「ファイルブラウザ」にしかなく、セッションを1つも開いていない状態だと到達手段がゼロだった。

`WorkspaceList` は既に `onToggleDashboard` を受け取ってヘッダー（検索アイコンの左）にダッシュボードボタンを描画する実装を持っており、デスクトップの `Ctrl+B` モーダル (`SessionModal`) では表示されている。モバイルの一覧オーバーレイから prop を渡していないだけだった。

## 変更

- `App.tsx` の一覧オーバーレイの `WorkspaceList` に `onToggleDashboard` / `dashboardOpen` を渡す
- モバイルダッシュボード overlay の z を `z-50` → `z-[70]` に変更。一覧オーバーレイが `z-[60]` なので、上げないと一覧の裏に隠れて見えない。閉じると一覧に戻る

## 検証（420×900 モバイル幅 / dev）

1. 一覧ヘッダーにグラフアイコンが表示される
2. タップでダッシュボードが一覧の上に全画面表示（Dashboard / Servers 両タブ動作）
3. × で閉じると一覧に戻る
4. `bun run lint` / `tsc --noEmit` / `bun run test`（backend 470 pass, frontend 74 pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFJJ7FBdg7koTsEKatL1pa