### PR TITLE
fix(glasses): テーブルを本文として描画し、行頭に句読点が落ちないようにする

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
       },
       "devDependencies": {
         "@evenrealities/evenhub-cli": "^0.1.13",
+        "@types/bun": "^1.3.14",
         "typescript": "~5.9.3",
         "vite": "^8.0.1",
       },
@@ -1410,6 +1411,8 @@
 
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
+    "glasses/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
@@ -1501,6 +1504,8 @@
     "@tailwindcss/vite/vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "@tailwindcss/vite/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "glasses/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/glasses/package.json
+++ b/glasses/package.json
@@ -10,7 +10,7 @@
     "build:web": "tsc && vite build --base=/glasses/ --outDir=dist-web",
     "preview": "vite preview",
     "pack": "evenhub pack",
-    "test": "echo 'no tests'",
+    "test": "bun test",
     "lint": "echo 'no lint'",
     "typecheck": "tsgo --noEmit"
   },
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@evenrealities/evenhub-cli": "^0.1.13",
+    "@types/bun": "^1.3.14",
     "typescript": "~5.9.3",
     "vite": "^8.0.1"
   }

--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test'
+import { sanitizeForG2, formatMessage } from '../types.ts'
+import { wrapForPanel } from '../display.ts'
+
+const LINE_WIDTH = 52
+const CJK_RATIO = 52 / 28
+
+function width(text: string): number {
+  let w = 0
+  for (let i = 0; i < text.length; i++) {
+    const code = text.codePointAt(i) ?? 0
+    const wide =
+      (code >= 0x3000 && code <= 0x9fff) ||
+      (code >= 0xf900 && code <= 0xfaff) ||
+      (code >= 0xff01 && code <= 0xff60) ||
+      (code >= 0xffe0 && code <= 0xffe6)
+    w += wide ? CJK_RATIO : 1
+  }
+  return w
+}
+
+describe('sanitizeForG2: tables', () => {
+  const table = [
+    '| 対象 | 版 |',
+    '|---|---|',
+    '| CC Hub 本体 | **v0.2.55**（本番更新済み） |',
+    '| G2 グラスアプリ | `v0.1.32` |',
+  ].join('\n')
+
+  test('renders the cells instead of a meaningless [table] marker', () => {
+    const out = sanitizeForG2(table)
+    expect(out).not.toContain('[table]')
+    expect(out).toContain('CC Hub 本体 | v0.2.55（本番更新済み）')
+  })
+
+  test('drops the |---|---| delimiter row', () => {
+    expect(sanitizeForG2(table).split('\n')).toEqual([
+      '対象 | 版',
+      'CC Hub 本体 | v0.2.55（本番更新済み）',
+      'G2 グラスアプリ | v0.1.32',
+    ])
+  })
+
+  test('handles alignment markers and empty cells', () => {
+    const out = sanitizeForG2('| a | b |\n|:--|--:|\n| 1 |  |')
+    expect(out.split('\n')).toEqual(['a | b', '1'])
+  })
+
+  test('leaves prose containing a pipe alone', () => {
+    expect(sanitizeForG2('grep foo | wc -l を実行')).toBe('grep foo | wc -l を実行')
+  })
+})
+
+describe('wrapForPanel: line breaking', () => {
+  test('never opens a line with a prohibited character (行頭禁則)', () => {
+    const text =
+      'その loadConversation が末尾でこうしていました。新着を取ってくるついでに、読んでいる人を毎回先頭へ戻していたわけです。'
+    for (const line of wrapForPanel(text).split('\n')) {
+      expect('。、）」！？…'.includes(line[0] ?? '')).toBe(false)
+    }
+  })
+
+  test('never ends a line with a dangling opening bracket (行末禁則)', () => {
+    const text = `${'あ'.repeat(27)}（補足です）そのあとに続く文章がここにあります`
+    for (const line of wrapForPanel(text).split('\n')) {
+      expect('（(「『'.includes(line.at(-1) ?? '')).toBe(false)
+    }
+  })
+
+  test('keeps a short ASCII word whole', () => {
+    const text = `${'あ'.repeat(26)}という理由で Beta に上げました`
+    expect(wrapForPanel(text)).toContain('Beta')
+    for (const line of wrapForPanel(text).split('\n')) {
+      expect(line).not.toMatch(/(Bet|Be|B)$/)
+    }
+  })
+
+  test('splits rather than leave a wide ragged margin', () => {
+    // 14 characters of the identifier already sit on the line; carrying them
+    // down would blank more than a quarter of it.
+    const long = 'maybeRefreshConversation'
+    const lines = wrapForPanel(`${'あ'.repeat(20)}${long}が動く`).split('\n')
+    expect(lines.some((l) => l.includes(long))).toBe(false)
+  })
+
+  test('splits a word too long to ever fit on one line', () => {
+    const url = `https://example.com/${'x'.repeat(80)}`
+    const lines = wrapForPanel(`参照は ${url} です`).split('\n')
+    // No blank columns bought anything — the URL was going to split regardless.
+    expect(width(lines[0])).toBeGreaterThan(LINE_WIDTH - 2)
+  })
+
+  test('no line exceeds the panel width', () => {
+    const text = sanitizeForG2(
+      '会話を遡ると数秒で最新に戻る件は、**自動更新がスクロール位置を巻き添えにしていた**のが原因でした。\n\n| 対象 | 版 |\n|---|---|\n| CC Hub 本体 | v0.2.55 |',
+    )
+    for (const line of wrapForPanel(text).split('\n')) {
+      expect(width(line)).toBeLessThanOrEqual(LINE_WIDTH)
+    }
+  })
+
+  test('loses no characters while re-wrapping', () => {
+    const text = 'あいうえお、かきくけこ。Beta と push のたびに（3 秒）動きます。'
+    const strip = (s: string) => s.replace(/\s/g, '')
+    expect(strip(wrapForPanel(text))).toBe(strip(text))
+  })
+
+  test('a single character wider than the line does not loop forever', () => {
+    expect(wrapForPanel('あ'.repeat(200)).split('\n').length).toBeGreaterThan(1)
+  })
+})
+
+describe('formatMessage', () => {
+  test('carries a table through to the rendered message', () => {
+    const out = formatMessage({
+      role: 'assistant',
+      content: 'まとめ\n\n| 対象 | 版 |\n|---|---|\n| 本体 | v0.2.55 |',
+    })
+    expect(out).toContain('本体 | v0.2.55')
+    expect(out).not.toContain('[table]')
+  })
+})

--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -99,6 +99,21 @@ describe('wrapForPanel: line breaking', () => {
     }
   })
 
+  test('a space falling on the wrap point does not indent the next line', () => {
+    // The gap between two words is where the break happened; carrying it down
+    // showed up on the panel as an unexplained space mid-sentence.
+    const text =
+      'glasses ワークスペースは今までテストゼロだったので、bun test を入れて 13 件書きました。lint / test / typecheck / device・web 両ビルドとも通っています。'
+    for (const line of wrapForPanel(text).split('\n')) {
+      expect(line).not.toMatch(/^\s/)
+      expect(line).not.toMatch(/\s$/)
+    }
+  })
+
+  test('keeps indentation that came from a real newline', () => {
+    expect(wrapForPanel('あ\n  いんでんと').split('\n')[1]).toBe('  いんでんと')
+  })
+
   test('loses no characters while re-wrapping', () => {
     const text = 'あいうえお、かきくけこ。Beta と push のたびに（3 秒）動きます。'
     const strip = (s: string) => s.replace(/\s/g, '')

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -39,6 +39,72 @@ function charWidth(ch: string): number {
   return 1
 }
 
+/** Total display width of a string, in the same half-width units as the panel. */
+function displayWidth(text: string): number {
+  let w = 0
+  for (let i = 0; i < text.length; i++) w += charWidth(text[i])
+  return w
+}
+
+/** 行頭禁則: characters that must not open a line. A lone `。` pushed onto the
+ *  next line is the most visible artefact of a naive 52-column split. */
+const NO_LINE_START = '。、．，・：；！？!?)）］」』｝》〉”’…ー〜%％'
+
+/** 行末禁則: opening brackets must not be left dangling at the end of a line. */
+const NO_LINE_END = '（(［[「『｛{《〈“‘'
+
+/** Columns we are willing to leave blank to keep an ASCII word whole. Beyond
+ *  this the ragged margin costs more than the broken word — with only seven
+ *  lines on screen, half a blank line is not worth an unbroken identifier. */
+const MAX_WORD_CARRY = 12
+
+const WORD_CHAR = /[A-Za-z0-9'._-]/
+
+/**
+ * Decide where to actually cut a full line, given the character at `i` that no
+ * longer fits. Returns [keep, carry]: `keep` closes the line, `carry` moves
+ * down ahead of that character.
+ *
+ * All three rules push characters down rather than letting them overflow — the
+ * column widths here are measured approximations, so an overflowing line would
+ * be re-wrapped by the G2's own container and land right back on the artefact
+ * we are avoiding.
+ */
+function chooseBreak(line: string, text: string, i: number): [string, string] {
+  const next = text[i]
+
+  if (NO_LINE_START.includes(next)) {
+    // Carry at most two characters, or a run of closers would empty the line.
+    for (let n = 1; n <= 2 && n < line.length; n++) {
+      const cut = line.length - n
+      if (!NO_LINE_START.includes(line[cut]) && line[cut] !== ' ') {
+        return [line.slice(0, cut), line.slice(cut)]
+      }
+    }
+    return [line, '']
+  }
+
+  if (line.length > 1 && NO_LINE_END.includes(line[line.length - 1])) {
+    return [line.slice(0, -1), line.slice(-1)]
+  }
+
+  if (/[A-Za-z0-9]/.test(next)) {
+    let start = line.length
+    while (start > 0 && WORD_CHAR.test(line[start - 1])) start--
+    const carried = line.length - start
+    if (start === 0 || carried === 0 || carried > MAX_WORD_CARRY) return [line, '']
+    // Only worth a ragged margin if the word then fits whole. A URL or a very
+    // long path is going to be split wherever it lands, so leave the blank
+    // columns out of it.
+    let end = i
+    while (end < text.length && WORD_CHAR.test(text[end])) end++
+    if (carried + (end - i) > LINE_WIDTH) return [line, '']
+    return [line.slice(0, start).trimEnd(), line.slice(start)]
+  }
+
+  return [line, '']
+}
+
 /** Split text into display lines respecting character widths and newlines */
 function splitDisplayLines(text: string): string[] {
   const lines: string[] = []
@@ -54,10 +120,11 @@ function splitDisplayLines(text: string): string[] {
       continue
     }
     const w = charWidth(ch)
-    if (currentWidth + w > LINE_WIDTH) {
-      lines.push(currentLine)
-      currentLine = ch
-      currentWidth = w
+    if (currentWidth + w > LINE_WIDTH && currentLine) {
+      const [keep, carry] = chooseBreak(currentLine, text, i)
+      lines.push(keep)
+      currentLine = carry + ch
+      currentWidth = displayWidth(currentLine)
     } else {
       currentLine += ch
       currentWidth += w

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -110,6 +110,9 @@ function splitDisplayLines(text: string): string[] {
   const lines: string[] = []
   let currentLine = ''
   let currentWidth = 0
+  // True while the line was opened by a wrap rather than by a newline, so the
+  // space the wrap fell on can be dropped without eating real indentation.
+  let wrapped = false
 
   for (let i = 0; i < text.length; i++) {
     const ch = text[i]
@@ -117,20 +120,27 @@ function splitDisplayLines(text: string): string[] {
       lines.push(currentLine)
       currentLine = ''
       currentWidth = 0
+      wrapped = false
       continue
     }
+    // The space between two words is where the break happened — carrying it to
+    // the next line leaves a stray indent, which on the panel reads as an
+    // unexplained gap in the middle of a sentence.
+    if (wrapped && !currentLine && ch === ' ') continue
     const w = charWidth(ch)
     if (currentWidth + w > LINE_WIDTH && currentLine) {
       const [keep, carry] = chooseBreak(currentLine, text, i)
-      lines.push(keep)
-      currentLine = carry + ch
-      currentWidth = displayWidth(currentLine)
-    } else {
-      currentLine += ch
-      currentWidth += w
+      lines.push(keep.trimEnd())
+      currentLine = carry
+      currentWidth = displayWidth(carry)
+      wrapped = true
+      i-- // re-examine ch against the fresh line
+      continue
     }
+    currentLine += ch
+    currentWidth += w
   }
-  if (currentLine) lines.push(currentLine)
+  if (currentLine) lines.push(currentLine.trimEnd())
   return lines
 }
 

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -84,17 +84,54 @@ export interface GlassesRelayItem {
 
 // ─── G2 display helpers ───
 
+/** Unwrap inline Markdown — the syntax itself is unreadable on the G2. */
+function stripInline(raw: string): string {
+  return raw
+    .replace(/^\s{0,3}#{1,6}\s+/, '') // headers
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → text
+    .replace(/\*\*([^*]+)\*\*/g, '$1') // bold
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/\*([^*\n]+)\*/g, '$1') // italic
+    .replace(/\b_([^_\n]+)_\b/g, '$1')
+    .replace(/`([^`]+)`/g, '$1') // inline code
+    .replace(/^\s*>\s?/, '') // blockquote marker
+    .replace(/~~([^~]+)~~/g, '$1') // strikethrough
+    .trimEnd()
+}
+
+/**
+ * One Markdown table row → one plain line (`cell | cell`).
+ *
+ * The whole table used to collapse into a `[table]` marker, which threw the
+ * content away and told the reader nothing — the marker itself carries no
+ * information (real-device feedback). Tables in agent replies are nearly
+ * always short key/value pairs, which read fine one row per line even at 52
+ * columns. Returns null for the `|---|---|` delimiter row, which has nothing
+ * to say without column alignment to describe.
+ */
+function tableRowToLine(raw: string): string | null {
+  const cells = raw
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((c) => c.trim())
+  if (cells.every((c) => /^:?-+:?$/.test(c))) return null
+  const kept = cells.filter((c) => c !== '')
+  return kept.length ? kept.join(' | ') : null
+}
+
 /**
  * Strip Markdown / collapse noisy blocks for the G2's plain-text 7-line page.
  * Mechanical only — no semantic summarization (that's the v2 server-side LLM
- * plan). Fenced code and tables collapse to one marker line; emphasis,
- * headers, links and inline-code backticks are unwrapped; blank lines and
- * horizontal rules are dropped (every line is scarce on the glasses).
+ * plan). Fenced code collapses to one marker line (code is unreadable at this
+ * size anyway); table rows are flattened to text; emphasis, headers, links and
+ * inline-code backticks are unwrapped; blank lines and horizontal rules are
+ * dropped (every line is scarce on the glasses).
  */
 export function sanitizeForG2(text: string): string {
   const out: string[] = []
   let inCode = false
-  let inTable = false
   for (const raw of text.split('\n')) {
     if (/^\s*```/.test(raw)) {
       inCode = !inCode
@@ -102,24 +139,12 @@ export function sanitizeForG2(text: string): string {
       continue
     }
     if (inCode) continue
-    const isTableRow = /^\s*\|.*\|?\s*$/.test(raw) && raw.includes('|')
-    if (isTableRow) {
-      if (!inTable) out.push('[table]')
-      inTable = true
+    if (/^\s*\|.*\|?\s*$/.test(raw) && raw.includes('|')) {
+      const row = tableRowToLine(raw)
+      if (row) out.push(stripInline(row))
       continue
     }
-    inTable = false
-    const line = raw
-      .replace(/^\s{0,3}#{1,6}\s+/, '') // headers
-      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → text
-      .replace(/\*\*([^*]+)\*\*/g, '$1') // bold
-      .replace(/__([^_]+)__/g, '$1')
-      .replace(/\*([^*\n]+)\*/g, '$1') // italic
-      .replace(/\b_([^_\n]+)_\b/g, '$1')
-      .replace(/`([^`]+)`/g, '$1') // inline code
-      .replace(/^\s*>\s?/, '') // blockquote marker
-      .replace(/~~([^~]+)~~/g, '$1') // strikethrough
-      .trimEnd()
+    const line = stripInline(raw)
     if (!line.trim()) continue // blank lines / horizontal rules (---, ***)
     if (/^[-*_]{3,}$/.test(line.trim())) continue
     out.push(line)

--- a/glasses/tsconfig.json
+++ b/glasses/tsconfig.json
@@ -4,7 +4,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
-    "types": ["vite/client"],
+    "types": ["vite/client", "bun"],
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
実機からの指摘 2 件。どちらも文字レイアウトの問題です。

> テーブルって意味のない情報になってます
> あと変なところでたくさん改行がはいるのも読みづらい

## Before / After

```
 3|[table]                                              ← 版数が丸ごと消える
 9|びます。その loadConversation が末尾でこうしていました
10|。                                                    ← 句点だけが行頭に落ちる
```
```
 3|対象 | 版
 4|CC Hub 本体 | v0.2.55（本番更新済み）
 5|G2 グラスアプリ | v0.1.32（EVEN Hub の Beta）
11|びます。その loadConversation が末尾でこうしていまし
12|た。
```

## テーブル

`[table]` マーカーは「表があった」以外に何も伝えず、読みたかったセル自体を捨てていました。エージェントの表はほぼ短い key/value なので、1 行 1 レコードの `セル | セル` として出します。`|---|---|` の区切り行だけは落とします。

## 行分割

52 桁での折り返しに禁則処理がなく、行末付近で文が終わると `。` だけが次の行の先頭に残っていました。`splitDisplayLines` に行頭・行末禁則と、短い英単語を割らない規則を入れています。

3 つとも **文字を次行に送り出す**方式で、はみ出させてはいません。ここの桁幅は実測値の近似なので、あふれた行は G2 側のコンテナが再度折り返し、避けたはずの状態に戻ってしまうためです。

どう分割しても 1 行に収まらない語（URL、長いパス）は、空けた桁が何も買わないのでそのまま割ります。

## テスト

glasses ワークスペースに初めてテストを追加しました（`bun test`、13 件）。禁則、桁幅超過なし、再折り返しで文字が消えないこと、テーブルの各パターンを固定しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np