### PR TITLE
fix(ui): タブの閉じるボタンがタッチ端末で不可視のタップ領域になっていた

### DIFF
--- a/frontend/src/components/WorkspaceList.tsx
+++ b/frontend/src/components/WorkspaceList.tsx
@@ -993,13 +993,17 @@ function TabRow({
 					{t("session.panes", { count: tab.paneCount })}
 				</span>
 			</div>
+			{/* Desktop only. opacity-0 still takes hit tests, so on a phone — where
+			    the hover that reveals it never happens — this left an invisible
+			    26px "close tab" target at the row's edge. Touch closes by long
+			    press instead. */}
 			{closeTab && (
 				<button
 					type="button"
 					onClick={closeTab}
 					title={t("session.closeTabTitle")}
 					aria-label={t("session.closeTabTitle")}
-					className="shrink-0 min-h-11 px-2 rounded-md text-zinc-600 opacity-0 transition-opacity hover:text-red-400 hover:bg-red-500/10 group-hover/tab:opacity-100 focus-visible:opacity-100"
+					className="hidden [@media(hover:hover)]:flex shrink-0 min-h-11 px-2.5 items-center justify-center rounded-md text-zinc-600 opacity-0 transition-opacity hover:text-red-400 hover:bg-red-500/10 group-hover/tab:opacity-100 focus-visible:opacity-100"
 				>
 					<X className="w-3.5 h-3.5" />
 				</button>


### PR DESCRIPTION
## 症状

タブ行の ✕ は `group-hover` で出す設計で、非ホバー時は `opacity-0`。ところが **`opacity-0` の要素はヒットテストを受ける**ため、ホバーが発生しないスマホ・タブレットでは、タブ行の右端に**見えないまま反応する26pxの「タブを閉じる」ボタン**が残っていた。

そこをタップすると、タブ切り替えではなく**閉じる確認ダイアログ**が出る。

iPhone 14 ビューポートで再現確認:

```
elementFromPoint(ボタン中心) → <button aria-label="タブを閉じる">
opacity: 0 / pointer-events: auto / hitIsCloseBtn: true
```

## 修正

`[@media(hover:hover)]` で囲い、タッチ端末では描画自体をしない（`display: none` → レイアウトからも消え、幅も食わない）。タッチでの閉じる操作は従来どおり長押し。

ついでに `px-2` → `px-2.5` でデスクトップのヒット領域を 26px → 30px に。

## レスポンシブ e2e が拾えなかった理由

`frontend/tests/e2e/responsive/touch-targets.spec.ts` は `rect.height < MIN_TOUCH_PX` の**高さしか見ていない**。このボタンは `min-h-11` = 39px で基準を満たしていたため通過していた。`opacity` も見ていないので、不可視要素という観点でも検出対象外だった。

（#514 のガード強化として「幅も見る」「opacity:0 かつ pointer-events が生きている要素を検出する」を足す価値はありそうだが、既存分の棚卸しが要るので別作業にした）

## 検証

- iPhone 14 ビューポート: `display: none`、幅0、`elementFromPoint` が返さない
- hover 対応ポインタのフラグ付き Chrome（`--blink-settings=primaryHoverType=2,...`）: ホバーで opacity 1、クリック可能。headless はデフォルトで `(hover: none)` を返すためデスクトップ経路をそのままでは再現できない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STv3pQwmpdxMa9fJ4TK7a6