### PR TITLE
Release v0.2.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.60] - 2026-07-27
+
+### Added
+- **グラス: 実機の画面をシミュレータにミラーする** (#560): デモ用途。装着者が今見ている画面を、ブラウザで何台でも同時に見られる（ehpk v0.1.37）
+  ```
+  実機（スマホの WebView）              CC Hub               ブラウザ（何台でも）
+    render(state)
+      ├→ updateDisplay(bridge)  →  G2 パネル
+      └→ publish screenText()   →  /ws/mux  →  broadcast  →  drawPanel()
+  ```
+  - グラスアプリは `screenText()` で画面を**一度だけ**計算し、同じ3本の文字列をパネルとシミュレータの描画器の両方に渡している。したがってミラーは画面の再現ではなく**画面そのもの**
+  - publish は `GlassesPlatform.render` にぶら下げた。両プラットフォーム共通の唯一の描画口なので、全モード・全リング操作が列挙なしで乗る。直前と同一のフレームは送らない（描画は5秒ごとに走るため）
+  - サーバは**最後のフレームを保持**。途中から参加した viewer は空パネルではなく現在の画面を即座に見られる
+  - publisher のソケットが閉じたら **null を配信**し `実機が接続されていません` と表示。最後のフレームを出し続けるミラーは「静止している生きた画面」と見分けがつかず、聴衆の前で気づくには最悪の種類の曖昧さになる
+  - **読み取り専用**。viewer がリングを押すと装着者と画面を奪い合うため、ミラー中はリングのボタンを無効化する。ノートPCからグラスを操作するのは別の機能
+  - WS プロトコル: `glasses-screen`（publish / broadcast）、`subscribe-glasses-screen` / `unsubscribe-glasses-screen`。zod スキーマでペイロード上限も検証
+
 ## [0.2.59] - 2026-07-27
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "generated": "2026-07-27",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "generated": "2026-07-27",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
グラスの画面ミラー（#560）。装着者が今見ている画面を、ブラウザで何台でも同時に見られます。デモ用途。

グラスアプリは `screenText()` で画面を一度だけ計算し、同じ3本の文字列をパネルとシミュレータの描画器の両方に渡しています。ミラーは画面の再現ではなく**画面そのもの**です。

- 途中参加した viewer にはサーバが保持した最新フレームを即配信
- 実機が切断したら null を配信し `実機が接続されていません` と表示（静止した生きた画面と区別がつかないのを避ける）
- 読み取り専用（ミラー中はリングのボタンを無効化）

**ehpk の再ビルドと Beta 昇格が必要**（v0.1.37）。publish は実機側の実装なので、スマホを更新するまでミラーは映りません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np