### PR TITLE
fix: 別タブのペインに返信できるようにする

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -148,6 +148,9 @@ async function sendTextToSession(
   opts?: { bracketed?: boolean; paneId?: string },
 ): Promise<string> {
   return withControlSession(sessionId, async (cs) => {
+    // Same as raw pane input: an addressed pane may be sitting in another tab,
+    // and a reply that cannot land is worse than one that moves the view.
+    if (opts?.paneId) await cs.ensurePaneReachable(opts.paneId);
     const panes = await cs.listPanes();
     // An explicit paneId (e.g. a relay item's replyTo pane) wins: in a
     // multi-pane workspace the blocked pane is not necessarily the active one.
@@ -1109,6 +1112,9 @@ sessions.post('/:id/panes/input', async (c) => {
 
   try {
     return await withControlSession(id, async (controlSession) => {
+      // A pane in another tab is still a live agent; bring it into view rather
+      // than refusing to answer it.
+      await controlSession.ensurePaneReachable(parsed.data.paneId);
       const panes = await controlSession.listPanes();
       const targetPane = panes.find((p) => p.paneId === parsed.data.paneId);
       if (!targetPane) {

--- a/backend/src/services/__tests__/pane-reach.test.ts
+++ b/backend/src/services/__tests__/pane-reach.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { toTmuxPaneId } from '../herdr-client';
+
+/**
+ * `ensurePaneReachable` resolves a pane by its tmux-convention id against
+ * herdr's own ids, so the mapping is the part worth pinning: get it wrong and
+ * a reply to a pane in another tab silently keeps 404ing.
+ */
+describe('pane id mapping for cross-tab delivery', () => {
+  test('herdr ids map to the ids the API and the glasses speak', () => {
+    expect(toTmuxPaneId('w4H:p4')).toBe('%4');
+    expect(toTmuxPaneId('w2H:p6')).toBe('%6');
+  });
+
+  test('an id that is already tmux-shaped is left alone', () => {
+    // The lookup falls back to the raw id, so this must not become something
+    // else on the way through.
+    expect(toTmuxPaneId('%4') ?? '%4').toBe('%4');
+  });
+});

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -891,6 +891,31 @@ export class HerdrControlSession {
     await this.reconcilePanes();
   }
 
+  /**
+   * Bring a pane into view before acting on it.
+   *
+   * The split tree only holds the live tab's panes, so input aimed at a pane
+   * parked in another tab found nothing and the caller returned 404 — readable
+   * from the history API, unanswerable. Switching first makes the reply land,
+   * and leaves the terminal showing the pane that was just answered, which is
+   * where the next thing happens anyway.
+   *
+   * Returns false when the pane is nowhere in the workspace; the caller still
+   * owns the 404.
+   */
+  async ensurePaneReachable(paneId: string): Promise<boolean> {
+    if (this.tree.paneIds().includes(paneId)) return true;
+    if (!this.workspaceId) return false;
+    const all = await listPanes(this.workspaceId);
+    const target = all.find((p) => (toTmuxPaneId(p.pane_id) ?? p.pane_id) === paneId);
+    if (!target?.tab_id || target.tab_id === this.activeTabId) return false;
+    console.log(
+      `[herdr-control] ${this.sessionId}: pane ${paneId} lives in ${target.tab_id}, switching from ${this.activeTabId ?? 'n/a'}`,
+    );
+    await this.selectTab(target.tab_id);
+    return this.tree.paneIds().includes(paneId);
+  }
+
   /** Create a new focused tab in this workspace and switch to it. */
   async createTab(): Promise<void> {
     if (!this.workspaceId) throw new Error('Control session not active');

--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -708,22 +708,13 @@ describe('panes across tabs', () => {
     overlayItemId: null,
   }
 
-  test('a pane the terminal cannot show says so', () => {
-    // "There are two" and "one of them is somewhere you are not looking" are
-    // different things to know.
+  test('a pane in another tab looks like any other', () => {
+    // It was marked while a reply to it could not land. The server switches
+    // tabs to deliver now, so the tab is a fact with no decision attached.
     const body = screenText(st).body
     expect(body).toContain('%1  31%')
-    expect(body).toContain('%4  6%  別タブ')
-  })
-
-  test('panes of the active tab are not marked', () => {
-    const line = screenText(st).body.split('\n').find((l) => l.includes('%1')) ?? ''
-    expect(line).not.toContain('別タブ')
-  })
-
-  test('nothing is marked when the session reports no active tab', () => {
-    const noTab = { ...st, sessions: [{ ...sessions[0], activeTabId: undefined }] }
-    expect(screenText(noTab).body).not.toContain('別タブ')
+    expect(body).toContain('%4  6%')
+    expect(body).not.toContain('別タブ')
   })
 })
 

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -369,15 +369,15 @@ function paneStatusLabel(p: Pane, frame: string): string {
  * learns nothing from the second one. What is left is the context figure,
  * which does differ, and says which of the two has been running longer.
  */
-function paneDetail(p: Pane, siblings: Pane[], activeTabId?: string): string {
+function paneDetail(p: Pane, siblings: Pane[]): string {
   const dirOf = (x: Pane) => x.currentPath?.split('/').filter(Boolean).pop() ?? ''
   const dirs = new Set(siblings.map(dirOf))
   const pct = p.metrics?.contextPercent
-  // A pane in another tab is running where the terminal cannot show it. Saying
-  // so is the difference between "there are three" and "one of them is
-  // somewhere you are not looking".
-  const offscreen = activeTabId && p.tabId && p.tabId !== activeTabId ? '別タブ' : ''
-  return [pct != null ? `${Math.round(pct)}%` : '', dirs.size > 1 ? dirOf(p) : '', offscreen]
+  // Which tab a pane sits in is not shown. It was, while a reply to one in
+  // another tab could not land — a mark for "readable but unanswerable". The
+  // server switches tabs to deliver now, so the pane behaves like any other
+  // and the label would be a fact with no decision attached to it.
+  return [pct != null ? `${Math.round(pct)}%` : '', dirs.size > 1 ? dirOf(p) : '']
     .filter(Boolean)
     .join('  ')
 }
@@ -409,7 +409,7 @@ function sessionListBody(state: AppState): string {
     }
     const panes = s.panes ?? []
     const p = panes.find((x) => x.paneId === row.paneId)
-    const detail = p ? paneDetail(p, panes, s.activeTabId) : ''
+    const detail = p ? paneDetail(p, panes) : ''
     // Drawn as a tree so the panes read as belonging to the name above them
     // rather than as more workspaces that happen to be indented. The firmware
     // carries the light box-drawing set at full width, so the branch lines up


### PR DESCRIPTION
> 別タブって名称を出す必要ある？
> Aで（送信時にタブを切り替える）

ラベルの要否を調べていて、**もっと悪いもの**が出ました。

```
%1（アクティブタブ）  peek → 取得できる
%4（別タブ）          peek → HTTP 404 Pane not found
```

一覧は全タブのペインを出すのに、分割ツリーはアクティブタブぶんしか持ちません。会話は履歴 API から読めるので**開けてしまい**、返信・キー送信は 404 になります。**読めるが答えられない**——ペインが無いことより悪い状態を出していました。

## 直し方

`ensurePaneReachable` が、操作する前にそのペインのタブへ切り替えます。

```
input %4 → 200   （w4H:t1 → w4H:t2 に切り替えて到達）
```

返信した先に視界が付いていくのは、次に何かが起きる場所がそこだからです。**読み取り専用の経路は 404 のまま**にしました。覗いただけで机が並び替わるのは誰も頼んでいません。

## ラベルを外した

`別タブ` は「読めるが答えられない」ペインの警告でした。返信が届くようになった以上、タブは**行動につながらない事実**です。`[!]` を外したのと同じ理由で消します。

## 検証

実機で `w4H:t1` → `w4H:t2` の切り替えと 200 応答を確認。ペインID対応のテストを追加（全622件）。lint / typecheck / test / device・web 両ビルド通過。

**ehpk の更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np