### PR TITLE
Release v0.2.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.52] - 2026-07-27
+
+### Fixed
+- **Service Worker が `/glasses` を横取りしていた問題** (#536): CC Hub の Service Worker が既に入っているブラウザでは、`/glasses` を開くとグラスシミュレータではなく CC Hub 本体が表示されていた（タイトルが「CC Hub」でシミュレータの要素が1つも無い状態）。vite-plugin-pwa の `navigateFallback` はあらゆるナビゲーションを precache した `index.html` で応答するため、SPA のルートではなくバックエンドが配信している `/glasses` がフォールバックに横取りされていた。該当プレフィックスを `navigateFallbackDenylist` に入れて素通りさせる（`frontend/vite.config.ts`）
+  - 新規プロファイルのブラウザでは再現しない（SW 未登録の間だけリクエストがネットワークに到達するため）。v0.2.51 の検証がその状態で行われており、実際に使う側の環境で初めて出た
+  - **新しい Service Worker が有効化されて初めて効く**。`registerType` が `'prompt'` のため、既に開いているクライアントは更新を承認するまで古い worker を使い続ける
+
 ## [0.2.51] - 2026-07-26
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.51",
-  "generated": "2026-07-26",
+  "version": "0.2.52",
+  "generated": "2026-07-27",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.2.51",
-  "generated": "2026-07-26",
+  "version": "0.2.52",
+  "generated": "2026-07-27",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- fix(glasses): Service Worker が `/glasses` を横取りしていた問題を修正 (#536)

## Notes
- SW 登録済みのブラウザで `/glasses` が CC Hub 本体になっていた。`navigateFallbackDenylist` で素通りさせる
- **新しい Service Worker が有効化されて初めて効く**（`registerType: 'prompt'`）。更新プロンプトを承認するか、シークレットウィンドウで開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np