### PR TITLE
feat(glasses): ページング中のダブルタップで先頭に戻る

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -496,3 +496,37 @@ describe('working indicator', () => {
     expect(screenText(st(1, 'completed')).header).not.toContain('[!]')
   })
 })
+
+describe('back label', () => {
+  const st = (offset: number, page: number) => ({
+    mode: 'conversation' as const,
+    sessions: [{ id: 'a', name: 'グラス開発', state: 'idle' as const }],
+    sessionIndex: 0,
+    conversation: [
+      { role: 'user' as const, content: '質問' },
+      { role: 'assistant' as const, content: Array.from({ length: 20 }, (_, i) => `${i} 行目`).join('\n') },
+    ],
+    conversationOffset: offset,
+    conversationPage: page,
+    conversationLastLoaded: 2,
+    conversationHasMore: false,
+    conversationLoading: false,
+    choiceIndex: 0,
+    choiceOptions: [],
+    relayWaiting: [],
+    relayInfo: [],
+    overlayItemId: null,
+  })
+
+  test('leaves the session from the newest message', () => {
+    expect(screenText(st(0, 0)).footer).toContain('dbl:back')
+  })
+
+  test('returns to the top once the reader has paged', () => {
+    expect(screenText(st(0, 1)).footer).toContain('dbl:top')
+  })
+
+  test('returns to the top once the reader has gone back a message', () => {
+    expect(screenText(st(1, 0)).footer).toContain('dbl:top')
+  })
+})

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -306,6 +306,20 @@ export class GlassesController {
           await this.dismissItem(top)
           return
         }
+        // Back out one level at a time. Having read some way into the history,
+        // the way out is to the top of it — swiping all the way down again to
+        // leave is the wrong amount of work. Only from the newest message does
+        // the same gesture leave the session.
+        if (st.conversationOffset > 0 || st.conversationPage > 0) {
+          st.conversationOffset = 0
+          st.conversationPage = 0
+          this.render()
+          // Live updates resume at the top, and whatever arrived while the
+          // reader was back there should be waiting for them.
+          await this.loadConversation()
+          this.render()
+          return
+        }
         st.mode = 'session_list'
         this.render()
         return

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -349,7 +349,13 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
   const bodyText = [...banner, ...recap, ...content].slice(0, MAX_LINES).join('\n')
   // With a waiting banner up, the ring is routed to the overlay item:
   // tap = respond/jump, double-tap = dismiss ("later / on PC").
-  const action = state.relayWaiting.length > 0 ? 'tap:対応  dbl:後で' : waiting ? 'tap:respond  dbl:back' : 'dbl:back'
+  // Read some way back, the double-tap returns to the newest message rather
+  // than leaving the session, so the label has to say which one it will do.
+  const scrolled = state.conversationOffset > 0 || state.conversationPage > 0
+  const back = scrolled ? 'dbl:top' : 'dbl:back'
+  const action = state.relayWaiting.length > 0
+    ? 'tap:対応  dbl:後で'
+    : waiting ? `tap:respond  ${back}` : back
   // Who is speaking is in the body — the user's turn carries `$` and the
   // agent's carries nothing — so repeating it here said nothing twice. The
   // message counter went with it: its denominator was the number of messages


### PR DESCRIPTION
> 会話画面なんですけど、ページング中はダブルタップで先頭に戻るようにできますか

**1段ずつ戻る**ようにしました。履歴を読み進めた状態からの出口はまず「その先頭」で、抜けるためだけに下スワイプで全部戻るのは、ジェスチャが2つしかないリングには重すぎる操作です。最新にいるときだけ、同じダブルタップがセッションを抜けます——そこでは元々そういう意味でした。

```
最新（0,0）           dbl:back  p1/3
ページ2               dbl:top  p2/3
1件遡り               dbl:top
ページ2＋入力待ち      tap:respond  dbl:top  p2/3
```

戻るときに**再読み込み**もします。遡っている間に届いたものが待っている状態になりますし、ライブ更新は先頭にいるときだけ動くので自然に再開します。

## 検証

```
開始              mode=conversation off=0 page=0
上スワイプ×2       off=2 page=4
ダブルタップ       off=0 page=0（会話画面のまま）   ✓
もう一度           → session_list                  ✓
```

テスト3件追加（全53件）。lint / typecheck / test（全597件）/ device・web 両ビルド通過。**ehpk の更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np