### PR TITLE
fix: ワークスペース一覧でタップしたペインを開く（別タブでも）

### DIFF
--- a/backend/src/services/__tests__/pane-reach.test.ts
+++ b/backend/src/services/__tests__/pane-reach.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { toTmuxPaneId } from '../herdr-client';
+import { HerdrControlSession } from '../herdr-control';
 
 /**
  * `ensurePaneReachable` resolves a pane by its tmux-convention id against
@@ -16,5 +17,29 @@ describe('pane id mapping for cross-tab delivery', () => {
     // The lookup falls back to the raw id, so this must not become something
     // else on the way through.
     expect(toTmuxPaneId('%4') ?? '%4').toBe('%4');
+  });
+});
+
+/**
+ * Focusing a pane is how the workspace list opens one, and the list spans every
+ * tab while the split tree holds only the live one. Without the tab check the
+ * focus resolves to nothing and the terminal stays where it was — the user taps
+ * one pane and gets another, silently.
+ */
+describe('focusing a pane reaches across tabs', () => {
+  test('selectPane asks for the pane to be brought into view first', async () => {
+    const session = new HerdrControlSession('focus-across-tabs');
+    const asked: string[] = [];
+    session.ensurePaneReachable = async (paneId: string) => {
+      asked.push(paneId);
+      return false;
+    };
+
+    // No workspace is attached, so the focus RPC never leaves the process:
+    // what is under test is that the tab check happens at all.
+    await session.selectPane('%3');
+
+    expect(asked).toEqual(['%3']);
+    session.destroy();
   });
 });

--- a/backend/src/services/herdr-control.ts
+++ b/backend/src/services/herdr-control.ts
@@ -870,6 +870,11 @@ export class HerdrControlSession {
 
   async selectPane(paneId: string): Promise<void> {
     assertPaneId(paneId);
+    // Picking a pane is the same intent as answering one: the split tree only
+    // holds the live tab's panes, so without this a pane parked in another tab
+    // resolves to nothing and the view stays on whatever tab it was already
+    // showing — the pane the user pointed at is not the pane they get.
+    await this.ensurePaneReachable(paneId);
     this.activePaneId = paneId;
     try {
       await herdrRpc('pane.focus', { pane_id: this.toHerdr(paneId) });

--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -9,7 +9,6 @@ import { CSS } from "@dnd-kit/utilities";
 import {
 	ArrowRight,
 	BarChart3,
-	ChevronDown,
 	ChevronLeft,
 	ChevronRight,
 	ExternalLink,
@@ -788,6 +787,7 @@ function PaneRow({
 	onSelect,
 	onSelectPane,
 	onClosePane,
+	activateTab,
 }: {
 	session: ExtendedSessionResponse;
 	pane: PaneInfo;
@@ -795,6 +795,12 @@ function PaneRow({
 	onSelect: (session: ExtendedSessionResponse) => void;
 	onSelectPane?: (session: ExtendedSessionResponse, paneId: string) => void;
 	onClosePane?: (sessionId: string, paneId: string, name: string) => void;
+	/**
+	 * Set only when this pane sits in a tab the workspace is not rendering.
+	 * Awaited before opening the pane so the terminal is already on the right
+	 * tab by the time it subscribes.
+	 */
+	activateTab?: () => void | Promise<void>;
 }) {
 	const { t, i18n } = useTranslation();
 	const cmd = pane.currentCommand || "shell";
@@ -824,8 +830,12 @@ function PaneRow({
 		<div>
 			<button
 				type="button"
-				onClick={() => {
+				onClick={async () => {
 					if (consumeLongPress()) return;
+					// A pane in another tab is only readable from here; the terminal
+					// shows one tab at a time. Switch before opening it, or the tap
+					// lands on some other tab's pane.
+					if (activateTab) await activateTab();
 					if (onSelectPane) {
 						onSelectPane(session, pane.paneId);
 					} else {
@@ -925,23 +935,23 @@ function PaneRow({
 }
 
 /**
- * One tab of the workspace. The disclosure chevron doubles as the active
- * marker: only the active tab can show its panes (the backend renders a single
- * tab), so selecting a collapsed tab is what expands it.
+ * The heading a tab's panes sit under. Every tab lists its panes, so there is
+ * nothing here to open or expand — tapping a pane is what switches the
+ * workspace to the tab that owns it. The highlight marks the tab the terminal
+ * is currently rendering; the row itself only closes (long press, or the ✕ on
+ * hover for desktop, which has no long press).
  */
 function TabRow({
 	session,
 	tab,
 	isActive,
 	canClose,
-	onSelectTab,
 	onCloseTab,
 }: {
 	session: ExtendedSessionResponse;
 	tab: TabInfo;
 	isActive: boolean;
 	canClose: boolean;
-	onSelectTab?: (session: ExtendedSessionResponse, tabId: string) => void;
 	onCloseTab?: (
 		session: ExtendedSessionResponse,
 		tabId: string,
@@ -959,40 +969,28 @@ function TabRow({
 		canClose && onCloseTab
 			? () => onCloseTab(session, tab.id, tab.label)
 			: undefined;
-	const { consumeLongPress, handlers } = useRowLongPress(closeTab);
+	const { handlers } = useRowLongPress(closeTab);
 
 	return (
 		<div className="group/tab flex items-center gap-1">
-			<button
-				type="button"
-				onClick={() => {
-					if (consumeLongPress()) return;
-					if (!isActive) onSelectTab?.(session, tab.id);
-				}}
+			<div
 				{...handlers}
-				className={`flex-1 min-w-0 min-h-11 flex items-center gap-2 px-2 py-1.5 rounded-md text-left transition-colors ${
-					isActive ? "bg-cyan-500/10" : "hover:bg-white/[0.04]"
+				className={`flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded-md ${
+					isActive ? "bg-cyan-500/10" : ""
 				}`}
 			>
-				{isActive ? (
-					<ChevronDown className="w-3.5 h-3.5 shrink-0 text-cyan-400" />
-				) : (
-					<ChevronRight className="w-3.5 h-3.5 shrink-0 text-zinc-500" />
-				)}
 				<span
 					className={`text-[13px] font-medium truncate ${
-						isActive ? "text-cyan-200" : "text-zinc-300"
+						isActive ? "text-cyan-200" : "text-zinc-400"
 					}`}
 				>
 					{label}
 				</span>
 				<span className="flex-1" />
-				{!isActive && (
-					<span className="text-[11px] text-zinc-600 shrink-0">
-						{t("session.panes", { count: tab.paneCount })}
-					</span>
-				)}
-			</button>
+				<span className="text-[11px] text-zinc-600 shrink-0">
+					{t("session.panes", { count: tab.paneCount })}
+				</span>
+			</div>
 			{closeTab && (
 				<button
 					type="button"
@@ -1040,7 +1038,11 @@ function SessionItem({
 		direction?: "h" | "v",
 	) => void;
 	onClosePane?: (sessionId: string, paneId: string, name: string) => void;
-	onSelectTab?: (session: ExtendedSessionResponse, tabId: string) => void;
+	/** Switch the workspace to a tab. Awaited before opening a pane it owns. */
+	onSelectTab?: (
+		session: ExtendedSessionResponse,
+		tabId: string,
+	) => void | Promise<void>;
 	onCreateTab?: (session: ExtendedSessionResponse) => void;
 	onCloseTab?: (session: ExtendedSessionResponse, tabId: string, label: string) => void;
 }) {
@@ -1508,12 +1510,12 @@ function SessionItem({
 			)}
 
 			{/* Tab / pane tree (expandable). herdr's model is workspace > tab >
-			    pane, so the panes nest under the tab that owns them. Only the
-			    active tab's panes are known (the backend renders one tab at a
-			    time), so the other tabs collapse to a single row carrying their
-			    pane count — selecting one switches the workspace over to it, which
-			    is what expands it. Long-press a row to close it (tabs also get a
-			    hover ✕, since desktop has no long press). */}
+			    pane, so the panes nest under the tab that owns them, every tab
+			    showing its own. The terminal still renders one tab at a time, so
+			    opening a pane parked in another one switches the workspace over
+			    first — the tab row itself has nothing left to select. Long-press a
+			    row to close it (tabs also get a hover ✕, since desktop has no long
+			    press). */}
 			{panesExpanded && (hasTabTree || extSession.panes) && (
 				<div
 					className="mx-4 mb-3 pt-2 border-t border-white/[0.06]"
@@ -1532,7 +1534,6 @@ function SessionItem({
 											tab={tab}
 											isActive={isActive}
 											canClose={(extSession.tabs?.length ?? 0) > 1}
-											onSelectTab={onSelectTab}
 											onCloseTab={onCloseTab}
 										/>
 										{/* `panes` spans every tab now, so each tab takes its
@@ -1547,14 +1548,19 @@ function SessionItem({
 														p.tabId ? p.tabId === tab.id : isActive,
 													)
 													.map((pane) => (
-													<PaneRow
-														key={pane.paneId}
-														session={extSession}
-														pane={pane}
-														bridgePaneId={bridgePaneId}
-														onSelect={onSelect}
-														onSelectPane={onSelectPane}
+														<PaneRow
+															key={pane.paneId}
+															session={extSession}
+															pane={pane}
+															bridgePaneId={bridgePaneId}
+															onSelect={onSelect}
+															onSelectPane={onSelectPane}
 															onClosePane={onClosePane}
+															activateTab={
+																isActive
+																	? undefined
+																	: () => onSelectTab?.(session, tab.id)
+															}
 														/>
 													))}
 											</div>

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -244,6 +244,11 @@ export const TerminalPage = forwardRef<TerminalRef, TerminalPageProps>(
 			const active = effectiveActivePaneId;
 			if (!active || !allPanes.some((p) => p.paneId === active)) {
 				prevActivePaneIdRef.current = active ?? null;
+				// The layout only carries the tab being rendered, so a pane picked
+				// from the workspace list may not be in it yet. Ask for it anyway:
+				// the server switches to its tab and the next layout brings it in.
+				// A pane that is genuinely gone just leaves this a no-op.
+				if (active) controlTerminal.selectPane(active);
 				return;
 			}
 			const isActualSwitch =


### PR DESCRIPTION
## 背景

スマホのワークスペース一覧で、タブ行にフォーカスを合わせられることに意味があるのか、という指摘から。

調べると、タブ行のタップは元々「畳まれたタブを展開する」ためのものだった。#593 で全タブのペインを列挙するようになって畳まれるタブは無くなり、役割だけが消えてタップ判定が残っていた。

さらに、その裏に本当の不具合があった。一覧は全タブのペインを載せるが、ターミナルは1タブしか描画しない。別タブのペインをタップすると `mobileActivePaneId` は立つものの、届くレイアウトにそのペインは無く、クライアントが黙って現タブの先頭ペインに落ちる。**一覧で見えていた別のエージェントに着地する**という、一番まずい形の誤動作になっていた。

## 変更

**ペインをタップしたら、そのペインが開く**
- `WorkspaceList.tsx` — 非アクティブなタブのペイン行は、開く前にそのタブへの切り替えを `await` する
- `herdr-control.ts` — `selectPane` が `ensurePaneReachable` を通る。フォーカスが返る時点で split tree に当該ペインが入っている（herdr も `pane.focus` の副作用でタブを動かすが非同期で、直後の zoom/viewport 要求がツリー更新前に走り得る）
- `TerminalPage.tsx` — レイアウトに無いペインを黙って捨てず `select-pane` を投げる。サーバがタブを切り替え、次のレイアウトで入ってくる

**タブ行は見出しに戻す**
- タップでの選択を削除。閉じる操作（長押し / hover の ✕）だけ残す
- 開閉シェブロンを削除（畳まれるタブがもう無い）
- ペイン数バッジを全タブに表示（非アクティブ時だけ出ていた非対称を解消）
- 実装と食い違っていたコメント2箇所を修正

## 検証

dev 環境に2タブ・各1ペインの検証用ワークスペースを作って実施（終了後に削除済み）:

| 操作 | 結果 |
|---|---|
| タブ1行をタップ | `activeTabId` は `t2` のまま＝無反応（意図どおり） |
| 非アクティブなタブ1の `zsh` をタップ | `t1` に切替・`%1` が active、ブラウザ入力 `UI-TAPPED-PANE` が **`%1` に着弾** |
| 戻ってタブ2の `zsh` をタップ | `t2` に復帰、`SECOND-TAP-PANE` が **`%2` に着弾** |

lint / tsc クリーン。テスト 472 (backend) + 74 (frontend) + 75 (glasses) 全 pass。`selectPane` がタブ確認を通ることを固定するテストを1本追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFJJ7FBdg7koTsEKatL1pa