### PR TITLE
feat: 全タブのペインを一覧に出し、グラスから開けるようにする

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -353,6 +353,7 @@ export async function buildSessionsList(): Promise<ExtendedSessionResponse[]> {
           agent: p.agent,
           agentSessionId: p.agentSessionId,
           isActive: p.isActive,
+          tabId: p.tabId,
           indicatorState: isSessionAgentOnPane ? (hookState ?? paneIndicator) : paneIndicator,
           pid: p.pid,
           metrics: paneMetrics,

--- a/backend/src/services/herdr.ts
+++ b/backend/src/services/herdr.ts
@@ -29,6 +29,8 @@ interface HerdrPaneInfo {
   agentSessionId?: string;
   agentStatus?: HerdrAgentStatus;
   isActive: boolean;
+  /** Tab the pane belongs to. `panes` spans every tab of the workspace. */
+  tabId?: string;
   pid?: number;
 }
 
@@ -190,15 +192,21 @@ export class HerdrService {
 
       const result: WorkspaceInfo[] = await Promise.all(
         workspaces.map(async (ws) => {
-          // Only the active tab's panes represent the session: herdr stacks
-          // multiple tabs' panes under one workspace, but the terminal view
-          // (HerdrControlSession) renders a single tab, so the list must agree
-          // or the pane count / preview would count panes the user can't see.
-          const wsPanes = allPanes.filter(
-            (p) =>
-              p.workspace_id === ws.workspace_id &&
-              (!ws.active_tab_id || p.tab_id === ws.active_tab_id),
-          );
+          // Every pane of the workspace, tagged with the tab it belongs to.
+          //
+          // The terminal view renders one tab, and the list used to be filtered
+          // to match it. But listing and rendering are different questions:
+          // a pane in another tab is still a running agent with its own
+          // conversation, and hiding it from the list made it unreachable
+          // rather than merely off-screen. Consumers that describe the terminal
+          // — preview, the representative agent, the pane count on a card —
+          // stay on the active tab via `activeWsPanes` below; consumers that
+          // enumerate agents get all of them and can tell which is which from
+          // `tabId`.
+          const wsPanes = allPanes.filter((p) => p.workspace_id === ws.workspace_id);
+          const activeWsPanes = ws.active_tab_id
+            ? wsPanes.filter((p) => p.tab_id === ws.active_tab_id)
+            : wsPanes;
           const panes: HerdrPaneInfo[] = await Promise.all(
             wsPanes.map(async (p) => {
               const tmuxId = toTmuxPaneId(p.pane_id) ?? p.pane_id;
@@ -212,18 +220,22 @@ export class HerdrService {
                 agentSessionId: agentPane?.sessionId,
                 agentStatus: agentPane?.status ?? p.agent_status,
                 isActive: p.focused,
+                tabId: p.tab_id,
                 pid,
               };
             }),
           );
 
-          // Keep the representative session fields paired to one pane. Prefer
-          // the currently focused agent pane, then the first agent pane.
+          // Keep the representative session fields paired to one pane, and to a
+          // pane the terminal is actually showing — a workspace summarised by
+          // an agent in a tab nobody is looking at describes the wrong thing.
+          const activeTabIds = new Set(activeWsPanes.map((p) => toTmuxPaneId(p.pane_id) ?? p.pane_id));
+          const shownPanes = panes.filter((p) => activeTabIds.has(p.paneId));
           const agentPane =
-            panes.find((p) => p.isActive && p.agent) ?? panes.find((p) => p.agent);
+            shownPanes.find((p) => p.isActive && p.agent) ?? shownPanes.find((p) => p.agent);
           const agent = agentPane?.agent;
 
-          const rootPane = wsPanes[0];
+          const rootPane = activeWsPanes[0];
           const rootHerdrId = rootPane?.pane_id;
           let preview: string | undefined;
           if (rootHerdrId) {
@@ -245,7 +257,10 @@ export class HerdrService {
           // `blocked` anywhere in the workspace wins: an agent waiting on a
           // prompt is the state the user has to act on, even if the split it
           // sits in isn't the one we matched an agent process to.
-          const agentStatus: HerdrAgentStatus | undefined = wsPanes.some(
+          // Also the terminal's view: a badge on the card saying "blocked" while
+          // the tab on screen is idle sends the reader looking for something
+          // that is not there. The blocked pane still says so on its own row.
+          const agentStatus: HerdrAgentStatus | undefined = activeWsPanes.some(
             (p) => p.agent_status === 'blocked',
           )
             ? 'blocked'
@@ -272,7 +287,7 @@ export class HerdrService {
           } else if (ws.active_tab_id) {
             const num = ws.active_tab_id.match(/:t(\d+)$/)?.[1] ?? '1';
             tabs = [
-              { id: ws.active_tab_id, label: num, paneCount: wsPanes.length, active: true },
+              { id: ws.active_tab_id, label: num, paneCount: activeWsPanes.length, active: true },
             ];
           }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,7 @@ import {
 	parseNotificationTarget,
 	type NotificationTarget,
 } from "./utils/notificationNavigation";
+import { soleVisiblePane } from "./utils/panes";
 
 // Loading screen with phase display and timeout detection
 function LoadingScreen({
@@ -874,9 +875,7 @@ export function App() {
 				(p) => mobileActivePaneId && p.paneId === mobileActivePaneId,
 			) ??
 			activeSession?.panes?.find((p) => p.isActive) ??
-			(activeSession?.panes?.length === 1
-				? activeSession.panes[0]
-				: undefined);
+			soleVisiblePane(activeSession);
 		if (!activePane?.agent || !activePane.agentSessionId) return;
 		setShowConversation(true);
 	}, [openSessions, activeSessionKey, mobileActivePaneId]);
@@ -1094,9 +1093,7 @@ export function App() {
 			(p) => mobileActivePaneId && p.paneId === mobileActivePaneId,
 		) ??
 		activeSession?.panes?.find((p) => p.isActive) ??
-		(activeSession?.panes?.length === 1
-			? activeSession.panes[0]
-			: undefined);
+		soleVisiblePane(activeSession);
 	const conversationAvailable = !!(
 		activeConversationPane?.agent && activeConversationPane.agentSessionId
 	);

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -21,6 +21,7 @@ import { toHomeShortPath } from "../utils/path";
 import { ChatView } from "./chat/ChatView";
 import type { ControlModeConfig } from "./Terminal";
 import { TerminalComponent, type TerminalRef } from "./Terminal";
+import { soleVisiblePane } from "../utils/panes";
 
 // ペインノード型定義。
 // sessionKey は `peerId:id` の複合キー (utils/sessionKey.ts) — セッション id
@@ -324,7 +325,7 @@ function TerminalPane({
 	const activeTmuxPane =
 		session?.panes?.find((p) => p.paneId === controlledPaneId) ??
 		session?.panes?.find((p) => p.isActive) ??
-		(session?.panes?.length === 1 ? session.panes[0] : undefined);
+		soleVisiblePane(session);
 	const conversationAvailable = !!(
 		activeTmuxPane?.agent && activeTmuxPane.agentSessionId
 	);

--- a/frontend/src/components/PaneContainer.tsx
+++ b/frontend/src/components/PaneContainer.tsx
@@ -21,7 +21,7 @@ import { toHomeShortPath } from "../utils/path";
 import { ChatView } from "./chat/ChatView";
 import type { ControlModeConfig } from "./Terminal";
 import { TerminalComponent, type TerminalRef } from "./Terminal";
-import { soleVisiblePane } from "../utils/panes";
+import { soleVisiblePane, visiblePanes } from "../utils/panes";
 
 // ペインノード型定義。
 // sessionKey は `peerId:id` の複合キー (utils/sessionKey.ts) — セッション id
@@ -476,11 +476,13 @@ function TerminalPane({
 							</svg>
 						</button>
 					)}
-					{/* Zoom button — only meaningful when there are multiple panes */}
+					{/* Zoom button — only meaningful when there are multiple panes.
+              Counted among the ones on screen: `panes` spans every tab, and
+              zooming is about the layout in front of you. */}
 					{sessionKey &&
 						!showConversation &&
 						controlModeContext.zoomPane &&
-						(session?.panes?.length ?? 0) > 1 && (
+						visiblePanes(session).length > 1 && (
 							<button
 								type="button"
 								onClick={(e) => {
@@ -576,8 +578,10 @@ function TerminalPane({
 						</div>
 					)}
 					{/* Close button with confirmation — only shown when there are
-              multiple panes (the backend rejects closing the last pane). */}
-					{(session?.panes?.length ?? 0) > 1 && (
+              multiple panes on screen (the backend rejects closing the last
+              one). Counting every tab's panes would offer to close the only
+              pane the reader can see. */}
+					{visiblePanes(session).length > 1 && (
 						<button
 							type="button"
 							onClick={(e) => {

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -1535,9 +1535,18 @@ function SessionItem({
 											onSelectTab={onSelectTab}
 											onCloseTab={onCloseTab}
 										/>
-										{isActive && extSession.panes && (
+										{/* `panes` spans every tab now, so each tab takes its
+                        own. Rendering them all under the active one would
+                        claim a pane belongs where it does not. A pane with no
+                        tabId predates the field and stays with the active tab,
+                        which is where it always appeared. */}
+										{extSession.panes && (
 											<div className="ml-4 pl-1 border-l border-white/[0.08]">
-												{extSession.panes.map((pane) => (
+												{extSession.panes
+													.filter((p) =>
+														p.tabId ? p.tabId === tab.id : isActive,
+													)
+													.map((pane) => (
 													<PaneRow
 														key={pane.paneId}
 														session={extSession}
@@ -1545,9 +1554,9 @@ function SessionItem({
 														bridgePaneId={bridgePaneId}
 														onSelect={onSelect}
 														onSelectPane={onSelectPane}
-														onClosePane={onClosePane}
-													/>
-												))}
+															onClosePane={onClosePane}
+														/>
+													))}
 											</div>
 										)}
 									</div>

--- a/frontend/src/utils/panes.ts
+++ b/frontend/src/utils/panes.ts
@@ -1,0 +1,39 @@
+import type { ExtendedSessionResponse, PaneInfo } from "../../../shared/types";
+
+/**
+ * The panes the terminal is showing.
+ *
+ * `session.panes` spans every tab of the workspace — a pane in another tab is
+ * still a running agent, and the list is where you reach it. The terminal
+ * renders one tab, so anything describing what is on screen has to narrow back
+ * down, or a workspace with a pane parked in a second tab stops looking like
+ * the single-pane workspace it appears to be.
+ *
+ * Falls back to all panes when the session reports no active tab: an older
+ * server, or a workspace herdr has not tagged, should behave as it always did.
+ */
+export function visiblePanes(
+	session:
+		| Pick<ExtendedSessionResponse, "panes" | "activeTabId">
+		| null
+		| undefined,
+): PaneInfo[] {
+	const panes = session?.panes;
+	if (!panes) return [];
+	const activeTabId = session?.activeTabId;
+	if (!activeTabId) return panes;
+	// A pane with no tabId predates the field; keeping it is the safer read.
+	const inTab = panes.filter((p) => !p.tabId || p.tabId === activeTabId);
+	return inTab.length > 0 ? inTab : panes;
+}
+
+/** The pane to describe a session by, when exactly one is on screen. */
+export function soleVisiblePane(
+	session:
+		| Pick<ExtendedSessionResponse, "panes" | "activeTabId">
+		| null
+		| undefined,
+): PaneInfo | undefined {
+	const panes = visiblePanes(session);
+	return panes.length === 1 ? panes[0] : undefined;
+}

--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 import { sanitizeForG2, formatMessage } from '../types.ts'
 import { screenText, wrapForPanel, wrapHeader } from '../display.ts'
-import { BODY_WIDTH, HEADER_WIDTH, textWidth as width } from '../metrics.ts'
+import { BODY_WIDTH, HEADER_WIDTH, LIST_LINES, textWidth as width } from '../metrics.ts'
+import { listRows, rowCursor } from '../display.ts'
+import { MAX_LINES } from '../metrics.ts'
 
 describe('sanitizeForG2: tables', () => {
   const table = [
@@ -225,7 +227,10 @@ describe('header clock', () => {
   }
 
   test('sits at the right edge on every screen', () => {
-    for (const mode of ['session_list', 'conversation', 'choice', 'voice', 'overlay'] as const) {
+    // The list screen has no header; its clock rides in the footer, which is
+    // the same bar geometry and the same right edge.
+    expect(screenText({ ...base, mode: 'session_list' as const }).footer).toMatch(/ \d\d:\d\d$/)
+    for (const mode of ['conversation', 'choice', 'voice', 'overlay'] as const) {
       const header = screenText({ ...base, mode }).header
       expect(header).toMatch(/ \d\d:\d\d$/)
       // The header container holds exactly one line — 28px of inner height
@@ -560,5 +565,84 @@ describe('fenced code', () => {
 
   test('an empty block leaves nothing behind', () => {
     expect(sanitizeForG2('前\n```\n\n```\n後').split('\n')).toEqual(['前', '後'])
+  })
+})
+
+describe('workspace and pane list', () => {
+  const panes = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      paneId: `%${i + 1}`,
+      currentPath: '/home/m0a/repos/wheel-leg-bot',
+      agentSessionId: `agent-${i}`,
+      indicatorState: 'waiting_input' as const,
+      metrics: { contextPercent: 30 - i * 15 },
+    }))
+  const sessions = [
+    { id: 'a', name: 'グラス開発', state: 'working' as const, panes: panes(1) },
+    { id: 'b', name: '2脚ロボ開発', state: 'idle' as const, panes: panes(2) },
+    { id: 'c', name: 'life', state: 'idle' as const },
+  ]
+  const st = (sessionIndex: number, selectedPaneId?: string) => ({
+    mode: 'session_list' as const,
+    sessions,
+    sessionIndex,
+    conversation: [],
+    conversationOffset: 0,
+    conversationPage: 0,
+    conversationLastLoaded: 0,
+    conversationHasMore: false,
+    conversationLoading: false,
+    choiceIndex: 0,
+    choiceOptions: [],
+    relayWaiting: [],
+    relayInfo: [],
+    overlayItemId: null,
+    selectedPaneId,
+  })
+
+  test('a workspace with one pane is not expanded', () => {
+    // `%1` under a name it already carries is hierarchy that says nothing.
+    expect(listRows(sessions).filter((r) => r.sessionIndex === 0)).toEqual([{ sessionIndex: 0 }])
+  })
+
+  test('a workspace with two panes lists them', () => {
+    expect(listRows(sessions).filter((r) => r.sessionIndex === 1)).toEqual([
+      { sessionIndex: 1 },
+      { sessionIndex: 1, paneId: '%1' },
+      { sessionIndex: 1, paneId: '%2' },
+    ])
+  })
+
+  test('the cursor walks workspaces and panes with one gesture', () => {
+    expect(rowCursor(st(1))).toBe(1)
+    expect(rowCursor(st(1, '%2'))).toBe(3)
+  })
+
+  test('the list gets the row the header used to occupy', () => {
+    expect(LIST_LINES).toBe(MAX_LINES + 1)
+  })
+
+  test('the footer carries the position and the clock', () => {
+    const footer = screenText(st(1)).footer
+    expect(footer).toMatch(/2\/5/)
+    expect(footer).toMatch(/ \d\d:\d\d$/)
+    expect(width(footer)).toBeLessThanOrEqual(HEADER_WIDTH)
+  })
+
+  test('the list screen has no header', () => {
+    expect(screenText(st(0)).header).toBe('')
+  })
+
+  test('a pane row drops the directory its siblings share', () => {
+    // Two panes of one repo repeat the same folder name; the second one
+    // teaches the reader nothing.
+    const body = screenText(st(1)).body
+    expect(body).toContain('%1  30%')
+    expect(body).not.toContain('wheel-leg-bot')
+  })
+
+  test('the conversation header names the pane being read', () => {
+    const header = screenText({ ...st(1, '%2'), mode: 'conversation' as const }).header
+    expect(header).toContain('2脚ロボ開発 %2')
   })
 })

--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -646,3 +646,52 @@ describe('workspace and pane list', () => {
     expect(header).toContain('2脚ロボ開発 %2')
   })
 })
+
+describe('panes across tabs', () => {
+  const sessions = [
+    {
+      id: 'a',
+      name: '2脚ロボ開発',
+      state: 'idle' as const,
+      activeTabId: 'w4H:t1',
+      panes: [
+        { paneId: '%1', tabId: 'w4H:t1', metrics: { contextPercent: 31 } },
+        { paneId: '%4', tabId: 'w4H:t2', metrics: { contextPercent: 6 } },
+      ],
+    },
+  ]
+  const st = {
+    mode: 'session_list' as const,
+    sessions,
+    sessionIndex: 0,
+    conversation: [],
+    conversationOffset: 0,
+    conversationPage: 0,
+    conversationLastLoaded: 0,
+    conversationHasMore: false,
+    conversationLoading: false,
+    choiceIndex: 0,
+    choiceOptions: [],
+    relayWaiting: [],
+    relayInfo: [],
+    overlayItemId: null,
+  }
+
+  test('a pane the terminal cannot show says so', () => {
+    // "There are two" and "one of them is somewhere you are not looking" are
+    // different things to know.
+    const body = screenText(st).body
+    expect(body).toContain('%1  31%')
+    expect(body).toContain('%4  6%  別タブ')
+  })
+
+  test('panes of the active tab are not marked', () => {
+    const line = screenText(st).body.split('\n').find((l) => l.includes('%1')) ?? ''
+    expect(line).not.toContain('別タブ')
+  })
+
+  test('nothing is marked when the session reports no active tab', () => {
+    const noTab = { ...st, sessions: [{ ...sessions[0], activeTabId: undefined }] }
+    expect(screenText(noTab).body).not.toContain('別タブ')
+  })
+})

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -26,11 +26,11 @@
 //   voice:        tap=stop→transcribe / send  doubleTap=cancel
 
 import { getConversation, sendPrompt, sendPaneInput, dismissRelayItem } from './api.ts'
-import { SPINNER_INTERVAL_MS, getTotalPagesAt, getMultiCountAt } from './display.ts'
+import { SPINNER_INTERVAL_MS, getTotalPagesAt, getMultiCountAt, listRows, rowCursor } from './display.ts'
 import type { AppState } from './display.ts'
 import { RelayQueue } from './relay-queue.ts'
 import { CcHubWsClient } from './ws-client.ts'
-import type { Session, ConversationMessage, GlassesRelayItem, ClientFocus } from './types.ts'
+import type { Session, Pane, ConversationMessage, GlassesRelayItem, ClientFocus } from './types.ts'
 
 const INITIAL_LOAD_COUNT = 20
 const LOAD_MORE_INCREMENT = 20
@@ -190,15 +190,27 @@ export class GlassesController {
 
   // ── session_list ──
 
+  /** Walk the list one row at a time. Rows are workspaces and, where a
+   *  workspace holds more than one, its panes — so the same gesture moves
+   *  between workspaces and into them without a second control. */
+  private moveListCursor(step: number): void {
+    const st = this.state
+    const rows = listRows(st.sessions)
+    if (!rows.length) return
+    const next = rows[Math.min(rows.length - 1, Math.max(0, rowCursor(st) + step))]
+    st.sessionIndex = next.sessionIndex
+    st.selectedPaneId = next.paneId
+  }
+
   private async onSessionListAction(action: RingAction): Promise<void> {
     const st = this.state
     switch (action) {
       case 'swipeUp':
-        if (st.sessionIndex > 0) st.sessionIndex--
+        this.moveListCursor(-1)
         this.render()
         return
       case 'swipeDown':
-        if (st.sessionIndex < st.sessions.length - 1) st.sessionIndex++
+        this.moveListCursor(1)
         this.render()
         return
       case 'tap': {
@@ -288,15 +300,18 @@ export class GlassesController {
           await this.startVoice({ sessionId: top.sessionId, paneId: top.paneId, itemId: top.id })
           return
         }
-        // No relay items — legacy indicator flow (scrape, else voice).
+        // No relay items — legacy indicator flow (scrape, else voice). Reading
+        // one pane, the reply belongs to that pane: sending it to the
+        // workspace would land wherever herdr happens to have focus.
+        const paneId = this.state.selectedPaneId
         if (cur && isSessionWaiting(cur)) {
           const scraped = await this.scrapeChoices(cur.id)
           if (scraped.length > 0) {
-            this.enterChoice(scraped, { sessionId: cur.id })
+            this.enterChoice(scraped, { sessionId: cur.id, paneId })
             return
           }
         }
-        if (cur) await this.startVoice({ sessionId: cur.id })
+        if (cur) await this.startVoice({ sessionId: cur.id, paneId })
         return
       }
       case 'doubleTap': {
@@ -722,8 +737,28 @@ export class GlassesController {
     return getTotalPagesAt(this.state.conversation, this.state.conversationOffset)
   }
 
+  /** The pane the cursor is on, when the list row was a pane. */
+  private currentPane(): Pane | undefined {
+    const id = this.state.selectedPaneId
+    if (!id) return undefined
+    return (this.currentSession()?.panes ?? []).find((p) => p.paneId === id)
+  }
+
   private async loadConversation(): Promise<void> {
     const session = this.currentSession()
+    // A pane of a multi-pane workspace is its own agent conversation, with its
+    // own session id. Reading the workspace's showed one of them and silently
+    // omitted the rest.
+    const paneAgent = this.currentPane()?.agentSessionId
+    if (paneAgent) {
+      const rawPane = await getConversation(paneAgent, INITIAL_LOAD_COUNT)
+      this.state.conversation = filterConversation(rawPane)
+      this.state.conversationLastLoaded = INITIAL_LOAD_COUNT
+      this.state.conversationHasMore = rawPane.length >= INITIAL_LOAD_COUNT
+      this.state.conversationOffset = 0
+      this.state.conversationPage = 0
+      return
+    }
     if (!session?.ccSessionId) {
       this.state.conversation = []
       this.state.conversationLastLoaded = 0

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -350,7 +350,9 @@ export function startDebugUI(): void {
   const mirrorToggle = document.getElementById('g2-mirror') as HTMLInputElement
   const mirrorStatus = el('g2-mirror-status')
 
-  let lastScreen = { header: '', body: '', footer: '' }
+  let lastScreen: { header: string; body: string; footer: string; headerless?: boolean } = {
+    header: '', body: '', footer: '',
+  }
   let lastMode = 'session_list'
 
   // ── Device mirror (demo) ──
@@ -362,7 +364,10 @@ export function startDebugUI(): void {
   let localScreen = { header: '', body: '', footer: '' }
   let localMode = 'session_list'
 
-  function paint(screen: { header: string; body: string; footer: string }, mode: string): void {
+  function paint(
+    screen: { header: string; body: string; footer: string; headerless?: boolean },
+    mode: string,
+  ): void {
     lastScreen = screen
     lastMode = mode
     drawPanel(screen)
@@ -425,7 +430,7 @@ export function startDebugUI(): void {
     }
   }
 
-  function drawPanel(screen: { header: string; body: string; footer: string }): void {
+  function drawPanel(screen: { header: string; body: string; footer: string; headerless?: boolean }): void {
     const ctx = canvas.getContext('2d')
     if (!ctx) return
     ctx.clearRect(0, 0, canvas.width, canvas.height)
@@ -436,10 +441,13 @@ export function startDebugUI(): void {
     ctx.shadowBlur = 6
 
     ctx.fillStyle = `rgb(${GREEN})`
-    drawRow(ctx, screen.header, HEADER_PAD, HEADER_BASE)
+    if (!screen.headerless) drawRow(ctx, screen.header, HEADER_PAD, HEADER_BASE)
 
+    // Without a header container the body owns that band too, and starts where
+    // it does rather than a bar below it.
+    const bodyTop = screen.headerless ? BODY_PAD + BASELINE : BODY_TOP
     for (const [i, line] of screen.body.split('\n').entries()) {
-      drawRow(ctx, line, 4 + BODY_PAD, BODY_TOP + i * LINE_H)
+      drawRow(ctx, line, 4 + BODY_PAD, bodyTop + i * LINE_H)
     }
 
     ctx.fillStyle = `rgba(${GREEN}, 0.78)`

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -338,11 +338,15 @@ function paneStatusLabel(p: Pane): string {
  * learns nothing from the second one. What is left is the context figure,
  * which does differ, and says which of the two has been running longer.
  */
-function paneDetail(p: Pane, siblings: Pane[]): string {
+function paneDetail(p: Pane, siblings: Pane[], activeTabId?: string): string {
   const dirOf = (x: Pane) => x.currentPath?.split('/').filter(Boolean).pop() ?? ''
   const dirs = new Set(siblings.map(dirOf))
   const pct = p.metrics?.contextPercent
-  return [pct != null ? `${Math.round(pct)}%` : '', dirs.size > 1 ? dirOf(p) : '']
+  // A pane in another tab is running where the terminal cannot show it. Saying
+  // so is the difference between "there are three" and "one of them is
+  // somewhere you are not looking".
+  const offscreen = activeTabId && p.tabId && p.tabId !== activeTabId ? '別タブ' : ''
+  return [pct != null ? `${Math.round(pct)}%` : '', dirs.size > 1 ? dirOf(p) : '', offscreen]
     .filter(Boolean)
     .join('  ')
 }
@@ -369,7 +373,7 @@ function sessionListBody(state: AppState): string {
       return `${here}${label.padEnd(3)} ${sName(s)}`
     }
     const p = (s.panes ?? []).find((x) => x.paneId === row.paneId)
-    const detail = p ? paneDetail(p, s.panes ?? []) : ''
+    const detail = p ? paneDetail(p, s.panes ?? [], s.activeTabId) : ''
     // Indented under its workspace, and only ever shown beneath it.
     return `${here}${(p ? paneStatusLabel(p) : '').padEnd(3)}  ${row.paneId}${detail ? `  ${detail}` : ''}`
   }).join('\n')

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -10,6 +10,7 @@ import {
 import {
   BODY_WIDTH,
   HEADER_WIDTH,
+  LIST_LINES,
   MAX_LINES,
   SPACE_W,
   ellipsize,
@@ -17,7 +18,7 @@ import {
   textWidth,
 } from './metrics.ts'
 import { formatMessage, recapBlockLines } from './types.ts'
-import type { Session, ConversationMessage, GlassesRelayItem } from './types.ts'
+import type { Session, Pane, ConversationMessage, GlassesRelayItem } from './types.ts'
 
 const W = 576
 const H = 288
@@ -132,6 +133,10 @@ export interface AppState {
   conversationLoading: boolean
   choiceIndex: number
   choiceOptions: string[]
+  /** Pane the cursor is on, when the list row is a pane rather than its
+   *  workspace. Carries into the conversation: its own agent session, its own
+   *  status, and the pane replies are routed to. */
+  selectedPaneId?: string
   /** Advances one frame per spinner tick while the shown session is working.
    *  Absent in states built before the spinner existed; treated as 0. */
   spinnerTick?: number
@@ -281,27 +286,93 @@ function relayBannerLines(state: AppState): string[] {
 
 // ─── Content helpers (shared by build and in-place update) ───
 
-function sessionListHeader(state: AppState): string {
-  const { sessionIndex, sessions, relayWaiting } = state
-  const badge = relayWaiting.length > 0 ? ` !${relayWaiting.length}` : ''
-  return withClock(`CC Hub ${sessionIndex + 1}/${sessions.length}${badge}`)
+
+/** One navigable line of the list: a workspace, or a pane inside one. */
+export interface ListRow {
+  sessionIndex: number
+  /** Absent on the workspace's own row. */
+  paneId?: string
+}
+
+/**
+ * The list, flattened for navigation.
+ *
+ * A workspace with one pane is not expanded. `%1` under a name it already
+ * carries is a level of hierarchy that says nothing, and lines are the
+ * scarcest thing on this screen. Two or more panes are separate agent
+ * conversations with separate session ids, and only then does the workspace
+ * row stop being the whole story.
+ */
+export function listRows(sessions: Session[]): ListRow[] {
+  const rows: ListRow[] = []
+  sessions.forEach((s, sessionIndex) => {
+    rows.push({ sessionIndex })
+    const panes = s.panes ?? []
+    if (panes.length < 2) return
+    for (const p of panes) rows.push({ sessionIndex, paneId: p.paneId })
+  })
+  return rows
+}
+
+/** Index of the row the cursor is on. */
+export function rowCursor(state: AppState): number {
+  const rows = listRows(state.sessions)
+  const found = rows.findIndex(
+    (r) => r.sessionIndex === state.sessionIndex && r.paneId === state.selectedPaneId,
+  )
+  return found >= 0 ? found : Math.max(0, rows.findIndex((r) => r.sessionIndex === state.sessionIndex))
+}
+
+function paneStatusLabel(p: Pane): string {
+  if (p.indicatorState === 'waiting_input' || (!!p.waitingToolName && p.waitingToolName !== 'UserInput')) return '[!]'
+  if (p.indicatorState === 'processing') return '[*]'
+  return ''
+}
+
+/**
+ * What tells two panes of one workspace apart.
+ *
+ * Not the command: every pane here runs `claude`, so printing it fills a line
+ * with a constant. Not the directory either, unless the panes actually differ
+ * in it — two panes of one repo repeat the same folder name and the reader
+ * learns nothing from the second one. What is left is the context figure,
+ * which does differ, and says which of the two has been running longer.
+ */
+function paneDetail(p: Pane, siblings: Pane[]): string {
+  const dirOf = (x: Pane) => x.currentPath?.split('/').filter(Boolean).pop() ?? ''
+  const dirs = new Set(siblings.map(dirOf))
+  const pct = p.metrics?.contextPercent
+  return [pct != null ? `${Math.round(pct)}%` : '', dirs.size > 1 ? dirOf(p) : '']
+    .filter(Boolean)
+    .join('  ')
 }
 
 function sessionListBody(state: AppState): string {
-  const { sessions, sessionIndex } = state
+  const { sessions } = state
   // Relay waiting covers agent-declared items whose session indicator is not
   // waiting_input; those sessions still get the [!] marker.
   const relayWaitingIds = new Set(state.relayWaiting.map((i) => i.sessionId))
-  const start = Math.max(0, sessionIndex - 3)
-  const visible = sessions.slice(start, start + MAX_LINES)
-  return visible.map((s, i) => {
-    const idx = start + i
-    const cursor = idx === sessionIndex ? '>' : ' '
-    const label = relayWaitingIds.has(s.id) ? '[!]' : statusLabel(s)
-    // Pad the badge so every name starts in the same column: a list where
-    // `>[!] name` and `  name` begin three columns apart is hard to scan.
-    return `${cursor}${label.padEnd(3)} ${sName(s)}`
-  }).join('\n') || '(no sessions)'
+  const rows = listRows(sessions)
+  if (!rows.length) return '(no sessions)'
+  const cursor = rowCursor(state)
+  const start = Math.max(0, Math.min(cursor - 3, rows.length - LIST_LINES))
+  const visible = rows.slice(Math.max(0, start), Math.max(0, start) + LIST_LINES)
+
+  return visible.map((row, i) => {
+    const idx = Math.max(0, start) + i
+    const here = idx === cursor ? '>' : ' '
+    const s = sessions[row.sessionIndex]
+    if (!row.paneId) {
+      const label = relayWaitingIds.has(s.id) ? '[!]' : statusLabel(s)
+      // Pad the badge so every name starts in the same column: a list where
+      // `>[!] name` and `  name` begin three columns apart is hard to scan.
+      return `${here}${label.padEnd(3)} ${sName(s)}`
+    }
+    const p = (s.panes ?? []).find((x) => x.paneId === row.paneId)
+    const detail = p ? paneDetail(p, s.panes ?? []) : ''
+    // Indented under its workspace, and only ever shown beneath it.
+    return `${here}${(p ? paneStatusLabel(p) : '').padEnd(3)}  ${row.paneId}${detail ? `  ${detail}` : ''}`
+  }).join('\n')
 }
 
 /**
@@ -315,8 +386,7 @@ function sessionListBody(state: AppState): string {
  * Anything unknown means keep showing it: a missing timestamp is not evidence
  * that the recap is stale.
  */
-function recapIsCurrent(session: Session | undefined, msgs: ConversationMessage[]): boolean {
-  const recapAt = session?.ccRecapAt
+function recapIsCurrent(recapAt: string | undefined, msgs: ConversationMessage[]): boolean {
   const newestAt = msgs[msgs.length - 1]?.timestamp
   if (!recapAt || !newestAt) return true
   const recapTime = Date.parse(recapAt)
@@ -327,8 +397,15 @@ function recapIsCurrent(session: Session | undefined, msgs: ConversationMessage[
 
 function conversationContent(state: AppState): { headerText: string; bodyText: string; footerText: string } {
   const session = state.sessions[state.sessionIndex]
-  const waiting = session ? isWaiting(session) : false
-  const ind = session?.indicatorState
+  // Reading one pane of a workspace, its status is the one that applies — the
+  // workspace's is a summary of panes the reader is not looking at.
+  const pane = state.selectedPaneId
+    ? (session?.panes ?? []).find((p) => p.paneId === state.selectedPaneId)
+    : undefined
+  const waiting = pane
+    ? pane.indicatorState === 'waiting_input' || (!!pane.waitingToolName && pane.waitingToolName !== 'UserInput')
+    : session ? isWaiting(session) : false
+  const ind = pane ? pane.indicatorState : session?.indicatorState
   const statusBadge = waiting ? '  [!] WAITING' : ind === 'processing' ? `  ${spinnerFrame(state)}` : ''
 
   const msgs = state.conversation
@@ -340,7 +417,9 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
   // Recap heads the latest view; deeper paging drops it for message space,
   // and so does the conversation moving past it.
   const onLatest = state.conversationOffset === 0 && state.conversationPage === 0
-  const recap = onLatest && recapIsCurrent(session, msgs) ? recapBlock(session?.ccRecap) : []
+  const recapText = pane ? pane.recap : session?.ccRecap
+  const recapAt = pane ? pane.recapAt : session?.ccRecapAt
+  const recap = onLatest && recapIsCurrent(recapAt, msgs) ? recapBlock(recapText) : []
   // The body container clips overflow: cap the banner+recap+content block at
   // one page so a waiting overlay never pushes conversation text off-screen.
   // Everything is measured in display lines — counting the conversation in
@@ -364,7 +443,7 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
   // anything. Only the page number is left, which does mean what it says.
 
   return {
-    headerText: withClock(`${session ? sName(session) : '---'}${statusBadge}`),
+    headerText: withClock(`${session ? sName(session) : '---'}${pane ? ` ${pane.paneId}` : ''}${statusBadge}`),
     bodyText,
     footerText: pageInfo ? `${action}  ${pageInfo.trim()}` : action,
   }
@@ -373,7 +452,13 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
 // Footers that are fixed per mode (the rest are built with their content).
 // Named so the browser simulator renders the same string the G2 does instead
 // of a hand-copied approximation.
-const FOOTER_SESSION_LIST = 'tap:open  swipe:nav'
+/** Everything the list screen has to say, in the one bar it still has. */
+function sessionListFooter(state: AppState): string {
+  const cursor = rowCursor(state) + 1
+  const total = listRows(state.sessions).length
+  const badge = state.relayWaiting.length > 0 ? `  !${state.relayWaiting.length}` : ''
+  return withClock(`tap:open  swipe:nav  ${cursor}/${total}${badge}`)
+}
 const FOOTER_CHOICE = 'swipe:select  tap:confirm  dbl:skip'
 
 /** Reply target shown in the choice header — the session the Enter actually
@@ -411,14 +496,19 @@ export function wrapHeader(text: string): string {
  * the device's own output — same wrapping at 52 columns, same 7-line clamp,
  * same pagination — rather than a second implementation that silently drifts.
  */
-export function screenText(state: AppState): { header: string; body: string; footer: string } {
+export function screenText(state: AppState): {
+  header: string
+  body: string
+  footer: string
+  /** The list screen drops its header container, so its body starts at the top
+   *  of the panel rather than below a bar. Anything drawing these strings has
+   *  to know, or it renders a row lower than the device does. */
+  headerless?: boolean
+} {
   switch (state.mode) {
     case 'session_list':
-      return {
-        header: sessionListHeader(state),
-        body: sessionListBody(state),
-        footer: FOOTER_SESSION_LIST,
-      }
+      // No header: the list screen gave that bar back to the list.
+      return { header: '', body: sessionListBody(state), footer: sessionListFooter(state), headerless: true }
     case 'conversation': {
       const { headerText, bodyText, footerText } = conversationContent(state)
       return { header: headerText, body: bodyText, footer: footerText }
@@ -497,44 +587,38 @@ function voiceContent(state: AppState): { headerText: string; bodyText: string; 
 
 // ─── Page builders ───
 
+/**
+ * The list screen: two containers, not three.
+ *
+ * A title bar over a list of titles is a line spent saying nothing. The
+ * counter and the clock it carried fit in the footer beside the gestures, and
+ * the list gets the 36px — a whole extra row, which is what a list that now
+ * includes panes needs.
+ */
 function buildSessionList(state: AppState): RebuildPageContainer {
-  const headerText = sessionListHeader(state)
-  const listText = sessionListBody(state)
-
-  const header = new TextContainerProperty({
-    xPosition: 0, yPosition: 0,
-    width: W, height: 36,
-    borderWidth: 0,
-    paddingLength: 4,
-    containerID: 1, containerName: 'header',
-    isEventCapture: 0,
-    content: headerText,
-  })
-
   const list = new TextContainerProperty({
-    xPosition: 4, yPosition: 36,
-    width: W - 8, height: H - 36 - 36,
+    xPosition: 4, yPosition: 0,
+    width: W - 8, height: H - 36,
     borderWidth: 0,
     paddingLength: 6,
-    containerID: 2, containerName: 'list',
+    containerID: 1, containerName: 'list',
     isEventCapture: 0,
-    content: listText,
+    content: sessionListBody(state),
   })
 
-  // Footer - minimal
   const footer = new TextContainerProperty({
     xPosition: 0, yPosition: H - 36,
     width: W, height: 36,
     borderWidth: 0,
     paddingLength: 4,
-    containerID: 3, containerName: 'footer',
+    containerID: 2, containerName: 'footer',
     isEventCapture: 1,
-    content: FOOTER_SESSION_LIST,
+    content: sessionListFooter(state),
   })
 
   return new RebuildPageContainer({
-    containerTotalNum: 3,
-    textObject: [header, list, footer],
+    containerTotalNum: 2,
+    textObject: [list, footer],
   })
 }
 
@@ -816,12 +900,13 @@ export async function updateDisplay(bridge: Bridge | null, state: AppState): Pro
     case 'session_list': {
       await Promise.all([
         bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 1, containerName: 'header',
-          content: sessionListHeader(state),
-        })),
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 2, containerName: 'list',
+          containerID: 1, containerName: 'list',
           content: sessionListBody(state),
+        })),
+        // The footer moves now — it holds the clock and the position.
+        bridge.textContainerUpgrade(new TextContainerUpgrade({
+          containerID: 2, containerName: 'footer',
+          content: sessionListFooter(state),
         })),
       ])
       break

--- a/glasses/src/metrics.ts
+++ b/glasses/src/metrics.ts
@@ -40,6 +40,16 @@ export const BODY_WIDTH = PANEL_W - 8 - 2 * BODY_PAD
 /** Lines the body container shows before clipping. */
 export const MAX_LINES = Math.floor((PANEL_H - 2 * BAR_H - 2 * BODY_PAD) / LINE_H)
 
+/**
+ * Lines the list gets, which is one more.
+ *
+ * The list screen carries no header: a title bar over a list of titles is a
+ * line spent saying nothing, and the counter and clock it held fit in the
+ * footer beside the gestures. Giving the container that 36px back buys a
+ * whole row — which is exactly what a list that now includes panes needs.
+ */
+export const LIST_LINES = Math.floor((PANEL_H - BAR_H - 2 * BODY_PAD) / LINE_H)
+
 export const SPACE_W = getTextWidth(' ')
 
 // ─── Measuring ───

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -17,6 +17,8 @@ export interface Session {
   /** When the recap was written. The conversation is compared against it: a
    *  message newer than the recap means the reader is already past it. */
   ccRecapAt?: string
+  /** Tab the terminal is showing. Panes outside it are marked in the list. */
+  activeTabId?: string
   ccFirstPrompt?: string
   ccSessionId?: string
   durationMinutes?: number
@@ -38,6 +40,10 @@ export interface Session {
 export interface Pane {
   paneId: string
   isActive?: boolean
+  /** Tab the pane belongs to. `panes` spans every tab of the workspace, so a
+   *  pane whose tab is not the active one is running out of sight of the
+   *  terminal — still a live agent, and now reachable from here. */
+  tabId?: string
   currentCommand?: string
   currentPath?: string
   agent?: string

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -22,7 +22,33 @@ export interface Session {
   durationMinutes?: number
   messageCount?: number
   gitBranch?: string
-  panes?: { paneId: string; isActive?: boolean; currentCommand?: string }[]
+  panes?: Pane[]
+}
+
+/**
+ * A pane, as the server already describes it.
+ *
+ * The glasses used to declare three of these fields and drop the rest, which
+ * hid the one that matters: `indicatorState` is per pane, and which pane is
+ * blocked is a question a workspace-level status cannot answer. Each agent
+ * pane is also its own conversation — `agentSessionId` differs between panes
+ * of the same workspace — so a workspace with two panes was showing one of
+ * them and silently omitting the other.
+ */
+export interface Pane {
+  paneId: string
+  isActive?: boolean
+  currentCommand?: string
+  currentPath?: string
+  agent?: string
+  /** Native agent session id. Distinct per pane; the conversation key. */
+  agentSessionId?: string
+  indicatorState?: IndicatorState
+  waitingToolName?: string
+  /** Per-pane recap, sent only for multi-pane workspaces. */
+  recap?: string
+  recapAt?: string
+  metrics?: { contextPercent?: number }
 }
 
 export interface ConversationMessage {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -205,6 +205,10 @@ export interface PaneInfo {
   agentName?: string;      // Team agent name from --agent-name process arg
   agentColor?: string;     // Team agent color from --agent-color process arg
   isActive: boolean;
+  /** Tab this pane belongs to. `panes` spans every tab of the workspace, so a
+   *  consumer describing the terminal — which renders one tab — filters on
+   *  this against the session's `activeTabId`. */
+  tabId?: string;
   indicatorState?: IndicatorState;
   pid?: number;            // shell/subprocess PID of the pane's foreground group
   /** Per-pane agent metrics (model / context% / memory). Populated only for


### PR DESCRIPTION
> session_list ですが実際には herdr 的にはワークスペースリストだと思います
> ペインのリストが必要かもしれません。ワークスペースで区切られて一覧表示されているイメージです
> ペインリストはヘッダ不要かもです。フッタに情報を固めてください
> 基本的にクロードのセッションとペインは対応しているのでタブは気にする必要ないと思うのです
> A（panes を全タブぶんにする）で進めてください

## 見えていなかったもの

「Claude セッション ↔ ペイン」の対応は正しいのですが、その前提のもとで **2 つのペインが到達不能でした**。

```
ワークスペース          herdr tab  herdr pane  CC Hub pane
wheel-leg-bot                 2          3           2   ← 1 個見えていない
life                          2          2           1   ← 1 個見えていない
```

herdr は最初からデータを持っていて、**CC Hub がアクティブタブで絞っていた**のが原因です。ターミナルは1タブしか描かないので一覧もそれに合わせる、という判断でしたが、**一覧と描画は別の問いです**。別タブのペインも動いている agent で、一覧から消すと「画面外」ではなく「到達不能」になります。

## 変更

`panes` が全タブぶんになり、各ペインが `tabId` を持ちます。ターミナルを説明する側は絞り直します——プレビュー、代表 agent、カードのペイン数、blocked バッジはアクティブタブのまま。画面のタブが idle なのにカードが blocked と言えば、読み手は無いものを探しに行くからです。

フロントの「ペインがちょうど1つ」の判定は `panes.length === 1` で、別タブにペインが1つあるだけで静かに壊れます。`soleVisiblePane`（ターミナルが見せている数を数える）に置き換えました。

## グラス側

```
 [!] グラス開発
>    2脚ロボ開発
 [!]  %1  31%
 [!]  %3  15%
 [!]  %4  6%  別タブ
     life
 [!]  %1  14%
 [!]  %6  5%  別タブ
─────────────────────────────────────────
tap:open  swipe:nav  2/24          21:07
```

- ペインを開くと**そのペインの agent session** を読み、状態も要約もそのペインのもの。返信も `paneId` に届きます
- **1ペインのワークスペースは展開しません**。`%1` は名前が既に持っている情報です
- **コマンドは出しません**（全部 `claude`）。**ディレクトリもペイン同士で違うときだけ**。残るのは context% で、これは実際に違います
- スワイプが**ワークスペースとペインを1つのジェスチャで横断**します（`1 → 1:%1 → 1:%3 → 2` を実測）
- **リスト画面のヘッダーを廃止**。タイトルの一覧の上のタイトルバーは何も言いません。カウンタと時計はフッターに収まり（565px/568px）、コンテナが 36px を取り戻して **8行目**になります

## 検証

実データで別タブの2ペインが出ることを確認。2ペインが別々の会話と別々の要約を返すことも確認済み。テスト11件追加（全70件）。lint / typecheck / test（全614件）/ device・web 両ビルド通過。

**ehpk の更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np