### PR TITLE
fix(glasses): 文字幅を実測ピクセルで測る（@evenrealities/pretext 採用）

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@evenrealities/even_hub_sdk": "^0.0.12",
+        "@evenrealities/pretext": "^0.1.4",
       },
       "devDependencies": {
         "@evenrealities/evenhub-cli": "^0.1.13",
@@ -334,6 +335,8 @@
     "@evenrealities/even_hub_sdk": ["@evenrealities/even_hub_sdk@0.0.12", "", {}, "sha512-PXAeuPl7dMIlSWlctDeQAodIr7iuNROaH9GvRrZ86xzRh33DkMJYY1hSxy6BTk+TLkDA0tYlVi4bOsSIJngINA=="],
 
     "@evenrealities/evenhub-cli": ["@evenrealities/evenhub-cli@0.1.13", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^14.0.2", "inquirer": "^13.1.0", "js-yaml": "^4.1.1", "open": "^11.0.0", "qr-image": "^3.2.0", "qrcode-terminal": "^0.12.0", "zod": "^4.3.2" }, "peerDependencies": { "typescript": "^5" }, "bin": { "evenhub": "main.js", "eh": "main.js" } }, "sha512-glkkGfImds8ceh1YTbVvwuw7jlcSAKnI6Q7ATrDynKSvODs9/FV/R+0CliyCog3JJRTON0+EXBLW3lxU4x8NBQ=="],
+
+    "@evenrealities/pretext": ["@evenrealities/pretext@0.1.4", "", {}, "sha512-gSZk/uxIhZW3geOM5bP1IS0s1sg7cA7KLLpBDgH9T1+ZNHMIFTMcgQN1qw4+/Xi/rcxsDsWZ7UZndIS/s4fRcA=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
 

--- a/glasses/package.json
+++ b/glasses/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@evenrealities/even_hub_sdk": "^0.0.12"
+    "@evenrealities/even_hub_sdk": "^0.0.12",
+    "@evenrealities/pretext": "^0.1.4"
   },
   "devDependencies": {
     "@evenrealities/evenhub-cli": "^0.1.13",

--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -1,23 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { sanitizeForG2, formatMessage } from '../types.ts'
-import { screenText, wrapForPanel } from '../display.ts'
-
-const LINE_WIDTH = 52
-const CJK_RATIO = 52 / 28
-
-function width(text: string): number {
-  let w = 0
-  for (let i = 0; i < text.length; i++) {
-    const code = text.codePointAt(i) ?? 0
-    const wide =
-      (code >= 0x3000 && code <= 0x9fff) ||
-      (code >= 0xf900 && code <= 0xfaff) ||
-      (code >= 0xff01 && code <= 0xff60) ||
-      (code >= 0xffe0 && code <= 0xffe6)
-    w += wide ? CJK_RATIO : 1
-  }
-  return w
-}
+import { screenText, wrapForPanel, wrapHeader } from '../display.ts'
+import { BODY_WIDTH, HEADER_WIDTH, textWidth as width } from '../metrics.ts'
 
 describe('sanitizeForG2: tables', () => {
   const table = [
@@ -87,7 +71,7 @@ describe('wrapForPanel: line breaking', () => {
     const url = `https://example.com/${'x'.repeat(80)}`
     const lines = wrapForPanel(`参照は ${url} です`).split('\n')
     // No blank columns bought anything — the URL was going to split regardless.
-    expect(width(lines[0])).toBeGreaterThan(LINE_WIDTH - 2)
+    expect(width(lines[0])).toBeGreaterThan(BODY_WIDTH - 40)
   })
 
   test('no line exceeds the panel width', () => {
@@ -95,7 +79,7 @@ describe('wrapForPanel: line breaking', () => {
       '会話を遡ると数秒で最新に戻る件は、**自動更新がスクロール位置を巻き添えにしていた**のが原因でした。\n\n| 対象 | 版 |\n|---|---|\n| CC Hub 本体 | v0.2.55 |',
     )
     for (const line of wrapForPanel(text).split('\n')) {
-      expect(width(line)).toBeLessThanOrEqual(LINE_WIDTH)
+      expect(width(line)).toBeLessThanOrEqual(BODY_WIDTH)
     }
   })
 
@@ -154,7 +138,7 @@ describe('formatMessage', () => {
         toolUse: [{ name, input: { command: 'x'.repeat(300), file_path: `/a/${'b'.repeat(300)}` } }],
       })
       expect(wrapForPanel(out).split('\n')).toHaveLength(1)
-      expect(width(out)).toBeLessThanOrEqual(LINE_WIDTH)
+      expect(width(out)).toBeLessThanOrEqual(BODY_WIDTH)
     }
   })
 
@@ -219,6 +203,9 @@ describe('conversation body', () => {
   })
 })
 
+/** One space of granularity: the gap is padded with 5px spaces. */
+const SPACE_SLACK = 6
+
 describe('header clock', () => {
   const base = {
     sessions: [{ id: 'a', name: 'グラス開発', state: 'working' as const }],
@@ -241,7 +228,10 @@ describe('header clock', () => {
     for (const mode of ['session_list', 'conversation', 'choice', 'voice', 'overlay'] as const) {
       const header = screenText({ ...base, mode }).header
       expect(header).toMatch(/ \d\d:\d\d$/)
-      expect(width(header)).toBeLessThanOrEqual(LINE_WIDTH)
+      // The header container holds exactly one line — 28px of inner height
+      // against a 27px line — so an overflow takes the clock off the panel.
+      expect(width(header)).toBeLessThanOrEqual(HEADER_WIDTH)
+      expect(wrapHeader(header).split('\n')).toHaveLength(1)
     }
   })
 
@@ -252,12 +242,25 @@ describe('header clock', () => {
       sessions: [{ id: 'a', name: 'と'.repeat(60), state: 'working' as const }],
     }).header
     expect(header).toMatch(/ \d\d:\d\d$/)
-    expect(width(header)).toBeLessThanOrEqual(LINE_WIDTH)
+    expect(width(header)).toBeLessThanOrEqual(HEADER_WIDTH)
   })
 
   test('leaves at least one space between title and clock', () => {
     const header = screenText({ ...base, mode: 'conversation' as const }).header
     expect(header).toMatch(/[^ ] +\d\d:\d\d$/)
+  })
+
+  test('actually reaches the right edge', () => {
+    // A space is 5px on this panel. Padding it out as if it were a 10.69px
+    // column left the clock near the middle — 293px into a 568px header.
+    for (const name of ['linux', 'グラス開発', 'cchub-work-1']) {
+      const header = screenText({
+        ...base,
+        mode: 'conversation' as const,
+        sessions: [{ id: 'a', name, state: 'working' as const }],
+      }).header
+      expect(width(header)).toBeGreaterThan(HEADER_WIDTH - SPACE_SLACK)
+    }
   })
 })
 

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -12,7 +12,8 @@
 import { setBaseUrl, transcribe } from './api.ts'
 import { GlassesController } from './controller.ts'
 import type { GlassesPlatform } from './controller.ts'
-import { charWidth, screenText, wrapForPanel } from './display.ts'
+import { screenText, wrapForPanel } from './display.ts'
+import { advance } from './metrics.ts'
 import type { AppState } from './display.ts'
 
 /** Japanese screen names — the shared vocabulary used when reporting issues. */
@@ -147,7 +148,7 @@ export function startDebugUI(): void {
     <div class="sim-wrap">
       <div class="sim-title">
         <h1>CC Hub Glasses シミュレータ</h1>
-        <span class="sub">実機と同じ描画（576×288 / 52字×7行）</span>
+        <span class="sub">実機と同じ描画（576×288 / 7行・幅は実測px）</span>
       </div>
       <div class="sim-main">
         <div class="lens-col">
@@ -263,40 +264,45 @@ export function startDebugUI(): void {
   // Panel geometry, straight from display.ts's container layout.
   const HEADER_H = 36
   const FOOTER_Y = PANEL_H - 36
-  const FONT = '19px ui-monospace, "SF Mono", Menlo, Consolas, monospace'
+  // Proportional, not monospace: the G2 font is proportional (a space is 5px,
+  // `i` is 4, `W` is 16) and drawing into those cells with a monospace face
+  // meant squeezing almost every ASCII glyph. A plain sans lands within about
+  // 1px of the firmware's advances instead of 4.
+  const FONT = '19px system-ui, "Noto Sans", "DejaVu Sans", sans-serif'
   // The panel's phosphor green, bright enough to hold against a lit room.
   const GREEN = '106, 255, 122'
 
   /** Draw one screen at the hardware's real pixel count, then crush it to the
    *  panel's 16 levels of green. Anti-aliasing finer than 4 bits is exactly
    *  what the wearer does not get. */
-  // The panel's column pitch, measured on the hardware: 52 columns across the
-  // body's 556px. No browser monospace matches the device font — at this size
-  // it draws ASCII at 9.5px against the device's 10.69 and CJK at 19 against
-  // 19.85 — so letting the browser lay out a whole string drifts by several
-  // columns across one line. Right-aligned content ended up nowhere near the
-  // edge. Advancing per character by the device's own pitch puts every glyph
-  // where the G2 puts it, which is the entire point of this window.
-  const PITCH = 556 / 52
-
+  // Every glyph lands where the firmware puts it.
+  //
+  // Letting the browser lay out a whole string drifts badly: the G2 font is
+  // proportional (a space is 5px, `i` is 4, `W` is 16) and no browser
+  // monospace comes close, so a right-aligned clock ended up near the middle
+  // of the panel. Advancing by the firmware's own per-character widths —
+  // kerning included — is the only way this window earns the phrase "実機と
+  // 同じ描画" in its own subtitle.
   function drawRow(ctx: CanvasRenderingContext2D, text: string, x: number, y: number): void {
-    let col = 0
+    let dx = 0
+    let prev = ''
     for (const ch of text) {
-      const cell = charWidth(ch) * PITCH
+      const cell = advance(prev, ch)
       const natural = ctx.measureText(ch).width
       if (natural > cell + 0.5) {
-        // A glyph the width table misjudges — an emoji, a box-drawing rune —
-        // would otherwise run over its neighbour. Squeeze it into the cell the
-        // device gives it, which is also what the reader needs to know.
+        // The browser's glyph is wider than the cell the firmware gives it —
+        // an emoji, a box-drawing rune. Squeeze it in rather than let it run
+        // over its neighbour, which is also what the reader needs to know.
         ctx.save()
-        ctx.translate(x + col * PITCH, y)
+        ctx.translate(x + dx, y)
         ctx.scale(cell / natural, 1)
         ctx.fillText(ch, 0, 0)
         ctx.restore()
       } else {
-        ctx.fillText(ch, x + col * PITCH, y)
+        ctx.fillText(ch, x + dx, y)
       }
-      col += charWidth(ch)
+      dx += cell
+      prev = ch
     }
   }
 

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -7,7 +7,16 @@ import {
   OsEventTypeList,
   AudioInputSource,
 } from '@evenrealities/even_hub_sdk'
-import { PANEL_WIDTH, formatMessage, recapBlockLines } from './types.ts'
+import {
+  BODY_WIDTH,
+  HEADER_WIDTH,
+  MAX_LINES,
+  SPACE_W,
+  ellipsize,
+  splitLines,
+  textWidth,
+} from './metrics.ts'
+import { formatMessage, recapBlockLines } from './types.ts'
 import type { Session, ConversationMessage, GlassesRelayItem } from './types.ts'
 
 const W = 576
@@ -17,131 +26,9 @@ export type Bridge = Awaited<ReturnType<typeof waitForEvenAppBridge>>
 type Mode = 'session_list' | 'conversation' | 'choice' | 'voice' | 'overlay'
 export type VoicePhase = 'recording' | 'transcribing' | 'confirm'
 
-// Display metrics (measured on actual G2 hardware)
-// Body container: 568x210, border=0, padding=6 → effective 556x198
-const LINE_WIDTH = PANEL_WIDTH   // max half-width (ASCII) chars per line
-const MAX_LINES = 7         // max visible lines in body container
-const CJK_RATIO = 52 / 28  // CJK char width relative to ASCII (~1.857)
-
-/** Returns the display width of a single character in half-width units */
-export function charWidth(ch: string): number {
-  const code = ch.codePointAt(0) ?? 0
-  // CJK Unified Ideographs, Hiragana, Katakana, Fullwidth forms, CJK Symbols
-  if (
-    (code >= 0x3000 && code <= 0x9FFF) ||   // CJK, Hiragana, Katakana, symbols
-    (code >= 0xF900 && code <= 0xFAFF) ||   // CJK Compatibility
-    (code >= 0xFF01 && code <= 0xFF60) ||   // Fullwidth Latin
-    (code >= 0xFFE0 && code <= 0xFFE6) ||   // Fullwidth symbols
-    (code >= 0x20000 && code <= 0x2FA1F)    // CJK Extension B+
-  ) {
-    return CJK_RATIO
-  }
-  return 1
-}
-
-/** Total display width of a string, in the same half-width units as the panel. */
-function displayWidth(text: string): number {
-  let w = 0
-  for (let i = 0; i < text.length; i++) w += charWidth(text[i])
-  return w
-}
-
-/** 行頭禁則: characters that must not open a line. A lone `。` pushed onto the
- *  next line is the most visible artefact of a naive 52-column split. */
-const NO_LINE_START = '。、．，・：；！？!?)）］」』｝》〉”’…ー〜%％'
-
-/** 行末禁則: opening brackets must not be left dangling at the end of a line. */
-const NO_LINE_END = '（(［[「『｛{《〈“‘'
-
-/** Columns we are willing to leave blank to keep an ASCII word whole. Beyond
- *  this the ragged margin costs more than the broken word — with only seven
- *  lines on screen, half a blank line is not worth an unbroken identifier. */
-const MAX_WORD_CARRY = 12
-
-const WORD_CHAR = /[A-Za-z0-9'._-]/
-
-/**
- * Decide where to actually cut a full line, given the character at `i` that no
- * longer fits. Returns [keep, carry]: `keep` closes the line, `carry` moves
- * down ahead of that character.
- *
- * All three rules push characters down rather than letting them overflow — the
- * column widths here are measured approximations, so an overflowing line would
- * be re-wrapped by the G2's own container and land right back on the artefact
- * we are avoiding.
- */
-function chooseBreak(line: string, text: string, i: number): [string, string] {
-  const next = text[i]
-
-  if (NO_LINE_START.includes(next)) {
-    // Carry at most two characters, or a run of closers would empty the line.
-    for (let n = 1; n <= 2 && n < line.length; n++) {
-      const cut = line.length - n
-      if (!NO_LINE_START.includes(line[cut]) && line[cut] !== ' ') {
-        return [line.slice(0, cut), line.slice(cut)]
-      }
-    }
-    return [line, '']
-  }
-
-  if (line.length > 1 && NO_LINE_END.includes(line[line.length - 1])) {
-    return [line.slice(0, -1), line.slice(-1)]
-  }
-
-  if (/[A-Za-z0-9]/.test(next)) {
-    let start = line.length
-    while (start > 0 && WORD_CHAR.test(line[start - 1])) start--
-    const carried = line.length - start
-    if (start === 0 || carried === 0 || carried > MAX_WORD_CARRY) return [line, '']
-    // Only worth a ragged margin if the word then fits whole. A URL or a very
-    // long path is going to be split wherever it lands, so leave the blank
-    // columns out of it.
-    let end = i
-    while (end < text.length && WORD_CHAR.test(text[end])) end++
-    if (carried + (end - i) > LINE_WIDTH) return [line, '']
-    return [line.slice(0, start).trimEnd(), line.slice(start)]
-  }
-
-  return [line, '']
-}
-
-/** Split text into display lines respecting character widths and newlines */
+/** Break text into the lines the body container will show. */
 function splitDisplayLines(text: string): string[] {
-  const lines: string[] = []
-  let currentLine = ''
-  let currentWidth = 0
-  // True while the line was opened by a wrap rather than by a newline, so the
-  // space the wrap fell on can be dropped without eating real indentation.
-  let wrapped = false
-
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i]
-    if (ch === '\n') {
-      lines.push(currentLine)
-      currentLine = ''
-      currentWidth = 0
-      wrapped = false
-      continue
-    }
-    // The space between two words is where the break happened — carrying it to
-    // the next line leaves a stray indent, which on the panel reads as an
-    // unexplained gap in the middle of a sentence.
-    if (wrapped && !currentLine && ch === ' ') continue
-    const w = charWidth(ch)
-    if (currentWidth + w > LINE_WIDTH && currentLine) {
-      const [keep, carry] = chooseBreak(currentLine, text, i)
-      lines.push(keep.trimEnd())
-      currentLine = carry
-      currentWidth = displayWidth(carry)
-      wrapped = true
-      i-- // re-examine ch against the fresh line
-      continue
-    }
-    currentLine += ch
-    currentWidth += w
-  }
-  if (currentLine) lines.push(currentLine.trimEnd())
-  return lines
+  return splitLines(text, BODY_WIDTH)
 }
 
 /** Paginate a single message by display lines */
@@ -284,12 +171,15 @@ function sName(s: Session): string {
 /**
  * Park a wall clock at the right edge of a header.
  *
- * Padded to the body's 52 columns rather than the 53 the header's own 4px
- * padding allows: the browser simulator measures CJK a little wider than the
- * device does, and a column of slack costs nothing visible while an overflow
- * would wrap the clock out of a 36px-tall container. A long title is clipped
- * rather than pushing the clock off — the time is the part that has to stay
- * put to be readable at a glance.
+ * The padding is spaces, and a space is 5px on this panel — a fifth of what a
+ * column-counting model assumed, which is why the clock used to stop near the
+ * middle. Widths come from the firmware's own metrics now, so the gap is
+ * computed in pixels and verified before it goes out.
+ *
+ * A long title is clipped rather than pushing the clock off: the time is the
+ * part that has to stay put to be readable at a glance. Overflow is never an
+ * option — the header container is 28px of inner height against a 27px line,
+ * so a wrap takes the second line, and the clock with it, off the panel.
  *
  * No timer drives this: the server pushes `sessions-updated` every five
  * seconds and each push re-renders, so the minute is never stale.
@@ -297,13 +187,18 @@ function sName(s: Session): string {
 function withClock(title: string): string {
   const now = new Date()
   const clock = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
-  const room = LINE_WIDTH - displayWidth(clock) - 1 // keep at least one space
+  const clockPx = textWidth(clock)
   let head = title
-  while (head && displayWidth(head) > room) head = head.slice(0, -1)
-  // Floor, not round: a CJK title measures fractionally, and rounding the gap
-  // up put the header a third of a column past the edge.
-  const gap = Math.max(1, Math.floor(LINE_WIDTH - displayWidth(head) - displayWidth(clock)))
-  return `${head}${' '.repeat(gap)}${clock}`
+  while (head && textWidth(head) + SPACE_W + clockPx > HEADER_WIDTH) head = head.slice(0, -1)
+  let spaces = Math.max(1, Math.floor((HEADER_WIDTH - textWidth(head) - clockPx) / SPACE_W))
+  // Kerning across the join can cost a pixel or two; give it back rather than
+  // hand the container a line it has to wrap.
+  let out = `${head}${' '.repeat(spaces)}${clock}`
+  while (spaces > 1 && textWidth(out) > HEADER_WIDTH) {
+    spaces--
+    out = `${head}${' '.repeat(spaces)}${clock}`
+  }
+  return out
 }
 
 function isWaiting(s: Session): boolean {
@@ -317,13 +212,6 @@ function statusLabel(s: Session): string {
 }
 
 const SEPARATOR = '-'.repeat(24)
-
-/** Trim a line down until an appended ellipsis still fits the panel. */
-function ellipsize(line: string): string {
-  let out = line
-  while (out && displayWidth(out) + 1 > LINE_WIDTH) out = out.slice(0, -1)
-  return `${out}…`
-}
 
 /**
  * The recap block, capped in *display* lines.
@@ -456,6 +344,11 @@ function choiceHeader(state: AppState): string {
  */
 export function wrapForPanel(text: string): string {
   return text.split('\n').flatMap(splitDisplayLines).join('\n')
+}
+
+/** Re-wrap a header string the way the header container would. */
+export function wrapHeader(text: string): string {
+  return splitLines(text, HEADER_WIDTH).join('\n')
 }
 
 /**

--- a/glasses/src/metrics.ts
+++ b/glasses/src/metrics.ts
@@ -1,0 +1,195 @@
+import { getTextWidth } from '@evenrealities/pretext'
+
+/**
+ * How the G2 panel measures text.
+ *
+ * The firmware renders with LVGL and a proportional font: a space is 5px, `i`
+ * is 4, `W` is 16, CJK is 20. Everything here used to be counted in "columns"
+ * of a notional 52-per-line monospace grid, which was close enough on average
+ * to look right and wrong enough that a right-aligned clock landed near the
+ * middle of the panel. `@evenrealities/pretext` embeds the firmware's own font
+ * metrics — same kerning, same per-glyph rounding — so widths are exact and
+ * the guessing stops.
+ */
+
+export { getTextWidth as textWidth }
+
+// ─── Container geometry ───
+//
+// Inner content width is `width - 2 * (paddingLength + borderWidth)`; the
+// containers below carry no border. LVGL gives every line 27px and no
+// fraction of one, so a container's line capacity is a floor division.
+
+export const PANEL_W = 576
+export const PANEL_H = 288
+/** Header and footer container height. */
+export const BAR_H = 36
+/** LVGL's fixed line height. */
+export const LINE_H = 27
+
+const HEADER_PAD = 4
+const BODY_PAD = 6
+
+/** Usable width of the header (and footer) container. Holds exactly one line:
+ *  28px of inner height against a 27px line, so anything that wraps is gone. */
+export const HEADER_WIDTH = PANEL_W - 2 * HEADER_PAD
+
+/** Usable width of the body container. */
+export const BODY_WIDTH = PANEL_W - 8 - 2 * BODY_PAD
+
+/** Lines the body container shows before clipping. */
+export const MAX_LINES = Math.floor((PANEL_H - 2 * BAR_H - 2 * BODY_PAD) / LINE_H)
+
+export const SPACE_W = getTextWidth(' ')
+
+// ─── Measuring ───
+
+/** The last code point of a string, kept whole so a surrogate pair is not cut. */
+function lastCodePoint(s: string): string {
+  if (!s) return ''
+  const tail = s.charCodeAt(s.length - 1)
+  return tail >= 0xdc00 && tail <= 0xdfff && s.length >= 2 ? s.slice(-2) : s.slice(-1)
+}
+
+/**
+ * Width `ch` adds when it follows `prev`, kerning included.
+ *
+ * Summing these deltas character by character reproduces `textWidth` of the
+ * whole string exactly (verified against kerning-heavy samples), which is what
+ * lets the line breaker below run in one pass instead of re-measuring a
+ * growing prefix.
+ */
+export function advance(prev: string, ch: string): number {
+  return getTextWidth(prev + ch) - getTextWidth(prev)
+}
+
+/**
+ * Clip to a pixel budget, with the ellipsis inside it.
+ *
+ * Appending the ellipsis after the fit check put the result over budget, so
+ * the "clipped" string wrapped anyway and left a stub on a line of its own.
+ */
+export function clipToWidth(text: string, maxPx: number): string {
+  const ellipsis = '…'
+  let width = 0
+  let fits = 0 // longest prefix that still leaves room for the ellipsis
+  let prev = ''
+  for (const ch of text) {
+    const w = advance(prev, ch)
+    if (width + w + getTextWidth(ellipsis) <= maxPx) fits += ch.length
+    width += w
+    if (width > maxPx) return `${text.slice(0, fits)}${ellipsis}`
+    prev = ch
+  }
+  return text
+}
+
+// ─── Line breaking ───
+
+/** 行頭禁則: characters that must not open a line. A lone `。` pushed onto the
+ *  next line is the most visible artefact of a naive wrap. */
+const NO_LINE_START = '。、．，・：；！？!?)）］」』｝》〉”’…ー〜%％'
+
+/** 行末禁則: opening brackets must not be left dangling at the end of a line. */
+const NO_LINE_END = '（(［[「『｛{《〈“‘'
+
+/** Blank space we will leave to keep an ASCII word whole. Beyond this the
+ *  ragged margin costs more than the broken word — with seven lines on screen,
+ *  a fifth of one is not worth an unbroken identifier. */
+const MAX_WORD_CARRY = 110
+
+const WORD_CHAR = /[A-Za-z0-9'._-]/
+
+/**
+ * Decide where to actually cut a full line, given the character that no longer
+ * fits. Returns [keep, carry]: `keep` closes the line, `carry` moves down
+ * ahead of that character.
+ *
+ * All three rules push characters down rather than letting them overflow.
+ * Overflow is never an option: the firmware would wrap the line itself, right
+ * back into the artefact being avoided.
+ */
+function chooseBreak(line: string, next: string, rest: string, maxPx: number): [string, string] {
+  if (NO_LINE_START.includes(next)) {
+    // Carry at most two characters, or a run of closers would empty the line.
+    for (let n = 1; n <= 2 && n < line.length; n++) {
+      const cut = line.length - n
+      if (!NO_LINE_START.includes(line[cut]) && line[cut] !== ' ') {
+        return [line.slice(0, cut), line.slice(cut)]
+      }
+    }
+    return [line, '']
+  }
+
+  if (line.length > 1 && NO_LINE_END.includes(line[line.length - 1])) {
+    return [line.slice(0, -1), line.slice(-1)]
+  }
+
+  if (/[A-Za-z0-9]/.test(next)) {
+    let start = line.length
+    while (start > 0 && WORD_CHAR.test(line[start - 1])) start--
+    if (start === 0 || start === line.length) return [line, '']
+    const carried = line.slice(start)
+    const carriedPx = getTextWidth(carried)
+    if (carriedPx > MAX_WORD_CARRY) return [line, '']
+    // Only worth a ragged margin if the word then fits whole. A URL or a long
+    // path is going to be split wherever it lands, so leave the blank pixels
+    // out of it.
+    let end = 0
+    while (end < rest.length && WORD_CHAR.test(rest[end])) end++
+    if (carriedPx + getTextWidth(rest.slice(0, end)) > maxPx) return [line, '']
+    return [line.slice(0, start).trimEnd(), carried]
+  }
+
+  return [line, '']
+}
+
+/** Break text into the lines the panel will show, at a pixel width. */
+export function splitLines(text: string, maxPx: number = BODY_WIDTH): string[] {
+  const lines: string[] = []
+  let line = ''
+  let width = 0
+  // True while the line was opened by a wrap rather than by a newline, so the
+  // space the wrap fell on can be dropped without eating real indentation.
+  let wrapped = false
+
+  for (let i = 0; i < text.length; ) {
+    const ch = String.fromCodePoint(text.codePointAt(i) as number)
+    if (ch === '\n') {
+      lines.push(line)
+      line = ''
+      width = 0
+      wrapped = false
+      i += ch.length
+      continue
+    }
+    // The space between two words is where the break happened — carrying it to
+    // the next line leaves a stray indent, which reads as an unexplained gap
+    // in the middle of a sentence.
+    if (wrapped && !line && ch === ' ') {
+      i += ch.length
+      continue
+    }
+    const w = advance(lastCodePoint(line), ch)
+    if (width + w > maxPx && line) {
+      const [keep, carry] = chooseBreak(line, ch, text.slice(i + ch.length), maxPx)
+      lines.push(keep.trimEnd())
+      line = carry
+      width = getTextWidth(carry)
+      wrapped = true
+      continue // re-examine ch against the fresh line
+    }
+    line += ch
+    width += w
+    i += ch.length
+  }
+  if (line) lines.push(line.trimEnd())
+  return lines
+}
+
+/** Trim a line until an appended ellipsis fits the given width. */
+export function ellipsize(line: string, maxPx: number = BODY_WIDTH): string {
+  let out = line
+  while (out && getTextWidth(out) + getTextWidth('…') > maxPx) out = out.slice(0, -1)
+  return `${out}…`
+}

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -1,4 +1,5 @@
 // CC Hub API response types (subset relevant to G2 display)
+import { BODY_WIDTH, clipToWidth, textWidth } from './metrics.ts'
 
 type IndicatorState = 'processing' | 'waiting_input' | 'idle' | 'completed'
 
@@ -166,36 +167,6 @@ export function recapBlockLines(recap: string | undefined, maxLines = 2): string
   return [`要約: ${capped[0]}`, ...capped.slice(1), '-'.repeat(24)]
 }
 
-/** Half-width columns the G2 panel fits on one line. `display.ts` wraps at the
- *  same width — it is the one measured number both modules have to agree on. */
-export const PANEL_WIDTH = 52
-
-/**
- * Clip to a display width (CJK counts ~1.86 columns, as on the panel).
- *
- * The ellipsis is part of the budget: appending it without reserving a column
- * put the result one column over, so the "clipped" line wrapped anyway and
- * left a two-character stub on a line of its own.
- */
-function clipToWidth(text: string, maxWidth: number): string {
-  const charW = (i: number): number => {
-    const code = text.codePointAt(i) ?? 0
-    const wide =
-      (code >= 0x3000 && code <= 0x9fff) ||
-      (code >= 0xff01 && code <= 0xff60) ||
-      (code >= 0xf900 && code <= 0xfaff)
-    return wide ? 1.86 : 1
-  }
-  let width = 0
-  let lastFit = 0 // longest prefix that still leaves room for the ellipsis
-  for (let i = 0; i < text.length; i++) {
-    const w = charW(i)
-    if (width + w <= maxWidth - 1) lastFit = i + 1
-    width += w
-    if (width > maxWidth) return `${text.slice(0, lastFit)}…`
-  }
-  return text
-}
 
 /**
  * The one thing worth knowing about a tool call.
@@ -252,15 +223,17 @@ function extractPath(output: string): string {
 }
 
 /**
- * Columns left for a tool call's detail on its own line.
+ * Pixels left for a tool call's detail on its own line.
  *
- * The line is rendered as `[Name] detail`, and the first line of a message
- * also carries the `A> ` role prefix. Clipping to a fixed width regardless of
- * those left the line just over the panel edge, so the ellipsis wrapped and a
+ * The line renders as `[Name] detail`, and the first line of a message also
+ * carries the `A> ` role prefix. Clipping to a fixed budget regardless of
+ * those put the line past the panel edge, so the ellipsis wrapped and a
  * two-character stub (`'…`) took a line of its own — on a seven-line screen.
+ * Both prefixes are measured, not estimated: `[NotebookEdit] ` is more than
+ * twice the width of `[Read] `.
  */
 function toolDetailWidth(toolName: string): number {
-  return PANEL_WIDTH - 3 /* `A> ` */ - (toolName.length + 3) /* `[Name] ` */
+  return BODY_WIDTH - textWidth('A> ') - textWidth(`[${toolName}] `)
 }
 
 /** Format a conversation message for G2 display */


### PR DESCRIPTION
> 実機はもう1文字分狭そうです。
> あと時刻が右上隅に行ってない。実機ではそう見えます。
> この辺のレイアウト周りの情報ってネットに正確なものはないんですかね

ありました。しかも公式です。**`@evenrealities/pretext`**（MIT・依存なし・SDK と同じメンテナ）が、G2 ファームウェアの LVGL フォントメトリクスを埋め込んでいます。カーニング、3段のフォントフォールバック、LVGL と同じ per-glyph 丸め（`(adv + kern + 8) >> 4`）まで再現。

## 「1文字分」ではありませんでした

**G2 のフォントは等幅ではありません。**

| | 実測 | 従来モデル |
|---|---|---|
| 空白 | **5px** | 10.69px |
| `i` / `:` | 4px | 10.69px |
| `a` | 12px | 10.69px |
| `W` | 16px | 10.69px |
| CJK | 20px | 19.85px |
| 行高 | 27px | 28px |

右詰めのパディングは空白です。それを 10.69px として並べていたので、実際の幅は想定の半分以下。`linux` + 空白 + `10:25` は **293px / 568px** ——「右上隅に行っていない」のではなく、パネルの真ん中で止まっていました。

修正後は **563〜567px / 568px** に到達します。

## 変更

- `metrics.ts` を新設。`types.ts` と `display.ts` の両方が使う計測層
  - コンテナ寸法を LVGL の実数から導出（行高 27px なので、36px のヘッダーは**ちょうど1行**しか持てない。あふれた行は時計ごとパネル外）
  - `advance(prev, ch)` はペア単位のカーニング差分。1文字ずつ足すと `getTextWidth` の全体幅と**誤差 0px** で一致するので、行分割は 1 パスのまま
  - 禁則処理・折り返し位置の空白除去・`…` を予算に含める切り詰めは維持
- `charWidth` / `displayWidth` / `PANEL_WIDTH` / `LINE_WIDTH` / `CJK_RATIO` は削除
- シミュレータは等幅フォントをやめてプロポーショナル sans へ。実機 advance との平均誤差 4.22px → **1.07px**。ASCII をほぼ毎回押し潰していたのが解消

## コスト

gzip **+40KB**（device bundle 37KB → 77KB gzip、ehpk 50KB → 約90KB）。スマホ側 WebView で動くので実害は小さいと判断しています。

## 検証

実データ **218 ページ**（cchub-work-1 / linux / wheel-leg-bot の全メッセージ・全ページ）を走査し、パネル幅超過ゼロ・7行超過ゼロ・ヘッダー折り返しゼロ。テスト 26 件、lint / typecheck / device・web 両ビルド通過。

Sources:
- [@evenrealities/pretext - npm](https://www.npmjs.com/package/@evenrealities/pretext)
- [even-toolkit](https://github.com/fabioglimb/even-toolkit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np