### PR TITLE
feat(glasses): 作業中インジケータを動かす

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -447,3 +447,52 @@ describe('turn prefixes', () => {
     expect(width(out)).toBeGreaterThan(BODY_WIDTH - 24)
   })
 })
+
+describe('working indicator', () => {
+  const st = (tick: number, indicatorState: 'processing' | 'waiting_input' | 'completed') => ({
+    mode: 'conversation' as const,
+    sessions: [{ id: 'a', name: 'グラス開発', state: 'working' as const, indicatorState }],
+    sessionIndex: 0,
+    conversation: [{ role: 'assistant' as const, content: '作業中' }],
+    conversationOffset: 0,
+    conversationPage: 0,
+    conversationLastLoaded: 1,
+    conversationHasMore: false,
+    conversationLoading: false,
+    choiceIndex: 0,
+    choiceOptions: [],
+    relayWaiting: [],
+    relayInfo: [],
+    overlayItemId: null,
+    spinnerTick: tick,
+  })
+  const mark = (tick: number) => screenText(st(tick, 'processing')).header.replace(/^グラス開発\s+|\s+\d\d:\d\d$/g, '')
+
+  test('moves while the session is working', () => {
+    const frames = [0, 1, 2, 3].map(mark)
+    expect(new Set(frames).size).toBe(4)
+  })
+
+  test('comes back round', () => {
+    expect(mark(4)).toBe(mark(0))
+  })
+
+  test('every frame is the same width, so nothing after it shifts', () => {
+    // An uneven set reads as a shiver rather than a rotation.
+    const widths = [0, 1, 2, 3].map((t) => width(mark(t)))
+    expect(new Set(widths).size).toBe(1)
+  })
+
+  test('the header still fits at every frame', () => {
+    for (const t of [0, 1, 2, 3]) {
+      expect(width(screenText(st(t, 'processing')).header)).toBeLessThanOrEqual(HEADER_WIDTH)
+    }
+  })
+
+  test('other states do not animate', () => {
+    const waiting = [0, 1, 2].map((t) => screenText(st(t, 'waiting_input')).header)
+    expect(new Set(waiting.map((h) => h.replace(/\d\d:\d\d/, ''))).size).toBe(1)
+    expect(waiting[0]).toContain('[!] WAITING')
+    expect(screenText(st(1, 'completed')).header).not.toContain('[!]')
+  })
+})

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -26,7 +26,7 @@
 //   voice:        tap=stop→transcribe / send  doubleTap=cancel
 
 import { getConversation, sendPrompt, sendPaneInput, dismissRelayItem } from './api.ts'
-import { getTotalPagesAt, getMultiCountAt } from './display.ts'
+import { SPINNER_INTERVAL_MS, getTotalPagesAt, getMultiCountAt } from './display.ts'
 import type { AppState } from './display.ts'
 import { RelayQueue } from './relay-queue.ts'
 import { CcHubWsClient } from './ws-client.ts'
@@ -43,6 +43,9 @@ export type RingAction = 'tap' | 'doubleTap' | 'swipeUp' | 'swipeDown'
 export interface GlassesPlatform {
   /** Re-render the whole UI from the (mutated) state. */
   render(state: AppState): void
+  /** Redraw only the header. The spinner changes nothing else, and on the
+   *  device a full update sends three containers where one will do. */
+  renderHeader(state: AppState): void
   /** Start mic capture. Returns false when audio is unavailable. */
   startMicCapture(): Promise<boolean>
   stopMicCapture(): Promise<void>
@@ -147,6 +150,20 @@ export class GlassesController {
   connect(): void {
     this.ws.subscribeGlassesRelay()
     this.ws.connect()
+    // One timer for the life of the app rather than start/stop bookkeeping on
+    // every state change. It costs nothing when nothing is working: the tick
+    // returns before touching the display.
+    setInterval(() => this.tickSpinner(), SPINNER_INTERVAL_MS)
+  }
+
+  /** Advance the working indicator, but only where it is being looked at and
+   *  only while there is something to indicate. */
+  private tickSpinner(): void {
+    const st = this.state
+    if (st.mode !== 'conversation') return
+    if (this.currentSession()?.indicatorState !== 'processing') return
+    st.spinnerTick = (st.spinnerTick ?? 0) + 1
+    this.platform.renderHeader(st)
   }
 
   // ── Ring input (the single handler set shared by G2 and debug) ──

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -527,6 +527,10 @@ export function startDebugUI(): void {
       // state keeps running underneath so switching back is instant.
       if (!mirroring) paint(screen, state.mode)
     },
+    // Drawing costs nothing here, so the header tick is just a render.
+    renderHeader(state) {
+      platform.render(state)
+    },
     startMicCapture: () => startMic(),
     stopMicCapture: () => stopMic(),
     // Typed text short-circuits the transcription, which is handy for driving

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -132,6 +132,9 @@ export interface AppState {
   conversationLoading: boolean
   choiceIndex: number
   choiceOptions: string[]
+  /** Advances one frame per spinner tick while the shown session is working.
+   *  Absent in states built before the spinner existed; treated as 0. */
+  spinnerTick?: number
   debugEvent?: string
   voicePhase?: VoicePhase
   voiceText?: string
@@ -213,6 +216,26 @@ function statusLabel(s: Session): string {
 }
 
 const SEPARATOR = '-'.repeat(24)
+
+/**
+ * The working indicator, one frame per tick.
+ *
+ * A static mark says the session was working when the screen was last drawn;
+ * a moving one says it is working now, which is the question being asked. The
+ * frames are all 320 units wide — an uneven set shifts everything after it on
+ * each turn and reads as a shiver rather than a rotation, which is what ruled
+ * out the ASCII `|/-\` and the Braille spinner the CLI world uses (the
+ * firmware has no glyphs for the latter at all).
+ */
+const SPINNER = ['▲', '▶', '▼', '◀']
+
+/** Slow on purpose: each frame costs a BLE round trip, and the question is
+ *  only whether something is alive. */
+export const SPINNER_INTERVAL_MS = 3000
+
+function spinnerFrame(state: AppState): string {
+  return SPINNER[(state.spinnerTick ?? 0) % SPINNER.length]
+}
 
 /**
  * The recap block, capped in *display* lines.
@@ -306,7 +329,7 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
   const session = state.sessions[state.sessionIndex]
   const waiting = session ? isWaiting(session) : false
   const ind = session?.indicatorState
-  const statusBadge = waiting ? '  [!] WAITING' : ind === 'processing' ? '  [*]' : ''
+  const statusBadge = waiting ? '  [!] WAITING' : ind === 'processing' ? `  ${spinnerFrame(state)}` : ''
 
   const msgs = state.conversation
   const msgIndex = msgs.length > 0
@@ -745,6 +768,22 @@ export async function initDisplay(): Promise<Bridge | null> {
     console.log('[display] Even Hub SDK not available — debug mode', e)
     return null
   }
+}
+
+/**
+ * Redraw the header alone.
+ *
+ * The spinner changes nothing else, and a full update sends three containers
+ * where one will do — three times the traffic, every tick, for the whole time
+ * a session is working.
+ */
+export async function updateHeader(bridge: Bridge | null, state: AppState): Promise<void> {
+  if (!bridge || state.mode !== currentMode) return
+  const { headerText } = conversationContent(state)
+  await bridge.textContainerUpgrade(new TextContainerUpgrade({
+    containerID: 1, containerName: 'header',
+    content: headerText,
+  }))
 }
 
 export async function updateDisplay(bridge: Bridge | null, state: AppState): Promise<void> {

--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -6,7 +6,7 @@
 // Groq STT) and the LocalStorage URL setup flow.
 
 import { setBaseUrl, transcribe, reportLog } from './api.ts'
-import { initDisplay, updateDisplay, setupEvents, buildSetupGuide, screenText, startMic, stopMic } from './display.ts'
+import { initDisplay, updateDisplay, updateHeader, setupEvents, buildSetupGuide, screenText, startMic, stopMic } from './display.ts'
 import type { AppState } from './display.ts'
 import { GlassesController } from './controller.ts'
 import type { GlassesPlatform } from './controller.ts'
@@ -99,20 +99,30 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
   // while one is in flight collapse into the latest state, which is the only
   // one worth drawing anyway.
   let renders = 0
-  let pending: AppState | null = null
+  let pending: { state: AppState; headerOnly: boolean } | null = null
   let draining = false
 
   async function drainRenders(): Promise<void> {
     while (pending) {
-      const state = pending
+      const { state, headerOnly } = pending
       pending = null
       try {
-        await updateDisplay(bridge, state)
+        await (headerOnly ? updateHeader(bridge, state) : updateDisplay(bridge, state))
       } catch (err) {
         trace(`updateDisplay failed (mode=${state.mode}): ${err}`, 'error', (err as Error)?.stack)
       }
     }
     draining = false
+  }
+
+  function enqueue(state: AppState, headerOnly: boolean): void {
+    // A full render supersedes a spinner tick waiting behind it — it draws the
+    // header too, and drawing it twice would be the overlap this queue exists
+    // to prevent.
+    pending = { state, headerOnly: headerOnly && (pending?.headerOnly ?? true) }
+    if (draining) return
+    draining = true
+    void drainRenders()
   }
 
   // Demo mirror: publish the same three strings the panel is about to show, so
@@ -139,10 +149,11 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
       // Just the startup burst — that is where frames used to pile up.
       if (++renders <= 10) trace(`render #${renders} mode=${state.mode} sessions=${state.sessions.length}`)
       publishScreen(state)
-      pending = state
-      if (draining) return
-      draining = true
-      void drainRenders()
+      enqueue(state, false)
+    },
+    renderHeader(state) {
+      publishScreen(state)
+      enqueue(state, true)
     },
     startMicCapture: () => startMic(bridge),
     stopMicCapture: () => stopMic(bridge),


### PR DESCRIPTION
> ヘッダーのビックリマークは作業中って分かるんですけど、できればアニメーションを入れたい。今動作中だよみたいな
> 感覚は3秒ごとで十分です

止まった印は「最後に描いたとき動いていた」としか言いません。動く印は「今動いている」と言います。聞かれているのは後者です。

```
0秒   グラス開発  ▲
3秒   グラス開発  ▶
6秒   グラス開発  ▼
9秒   グラス開発  ◀
12秒  グラス開発  ▲
```

## コマの選定

`▲▶▼◀` は**すべて 320 幅で揃っています**。不揃いだと回るたびに後ろの文字が動き、回転ではなく震えに見えます。それで ASCII の `|/-\`（64/128/160）が落ちました。CLI 定番のブライユ点字は、そもそもファームウェアにグリフがありません。

## 通信量

**1 コマ = BLE の往復 1 回**です。3 秒間隔で 20 回/分。セッションプッシュが既に使っている 36 回/分より少なく収まります。

- **ヘッダーだけ**再描画します（本文とフッターは触らない。3 倍の無駄を避ける）
- **作業中のセッションを見ているときだけ**動きます。他の状態では tick が表示に触れる前に return するので、待機中のアプリは何も送りません
- タイマーは 1 本をアプリの生存期間ずっと回します。状態変化のたびに start/stop するより単純で、止め忘れがありません
- tick は SDK 描画を直列化する既存のキューに乗ります。**フル描画は待機中の tick を追い越して置き換えます** — フル描画はヘッダーも描くので、二度描くのはこのキューが防いでいる重なりそのものだからです

## 検証

```
シミュレータ実測  13秒で renderHeader 4回 = 3秒間隔  ✓
コマ送り          ▲▶▼◀ で一周し元に戻る            ✓
幅                4コマとも同一（後ろがずれない）      ✓
他の状態          入力待ち・完了ではコマが進まない      ✓
```

テスト5件追加（全50件）。lint / typecheck / test（全594件）/ device・web 両ビルド通過。**ehpk の更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np