### PR TITLE
fix(glasses): 収まるコードブロックは中身を出す

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -530,3 +530,35 @@ describe('back label', () => {
     expect(screenText(st(1, 0)).footer).toContain('dbl:top')
   })
 })
+
+describe('fenced code', () => {
+  test('shows a short block instead of a marker', () => {
+    // `[code]` said only that something was there, and took the content a
+    // sentence had just promised.
+    const out = sanitizeForG2('フッターの表示です。\n\n```\n最新    dbl:back\nページ2  dbl:top\n```')
+    expect(out.split('\n')).toEqual(['フッターの表示です。', '最新    dbl:back', 'ページ2  dbl:top'])
+  })
+
+  test('drops the shared indentation so more of it fits', () => {
+    expect(sanitizeForG2('```ts\n    const a = 1\n      const b = 2\n```').split('\n'))
+      .toEqual(['const a = 1', '  const b = 2'])
+  })
+
+  test('summarises a block whose lines will not fit', () => {
+    const wide = 'x'.repeat(200)
+    expect(sanitizeForG2(`\`\`\`\n${wide}\n\`\`\``)).toBe('[code 1行]')
+  })
+
+  test('summarises a block long enough to become the page', () => {
+    const many = Array.from({ length: 6 }, (_, i) => `${i}行目`).join('\n')
+    expect(sanitizeForG2(`\`\`\`\n${many}\n\`\`\``)).toBe('[code 6行]')
+  })
+
+  test('an unterminated fence is still rendered', () => {
+    expect(sanitizeForG2('```\nbun run test')).toBe('bun run test')
+  })
+
+  test('an empty block leaves nothing behind', () => {
+    expect(sanitizeForG2('前\n```\n\n```\n後').split('\n')).toEqual(['前', '後'])
+  })
+})

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -142,24 +142,64 @@ function tableRowToLine(raw: string): string | null {
   return kept.length ? kept.join(' | ') : null
 }
 
+/** Lines a fenced block may take before it stops being an aside and starts
+ *  being the page. Four leaves three for the prose around it. */
+const MAX_CODE_LINES = 4
+
+/**
+ * A fenced block, shown when it can be shown.
+ *
+ * It used to collapse to `[code]` on the grounds that source is unreadable at
+ * this size. True of real source with deep indentation and long lines — and
+ * false of most fenced blocks in agent replies, which are a command, a couple
+ * of values, a short listing. Those fit the panel with room to spare, and
+ * throwing them away took the content a sentence had just promised.
+ *
+ * Common indentation goes first: on a panel this narrow, four leading spaces
+ * are the difference between fitting and not, and dropping the shared prefix
+ * keeps every line's relation to the others intact.
+ */
+function renderCodeBlock(lines: string[]): string[] {
+  const body = [...lines]
+  while (body.length && !body[0].trim()) body.shift()
+  while (body.length && !body[body.length - 1].trim()) body.pop()
+  if (!body.length) return []
+
+  const filled = body.filter((l) => l.trim())
+  const indent = Math.min(...filled.map((l) => (l.match(/^ */) as RegExpMatchArray)[0].length))
+  const dedented = body.map((l) => stripUnrenderable(l.slice(indent)))
+
+  const fits = dedented.length <= MAX_CODE_LINES && dedented.every((l) => textWidth(l) <= BODY_WIDTH)
+  // Still worth saying how much was withheld — `[code]` alone said only that
+  // something was there.
+  return fits ? dedented : [`[code ${dedented.length}行]`]
+}
+
 /**
  * Strip Markdown / collapse noisy blocks for the G2's plain-text 7-line page.
  * Mechanical only — no semantic summarization (that's the v2 server-side LLM
- * plan). Fenced code collapses to one marker line (code is unreadable at this
- * size anyway); table rows are flattened to text; emphasis, headers, links and
+ * plan). Fenced code is shown when it fits and summarised when it does not;
+ * table rows are flattened to text; emphasis, headers, links and
  * inline-code backticks are unwrapped; blank lines and horizontal rules are
  * dropped (every line is scarce on the glasses).
  */
 export function sanitizeForG2(text: string): string {
   const out: string[] = []
-  let inCode = false
+  let code: string[] | null = null
   for (const raw of text.split('\n')) {
     if (/^\s*```/.test(raw)) {
-      inCode = !inCode
-      if (!inCode) out.push('[code]')
+      if (code) {
+        out.push(...renderCodeBlock(code))
+        code = null
+      } else {
+        code = []
+      }
       continue
     }
-    if (inCode) continue
+    if (code) {
+      code.push(raw)
+      continue
+    }
     if (/^\s*\|.*\|?\s*$/.test(raw) && raw.includes('|')) {
       const row = tableRowToLine(raw)
       if (row) out.push(stripInline(row))
@@ -170,7 +210,7 @@ export function sanitizeForG2(text: string): string {
     if (/^[-*_]{3,}$/.test(line.trim())) continue
     out.push(line)
   }
-  if (inCode) out.push('[code]') // unterminated fence
+  if (code) out.push(...renderCodeBlock(code)) // unterminated fence
   return out.join('\n')
 }
 


### PR DESCRIPTION
> [code] って記載意味ありますか？

ほぼありません。「ここにコードがあった」以外に何も伝えず、中身を捨てています。`[table]` にいただいた指摘とまったく同じ形でした。

実際、ミラーで送っていただいた画面がそれです。直前の「フッターがどちらを行うか示します。」が指していた中身が `[code]` に潰れていました。そのブロックは 3 行で最大 265px、枠は 556px です。**余裕で収まるものを捨てていました。**

```
変更前:  [code]

変更後:  最新（0,0）        dbl:back  p1/3
        ページ2            dbl:top  p2/3
        1件遡り            dbl:top
```

## 判定

マーカーの根拠は「このサイズでソースは読めない」でした。深くインデントされた実ソースについては正しく、**エージェントの返答に出てくるフェンスの大半については誤り**です。コマンド1行、値がいくつか、短い一覧——それらは収まります。

- **4行以内、かつ全行が枠に収まる**なら中身を出す
- **共通インデントを落とす**。この幅では先頭4スペースが収まるかどうかの分かれ目で、共通の前置きを削っても行同士の相対関係は保たれる
- 出せないものは**どれだけ伏せたか**を言う（`[code 12行]`）

```
今回落ちたもの   → 3行そのまま表示
コマンド         → bun run test
インデント付き    → 共通分を落として表示
長いソース       → [code 2行]
6行のブロック    → [code 6行]
```

テスト6件追加（全59件）。lint / typecheck / test（全603件）/ device・web 両ビルド通過。**ehpk の更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np