### PR TITLE
feat(glasses): サスペンドから復帰できるようにする

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { OsEventTypeList } from '@evenrealities/even_hub_sdk'
 import { sanitizeForG2, formatMessage } from '../types.ts'
 import { screenText, wrapForPanel, wrapHeader } from '../display.ts'
 import { BODY_WIDTH, HEADER_WIDTH, LIST_LINES, textWidth as width } from '../metrics.ts'
@@ -762,5 +763,34 @@ describe('list badge', () => {
       ],
     }
     expect(screenText(withRelay).body).toContain('！ グラス開発')
+  })
+})
+
+describe('lifecycle events', () => {
+  test('the host reports every reason it stops us', () => {
+    // Whether the app was backgrounded or killed is the question a whole day
+    // of guessing could not settle from inside the page.
+    expect(OsEventTypeList.FOREGROUND_ENTER_EVENT).toBe(4)
+    expect(OsEventTypeList.FOREGROUND_EXIT_EVENT).toBe(5)
+    expect(OsEventTypeList.ABNORMAL_EXIT_EVENT).toBe(6)
+    expect(OsEventTypeList.SYSTEM_EXIT_EVENT).toBe(7)
+  })
+
+  test('lifecycle codes do not collide with ring gestures', () => {
+    // They are dispatched before the gesture debounce; sharing a value with a
+    // gesture would make a resume look like a tap.
+    const gestures = [
+      OsEventTypeList.CLICK_EVENT,
+      OsEventTypeList.DOUBLE_CLICK_EVENT,
+      OsEventTypeList.SCROLL_TOP_EVENT,
+      OsEventTypeList.SCROLL_BOTTOM_EVENT,
+    ]
+    const lifecycle = [
+      OsEventTypeList.FOREGROUND_ENTER_EVENT,
+      OsEventTypeList.FOREGROUND_EXIT_EVENT,
+      OsEventTypeList.ABNORMAL_EXIT_EVENT,
+      OsEventTypeList.SYSTEM_EXIT_EVENT,
+    ]
+    expect(gestures.some((g) => lifecycle.includes(g))).toBe(false)
   })
 })

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -51,6 +51,10 @@ export interface GlassesPlatform {
   stopMicCapture(): Promise<void>
   /** Transcribe collected PCM into text. */
   transcribeAudio(pcm: Uint8Array): Promise<string>
+  /** Durable across a WebView restart. The device writes to the host app's
+   *  storage, which outlives the page; the simulator uses localStorage. */
+  saveState(json: string): void
+  loadState(): Promise<string | null>
 }
 
 /** Where a reply (choice keys / voice prompt) is routed. paneId targets the
@@ -180,6 +184,82 @@ export class GlassesController {
         s.indicatorState === 'processing' ||
         (s.panes ?? []).some((p) => p.indicatorState === 'processing'),
     )
+  }
+
+  // ── Suspend and resume ──
+  //
+  // The phone suspends the WebView whenever the Even app goes to the
+  // background — lock screen, app switcher — and the app looks dead from the
+  // wearer's side. It is not a crash and cannot be prevented from here, so
+  // what is left is to come back well: notice the resume, reconnect, and pick
+  // up where the reader was rather than at the top of a fresh list.
+
+  /** Anything older than this is not where the reader still is. */
+  private static readonly RESUME_WINDOW_MS = 30 * 60 * 1000
+
+  private saveResumePoint(): void {
+    const st = this.state
+    const session = this.currentSession()
+    try {
+      this.platform.saveState(
+        JSON.stringify({
+          at: Date.now(),
+          mode: st.mode === 'conversation' ? 'conversation' : 'session_list',
+          sessionId: session?.id,
+          paneId: st.selectedPaneId,
+          offset: st.conversationOffset,
+          page: st.conversationPage,
+        }),
+      )
+    } catch { /* a resume point is a nicety; never let it take the app down */ }
+  }
+
+  /** Put the reader back where they were, if they were there recently. */
+  private async restoreResumePoint(): Promise<void> {
+    let saved: { at?: number; mode?: string; sessionId?: string; paneId?: string; offset?: number; page?: number }
+    try {
+      const raw = await this.platform.loadState()
+      if (!raw) return
+      saved = JSON.parse(raw)
+    } catch {
+      return
+    }
+    if (!saved.at || Date.now() - saved.at > GlassesController.RESUME_WINDOW_MS) return
+    if (saved.mode !== 'conversation' || !saved.sessionId) return
+    const idx = this.state.sessions.findIndex((s) => s.id === saved.sessionId)
+    if (idx < 0) return
+    const st = this.state
+    this.restoringResumePoint = true
+    try {
+      st.sessionIndex = idx
+      st.selectedPaneId = saved.paneId
+      st.mode = 'conversation'
+      this.ws.subscribe(saved.sessionId)
+      this.render()
+      await this.loadConversation()
+      // Offset survives; the page does not, because the conversation may have
+      // grown and page N of the old text is not page N of the new.
+      st.conversationOffset = Math.min(saved.offset ?? 0, Math.max(0, st.conversation.length - 1))
+      this.render()
+    } finally {
+      this.restoringResumePoint = false
+    }
+  }
+
+  /** The app is back. Its socket died while it slept and its screen is stale. */
+  onForegroundEnter(): void {
+    this.state.spinnerTick = 0
+    this.ws.connect()
+    this.render()
+    void this.maybeRefreshConversation()
+  }
+
+  onForegroundExit(): void {
+    this.saveResumePoint()
+  }
+
+  onHostExit(_kind: 'abnormal' | 'system'): void {
+    this.saveResumePoint()
   }
 
   // ── Ring input (the single handler set shared by G2 and debug) ──
@@ -613,12 +693,28 @@ export class GlassesController {
 
   // ── WS event wiring ──
 
+  /** Restore on the first list that arrives: before that there is no session
+   *  to match the saved id against. */
+  private maybeRestoreOnce(): void {
+    if (this.restoredResumePoint || this.state.sessions.length === 0) return
+    this.restoredResumePoint = true
+    if (this.state.mode !== 'session_list') return // already somewhere on purpose
+    void this.restoreResumePoint()
+  }
+
   private onWsReady(): void {
     // Re-subscribe the session being viewed after a reconnect (the relay
     // subscription itself is re-sent by the WS client).
     const s = this.currentSession()
     if (s && this.state.mode !== 'session_list') this.ws.subscribe(s.id)
   }
+
+  private restoredResumePoint = false
+  /** True while the resume point is being put back. `loadConversation` ends by
+   *  resetting the offset, so a periodic refresh landing mid-restore would
+   *  undo it and drop the reader at the newest message — the very thing the
+   *  resume point exists to avoid. */
+  private restoringResumePoint = false
 
   private onSessionsUpdated(sessions: Session[], focus?: ClientFocus): void {
     const st = this.state
@@ -645,6 +741,7 @@ export class GlassesController {
     } else if (st.sessionIndex >= st.sessions.length) {
       st.sessionIndex = Math.max(0, st.sessions.length - 1)
     }
+    this.maybeRestoreOnce()
     if (this.followFocus(focus)) return // already re-rendered
     this.render()
     this.maybeRefreshConversation()
@@ -824,6 +921,7 @@ export class GlassesController {
   /** Auto-refresh the conversation when terminal output arrives (throttled). */
   private maybeRefreshConversation(): void {
     if (this.state.mode !== 'conversation') return
+    if (this.restoringResumePoint) return
     // Never refresh out from under someone who has scrolled back:
     // loadConversation resets offset and page, so a reader was being yanked
     // to the newest message every few seconds. Paging back to the latest

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -539,6 +539,14 @@ export function startDebugUI(): void {
     renderHeader(state) {
       platform.render(state)
     },
+    // No host store in a browser; localStorage plays the same part, and it
+    // lets the simulator exercise the resume path without the device.
+    saveState(json) {
+      try { localStorage.setItem('cchub-glasses-resume', json) } catch { /* private mode */ }
+    },
+    async loadState() {
+      try { return localStorage.getItem('cchub-glasses-resume') } catch { return null }
+    },
     startMicCapture: () => startMic(),
     stopMicCapture: () => stopMic(),
     // Typed text short-circuits the transcription, which is handy for driving

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -1050,6 +1050,13 @@ export function setupEvents(
     onDoubleTap: () => void
     onRawEvent?: (raw: string) => void
     onAudioData?: (pcm: Uint8Array) => void
+    /** The app came back to the foreground. Its JS may have been suspended for
+     *  any length of time, so anything time-sensitive is now stale. */
+    onForegroundEnter?: () => void
+    /** Going away. Whatever should survive has to be written now. */
+    onForegroundExit?: () => void
+    /** The host is tearing the app down and says why. */
+    onExit?: (kind: 'abnormal' | 'system') => void
   },
 ): void {
   if (!bridge) return
@@ -1095,6 +1102,25 @@ export function setupEvents(
       lastEventTime = now
       callbacks.onSwipeDown()
       return
+    }
+
+    // Lifecycle, handled before the ring debounce: these are not gestures, and
+    // letting them share the debounce would have a resume swallow the tap that
+    // follows it. The host reports its own reason for stopping us, which is
+    // the difference between "backgrounded" and "killed".
+    switch (eventType) {
+      case OsEventTypeList.FOREGROUND_ENTER_EVENT:
+        callbacks.onForegroundEnter?.()
+        return
+      case OsEventTypeList.FOREGROUND_EXIT_EVENT:
+        callbacks.onForegroundExit?.()
+        return
+      case OsEventTypeList.ABNORMAL_EXIT_EVENT:
+        callbacks.onExit?.('abnormal')
+        return
+      case OsEventTypeList.SYSTEM_EXIT_EVENT:
+        callbacks.onExit?.('system')
+        return
     }
 
     // Ring tap: sysEvent with undefined eventType

--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -18,6 +18,7 @@ const MIC_SAMPLE_RATE = 16000
 // Slow now that the crash is understood: enough to date a silent death, not
 // so often that the log is mostly heartbeat.
 const HEARTBEAT_MS = 30_000
+const RESUME_KEY = 'cchub-glasses-resume'
 
 // ── Crash reporting ──
 //
@@ -155,6 +156,17 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
       publishScreen(state)
       enqueue(state, true)
     },
+    // The host app's own store, which outlives the WebView the phone suspends.
+    saveState(json) {
+      void bridge?.setLocalStorage(RESUME_KEY, json).catch(() => {})
+    },
+    async loadState() {
+      try {
+        return (await bridge?.getLocalStorage(RESUME_KEY)) || null
+      } catch {
+        return null
+      }
+    },
     startMicCapture: () => startMic(bridge),
     stopMicCapture: () => stopMic(bridge),
     transcribeAudio: (pcm) => transcribe(pcm, MIC_SAMPLE_RATE),
@@ -166,6 +178,21 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
   platform.render(controller.state)
 
   setupEvents(bridge, {
+    onForegroundEnter() {
+      trace('foreground: entered — reconnecting after suspend')
+      controller.onForegroundEnter()
+    },
+    onForegroundExit() {
+      trace('foreground: exited — saving resume point')
+      controller.onForegroundExit()
+    },
+    onExit(kind) {
+      // The host says why it is stopping us. Worth its own line: it is the
+      // difference between "backgrounded" and "killed", which no amount of
+      // guessing from inside the page could settle.
+      trace(`host exit: ${kind}`, 'error')
+      controller.onHostExit(kind)
+    },
     onSwipeDown: () => controller.swipeDown(),
     onSwipeUp: () => controller.swipeUp(),
     onTap: () => controller.tap(),


### PR DESCRIPTION
> それ終わってないですか。起動しっぱなしで放置って。回避策はないの？毎回落ちるしかないんですか？

「画面を消さないでください」は回避策ではありませんでした。取り下げます。

**SDK は終了理由を通知していて、我々はそれを捨てていました。**

```
OsEventTypeList:
  FOREGROUND_ENTER_EVENT = 4    ← 前面に戻った
  FOREGROUND_EXIT_EVENT  = 5    ← 背面に行った
  ABNORMAL_EXIT_EVENT    = 6    ← 異常終了
  SYSTEM_EXIT_EVENT      = 7    ← OSが終了させた
```

ハンドラはリング操作の4つしか見ておらず、残りは素通りしていました。

## 入れたもの

**1. 終了理由を記録** — 「バックグラウンドに行っただけ」か「殺された」かが、ページの中からの推測ではなく**ホストの申告**で確定します。

**2. 復帰時に再接続・再描画** — 戻ってきた瞬間を検知して繋ぎ直します。死んだ画面のまま放置されません。

**3. 中断位置の保存と復元** — 実機は SDK の `setLocalStorage`（ホストアプリの保存領域、WebView より長生き）、シミュレータは localStorage。

```
中断時:   life を2件遡って読書中（off=2）
再起動後: life の2件前に復帰（off=2）
```

ページ番号は捨てます。会話は伸びるので、古い本文の2ページ目と新しい本文の2ページ目は別物です。**30分より古い保存は無視**します——そこはもう読者がいる場所ではありません。

ライフサイクルはリング操作のデバウンスより**手前**で処理します。共有すると復帰が直後のタップを飲み込みます。

## 検証（シミュレータ実測）

```
遡って中断 → 再起動      → 会話・遡り位置とも復元        ✓
31分前の保存で再起動      → 無視して一覧から             ✓
一覧で中断 → 再起動      → 一覧のまま                   ✓
復元中の定期リフレッシュ   → 位置を巻き戻さない（競合修正） ✓
```

テスト2件追加（全77件）。lint / typecheck / test（全623件）/ device・web 両ビルド通過。**ehpk の更新が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np