### PR TITLE
feat(glasses): 実機の画面をシミュレータにミラーする

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -16,6 +16,7 @@ import { ConversationWatcher } from '../services/conversation-watcher';
 import type {
   ClientFocus,
   ControlClientMessage,
+  GlassesScreen,
   MuxClientMessage,
   ConversationMessage,
   SessionResponse,
@@ -79,6 +80,28 @@ export interface MuxData {
   /** Set by `subscribe-glasses-relay`: the glasses follow focus, never claim
    *  it, otherwise following would feed back into the election. */
   isGlasses?: boolean;
+  /** Set by `subscribe-glasses-screen`: this connection watches the mirror. */
+  watchesGlassesScreen?: boolean;
+}
+
+// ── Glasses screen mirror ──
+//
+// The device publishes the three strings it just drew; browsers render them
+// with the simulator's own painter. Last frame is retained so a viewer joining
+// mid-demo sees the current screen instead of a blank panel until the next
+// render.
+
+let lastGlassesScreen: GlassesScreen | null = null;
+let glassesScreenPublisher: ServerWebSocket<MuxData> | null = null;
+
+function sendGlassesScreen(ws: ServerWebSocket<MuxData>, screen: GlassesScreen | null) {
+  try { ws.send(JSON.stringify({ type: 'glasses-screen', screen })); } catch { /* disconnected */ }
+}
+
+function broadcastGlassesScreen(screen: GlassesScreen | null) {
+  for (const client of activeMuxConnections) {
+    if (client.data.watchesGlassesScreen) sendGlassesScreen(client, screen);
+  }
 }
 
 const herdrService = new HerdrService();
@@ -299,6 +322,27 @@ export async function muxMessage(ws: ServerWebSocket<MuxData>, message: string |
     return;
   }
 
+  // Screen mirror (demo). Publishing is not gated on `isGlasses`: a client
+  // that publishes has a real bridge by construction, and the simulator never
+  // calls this.
+  if (msg.type === 'glasses-screen') {
+    lastGlassesScreen = msg.screen;
+    glassesScreenPublisher = ws;
+    broadcastGlassesScreen(msg.screen);
+    return;
+  }
+
+  if (msg.type === 'subscribe-glasses-screen') {
+    ws.data.watchesGlassesScreen = true;
+    sendGlassesScreen(ws, lastGlassesScreen);
+    return;
+  }
+
+  if (msg.type === 'unsubscribe-glasses-screen') {
+    ws.data.watchesGlassesScreen = false;
+    return;
+  }
+
   // Keepalive. Handle before the sessionId/subscription gate below: the client
   // pings with sessionId="" whenever no terminal is selected (dashboard, file
   // viewer, history). If those pings were dropped, the client never gets a
@@ -326,6 +370,14 @@ export function muxClose(ws: ServerWebSocket<MuxData>, code: number, reason: str
   console.log(`[mux] WebSocket closed: ${ws.data.visitorId} (code=${code}, reason=${reason})`);
   activeMuxConnections.delete(ws);
   unsubscribeGlassesRelay(ws);
+  // The publisher going away must reach the viewers: a mirror that keeps
+  // showing the last frame is indistinguishable from a live one that has
+  // stopped changing.
+  if (glassesScreenPublisher === ws) {
+    glassesScreenPublisher = null;
+    lastGlassesScreen = null;
+    broadcastGlassesScreen(null);
+  }
   if (activeMuxConnections.size === 0) stopSessionsPush();
   // A disconnect can hand the focus to another device.
   else maybePushFocus();

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -113,6 +113,10 @@ const STYLE = `
   .bg-row { display: flex; gap: 8px; }
   .bg-row button { flex: 1; }
   body.dropping { outline: 2px dashed #7cc98f; outline-offset: -8px; }
+  .mirror { display: inline-flex; align-items: center; gap: 5px; font-size: 13px;
+            color: #cbd5e1; cursor: pointer; user-select: none; }
+  .mirror input { accent-color: #6affa0; }
+  .mirror-live { color: #6affa0; }
   .diag { font-family: ui-monospace, Menlo, monospace; font-size: 11.5px; color: #6b736a;
           line-height: 1.8; word-break: break-all; }
   .copied { color: #7cc98f; }
@@ -167,6 +171,8 @@ export function startDebugUI(): void {
             <span class="mode-pill" id="g2-mode-jp">一覧</span>
             <span class="mode-id" id="g2-mode-id">session_list</span>
             <button type="button" id="g2-copy">画面をコピー</button>
+            <label class="mirror"><input type="checkbox" id="g2-mirror" />実機ミラー</label>
+            <span class="hint" id="g2-mirror-status"></span>
             <span class="hint" id="g2-copied"></span>
           </div>
           <div class="diag" id="g2-diag"></div>
@@ -258,7 +264,28 @@ export function startDebugUI(): void {
   const relay = el('g2-relay')
   const sttInput = document.getElementById('dbg-stt') as HTMLInputElement
 
+  const mirrorToggle = document.getElementById('g2-mirror') as HTMLInputElement
+  const mirrorStatus = el('g2-mirror-status')
+
   let lastScreen = { header: '', body: '', footer: '' }
+  let lastMode = 'session_list'
+
+  // ── Device mirror (demo) ──
+  //
+  // The device publishes the three strings it just drew; this panel paints
+  // them with the same painter it uses for its own state. What the audience
+  // sees is the wearer's screen, not a second interpretation of it.
+  let mirroring = false
+  let localScreen = { header: '', body: '', footer: '' }
+  let localMode = 'session_list'
+
+  function paint(screen: { header: string; body: string; footer: string }, mode: string): void {
+    lastScreen = screen
+    lastMode = mode
+    drawPanel(screen)
+    modeJp.textContent = MODE_LABEL[mode] ?? mode
+    modeId.textContent = mode
+  }
 
   // Panel geometry, straight from the container definitions in display.ts.
   // Text starts below the container's own padding, and LVGL stacks lines at a
@@ -405,11 +432,12 @@ export function startDebugUI(): void {
       const raw = screenText(state)
       // The device's container wraps for it; this panel has to do it itself.
       const screen = { ...raw, body: wrapForPanel(raw.body) }
-      lastScreen = screen
-      drawPanel(screen)
-      modeJp.textContent = MODE_LABEL[state.mode] ?? state.mode
-      modeId.textContent = state.mode
+      localScreen = screen
+      localMode = state.mode
       renderDiag(state)
+      // While mirroring the device owns the panel; this connection's own
+      // state keeps running underneath so switching back is instant.
+      if (!mirroring) paint(screen, state.mode)
     },
     startMicCapture: () => startMic(),
     stopMicCapture: () => stopMic(),
@@ -456,7 +484,7 @@ export function startDebugUI(): void {
   function screenAsText(): string {
     const rule = '─'.repeat(52)
     return [
-      `[${MODE_LABEL[controller.state.mode] ?? controller.state.mode} / ${controller.state.mode}]`,
+      `[${MODE_LABEL[lastMode] ?? lastMode} / ${lastMode}]${mirroring ? ' 実機ミラー' : ''}`,
       rule,
       lastScreen.header,
       rule,
@@ -558,6 +586,42 @@ export function startDebugUI(): void {
 
   // Diag also changes outside controller render events (terminal buffers, WS
   // state) — keep it fresh on an interval.
+  // ── Mirror wiring ──
+
+  const RING_BUTTONS = ['btn-up', 'btn-down', 'btn-tap', 'btn-dbl']
+
+  function setMirrorUi(live: boolean, message: string): void {
+    mirrorStatus.textContent = message
+    mirrorStatus.className = live ? 'hint mirror-live' : 'hint'
+    // A viewer clicking the ring while the device drives the panel would fight
+    // the wearer for the screen. Mirroring is for watching.
+    for (const id of RING_BUTTONS) (el(id) as HTMLButtonElement).disabled = mirroring
+  }
+
+  controller.ws.setGlassesScreenHandler((screen) => {
+    if (!mirroring) return
+    if (!screen) {
+      // The publisher's socket closed. Say so — a mirror still showing the
+      // last frame is indistinguishable from a live one that has gone quiet.
+      setMirrorUi(false, '実機が接続されていません')
+      return
+    }
+    paint({ header: screen.header, body: wrapForPanel(screen.body), footer: screen.footer }, screen.mode)
+    setMirrorUi(true, '実機と同期中')
+  })
+
+  mirrorToggle.addEventListener('change', () => {
+    mirroring = mirrorToggle.checked
+    if (mirroring) {
+      controller.ws.subscribeGlassesScreen()
+      setMirrorUi(false, '実機を待っています…')
+    } else {
+      controller.ws.unsubscribeGlassesScreen()
+      setMirrorUi(false, '')
+      paint(localScreen, localMode)
+    }
+  })
+
   setInterval(() => renderDiag(controller.state), 500)
 
   ;(window as unknown as Record<string, unknown>)._ws = controller.ws

--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -6,7 +6,7 @@
 // Groq STT) and the LocalStorage URL setup flow.
 
 import { setBaseUrl, transcribe, reportLog } from './api.ts'
-import { initDisplay, updateDisplay, setupEvents, buildSetupGuide, startMic, stopMic } from './display.ts'
+import { initDisplay, updateDisplay, setupEvents, buildSetupGuide, screenText, startMic, stopMic } from './display.ts'
 import type { AppState } from './display.ts'
 import { GlassesController } from './controller.ts'
 import type { GlassesPlatform } from './controller.ts'
@@ -115,10 +115,30 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
     draining = false
   }
 
+  // Demo mirror: publish the same three strings the panel is about to show, so
+  // a browser can render the screen the wearer is looking at. Skipped when the
+  // frame is identical to the last one — renders fire every five seconds
+  // whether or not anything changed, and a demo audience does not need the
+  // traffic.
+  let lastPublished = ''
+  function publishScreen(state: AppState): void {
+    try {
+      const { header, body, footer } = screenText(state)
+      const key = `${state.mode}\u0000${header}\u0000${body}\u0000${footer}`
+      if (key === lastPublished) return
+      lastPublished = key
+      controller.ws.publishScreen({ header, body, footer, mode: state.mode, at: Date.now() })
+    } catch (err) {
+      // A mirror is a nicety; never let it take the panel down with it.
+      trace(`publishScreen failed: ${err}`, 'error', (err as Error)?.stack)
+    }
+  }
+
   const platform: GlassesPlatform = {
     render(state) {
       // Just the startup burst — that is where frames used to pile up.
       if (++renders <= 10) trace(`render #${renders} mode=${state.mode} sessions=${state.sessions.length}`)
+      publishScreen(state)
       pending = state
       if (draining) return
       draining = true

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -59,6 +59,18 @@ export interface ClientFocus {
 }
 
 /**
+ * Mirror of GlassesScreen in shared/types.ts: the three container strings the
+ * panel is showing. The device publishes it; the simulator draws it.
+ */
+export interface GlassesScreen {
+  header: string
+  body: string
+  footer: string
+  mode: string
+  at: number
+}
+
+/**
  * One relay item for the G2 glasses channel: a single piece of information the
  * user needs to make a decision, not a summary. `waiting` items live until the
  * blocked epoch ends or they are dismissed; `info` items are FYI with a TTL.

--- a/glasses/src/ws-client.ts
+++ b/glasses/src/ws-client.ts
@@ -1,5 +1,5 @@
 import { getBaseUrl } from './api.ts'
-import type { Session, GlassesRelayItem, ClientFocus } from './types.ts'
+import type { Session, GlassesRelayItem, ClientFocus, GlassesScreen } from './types.ts'
 
 export interface WsCallbacks {
   /** `focus` is the session the phone/tablet in the user's hand is
@@ -13,6 +13,8 @@ export interface WsCallbacks {
   onRelaySnapshot?: (items: GlassesRelayItem[]) => void
   onRelayUpsert?: (item: GlassesRelayItem) => void
   onRelayRemove?: (id: string) => void
+  /** Screen mirror (demo). `null` = no device publishing / publisher gone. */
+  onGlassesScreen?: (screen: GlassesScreen | null) => void
 }
 
 // Well inside the server's 60s ping timeout, with room for a dropped one.
@@ -61,6 +63,7 @@ export class CcHubWsClient {
   // Glasses relay subscription is connection-scoped (no sessionId); re-sent on
   // every (re)connect while this flag is set (#504).
   private relaySubscribed = false
+  private screenSubscribed = false
 
   // Buffer of last N lines per session
   private terminalBuffers = new Map<string, string[]>()
@@ -91,6 +94,9 @@ export class CcHubWsClient {
       // snapshot arrives around the same time as session re-subscribes.
       if (this.relaySubscribed) {
         this.send({ type: 'subscribe-glasses-relay' })
+      }
+      if (this.screenSubscribed) {
+        this.send({ type: 'subscribe-glasses-screen' })
       }
       this.callbacks.onReady()
     }
@@ -136,6 +142,8 @@ export class CcHubWsClient {
         this.callbacks.onRelayUpsert?.(msg.item as GlassesRelayItem)
       } else if (msg.type === 'glasses-relay-remove' && typeof msg.id === 'string') {
         this.callbacks.onRelayRemove?.(msg.id as string)
+      } else if (msg.type === 'glasses-screen') {
+        this.callbacks.onGlassesScreen?.((msg.screen ?? null) as GlassesScreen | null)
       }
     } catch { /* ignore */ }
   }
@@ -183,6 +191,32 @@ export class CcHubWsClient {
   unsubscribeGlassesRelay(): void {
     this.relaySubscribed = false
     this.send({ type: 'unsubscribe-glasses-relay' })
+  }
+
+  /** Publish the screen the panel is showing, for demo mirrors. Only the
+   *  device calls this — the simulator has no bridge and would otherwise echo
+   *  its own frames back at itself. */
+  publishScreen(screen: GlassesScreen): void {
+    this.send({ type: 'glasses-screen', screen })
+  }
+
+  /** Late-bound because only the browser simulator listens, and it is built
+   *  after the controller that owns this client. */
+  setGlassesScreenHandler(fn: (screen: GlassesScreen | null) => void): void {
+    this.callbacks.onGlassesScreen = fn
+  }
+
+  /** Watch the device's screen. The server replies with the retained frame, so
+   *  a viewer joining mid-demo sees the current screen rather than a blank
+   *  panel until the next render. */
+  subscribeGlassesScreen(): void {
+    this.screenSubscribed = true
+    this.send({ type: 'subscribe-glasses-screen' })
+  }
+
+  unsubscribeGlassesScreen(): void {
+    this.screenSubscribed = false
+    this.send({ type: 'unsubscribe-glasses-screen' })
   }
 
   getTerminalText(sessionId: string): string {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -964,6 +964,23 @@ export type ControlServerMessage =
 // =============================================================================
 
 /**
+ * The three container strings the G2 is showing right now.
+ *
+ * The glasses app computes these once and hands the same object to the panel
+ * and to this channel, so a mirror is not a re-derivation of the screen — it
+ * is the screen. Demo viewers render it with the simulator's own painter.
+ */
+export interface GlassesScreen {
+  header: string;
+  body: string;
+  footer: string;
+  /** Which screen this is, for the mirror's status line. */
+  mode: string;
+  /** Epoch ms the frame was produced, so a stalled mirror is visible. */
+  at: number;
+}
+
+/**
  * One relay item for the G2 glasses channel (#504): a single piece of
  * information the user needs to make a decision, not a summary. `waiting`
  * items are created by the blocked-transition tracker (source 'auto') or by
@@ -1024,6 +1041,12 @@ export type MuxClientMessage =
   // whole connection as "glasses present", which gates relay assembly/send.
   | { type: 'subscribe-glasses-relay' }
   | { type: 'unsubscribe-glasses-relay' }
+  // Screen mirroring for demos. The device publishes; browsers subscribe.
+  // Only a connection with a real Even Hub bridge publishes, so the simulator
+  // never echoes its own frames back at itself.
+  | { type: 'glasses-screen'; screen: GlassesScreen }
+  | { type: 'subscribe-glasses-screen' }
+  | { type: 'unsubscribe-glasses-screen' }
   | (ControlClientMessage & { sessionId: string });
 
 // Runtime validation for client→server /ws/mux frames. The unions above are
@@ -1086,6 +1109,20 @@ export const MuxClientMessageSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('unsubscribe-conversation'), sessionId: z.string().min(1) }),
   z.object({ type: z.literal('subscribe-glasses-relay') }),
   z.object({ type: z.literal('unsubscribe-glasses-relay') }),
+  z.object({
+    type: z.literal('glasses-screen'),
+    screen: z.object({
+      // One G2 page each; the caps only keep a rogue client from broadcasting
+      // a novel to every viewer.
+      header: z.string().max(500),
+      body: z.string().max(4000),
+      footer: z.string().max(500),
+      mode: z.string().max(40),
+      at: z.number(),
+    }),
+  }),
+  z.object({ type: z.literal('subscribe-glasses-screen') }),
+  z.object({ type: z.literal('unsubscribe-glasses-screen') }),
   // Control frames carry a sessionId in the mux protocol (ping may send "").
   ...controlClientMessageOptions.map((o) => o.extend({ sessionId: z.string() })),
 ]);
@@ -1106,4 +1143,8 @@ export type MuxServerMessage =
   | { type: 'glasses-relay'; item: GlassesRelayItem } // upsert (create / dismiss reflection)
   | { type: 'glasses-relay-remove'; id: string } // exit-blocked / TTL expiry
   | { type: 'glasses-relay-snapshot'; items: GlassesRelayItem[] } // on subscribe: current blocked set
+  // Screen mirror. `null` means no device is publishing — sent on subscribe
+  // when nothing is live, and again when the publisher disconnects, so a demo
+  // audience sees "切断" rather than a frozen screen.
+  | { type: 'glasses-screen'; screen: GlassesScreen | null }
   | (ControlServerMessage & { sessionId: string });


### PR DESCRIPTION
> 実機で操作した内容をシミュレーターに反映させて、自分が今見ている画面を誰かに見せたい。デモの目的で

```
実機（スマホの WebView）              CC Hub               ブラウザ（何台でも）
  render(state)
    ├→ updateDisplay(bridge)  →  G2 パネル
    └→ publish screenText()   →  /ws/mux  →  broadcast  →  drawPanel()
```

グラスアプリは `screenText()` で画面を**一度だけ**計算し、同じ 3 本の文字列をパネルとシミュレータの描画器の両方に渡しています。したがってミラーは画面の再現ではなく、**画面そのもの**です。

## 設計

- publish は `GlassesPlatform.render` にぶら下げました。両プラットフォーム共通の唯一の描画口なので、全モード・全リング操作が列挙なしで乗ります
- 直前と同一のフレームは送りません。描画は5秒ごとに走るので、変化がなければ黙ります
- サーバは**最後のフレームを保持**します。途中から参加した viewer は空パネルではなく現在の画面を即座に見られます
- publisher のソケットが閉じたら **null を配信**します。最後のフレームを出し続けるミラーは「静止している生きた画面」と見分けがつかず、聴衆の前で気づくには最悪の種類の曖昧さです
- **読み取り専用**です。viewer がリングを押すと装着者と画面を奪い合うので、ミラー中はリングのボタンを無効化します。ノートPCからグラスを操作するのは別の機能です

## 検証

raw WS クライアントによる E2E で全経路を確認:

```
購読直後（実機なし）      → null 1件            ✓
publish 後               → 配信される           ✓
後から参加した viewer     → 保持フレームを即受信  ✓
実機切断                 → null 配信            ✓
過大ペイロード            → zod で拒否          ✓
```

ブラウザ実測でもミラー ON→同期→実機切断→OFF→自前画面復帰まで確認済み。lint / typecheck / test（全 573 件）/ device・web 両ビルド通過。

**ehpk のリリースが必要**です（publish は実機側の実装）。スマホを更新するまでミラーは映りません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np