### PR TITLE
fix(glasses): 実機でタフになる文字を代替文字に置換する

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -338,3 +338,34 @@ describe('paging', () => {
     expect(screenText(state(total - 1)).body).not.toBe(screenText(state(0)).body)
   })
 })
+
+describe('glyph coverage', () => {
+  test('drops an emoji the panel renders as tofu', () => {
+    // pretext measures ✅ at 320px from an emoji font the device does not
+    // have, so measuring alone would have let it through.
+    expect(sanitizeForG2('- ✅ health-check.sh を修正')).toBe('- health-check.sh を修正')
+  })
+
+  test('drops marks the firmware fonts do not carry', () => {
+    expect(sanitizeForG2('結果: ✓ OK / ✗ NG')).toBe('結果: OK / NG')
+    expect(sanitizeForG2('❌ 失敗 ⚠ 注意 🎉 完了')).toBe('失敗 注意 完了')
+  })
+
+  test('keeps the symbols the panel can actually draw', () => {
+    const line = '★ 重要 ● 項目 → 次へ ※ 注記 ① ▲ ◆'
+    expect(sanitizeForG2(line)).toBe(line)
+  })
+
+  test('leaves ordinary text untouched', () => {
+    const line = '絵文字なしの普通の行です。'
+    expect(sanitizeForG2(line)).toBe(line)
+  })
+
+  test('keeps line structure while dropping glyphs', () => {
+    expect(sanitizeForG2('✅ 一行目\n❌ 二行目').split('\n')).toEqual(['一行目', '二行目'])
+  })
+
+  test('a stripped line never leaves a double space', () => {
+    expect(sanitizeForG2('前 ✅ 後')).not.toMatch(/ {2}/)
+  })
+})

--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -340,15 +340,23 @@ describe('paging', () => {
 })
 
 describe('glyph coverage', () => {
-  test('drops an emoji the panel renders as tofu', () => {
+  test('rewrites a status emoji the panel renders as tofu', () => {
     // pretext measures ✅ at 320px from an emoji font the device does not
     // have, so measuring alone would have let it through.
-    expect(sanitizeForG2('- ✅ health-check.sh を修正')).toBe('- health-check.sh を修正')
+    expect(sanitizeForG2('- ✅ health-check.sh を修正')).toBe('- ○ health-check.sh を修正')
   })
 
-  test('drops marks the firmware fonts do not carry', () => {
-    expect(sanitizeForG2('結果: ✓ OK / ✗ NG')).toBe('結果: OK / NG')
-    expect(sanitizeForG2('❌ 失敗 ⚠ 注意 🎉 完了')).toBe('失敗 注意 完了')
+  test('rewrites marks the firmware fonts do not carry', () => {
+    expect(sanitizeForG2('結果: ✓ OK / ✗ NG / ❓ 不明')).toBe('結果: ○ OK / × NG / ？ 不明')
+    expect(sanitizeForG2('⚠️ 注意 ⭐ 重要 💡 ヒント ➡️ 次へ')).toBe('！ 注意 ★ 重要 ※ ヒント → 次へ')
+  })
+
+  test('keeps the three states of a status light apart', () => {
+    expect(sanitizeForG2('🟢 稼働 🟡 警告 🔴 停止')).toBe('○ 稼働 △ 警告 × 停止')
+  })
+
+  test('drops decoration, which has nothing to become', () => {
+    expect(sanitizeForG2('🎉 完了 🚀 デプロイ')).toBe('完了 デプロイ')
   })
 
   test('keeps the symbols the panel can actually draw', () => {
@@ -361,11 +369,11 @@ describe('glyph coverage', () => {
     expect(sanitizeForG2(line)).toBe(line)
   })
 
-  test('keeps line structure while dropping glyphs', () => {
-    expect(sanitizeForG2('✅ 一行目\n❌ 二行目').split('\n')).toEqual(['一行目', '二行目'])
+  test('keeps line structure', () => {
+    expect(sanitizeForG2('✅ 一行目\n🎉 二行目').split('\n')).toEqual(['○ 一行目', '二行目'])
   })
 
-  test('a stripped line never leaves a double space', () => {
-    expect(sanitizeForG2('前 ✅ 後')).not.toMatch(/ {2}/)
+  test('a line that lost a glyph never leaves a double space', () => {
+    expect(sanitizeForG2('前 🎉 後')).not.toMatch(/ {2}/)
   })
 })

--- a/glasses/src/metrics.ts
+++ b/glasses/src/metrics.ts
@@ -1,4 +1,4 @@
-import { getTextWidth } from '@evenrealities/pretext'
+import { getAdvW, getTextWidth } from '@evenrealities/pretext'
 
 /**
  * How the G2 panel measures text.
@@ -82,6 +82,52 @@ export function clipToWidth(text: string, maxPx: number): string {
     prev = ch
   }
   return text
+}
+
+// ─── Glyph coverage ───
+
+const PICTOGRAPH = /\p{Extended_Pictographic}/u
+
+/**
+ * Drop what the panel has no glyph for.
+ *
+ * Two rules, because neither alone is enough. `getAdvW` returns 0 for a
+ * codepoint the firmware fonts do not carry, which catches ✓, ✗, ⚠ and most
+ * emoji. It does not catch ✅: pretext measures that one at 320px from an
+ * emoji font this device turns out not to have, and the panel draws tofu. So
+ * pictographs go regardless of what they measure.
+ *
+ * Sent anyway they cost a column and say nothing. Dropping them here also
+ * keeps the browser simulator honest — it would otherwise render an emoji
+ * beautifully that the wearer never sees.
+ */
+export function stripUnrenderable(text: string): string {
+  let out = ''
+  let dropped = false
+  for (const ch of text) {
+    if (ch === '\n') {
+      out += ch
+      continue
+    }
+    const cp = ch.codePointAt(0) as number
+    // Selectors and joiners only qualify the glyph beside them; alone they are
+    // leftovers from an emoji that has already gone.
+    const isModifier = cp === 0xfe0f || cp === 0x200d || (cp >= 0x1f3fb && cp <= 0x1f3ff)
+    if (isModifier || PICTOGRAPH.test(ch) || getAdvW(cp) === 0) {
+      dropped = true
+      continue
+    }
+    out += ch
+  }
+  // A dropped glyph leaves the spaces that flanked it behind: two in the middle
+  // of a line read as a gap rather than a word break, and one at the start as
+  // an indent that was never written. Only touched when something went, so a
+  // line nobody edited keeps its own spacing.
+  if (!dropped) return out
+  return out
+    .split('\n')
+    .map((line) => line.replace(/ {2,}/g, ' ').trim())
+    .join('\n')
 }
 
 // ─── Line breaking ───

--- a/glasses/src/metrics.ts
+++ b/glasses/src/metrics.ts
@@ -89,6 +89,42 @@ export function clipToWidth(text: string, maxPx: number): string {
 const PICTOGRAPH = /\p{Extended_Pictographic}/u
 
 /**
+ * Marks the panel cannot draw, rewritten as ones it can.
+ *
+ * The firmware carries the CJK symbol set — ○ × △ ！ ※ ★ all have real
+ * advances — and in a Japanese context those *are* the conventional marks for
+ * good, bad, partial and attention. So a status emoji does not have to be
+ * thrown away; it has an equivalent that says the same thing in the same
+ * column. Only glyphs with a genuine counterpart are here. Decoration (🎉, 🚀)
+ * has nothing to become and still goes.
+ */
+const SUBSTITUTES = new Map<string, string>([
+  // done / good
+  ...['✅', '✔', '✓', '☑', '🟢', '🆗', '👍', '⭕'].map((c) => [c, '○'] as const),
+  // failed / bad
+  ...['❌', '✗', '✘', '☒', '✕', '🔴', '🚫', '⛔', '👎'].map((c) => [c, '×'] as const),
+  // attention
+  ...['⚠', '❗', '❕', '‼', '🚨'].map((c) => [c, '！'] as const),
+  ...['❓', '❔'].map((c) => [c, '？'] as const),
+  // emphasis
+  ...['⭐', '🌟', '✨'].map((c) => [c, '★'] as const),
+  // note
+  ...['💡', 'ℹ', '📌', '📝'].map((c) => [c, '※'] as const),
+  // direction
+  ...['➡', '▶', '▷'].map((c) => [c, '→'] as const),
+  ...['⬅', '◀', '◁'].map((c) => [c, '←'] as const),
+  ...['⬆', '🔼'].map((c) => [c, '↑'] as const),
+  ...['⬇', '🔽'].map((c) => [c, '↓'] as const),
+  ...['🔺'].map((c) => [c, '▲'] as const),
+  ...['🔻'].map((c) => [c, '▼'] as const),
+  // Status dots keep their three states: a green and a yellow light both
+  // becoming ○ would lose the distinction they exist to make.
+  ...['⚪'].map((c) => [c, '○'] as const),
+  ...['🟡', '🟠'].map((c) => [c, '△'] as const),
+  ...['🔵', '🟣', '🟤', '⚫'].map((c) => [c, '●'] as const),
+])
+
+/**
  * Drop what the panel has no glyph for.
  *
  * Two rules, because neither alone is enough. `getAdvW` returns 0 for a
@@ -113,7 +149,15 @@ export function stripUnrenderable(text: string): string {
     // Selectors and joiners only qualify the glyph beside them; alone they are
     // leftovers from an emoji that has already gone.
     const isModifier = cp === 0xfe0f || cp === 0x200d || (cp >= 0x1f3fb && cp <= 0x1f3ff)
-    if (isModifier || PICTOGRAPH.test(ch) || getAdvW(cp) === 0) {
+    if (isModifier) continue
+    const swap = SUBSTITUTES.get(ch)
+    if (swap) {
+      // Substituted, not dropped: nothing was left behind, so the spacing
+      // around it is still the author's.
+      out += swap
+      continue
+    }
+    if (PICTOGRAPH.test(ch) || getAdvW(cp) === 0) {
       dropped = true
       continue
     }

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -1,5 +1,5 @@
 // CC Hub API response types (subset relevant to G2 display)
-import { BODY_WIDTH, clipToWidth, textWidth } from './metrics.ts'
+import { BODY_WIDTH, clipToWidth, stripUnrenderable, textWidth } from './metrics.ts'
 
 type IndicatorState = 'processing' | 'waiting_input' | 'idle' | 'completed'
 
@@ -97,19 +97,22 @@ export interface GlassesRelayItem {
 
 // ─── G2 display helpers ───
 
-/** Unwrap inline Markdown — the syntax itself is unreadable on the G2. */
+/** Unwrap inline Markdown — the syntax itself is unreadable on the G2 — and
+ *  drop anything the panel has no glyph for. */
 function stripInline(raw: string): string {
-  return raw
-    .replace(/^\s{0,3}#{1,6}\s+/, '') // headers
-    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → text
-    .replace(/\*\*([^*]+)\*\*/g, '$1') // bold
-    .replace(/__([^_]+)__/g, '$1')
-    .replace(/\*([^*\n]+)\*/g, '$1') // italic
-    .replace(/\b_([^_\n]+)_\b/g, '$1')
-    .replace(/`([^`]+)`/g, '$1') // inline code
-    .replace(/^\s*>\s?/, '') // blockquote marker
-    .replace(/~~([^~]+)~~/g, '$1') // strikethrough
-    .trimEnd()
+  return stripUnrenderable(
+    raw
+      .replace(/^\s{0,3}#{1,6}\s+/, '') // headers
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → text
+      .replace(/\*\*([^*]+)\*\*/g, '$1') // bold
+      .replace(/__([^_]+)__/g, '$1')
+      .replace(/\*([^*\n]+)\*/g, '$1') // italic
+      .replace(/\b_([^_\n]+)_\b/g, '$1')
+      .replace(/`([^`]+)`/g, '$1') // inline code
+      .replace(/^\s*>\s?/, '') // blockquote marker
+      .replace(/~~([^~]+)~~/g, '$1') // strikethrough
+      .trimEnd()
+  )
 }
 
 /**


### PR DESCRIPTION
> シミュレーターだとチェックボックスになってるけど実機だと豆腐になる
> チェックマークとかは変換しても良さそう。代替文字あるやつは変換できないですか？

その通りでした。**実機は CJK の記号セットを持っています** — ○ × △ ！ ※ ★ すべてに実 advance があります。そして日本語圏では、それらがそのまま「良し・不可・一部・注意」の慣用記号です。捨てる必要はなく、**同じ桁数で同じことを言う代替**があります。

```
✅ ✔ ✓ ☑ 🆗 👍 ⭕  → ○
❌ ✗ ✘ ☒ ✕ 🚫 ⛔ 👎 → ×
⚠ ❗ ❕ ‼ 🚨       → ！
❓ ❔              → ？
⭐ 🌟 ✨           → ★
💡 ℹ 📌 📝        → ※
➡ ▶ / ⬅ ◀ / ⬆ / ⬇ → → ← ↑ ↓
🔺 🔻              → ▲ ▼
```

**信号は三値を保ちます。** 🟢 と 🟡 が両方 ○ になっては、区別するために存在している意味がなくなるので、`○ / △ / ×` に割り当てています。

```
🟢 稼働 🟡 警告 🔴 停止  →  ○ 稼働 △ 警告 × 停止
```

**装飾は落とします。** 🎉 や 🚀 は状態を持たないので、なるべきものがありません。

## 判定の前段

**2つの規則が要ります。片方では足りません。**

`getAdvW` はフォントに無いコードポイントに 0 を返し、✓ ✗ ⚠ とほとんどの絵文字を捕まえます。**しかし ✅ は捕まりません** — pretext はこれを 320px と測ります。0.1.4 で追加された絵文字フォントの値で、この実機はそのフォントを持っていません。なので絵文字は測定値に関わらず対象にし、それ以外は実測に従います。

置換は削除ではないので、前後の空白は書かれたまま残します。削除が起きた行だけ空白を詰めます。

## 検証

テスト8件追加（全37件）。lint / typecheck / test（全581件）/ device・web 両ビルド通過。

**ehpk の更新が必要**です（実機側の文字整形なので）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np