### PR TITLE
chore(glasses): 版数がずれた ehpk をパックさせない

### DIFF
--- a/.claude/skills/glasses-upload/SKILL.md
+++ b/.claude/skills/glasses-upload/SKILL.md
@@ -18,9 +18,11 @@ description: G2グラスアプリをビルドしてEVEN Hubにアップロード
 
 3. **ehpkパック**:
    ```bash
-   bunx --bun evenhub pack app.json dist
+   bun run pack
    ```
-   → `out.ehpk` が生成される
+   → `out.ehpk` が生成される。**版数が `app.json` とバンドルで一致していなければ止まる** —
+   バンプしてビルドを忘れると、Hub は新しい番号を表示するのに実機は古い番号を名乗る、
+   という一番たちの悪いずれ方をするため（`glasses/scripts/pack.ts`）
    ※ `npx @evenrealities/evenhub-cli pack` は npm が workspace の package.json を見てしまい "Missing script" で失敗する。`bunx evenhub` の形が確実
 
 4. **コミット** & PR (必要に応じて main にマージ):
@@ -156,7 +158,7 @@ description: G2グラスアプリをビルドしてEVEN Hubにアップロード
 ## Important Notes
 
 - **viewport 設定が必須**: agent-browser のデフォルトは 393x852 (mobile)。CC Hub Glasses 詳細ページに遷移できなかったり、Beta バッジが viewport の外 (x=1200+) に出る。先頭で必ず `set viewport 1280 800`
-- **bun を使う**: ルートが bun workspaces なので、`npm run build` / `npx evenhub pack` は workspace package.json と干渉して失敗する。`bun run build` / `bunx --bun evenhub pack ...` を使う
+- **bun を使う**: ルートが bun workspaces なので、`npm run build` / `npx evenhub pack` は workspace package.json と干渉して失敗する。`bun run build` / `bun run pack` を使う（`pack` は版数一致を検査してから evenhub CLI に渡す）
 - **EVEN Hub CLI にアップロードコマンドはない**: ブラウザ自動化が必要
 - **session-name evenhub でセッション永続化**: 一度ログインすれば再実行時はスキップできる
 - **Beta バッジは snapshot ref では操作できない**: `elementFromPoint(x, y)?.click()` を使う。座標はバッジを `querySelectorAll` + `getBoundingClientRect` で動的取得

--- a/glasses/package.json
+++ b/glasses/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && vite build --mode device",
     "build:web": "tsc && vite build --base=/glasses/ --outDir=dist-web",
     "preview": "vite preview",
-    "pack": "evenhub pack",
+    "pack": "bun scripts/pack.ts",
     "test": "bun test",
     "lint": "echo 'no lint'",
     "typecheck": "tsgo --noEmit"

--- a/glasses/scripts/pack.ts
+++ b/glasses/scripts/pack.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env bun
+/**
+ * Pack the ehpk, refusing to ship a bundle that disagrees with the manifest.
+ *
+ * The version reaches the running app through the bundle (injected at build
+ * time from app.json) and reaches the store through app.json itself. Bump the
+ * manifest without rebuilding and the two part company silently: the Hub lists
+ * one number and the device reports another, which is worse than no number at
+ * all because it looks authoritative.
+ */
+import { $ } from 'bun'
+
+const manifest = await Bun.file('app.json').json()
+const want = manifest.version as string
+
+let bundles: string[] = []
+try {
+  bundles = [...new Bun.Glob('assets/*.js').scanSync('dist')]
+} catch {
+  // scanSync throws rather than returning empty when dist/ is not there.
+}
+if (bundles.length === 0) {
+  console.error('✗ dist/ has no bundle. Run `bun run build` first.')
+  process.exit(1)
+}
+
+const marker = /main: v([0-9][0-9.]*)/
+const found = new Set<string>()
+for (const rel of bundles) {
+  const m = marker.exec(await Bun.file(`dist/${rel}`).text())
+  if (m) found.add(m[1])
+}
+
+if (found.size === 0) {
+  console.error('✗ No version marker in the bundle. Is the build current?')
+  process.exit(1)
+}
+if (found.size > 1 || !found.has(want)) {
+  console.error(`✗ app.json says ${want}, the bundle says ${[...found].join(', ')}.`)
+  console.error('  The build is stale — run `bun run build` and pack again.')
+  process.exit(1)
+}
+
+console.log(`✓ app.json and bundle agree on v${want}`)
+await $`bunx --bun evenhub pack app.json dist`


### PR DESCRIPTION
> このままリリースするたびにちゃんとバージョン情報が埋め込まれるっていう認識であってる

**条件付きで合っています。** バンプ → ビルド → パックの順を守る限りは。逆に言うと、順序が崩れると静かにずれます。1コマンドで再現しました。

```
--- 版数だけ上げてビルドを忘れる ---
app.json=0.1.99  バンドル=0.1.48  ← 不一致のままパックできてしまう
```

Hub は 0.1.99 と表示し、実機は 0.1.48 と名乗ります。**番号が無いより悪い**——もっともらしく見えるからです。今日ちょうど 0.1.45 を作り直したときに、この順序を踏み外しかけました。

`bun run pack` が先に突き合わせます。

```
✓ app.json and bundle agree on v0.1.48      → パックする
✗ app.json says 0.1.99, the bundle says 0.1.48.
  The build is stale — run `bun run build` and pack again.   → 止まる
✗ dist/ has no bundle. Run `bun run build` first.            → 止まる
```

`/glasses-upload` スキルの手順も `bun run pack` に更新しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np