### PR TITLE
feat(glasses): ヘッダー右端に時計を表示

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -219,6 +219,48 @@ describe('conversation body', () => {
   })
 })
 
+describe('header clock', () => {
+  const base = {
+    sessions: [{ id: 'a', name: 'グラス開発', state: 'working' as const }],
+    sessionIndex: 0,
+    conversation: [{ role: 'assistant' as const, content: 'やあ' }],
+    conversationOffset: 0,
+    conversationPage: 0,
+    conversationLastLoaded: 1,
+    conversationHasMore: false,
+    conversationLoading: false,
+    choiceIndex: 0,
+    choiceOptions: ['はい', 'いいえ'],
+    relayWaiting: [],
+    relayInfo: [],
+    overlayItemId: null,
+    voicePhase: 'recording' as const,
+  }
+
+  test('sits at the right edge on every screen', () => {
+    for (const mode of ['session_list', 'conversation', 'choice', 'voice', 'overlay'] as const) {
+      const header = screenText({ ...base, mode }).header
+      expect(header).toMatch(/ \d\d:\d\d$/)
+      expect(width(header)).toBeLessThanOrEqual(LINE_WIDTH)
+    }
+  })
+
+  test('a long title is clipped rather than pushing the clock off', () => {
+    const header = screenText({
+      ...base,
+      mode: 'conversation' as const,
+      sessions: [{ id: 'a', name: 'と'.repeat(60), state: 'working' as const }],
+    }).header
+    expect(header).toMatch(/ \d\d:\d\d$/)
+    expect(width(header)).toBeLessThanOrEqual(LINE_WIDTH)
+  })
+
+  test('leaves at least one space between title and clock', () => {
+    const header = screenText({ ...base, mode: 'conversation' as const }).header
+    expect(header).toMatch(/[^ ] +\d\d:\d\d$/)
+  })
+})
+
 describe('session list', () => {
   const state = {
     mode: 'session_list' as const,

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -12,7 +12,7 @@
 import { setBaseUrl, transcribe } from './api.ts'
 import { GlassesController } from './controller.ts'
 import type { GlassesPlatform } from './controller.ts'
-import { screenText, wrapForPanel } from './display.ts'
+import { charWidth, screenText, wrapForPanel } from './display.ts'
 import type { AppState } from './display.ts'
 
 /** Japanese screen names — the shared vocabulary used when reporting issues. */
@@ -270,6 +270,36 @@ export function startDebugUI(): void {
   /** Draw one screen at the hardware's real pixel count, then crush it to the
    *  panel's 16 levels of green. Anti-aliasing finer than 4 bits is exactly
    *  what the wearer does not get. */
+  // The panel's column pitch, measured on the hardware: 52 columns across the
+  // body's 556px. No browser monospace matches the device font — at this size
+  // it draws ASCII at 9.5px against the device's 10.69 and CJK at 19 against
+  // 19.85 — so letting the browser lay out a whole string drifts by several
+  // columns across one line. Right-aligned content ended up nowhere near the
+  // edge. Advancing per character by the device's own pitch puts every glyph
+  // where the G2 puts it, which is the entire point of this window.
+  const PITCH = 556 / 52
+
+  function drawRow(ctx: CanvasRenderingContext2D, text: string, x: number, y: number): void {
+    let col = 0
+    for (const ch of text) {
+      const cell = charWidth(ch) * PITCH
+      const natural = ctx.measureText(ch).width
+      if (natural > cell + 0.5) {
+        // A glyph the width table misjudges — an emoji, a box-drawing rune —
+        // would otherwise run over its neighbour. Squeeze it into the cell the
+        // device gives it, which is also what the reader needs to know.
+        ctx.save()
+        ctx.translate(x + col * PITCH, y)
+        ctx.scale(cell / natural, 1)
+        ctx.fillText(ch, 0, 0)
+        ctx.restore()
+      } else {
+        ctx.fillText(ch, x + col * PITCH, y)
+      }
+      col += charWidth(ch)
+    }
+  }
+
   function drawPanel(screen: { header: string; body: string; footer: string }): void {
     const ctx = canvas.getContext('2d')
     if (!ctx) return
@@ -281,14 +311,14 @@ export function startDebugUI(): void {
     ctx.shadowBlur = 6
 
     ctx.fillStyle = `rgb(${GREEN})`
-    ctx.fillText(screen.header, 4, 25)
+    drawRow(ctx, screen.header, 4, 25)
 
     for (const [i, line] of screen.body.split('\n').entries()) {
-      ctx.fillText(line, 10, HEADER_H + 28 + i * 28)
+      drawRow(ctx, line, 10, HEADER_H + 28 + i * 28)
     }
 
     ctx.fillStyle = `rgba(${GREEN}, 0.78)`
-    ctx.fillText(screen.footer, 4, FOOTER_Y + 25)
+    drawRow(ctx, screen.footer, 4, FOOTER_Y + 25)
 
     ctx.shadowBlur = 0
     ctx.fillStyle = `rgba(${GREEN}, 0.3)`

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -24,7 +24,7 @@ const MAX_LINES = 7         // max visible lines in body container
 const CJK_RATIO = 52 / 28  // CJK char width relative to ASCII (~1.857)
 
 /** Returns the display width of a single character in half-width units */
-function charWidth(ch: string): number {
+export function charWidth(ch: string): number {
   const code = ch.codePointAt(0) ?? 0
   // CJK Unified Ideographs, Hiragana, Katakana, Fullwidth forms, CJK Symbols
   if (
@@ -281,6 +281,31 @@ function sName(s: Session): string {
   return s.customTitle || s.name || s.id.slice(0, 8)
 }
 
+/**
+ * Park a wall clock at the right edge of a header.
+ *
+ * Padded to the body's 52 columns rather than the 53 the header's own 4px
+ * padding allows: the browser simulator measures CJK a little wider than the
+ * device does, and a column of slack costs nothing visible while an overflow
+ * would wrap the clock out of a 36px-tall container. A long title is clipped
+ * rather than pushing the clock off — the time is the part that has to stay
+ * put to be readable at a glance.
+ *
+ * No timer drives this: the server pushes `sessions-updated` every five
+ * seconds and each push re-renders, so the minute is never stale.
+ */
+function withClock(title: string): string {
+  const now = new Date()
+  const clock = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
+  const room = LINE_WIDTH - displayWidth(clock) - 1 // keep at least one space
+  let head = title
+  while (head && displayWidth(head) > room) head = head.slice(0, -1)
+  // Floor, not round: a CJK title measures fractionally, and rounding the gap
+  // up put the header a third of a column past the edge.
+  const gap = Math.max(1, Math.floor(LINE_WIDTH - displayWidth(head) - displayWidth(clock)))
+  return `${head}${' '.repeat(gap)}${clock}`
+}
+
 function isWaiting(s: Session): boolean {
   return s.indicatorState === 'waiting_input' || (!!s.waitingToolName && s.waitingToolName !== 'UserInput')
 }
@@ -347,7 +372,7 @@ function relayBannerLines(state: AppState): string[] {
 function sessionListHeader(state: AppState): string {
   const { sessionIndex, sessions, relayWaiting } = state
   const badge = relayWaiting.length > 0 ? ` !${relayWaiting.length}` : ''
-  return `CC Hub ${sessionIndex + 1}/${sessions.length}${badge}`
+  return withClock(`CC Hub ${sessionIndex + 1}/${sessions.length}${badge}`)
 }
 
 function sessionListBody(state: AppState): string {
@@ -397,7 +422,7 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
   const action = state.relayWaiting.length > 0 ? 'tap:対応  dbl:後で' : waiting ? 'tap:respond  dbl:back' : 'dbl:back'
 
   return {
-    headerText: `${session ? sName(session) : '---'}${statusBadge}`,
+    headerText: withClock(`${session ? sName(session) : '---'}${statusBadge}`),
     bodyText,
     footerText: `${action}  ${pos}`,
     multiCount,
@@ -416,7 +441,7 @@ const FOOTER_CHOICE = 'swipe:select  tap:confirm  dbl:skip'
 function choiceHeader(state: AppState): string {
   const session = state.sessions[state.sessionIndex]
   const name = state.choiceSessionName || (session ? sName(session) : '---')
-  return `${name}  [SELECT]`
+  return withClock(`${name}  [SELECT]`)
 }
 
 /**
@@ -478,10 +503,10 @@ function overlayContent(state: AppState): { headerText: string; bodyText: string
   const waiting = state.relayWaiting
   const item = waiting.find((i) => i.id === state.overlayItemId) || waiting[0]
   if (!item) {
-    return { headerText: 'Relay', bodyText: '(waiting なし)', footerText: 'dbl:戻る' }
+    return { headerText: withClock('Relay'), bodyText: '(waiting なし)', footerText: 'dbl:戻る' }
   }
   const idx = waiting.indexOf(item)
-  const headerText = `${relayLabel(state, item)} [!] ${idx + 1}/${waiting.length}`
+  const headerText = withClock(`${relayLabel(state, item)} [!] ${idx + 1}/${waiting.length}`)
 
   const lines = splitDisplayLines(item.text)
   if (item.choices?.length) {
@@ -505,19 +530,19 @@ function voiceContent(state: AppState): { headerText: string; bodyText: string; 
   switch (state.voicePhase) {
     case 'recording':
       return {
-        headerText: `${name}  [録音中]`,
+        headerText: withClock(`${name}  [録音中]`),
         bodyText: '● 録音中\n\nマイクに向かって話してください',
         footerText: 'tap:停止して認識  dbl:キャンセル',
       }
     case 'transcribing':
       return {
-        headerText: `${name}  [認識中]`,
+        headerText: withClock(`${name}  [認識中]`),
         bodyText: '認識中…',
         footerText: 'dbl:キャンセル',
       }
     default: // 'confirm'
       return {
-        headerText: `${name}  [確認]`,
+        headerText: withClock(`${name}  [確認]`),
         bodyText: state.voiceText ? state.voiceText : '(認識できませんでした)',
         footerText: state.voiceText ? 'tap:送信  dbl:キャンセル' : 'dbl:戻る',
       }
@@ -858,10 +883,16 @@ export async function updateDisplay(bridge: Bridge | null, state: AppState): Pro
       break
     }
     case 'choice': {
-      await bridge.textContainerUpgrade(new TextContainerUpgrade({
-        containerID: 2, containerName: 'body',
-        content: choiceBody(state),
-      }))
+      await Promise.all([
+        bridge.textContainerUpgrade(new TextContainerUpgrade({
+          containerID: 1, containerName: 'header',
+          content: choiceHeader(state),
+        })),
+        bridge.textContainerUpgrade(new TextContainerUpgrade({
+          containerID: 2, containerName: 'body',
+          content: choiceBody(state),
+        })),
+      ])
       break
     }
     case 'voice': {


### PR DESCRIPTION
> 会話画面のセッションタイトルの一番右、画面の右端に時刻を入れられるとありがたいです。時間はいつ見えても嬉しいんで

```
linux                                          09:56
```

「いつ見えても嬉しい」とのことなので、会話画面だけでなく全画面（一覧・会話・選択・音声・オーバーレイ）のヘッダーに出します。

## 実装メモ

- **桁数は本文と同じ 52**。ヘッダー自身の padding では 53 桁入りますが、1 桁の余裕を残しています。あふれるとコンテナが折り返し、36px の箱から時計が消えるため
- **切り捨て（floor）で右詰め**。CJK タイトルは 1.857 桁と端数を持つので、四捨五入だと 1/3 桁ぶん右端を越えました
- **長いタイトルは切る**。時計を押し出さない。ひと目で読めることが時計の存在理由なので、動かないことを優先
- **タイマーなし**。`sessions-updated` が 5 秒ごとに再描画するので分は古くなりません。選択画面だけは本文しか更新しておらず時計が固まるため、ヘッダーも更新するようにしました

## シミュレータの描画忠実度

時計を入れて初めて分かったのですが、シミュレータは文字列全体をブラウザのメトリクスで配置しており、1 行で数桁ぶんずれていました（実機 ASCII 10.69px に対しブラウザ 9.5px、CJK は 19.85px に対し 19px）。右詰めが右端から程遠い位置に出ます。

実機実測のカラムピッチで 1 文字ずつ進めるよう変更しました。あわせて、幅テーブルが読み違えるグリフ（絵文字、罫線）は隣に重ならないよう実機のセル幅に押し込めます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np