### PR TITLE
fix(glasses): stop the service worker swallowing /glasses

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -138,6 +138,11 @@ export default defineConfig({
       workbox: {
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024, // 3 MiB
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        // /glasses is a separate app the backend serves, not a route of this
+        // SPA. navigateFallback defaults to answering EVERY navigation with
+        // our index.html, so without this the glasses simulator opens as CC
+        // Hub on any browser that has already installed the service worker.
+        navigateFallbackDenylist: [/^\/glasses/],
         importScripts: ['sw-notification.js'],
         runtimeCaching: [
           {


### PR DESCRIPTION
CC Hub の Service Worker が既に入っているブラウザでは、`/glasses` を開くとシミュレータではなく CC Hub 本体が表示される。再現確認済み: SW 登録済みの状態で開くと、タイトルが「CC Hub」でシミュレータの要素が1つも存在しない。

vite-plugin-pwa の `navigateFallback` は**あらゆるナビゲーションを precache した index.html で応答する**。`/glasses` はこの SPA のルートではなくバックエンドが配信しているため、フォールバックに横取りされていた。

新規プロファイルのブラウザでは起きない — SW が未登録の間だけリクエストがネットワークに到達するためで、私が検証に使ったのがまさにその状態だった。実機を持つ側の環境で初めて出る類の不具合を、こちらの検証環境がすり抜けていた。

該当プレフィックスを denylist に入れて素通りさせる。

```
denylist:[/^\/glasses/]   ← 生成された sw.js で確認
```

## 注意

**新しい Service Worker が有効化されて初めて効く。** `registerType` が `'prompt'` のため、既に開いているクライアントは更新を承認するまで古い worker を使い続ける。それまでの回避策はシークレットウィンドウ、または SW 更新後の再読み込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np