### PR TITLE
fix(glasses): 発話者の表記を整理して情報量を増やす

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -157,7 +157,7 @@ describe('formatMessage', () => {
       content: '',
       toolUse: [{ name: 'Bash', input: { description: 'テストを流す' } }],
     })
-    expect(out).toBe('A> [Bash] テストを流す')
+    expect(out).toBe('[Bash] テストを流す')
   })
 })
 
@@ -423,5 +423,27 @@ describe('recap lifetime', () => {
 
   test('keeps showing when a timestamp will not parse', () => {
     expect(hasRecap(state('not a date', '2026-07-27T05:00:00.000Z'))).toBe(true)
+  })
+})
+
+describe('turn prefixes', () => {
+  test('the user turn is marked like a shell prompt', () => {
+    expect(formatMessage({ role: 'user', content: 'リリースお願いします' })).toBe('$ リリースお願いします')
+  })
+
+  test('the agent turn carries no prefix', () => {
+    // The turn that is not marked is the answer to the one that is; an `A>` in
+    // front of every reply spends columns on something already visible.
+    expect(formatMessage({ role: 'assistant', content: '進めます' })).toBe('進めます')
+  })
+
+  test('the reclaimed columns go to the tool detail', () => {
+    const out = formatMessage({
+      role: 'assistant',
+      content: '',
+      toolUse: [{ name: 'Bash', input: { command: 'x'.repeat(300) } }],
+    })
+    expect(width(out)).toBeLessThanOrEqual(BODY_WIDTH)
+    expect(width(out)).toBeGreaterThan(BODY_WIDTH - 24)
   })
 })

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -243,22 +243,34 @@ function extractPath(output: string): string {
 }
 
 /**
+ * What marks whose turn it is.
+ *
+ * `$` for the user, the way a shell marks a prompt, and nothing at all for the
+ * agent. Every line is scarce on a seven-line screen, and an `A>` in front of
+ * every assistant message spends columns on something the reader can already
+ * see: the turn that is not marked is the answer to the one that is. Messages
+ * are separated by a blank line in the multi-message view, so the boundary
+ * survives without a label.
+ */
+const USER_PREFIX = '$ '
+const AGENT_PREFIX = ''
+
+/**
  * Pixels left for a tool call's detail on its own line.
  *
- * The line renders as `[Name] detail`, and the first line of a message also
- * carries the `A> ` role prefix. Clipping to a fixed budget regardless of
- * those put the line past the panel edge, so the ellipsis wrapped and a
+ * The line renders as `[Name] detail`. Clipping to a fixed budget regardless
+ * of the label put the line past the panel edge, so the ellipsis wrapped and a
  * two-character stub (`'…`) took a line of its own — on a seven-line screen.
- * Both prefixes are measured, not estimated: `[NotebookEdit] ` is more than
- * twice the width of `[Read] `.
+ * Measured, not estimated: `[NotebookEdit] ` is more than twice the width of
+ * `[Read] `. Tool lines belong to agent turns, which carry no prefix.
  */
 function toolDetailWidth(toolName: string): number {
-  return BODY_WIDTH - textWidth('A> ') - textWidth(`[${toolName}] `)
+  return BODY_WIDTH - textWidth(AGENT_PREFIX) - textWidth(`[${toolName}] `)
 }
 
 /** Format a conversation message for G2 display */
 export function formatMessage(m: ConversationMessage): string {
-  const prefix = m.role === 'user' ? 'U>' : 'A>'
+  const prefix = m.role === 'user' ? USER_PREFIX : AGENT_PREFIX
   const textParts: string[] = []
   const toolParts: string[] = []
 
@@ -302,5 +314,5 @@ export function formatMessage(m: ConversationMessage): string {
     .replace(/\n\s+/g, '\n')
     .trim()
 
-  return body ? `${prefix} ${body}` : `${prefix} (empty)`
+  return body ? `${prefix}${body}` : `${prefix}(empty)`
 }


### PR DESCRIPTION
> 以下の表記を整理して表示できる情報量を増やしたいです。 U> → $ / A> → 消しで

```
変更前:  U> 以下の表記を整理して…        変更後:  $ 以下の表記を整理して…
        A> 実機ミラー、動いていますね。          実機ミラー、動いていますね。
```

7行しかない画面で、返答のたびに `A>` を置くのは、読み手にすでに見えているものに桁を使うことです。**印のない方が、印のある方への返答**であって、複数メッセージ表示では空行が境界を保ちます。

空いた桁は使い道があります。ツール行の予算が、もう存在しない接頭辞のぶんを確保しなくなりました。

テスト3件追加（全45件）。lint / typecheck / test（全589件）/ device・web 両ビルド通過。**ehpk の更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np