### PR TITLE
chore(glasses): 心拍にJSヒープを記録する

### DIFF
--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -176,12 +176,34 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
   trace('events wired')
   trace('startup complete')
 
+  /**
+   * JS heap, when the engine will say.
+   *
+   * Deliberately narrow evidence: this is the JS heap alone, not the WebView's
+   * DOM, GPU textures or native allocations. If Android is killing the process
+   * on total footprint, this stays flat right up to the end — which is itself
+   * worth knowing, because it rules the JS heap out rather than leaving it a
+   * suspect. Non-standard and Chromium-only, hence the cast and the guard.
+   */
+  function heapNote(): string {
+    const mem = (performance as unknown as {
+      memory?: { usedJSHeapSize: number; totalJSHeapSize: number; jsHeapSizeLimit: number }
+    }).memory
+    if (!mem) return ''
+    const mb = (n: number) => Math.round(n / 1048576)
+    return ` heap=${mb(mem.usedJSHeapSize)}/${mb(mem.totalJSHeapSize)}MB(limit ${mb(mem.jsHeapSizeLimit)})`
+  }
+
   // Heartbeat. Startup already completes cleanly in every failing report, so
   // the question is no longer whether it starts but how long it survives —
-  // the last beat that arrives is the moment it died.
+  // the last beat that arrives is the moment it died. Its spacing is evidence
+  // too: the interval stretched from 30s to 65s before eight of twenty deaths,
+  // which is the engine being throttled rather than the app failing.
   const bootAt = Date.now()
   setInterval(() => {
-    trace(`alive ${((Date.now() - bootAt) / 1000).toFixed(1)}s renders=${renders} ws=${controller.ws.getState()}`)
+    trace(
+      `alive ${((Date.now() - bootAt) / 1000).toFixed(1)}s renders=${renders} ws=${controller.ws.getState()}${heapNote()}`,
+    )
   }, HEARTBEAT_MS)
 }
 


### PR DESCRIPTION
クラッシュ原因の推測を4回外しているので、理屈ではなく計測を足します。

```
変更前: alive 786.0s renders=438 ws=OPEN
変更後: alive 786.0s renders=438 ws=OPEN heap=42/64MB(limit 512)
```

心拍はもともと30秒ごとに送っているので、**送信量は増えません**。実機側のみ、1関数の追加です。

## これで分かること / 分からないこと

`performance.memory` は **JS ヒープしか見ません**。WebView の DOM・GPUテクスチャ・ネイティブ確保は含まれないので、Android がプロセス全体の使用量で殺しているならヒープは平常のまま落ちます。

- ヒープが上限に張り付いていた → 原因が絞れる
- ヒープは平常だった → **JS メモリは無実**と分かる（容疑者が減るのも前進）

一発で確定するとは限りません。そこは誇張せずに置きます。

## 併せて読む数字

心拍の**間隔そのもの**も証拠です。20回の稼働のうち8回で、死ぬ直前に 30秒 → 45〜65秒 に伸びていました。43回の起動すべてで JS 例外はゼロなので、アプリが失敗しているのではなくエンジンが絞られています。ヒープの数字と並べれば「絞られているのに JS メモリは平常」なのか「メモリ枯渇で GC が回っている」のかが判別できます。

シミュレータ実測で `heap=5/10MB(limit 4192)` と出力を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np