### PR TITLE
fix(glasses): 追い越された要約を引っ込める

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -377,3 +377,51 @@ describe('glyph coverage', () => {
     expect(sanitizeForG2('前 🎉 後')).not.toMatch(/ {2}/)
   })
 })
+
+describe('recap lifetime', () => {
+  const RECAP = 'beelink-arch の保守中。カーネル更新のため再起動を実施し正常復帰済み。'
+  const state = (recapAt?: string, newestAt?: string) => ({
+    mode: 'conversation' as const,
+    sessions: [{ id: 'a', name: 'linux', state: 'idle' as const, ccRecap: RECAP, ccRecapAt: recapAt }],
+    sessionIndex: 0,
+    conversation: [
+      { role: 'assistant' as const, content: '古いメッセージ', timestamp: '2026-07-27T04:00:00.000Z' },
+      { role: 'assistant' as const, content: '最新のメッセージ', timestamp: newestAt },
+    ],
+    conversationOffset: 0,
+    conversationPage: 0,
+    conversationLastLoaded: 2,
+    conversationHasMore: false,
+    conversationLoading: false,
+    choiceIndex: 0,
+    choiceOptions: [],
+    relayWaiting: [],
+    relayInfo: [],
+    overlayItemId: null,
+  })
+  const hasRecap = (st: ReturnType<typeof state>) => screenText(st).body.startsWith('要約: ')
+
+  test('shows while nothing newer has arrived', () => {
+    expect(hasRecap(state('2026-07-27T06:00:00.000Z', '2026-07-27T05:00:00.000Z'))).toBe(true)
+  })
+
+  test('goes once the conversation moves past it', () => {
+    // Three of seven lines are better spent on the conversation than on a
+    // description of what came before it.
+    expect(hasRecap(state('2026-07-27T04:48:00.000Z', '2026-07-27T05:30:00.000Z'))).toBe(false)
+  })
+
+  test('a message written at the same moment does not count as past it', () => {
+    const at = '2026-07-27T05:00:00.000Z'
+    expect(hasRecap(state(at, at))).toBe(true)
+  })
+
+  test('keeps showing when there is no timestamp to judge by', () => {
+    expect(hasRecap(state(undefined, '2026-07-27T05:00:00.000Z'))).toBe(true)
+    expect(hasRecap(state('2026-07-27T04:00:00.000Z', undefined))).toBe(true)
+  })
+
+  test('keeps showing when a timestamp will not parse', () => {
+    expect(hasRecap(state('not a date', '2026-07-27T05:00:00.000Z'))).toBe(true)
+  })
+})

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -281,6 +281,27 @@ function sessionListBody(state: AppState): string {
   }).join('\n') || '(no sessions)'
 }
 
+/**
+ * Whether the recap still has anything to add.
+ *
+ * It summarises what happened before it was written — the point of it is to
+ * fill in a stretch the reader missed. Once a message newer than the recap is
+ * on screen the reader is past it, and three of seven lines are better spent
+ * on the conversation than on a description of what came before it.
+ *
+ * Anything unknown means keep showing it: a missing timestamp is not evidence
+ * that the recap is stale.
+ */
+function recapIsCurrent(session: Session | undefined, msgs: ConversationMessage[]): boolean {
+  const recapAt = session?.ccRecapAt
+  const newestAt = msgs[msgs.length - 1]?.timestamp
+  if (!recapAt || !newestAt) return true
+  const recapTime = Date.parse(recapAt)
+  const newestTime = Date.parse(newestAt)
+  if (Number.isNaN(recapTime) || Number.isNaN(newestTime)) return true
+  return newestTime <= recapTime
+}
+
 function conversationContent(state: AppState): { headerText: string; bodyText: string; footerText: string; multiCount: number } {
   const session = state.sessions[state.sessionIndex]
   const waiting = session ? isWaiting(session) : false
@@ -293,9 +314,10 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
     : -1
   const { text: convText, pageInfo, multiCount } = paginateMessage(msgs, msgIndex, state.conversationPage)
   const banner = relayBannerLines(state)
-  // Recap heads the latest view; deeper paging drops it for message space.
+  // Recap heads the latest view; deeper paging drops it for message space,
+  // and so does the conversation moving past it.
   const onLatest = state.conversationOffset === 0 && state.conversationPage === 0
-  const recap = onLatest ? recapBlock(session?.ccRecap) : []
+  const recap = onLatest && recapIsCurrent(session, msgs) ? recapBlock(session?.ccRecap) : []
   // The body container clips overflow: cap the banner+recap+content block at
   // one page so a waiting overlay never pushes conversation text off-screen.
   // Everything is measured in display lines — counting the conversation in

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -14,6 +14,9 @@ export interface Session {
   /** Latest recap (Claude away_summary / /recap; other agents fall back to
    *  their last assistant message). Shown atop the conversation view. */
   ccRecap?: string
+  /** When the recap was written. The conversation is compared against it: a
+   *  message newer than the recap means the reader is already past it. */
+  ccRecapAt?: string
   ccFirstPrompt?: string
   ccSessionId?: string
   durationMinutes?: number
@@ -25,6 +28,8 @@ export interface Session {
 export interface ConversationMessage {
   role: 'user' | 'assistant'
   content: string
+  /** ISO 8601, as the history API sends it. */
+  timestamp?: string
   toolUse?: { name: string; input?: Record<string, unknown> }[]
   toolResult?: { toolName?: string; output: string; isError?: boolean }[]
 }


### PR DESCRIPTION
> 要約情報ってずっと貼り付けっぱなしなの？
> 追い越されたら消すという推奨案の方針で進めたい

要約は「離れている間に何があったか」を埋めるためのものです。それが最新ビューの先頭に恒久的に貼り付き、**7行のうち3行**を「今画面にあるメッセージより前の話」の説明に使い続けていました。しかも**古さが分かりません**。実際、8時間前の要約が今日の作業の上に、現在のものと同じ顔で載っていました。

画面に要約より新しいメッセージがある時点で、読み手はもう追い越しています。そのとき引っ込めます。

```
linux           要約 04:54 / 最新msg 04:51    → 表示（要約が最新）
wheel-leg-bot   要約 昨日15:27 / 最新msg 02:00 → 非表示（3行が会話に戻る）
life            要約 01:48 / 最新msg 01:45    → 表示
```

サーバは `ccRecapAt` を、履歴APIはメッセージごとの `timestamp` を既に送っていました。グラス側が型に持っていなかっただけです。

**判断できないときは出したまま**にします。タイムスタンプが無い・壊れているのは「要約が古い」証拠ではないので。

## 検証

テスト5件追加（全42件）。lint / typecheck / test（全586件）/ device・web 両ビルド通過。

**ehpk の更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np