### PR TITLE
fix(glasses): 見出し化・入れ子表示・バッジを処理中だけに

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -292,9 +292,11 @@ describe('session list', () => {
   }
 
   test('every name starts in the same column whether or not it has a badge', () => {
+    // The blank badge is a full-width space — the same 320 units as a spinner
+    // frame — so a row with nothing to say lines up with one that has.
     const starts = screenText(state)
       .body.split('\n')
-      .map((l) => l.search(/[^ >[\]!*]/))
+      .map((l) => l.search(/[^ >\u3000▲▶▼◀]/))
     expect(new Set(starts).size).toBe(1)
   })
 })
@@ -714,5 +716,52 @@ describe('panes across tabs', () => {
   test('nothing is marked when the session reports no active tab', () => {
     const noTab = { ...st, sessions: [{ ...sessions[0], activeTabId: undefined }] }
     expect(screenText(noTab).body).not.toContain('別タブ')
+  })
+})
+
+describe('list badge', () => {
+  const mk = (indicatorState?: 'processing' | 'waiting_input') => ({
+    mode: 'session_list' as const,
+    sessions: [{ id: 'a', name: 'グラス開発', state: 'working' as const, indicatorState }],
+    sessionIndex: 0,
+    conversation: [],
+    conversationOffset: 0,
+    conversationPage: 0,
+    conversationLastLoaded: 0,
+    conversationHasMore: false,
+    conversationLoading: false,
+    choiceIndex: 0,
+    choiceOptions: [],
+    relayWaiting: [],
+    relayInfo: [],
+    overlayItemId: null,
+    spinnerTick: 0,
+  })
+
+  test('a working row turns', () => {
+    expect(screenText({ ...mk('processing'), spinnerTick: 0 }).body).toContain('▲')
+    expect(screenText({ ...mk('processing'), spinnerTick: 1 }).body).toContain('▶')
+  })
+
+  test('waiting is no longer marked', () => {
+    // Seven of eight rows carried `[!]` on a real machine — a mark almost
+    // everything has stops distinguishing anything.
+    const body = screenText(mk('waiting_input')).body
+    expect(body).not.toContain('[!]')
+    expect(body).not.toContain('▲')
+  })
+
+  test('an unmarked row is padded to a badge width', () => {
+    expect(screenText(mk()).body).toContain('\u3000 グラス開発')
+  })
+
+  test('a relay item still marks its workspace', () => {
+    const withRelay = {
+      ...mk(),
+      relayWaiting: [
+        { id: 'r', sessionId: 'a', kind: 'waiting' as const, text: 'x', source: 'auto' as const, createdAt: 1 },
+      ],
+    }
+    expect(screenText(withRelay).body).toContain('！ グラス開発')
   })
 })

--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { sanitizeForG2, formatMessage } from '../types.ts'
 import { screenText, wrapForPanel, wrapHeader } from '../display.ts'
 import { BODY_WIDTH, HEADER_WIDTH, LIST_LINES, textWidth as width } from '../metrics.ts'
-import { listRows, rowCursor } from '../display.ts'
+import { listRows, rowCursor, selectableRows } from '../display.ts'
 import { MAX_LINES } from '../metrics.ts'
 
 describe('sanitizeForG2: tables', () => {
@@ -605,17 +605,36 @@ describe('workspace and pane list', () => {
     expect(listRows(sessions).filter((r) => r.sessionIndex === 0)).toEqual([{ sessionIndex: 0 }])
   })
 
-  test('a workspace with two panes lists them', () => {
+  test('a workspace with two panes lists them under a heading', () => {
     expect(listRows(sessions).filter((r) => r.sessionIndex === 1)).toEqual([
-      { sessionIndex: 1 },
+      { sessionIndex: 1, header: true },
       { sessionIndex: 1, paneId: '%1' },
       { sessionIndex: 1, paneId: '%2' },
     ])
   })
 
+  test('the heading is not a place the cursor can be', () => {
+    // Its own row would open the representative pane the server picked — one
+    // of them, arbitrarily, which is the ambiguity the pane rows remove.
+    expect(selectableRows(sessions).some((r) => r.sessionIndex === 1 && !r.paneId)).toBe(false)
+  })
+
+  test('a heading carries no cursor marker', () => {
+    const line = screenText(st(1, '%1')).body.split('\n')[1]
+    expect(line.startsWith('>')).toBe(false)
+    expect(line).toContain('2脚ロボ開発')
+  })
+
   test('the cursor walks workspaces and panes with one gesture', () => {
-    expect(rowCursor(st(1))).toBe(1)
     expect(rowCursor(st(1, '%2'))).toBe(3)
+    // A workspace with panes resolves to its first one, never to the heading.
+    expect(listRows(sessions)[rowCursor(st(1))].paneId).toBe('%1')
+  })
+
+  test('panes are drawn as a tree under their workspace', () => {
+    const body = screenText(st(1)).body.split('\n')
+    expect(body[2]).toContain('├ %1')
+    expect(body[3]).toContain('└ %2')
   })
 
   test('the list gets the row the header used to occupy', () => {
@@ -624,7 +643,9 @@ describe('workspace and pane list', () => {
 
   test('the footer carries the position and the clock', () => {
     const footer = screenText(st(1)).footer
-    expect(footer).toMatch(/2\/5/)
+    // Four selectable rows: the single-pane workspace, two panes, and the
+    // workspace with none. The heading is not among them.
+    expect(footer).toMatch(/2\/4/)
     expect(footer).toMatch(/ \d\d:\d\d$/)
     expect(width(footer)).toBeLessThanOrEqual(HEADER_WIDTH)
   })
@@ -637,7 +658,7 @@ describe('workspace and pane list', () => {
     // Two panes of one repo repeat the same folder name; the second one
     // teaches the reader nothing.
     const body = screenText(st(1)).body
-    expect(body).toContain('%1  30%')
+    expect(body).toContain('├ %1  30%')
     expect(body).not.toContain('wheel-leg-bot')
   })
 

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -160,10 +160,26 @@ export class GlassesController {
    *  only while there is something to indicate. */
   private tickSpinner(): void {
     const st = this.state
-    if (st.mode !== 'conversation') return
-    if (this.currentSession()?.indicatorState !== 'processing') return
+    if (!this.somethingIsWorking()) return
     st.spinnerTick = (st.spinnerTick ?? 0) + 1
     this.platform.renderHeader(st)
+  }
+
+  /** Whether a spinner is on screen at all. Nothing working means nothing to
+   *  redraw, and an idle app sends nothing. */
+  private somethingIsWorking(): boolean {
+    const st = this.state
+    if (st.mode === 'conversation') {
+      const pane = (this.currentSession()?.panes ?? []).find((p) => p.paneId === st.selectedPaneId)
+      return (pane ?? this.currentSession())?.indicatorState === 'processing'
+    }
+    if (st.mode !== 'session_list') return false
+    // The list shows every row's badge, so any working agent keeps it moving.
+    return st.sessions.some(
+      (s) =>
+        s.indicatorState === 'processing' ||
+        (s.panes ?? []).some((p) => p.indicatorState === 'processing'),
+    )
   }
 
   // ── Ring input (the single handler set shared by G2 and debug) ──

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -197,9 +197,14 @@ export class GlassesController {
     const st = this.state
     const rows = listRows(st.sessions)
     if (!rows.length) return
-    const next = rows[Math.min(rows.length - 1, Math.max(0, rowCursor(st) + step))]
-    st.sessionIndex = next.sessionIndex
-    st.selectedPaneId = next.paneId
+    // Step over headings: a multi-pane workspace's name has nothing to open.
+    let i = rowCursor(st)
+    do {
+      i += step
+    } while (i >= 0 && i < rows.length && rows[i].header)
+    if (i < 0 || i >= rows.length) return
+    st.sessionIndex = rows[i].sessionIndex
+    st.selectedPaneId = rows[i].paneId
   }
 
   private async onSessionListAction(action: RingAction): Promise<void> {

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -287,11 +287,20 @@ function relayBannerLines(state: AppState): string[] {
 // ─── Content helpers (shared by build and in-place update) ───
 
 
-/** One navigable line of the list: a workspace, or a pane inside one. */
+/** One line of the list: a workspace, a pane inside one, or a group label. */
 export interface ListRow {
   sessionIndex: number
   /** Absent on the workspace's own row. */
   paneId?: string
+  /**
+   * A label, not a target.
+   *
+   * A multi-pane workspace's own row has nothing to open: it would fall back
+   * to the representative agent the server picked, which is one of the panes
+   * chosen arbitrarily — exactly the ambiguity the pane rows exist to remove.
+   * So the name becomes a heading over them and the cursor passes it by.
+   */
+  header?: boolean
 }
 
 /**
@@ -306,21 +315,33 @@ export interface ListRow {
 export function listRows(sessions: Session[]): ListRow[] {
   const rows: ListRow[] = []
   sessions.forEach((s, sessionIndex) => {
-    rows.push({ sessionIndex })
     const panes = s.panes ?? []
-    if (panes.length < 2) return
+    if (panes.length < 2) {
+      rows.push({ sessionIndex })
+      return
+    }
+    rows.push({ sessionIndex, header: true })
     for (const p of panes) rows.push({ sessionIndex, paneId: p.paneId })
   })
   return rows
+}
+
+/** Rows the cursor can rest on. */
+export function selectableRows(sessions: Session[]): ListRow[] {
+  return listRows(sessions).filter((r) => !r.header)
 }
 
 /** Index of the row the cursor is on. */
 export function rowCursor(state: AppState): number {
   const rows = listRows(state.sessions)
   const found = rows.findIndex(
-    (r) => r.sessionIndex === state.sessionIndex && r.paneId === state.selectedPaneId,
+    (r) => !r.header && r.sessionIndex === state.sessionIndex && r.paneId === state.selectedPaneId,
   )
-  return found >= 0 ? found : Math.max(0, rows.findIndex((r) => r.sessionIndex === state.sessionIndex))
+  if (found >= 0) return found
+  // Landed on a workspace that turned out to have panes — a fresh state, or a
+  // pane count that grew underneath. Its first pane is what the row meant.
+  const fallback = rows.findIndex((r) => !r.header && r.sessionIndex === state.sessionIndex)
+  return fallback >= 0 ? fallback : 0
 }
 
 function paneStatusLabel(p: Pane): string {
@@ -366,16 +387,23 @@ function sessionListBody(state: AppState): string {
     const idx = Math.max(0, start) + i
     const here = idx === cursor ? '>' : ' '
     const s = sessions[row.sessionIndex]
-    if (!row.paneId) {
+    // Pad the badge so every name starts in the same column: a list where
+    // `>[!] name` and `  name` begin three columns apart is hard to scan.
+    if (row.header || !row.paneId) {
       const label = relayWaitingIds.has(s.id) ? '[!]' : statusLabel(s)
-      // Pad the badge so every name starts in the same column: a list where
-      // `>[!] name` and `  name` begin three columns apart is hard to scan.
-      return `${here}${label.padEnd(3)} ${sName(s)}`
+      // A heading takes no cursor, so it never carries the marker.
+      return `${row.header ? ' ' : here}${label.padEnd(3)} ${sName(s)}`
     }
-    const p = (s.panes ?? []).find((x) => x.paneId === row.paneId)
-    const detail = p ? paneDetail(p, s.panes ?? [], s.activeTabId) : ''
-    // Indented under its workspace, and only ever shown beneath it.
-    return `${here}${(p ? paneStatusLabel(p) : '').padEnd(3)}  ${row.paneId}${detail ? `  ${detail}` : ''}`
+    const panes = s.panes ?? []
+    const p = panes.find((x) => x.paneId === row.paneId)
+    const detail = p ? paneDetail(p, panes, s.activeTabId) : ''
+    // Drawn as a tree so the panes read as belonging to the name above them
+    // rather than as more workspaces that happen to be indented. The firmware
+    // carries the light box-drawing set at full width, so the branch lines up
+    // with the badges either side of it.
+    const last = panes[panes.length - 1]?.paneId === row.paneId
+    const branch = last ? '└' : '├'
+    return `${here}${(p ? paneStatusLabel(p) : '').padEnd(3)}${branch} ${row.paneId}${detail ? `  ${detail}` : ''}`
   }).join('\n')
 }
 
@@ -458,8 +486,12 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
 // of a hand-copied approximation.
 /** Everything the list screen has to say, in the one bar it still has. */
 function sessionListFooter(state: AppState): string {
-  const cursor = rowCursor(state) + 1
-  const total = listRows(state.sessions).length
+  // Counted among what can be opened; headings are not places to be.
+  const rows = listRows(state.sessions)
+  const at = rows[rowCursor(state)]
+  const selectable = rows.filter((r) => !r.header)
+  const cursor = selectable.findIndex((r) => r === at) + 1
+  const total = selectable.length
   const badge = state.relayWaiting.length > 0 ? `  !${state.relayWaiting.length}` : ''
   return withClock(`tap:open  swipe:nav  ${cursor}/${total}${badge}`)
 }

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -214,10 +214,22 @@ function isWaiting(s: Session): boolean {
   return s.indicatorState === 'waiting_input' || (!!s.waitingToolName && s.waitingToolName !== 'UserInput')
 }
 
-function statusLabel(s: Session): string {
-  if (isWaiting(s)) return '[!]'
-  if (s.indicatorState === 'processing') return '[*]'
-  return ''
+/**
+ * The one thing a list row has room to say about state.
+ *
+ * Waiting used to get `[!]`, and on a real machine seven of eight rows carried
+ * it — a mark almost everything has stopped distinguishing anything. Waiting
+ * is the resting state of an agent; running is the news. So the badge is the
+ * spinner and nothing else, and the rest of the answer is one tap away.
+ *
+ * The blank is a full-width space, not an ordinary one: at 320 units it is
+ * exactly a spinner frame wide, and 5-unit spaces would leave every unmarked
+ * name starting three-quarters of a column to the left of the marked ones.
+ */
+const BADGE_BLANK = '\u3000'
+
+function statusLabel(s: Session, frame: string): string {
+  return s.indicatorState === 'processing' ? frame : BADGE_BLANK
 }
 
 const SEPARATOR = '-'.repeat(24)
@@ -344,10 +356,8 @@ export function rowCursor(state: AppState): number {
   return fallback >= 0 ? fallback : 0
 }
 
-function paneStatusLabel(p: Pane): string {
-  if (p.indicatorState === 'waiting_input' || (!!p.waitingToolName && p.waitingToolName !== 'UserInput')) return '[!]'
-  if (p.indicatorState === 'processing') return '[*]'
-  return ''
+function paneStatusLabel(p: Pane, frame: string): string {
+  return p.indicatorState === 'processing' ? frame : BADGE_BLANK
 }
 
 /**
@@ -377,6 +387,7 @@ function sessionListBody(state: AppState): string {
   // Relay waiting covers agent-declared items whose session indicator is not
   // waiting_input; those sessions still get the [!] marker.
   const relayWaitingIds = new Set(state.relayWaiting.map((i) => i.sessionId))
+  const frame = spinnerFrame(state)
   const rows = listRows(sessions)
   if (!rows.length) return '(no sessions)'
   const cursor = rowCursor(state)
@@ -390,9 +401,11 @@ function sessionListBody(state: AppState): string {
     // Pad the badge so every name starts in the same column: a list where
     // `>[!] name` and `  name` begin three columns apart is hard to scan.
     if (row.header || !row.paneId) {
-      const label = relayWaitingIds.has(s.id) ? '[!]' : statusLabel(s)
+      // A relay item is a question already asked and still unanswered, which
+      // outlives the indicator that raised it; that one keeps its mark.
+      const label = relayWaitingIds.has(s.id) ? '！' : statusLabel(s, frame)
       // A heading takes no cursor, so it never carries the marker.
-      return `${row.header ? ' ' : here}${label.padEnd(3)} ${sName(s)}`
+      return `${row.header ? ' ' : here}${label} ${sName(s)}`
     }
     const panes = s.panes ?? []
     const p = panes.find((x) => x.paneId === row.paneId)
@@ -403,7 +416,7 @@ function sessionListBody(state: AppState): string {
     // with the badges either side of it.
     const last = panes[panes.length - 1]?.paneId === row.paneId
     const branch = last ? '└' : '├'
-    return `${here}${(p ? paneStatusLabel(p) : '').padEnd(3)}${branch} ${row.paneId}${detail ? `  ${detail}` : ''}`
+    return `${here}${p ? paneStatusLabel(p, frame) : BADGE_BLANK}${branch} ${row.paneId}${detail ? `  ${detail}` : ''}`
   }).join('\n')
 }
 
@@ -905,6 +918,15 @@ export async function initDisplay(): Promise<Bridge | null> {
  */
 export async function updateHeader(bridge: Bridge | null, state: AppState): Promise<void> {
   if (!bridge || state.mode !== currentMode) return
+  // Whichever container the spinner lives in — the conversation's header, or
+  // the list's rows. One container either way; a full update sends three.
+  if (state.mode === 'session_list') {
+    await bridge.textContainerUpgrade(new TextContainerUpgrade({
+      containerID: 1, containerName: 'list',
+      content: sessionListBody(state),
+    }))
+    return
+  }
   const { headerText } = conversationContent(state)
   await bridge.textContainerUpgrade(new TextContainerUpgrade({
     containerID: 1, containerName: 'header',


### PR DESCRIPTION
> 複数ペイン構成の場合ワークスペース名の箇所にカーソル合わせられるの変じゃないですか
> リスト表示は入れ子構造で見せてあげてください
> [!]って処理中だけでいいんじゃないですか しかも▲の回転で良いです

```
変更前:                        変更後（0秒 / 3秒）:
>[!] グラス開発                >▲ グラス開発        >▶ グラス開発
 [!]  %3  15%                  　 2脚ロボ開発        　 2脚ロボ開発
 [!]  %4  6%  別タブ            ▲├ %1  31%          ▶├ %1  31%
                                　├ %3  15%          　├ %3  15%
                                　└ %4  6%  別タブ    　└ %4  6%  別タブ
```

## バッジは処理中だけに

実機で **8行中7行が `[!]`** でした。ほとんど全部が持っている印は、何も区別しません。待機はエージェントの平常状態で、**動いていることのほうが情報**です。バッジは回転だけにして、残りはタップ1回先に置きました。

空欄は**全角スペース**です。320幅でコマ1つぶんちょうど。半角（5幅）だと、印の無い名前だけ4分の3桁ぶん左にずれます。

リレー項目は印を残します（`！`）。**既に投げられて未回答の質問**で、それを上げたインジケータより長生きするものだからです。

tick は**コマがある容器**を描き直します（会話ならヘッダー、一覧なら行）。条件も「読んでいるセッション」から「画面上で何か動いていれば」に広げました。

## 見出し化

複数ペインのワークスペース名は**開くものがありません**。タップすると `ccSessionId`（サーバが選んだ代表ペイン）にフォールバックする——どれかが恣意的に開くわけで、ペイン行が解消したはずの曖昧さです。カーソルもマーカーも乗らず、スワイプは飛び越えます。

```
cchub-work → wheel-leg:%1 → wheel-leg:%3 → wheel-leg:%4 → life:%1 → life:%6
```

## 入れ子

罫線（`├` `└`）で描きます。空白1つのインデントでは「インデントされた別のワークスペース」に見えました。実機は細罫線を**全部320幅**で持っています（二重線は欠けていて使えません）。

## 検証

テスト8件追加（全77件）。lint / typecheck / test（全621件）/ device・web 両ビルド通過。**ehpk の更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np