### PR TITLE
Release v0.2.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.55] - 2026-07-27
+
+### Fixed
+- **グラス: 会話を遡って読んでいると数秒で最新に引き戻される問題** (#545): `maybeRefreshConversation` はターミナル出力とセッション push のたび（3秒スロットル）に `loadConversation` を呼ぶが、`loadConversation` は末尾で `conversationOffset` と `conversationPage` を 0 にリセットしていた。つまり更新は新着を取ってくるだけでなく、**読んでいる途中の人を3秒ごとに先頭へ戻していた**。遡り表示中は更新を保留するよう修正（`glasses/src/controller.ts`、ehpk v0.1.32）。最新まで戻せばライブ更新が再開するので、通常のケース（最新メッセージが流れてくるのを眺める）には影響しない
+
 ## [0.2.54] - 2026-07-27
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.54",
+  "version": "0.2.55",
   "generated": "2026-07-27",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.54",
+  "version": "0.2.55",
   "generated": "2026-07-27",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.54",
+  "version": "0.2.55",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes
- fix(glasses): 会話を遡って読んでいると数秒で最新に引き戻される問題を修正 (#545)

## Notes
- 3秒ごとの自動更新が、新着取得のついでにスクロール位置を毎回 0 に戻していた
- 遡り表示中は更新を保留。最新に戻せばライブ更新が再開する
- ehpk v0.1.32（実機の挙動なので要アップロード）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np