### PR TITLE
fix(glasses): シミュレーターではブラウザ通知を止めない

### DIFF
--- a/backend/src/routes/terminal-mux.ts
+++ b/backend/src/routes/terminal-mux.ts
@@ -311,9 +311,12 @@ export async function muxMessage(ws: ServerWebSocket<MuxData>, message: string |
   // "glasses present", which gates relay assembly/sending.
   if (msg.type === 'subscribe-glasses-relay') {
     // Marks this connection as a follower, excluding it from the focus
-    // election.
+    // election. The simulator follows too, so this is not the device flag.
     ws.data.isGlasses = true;
-    await subscribeGlassesRelay(ws);
+    // Absent means device: an ehpk predating the field is on a face, while the
+    // simulator ships inside the server binary that reads it, so it can never
+    // be the older of the two.
+    await subscribeGlassesRelay(ws, msg.onDevice !== false);
     return;
   }
 

--- a/backend/src/services/__tests__/glasses-relay.test.ts
+++ b/backend/src/services/__tests__/glasses-relay.test.ts
@@ -7,6 +7,7 @@ import {
   displayWidth,
   extractNumberedChoices,
   extractQuestionLine,
+  glassesDeviceCount,
   glassesRelayDeps,
   normalizeRelayText,
   postAgentRelay,
@@ -571,3 +572,65 @@ describe('postHookRelay', () => {
     expect(snapshot.map((i) => i.id)).toContain(agentNote.id);
   });
 });
+
+describe('simulator vs device', () => {
+  test('a simulator sees the notification but does not silence the browser', async () => {
+    const sim = new FakeSocket();
+    glassesRelayDeps.listWorkspaces = async () => [];
+    await subscribeGlassesRelay(sim, false);
+    sim.messages = [];
+
+    // Undelivered as far as the browser is concerned...
+    expect(postHookRelay({ sessionId: 's1', text: '応答が完了しました' })).toBe(false);
+    // ...but the panel it previews still shows what the panel would show.
+    expect(sim.ofType('glasses-relay')).toHaveLength(1);
+  });
+
+  test('a device alongside a simulator still silences the browser', async () => {
+    const sim = new FakeSocket();
+    const dev = new FakeSocket();
+    glassesRelayDeps.listWorkspaces = async () => [];
+    await subscribeGlassesRelay(sim, false);
+    await subscribeGlassesRelay(dev, true);
+
+    expect(postHookRelay({ sessionId: 's1', text: '応答が完了しました' })).toBe(true);
+    expect(sim.ofType('glasses-relay')).toHaveLength(1);
+    expect(dev.ofType('glasses-relay')).toHaveLength(1);
+  });
+
+  test('an omitted flag counts as a device, so a pre-flag ehpk keeps working', async () => {
+    const old = new FakeSocket();
+    glassesRelayDeps.listWorkspaces = async () => [];
+    await subscribeGlassesRelay(old);
+    expect(postHookRelay({ sessionId: 's1', text: '応答が完了しました' })).toBe(true);
+  });
+
+  test('an unanswered question suppresses only when a device is watching', async () => {
+    const sim = new FakeSocket();
+    glassesRelayDeps.listWorkspaces = async () => [];
+    await subscribeGlassesRelay(sim, false);
+    postAgentRelay({ sessionId: 's1', kind: 'waiting', text: 'Which one?' });
+
+    expect(postHookRelay({ sessionId: 's1', text: 'ユーザー入力を待っています' })).toBe(false);
+  });
+
+  test('a device that disconnects stops counting', async () => {
+    const dev = new FakeSocket();
+    glassesRelayDeps.listWorkspaces = async () => [];
+    await subscribeGlassesRelay(dev, true);
+    expect(glassesDeviceCount()).toBe(1);
+    unsubscribeGlassesRelay(dev);
+    expect(glassesDeviceCount()).toBe(0);
+    expect(postHookRelay({ sessionId: 's1', text: '応答が完了しました' })).toBe(false);
+  });
+
+  test('resubscribing as a simulator drops the device claim', async () => {
+    // The socket is reused across a reconnect; a stale device claim would keep
+    // the browser silent for a tab that is only previewing.
+    const sock = new FakeSocket();
+    glassesRelayDeps.listWorkspaces = async () => [];
+    await subscribeGlassesRelay(sock, true);
+    await subscribeGlassesRelay(sock, false);
+    expect(glassesDeviceCount()).toBe(0);
+  });
+})

--- a/backend/src/services/glasses-relay.ts
+++ b/backend/src/services/glasses-relay.ts
@@ -148,12 +148,29 @@ export interface RelaySocket {
 
 const subscribers = new Set<RelaySocket>();
 
+/**
+ * Subscribers running on real glasses, as opposed to the browser simulator.
+ *
+ * Everything the device sees, the simulator sees — showing the panel is the
+ * whole point of it. The difference is only in what a subscription is taken to
+ * PROVE: a wearer has been told, so the browser push can stop; someone with a
+ * simulator tab open has not, and silencing their notifications because a
+ * preview window is up would lose them.
+ */
+const deviceSubscribers = new Set<RelaySocket>();
+
 export function glassesRelaySubscriberCount(): number {
   return subscribers.size;
 }
 
+/** Subscribers that are actual hardware — the ones a notification reaches. */
+export function glassesDeviceCount(): number {
+  return deviceSubscribers.size;
+}
+
 export function unsubscribeGlassesRelay(ws: RelaySocket): void {
   subscribers.delete(ws);
+  deviceSubscribers.delete(ws);
 }
 
 function sendToSubscribers(msg: Record<string, unknown>): void {
@@ -163,6 +180,7 @@ function sendToSubscribers(msg: Record<string, unknown>): void {
       ws.send(payload);
     } catch {
       subscribers.delete(ws);
+      deviceSubscribers.delete(ws);
     }
   }
 }
@@ -346,11 +364,14 @@ export async function resolveHookTarget(
  * A Claude Code / Codex hook event, shown on the glasses instead of pushed to
  * the browser.
  *
- * Returns true only when the glasses actually carry the notification, and the
- * caller suppresses the browser push on exactly that. Everything that can stop
- * the item from landing — no glasses subscribed, rate limit — returns false and
- * the push goes out as it always did: a notification nobody sees is a worse
- * failure than one seen twice.
+ * Returns true only when the notification reached a face — a device
+ * subscriber. The caller suppresses the browser push on exactly that.
+ * Everything that can stop it from landing — no glasses, only a simulator
+ * watching, rate limit — returns false and the push goes out as it always
+ * did: a notification nobody sees is a worse failure than one seen twice.
+ *
+ * The item itself is still created and broadcast for a simulator-only
+ * audience, because the simulator exists to show what the panel would show.
  */
 export function postHookRelay(input: {
   sessionId: string;
@@ -358,12 +379,13 @@ export function postHookRelay(input: {
   paneId?: string;
 }): boolean {
   if (subscribers.size === 0) return false;
+  const reachesAWearer = deviceSubscribers.size > 0;
 
   // An unanswered question already outranks anything a hook can say, and it is
   // on screen with its choices. "応答が完了しました" underneath it would only
   // describe the same moment a second time, less usefully.
   const existing = store.get(input.sessionId);
-  if (existing?.waiting && !existing.waiting.dismissed) return true;
+  if (existing?.waiting && !existing.waiting.dismissed) return reachesAWearer;
 
   if (!checkRateLimit(input.sessionId)) return false;
   evictStoreIfNeeded();
@@ -383,7 +405,7 @@ export function postHookRelay(input: {
   // Latest-one-per-session, same as agent info notes: without this a client
   // keyed by item id accumulates every completion the session ever reported.
   if (replaced && replaced.id !== item.id) broadcastRemove(replaced.id);
-  return true;
+  return reachesAWearer;
 }
 
 /** "Later / on PC": flag the item so snapshots skip it but the same blocked
@@ -588,9 +610,15 @@ export async function buildGlassesRelaySnapshot(): Promise<GlassesRelayItem[]> {
   return items;
 }
 
-/** Register a mux connection as a glasses relay subscriber and push the snapshot. */
-export async function subscribeGlassesRelay(ws: RelaySocket): Promise<void> {
+/**
+ * Register a mux connection as a glasses relay subscriber and push the
+ * snapshot. `onDevice` false marks a simulator: it still receives everything,
+ * it just does not count as the user having been told.
+ */
+export async function subscribeGlassesRelay(ws: RelaySocket, onDevice = true): Promise<void> {
   subscribers.add(ws);
+  if (onDevice) deviceSubscribers.add(ws);
+  else deviceSubscribers.delete(ws);
   try {
     const items = await buildGlassesRelaySnapshot();
     ws.send(JSON.stringify({ type: 'glasses-relay-snapshot', items }));
@@ -621,4 +649,5 @@ export function resetGlassesRelayForTest(): void {
   postLog.clear();
   paneStatus.clear();
   subscribers.clear();
+  deviceSubscribers.clear();
 }

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -41,6 +41,15 @@ export type RingAction = 'tap' | 'doubleTap' | 'swipeUp' | 'swipeDown'
 /** Platform capabilities the controller cannot provide itself. The G2 wires
  *  the real Even Hub bridge + mic; the debug simulator fakes them. */
 export interface GlassesPlatform {
+  /**
+   * Real hardware, not the browser simulator.
+   *
+   * Both run this controller and both show the same screen; the difference is
+   * that only a wearer has actually been told something. The server silences
+   * the browser push on this, so a simulator claiming it would take the user's
+   * notifications away while a preview window sat open on their desk.
+   */
+  onDevice: boolean
   /** Re-render the whole UI from the (mutated) state. */
   render(state: AppState): void
   /** Redraw only the header. The spinner changes nothing else, and on the
@@ -152,7 +161,7 @@ export class GlassesController {
    *  relay subscription is (re)sent on every connect; the server answers with
    *  a snapshot, then pushes upserts/removals. */
   connect(): void {
-    this.ws.subscribeGlassesRelay()
+    this.ws.subscribeGlassesRelay(this.platform.onDevice)
     this.ws.connect()
     // One timer for the life of the app rather than start/stop bookkeeping on
     // every state change. It costs nothing when nothing is working: the tick

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -524,6 +524,9 @@ export function startDebugUI(): void {
   }
 
   const platform: GlassesPlatform = {
+    // A browser panel, not a face. Claiming otherwise would silence the
+    // wearer's browser notifications for as long as this tab stayed open.
+    onDevice: false,
     render(state) {
       const raw = screenText(state)
       // The device's container wraps for it; this panel has to do it itself.

--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -146,6 +146,8 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
   }
 
   const platform: GlassesPlatform = {
+    // startGlassesMode only runs with a real Even Hub bridge.
+    onDevice: true,
     render(state) {
       // Just the startup burst — that is where frames used to pile up.
       if (++renders <= 10) trace(`render #${renders} mode=${state.mode} sessions=${state.sessions.length}`)

--- a/glasses/src/ws-client.ts
+++ b/glasses/src/ws-client.ts
@@ -63,6 +63,7 @@ export class CcHubWsClient {
   // Glasses relay subscription is connection-scoped (no sessionId); re-sent on
   // every (re)connect while this flag is set (#504).
   private relaySubscribed = false
+  private onDevice = true
   private screenSubscribed = false
 
   // Buffer of last N lines per session
@@ -93,7 +94,7 @@ export class CcHubWsClient {
       // Re-establish the relay subscription before onReady so the server's
       // snapshot arrives around the same time as session re-subscribes.
       if (this.relaySubscribed) {
-        this.send({ type: 'subscribe-glasses-relay' })
+        this.send({ type: 'subscribe-glasses-relay', onDevice: this.onDevice })
       }
       if (this.screenSubscribed) {
         this.send({ type: 'subscribe-glasses-screen' })
@@ -183,9 +184,13 @@ export class CcHubWsClient {
   /** Mark this connection as "glasses present" (#504). The server gates relay
    *  assembly/sending on this subscription and answers with a snapshot of the
    *  current waiting/info items. Re-sent automatically on reconnect. */
-  subscribeGlassesRelay(): void {
+  /** `onDevice` false = the browser simulator. It receives every relay item
+   *  either way; the flag only stops a preview window from being taken as
+   *  proof that the user was told, which would silence their browser push. */
+  subscribeGlassesRelay(onDevice: boolean): void {
     this.relaySubscribed = true
-    this.send({ type: 'subscribe-glasses-relay' })
+    this.onDevice = onDevice
+    this.send({ type: 'subscribe-glasses-relay', onDevice })
   }
 
   unsubscribeGlassesRelay(): void {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1048,7 +1048,13 @@ export type MuxClientMessage =
   | { type: 'unsubscribe-conversation'; sessionId: string }
   // Glasses relay presence subscription (#504). No sessionId: it marks the
   // whole connection as "glasses present", which gates relay assembly/send.
-  | { type: 'subscribe-glasses-relay' }
+  //
+  // `onDevice` separates a wearer from a spectator. Both get the items — the
+  // simulator's whole job is to show what the panel shows — but only real
+  // hardware silences the browser push, because only a wearer is actually
+  // being told. Absent means device: an older ehpk that predates the field is
+  // running on a face, and a simulator ships with the server that reads this.
+  | { type: 'subscribe-glasses-relay'; onDevice?: boolean }
   | { type: 'unsubscribe-glasses-relay' }
   // Screen mirroring for demos. The device publishes; browsers subscribe.
   // Only a connection with a real Even Hub bridge publishes, so the simulator
@@ -1116,7 +1122,7 @@ export const MuxClientMessageSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('unsubscribe'), sessionId: z.string().min(1) }),
   z.object({ type: z.literal('subscribe-conversation'), sessionId: z.string().min(1) }),
   z.object({ type: z.literal('unsubscribe-conversation'), sessionId: z.string().min(1) }),
-  z.object({ type: z.literal('subscribe-glasses-relay') }),
+  z.object({ type: z.literal('subscribe-glasses-relay'), onDevice: z.boolean().optional() }),
   z.object({ type: z.literal('unsubscribe-glasses-relay') }),
   z.object({
     type: z.literal('glasses-screen'),


### PR DESCRIPTION
## 問題

v0.2.79 の抑制判定が「リレーを購読している誰かが居るか」だった。シミュレーターは実機と同じ controller を使うので同じ購読をする。結果、**シミュレーターのタブを開いておくだけでブラウザ通知が止まり**、代わりに出るはずのグラスは誰もかけていない、という状態になっていた。

## 直し方

`subscribe-glasses-relay` に `onDevice` を持たせた。

**リレーアイテムは今までどおり両方に配る** — パネルに出るものを出すのがシミュレーターの仕事なので、そこは変えない。変わるのは「購読が何を証明するか」だけ。**装着者に伝わったことを証明できるのは実機だけ**なので、抑制するのも実機だけ。

- 実機 (`main.ts` / `startGlassesMode`): `onDevice: true`
- シミュレーター (`debug-ui.ts` / `startDebugUI`): `onDevice: false`

この2つは元々きれいに分岐しているので、`GlassesPlatform` の一項目として名乗らせている。

### 省略時は「実機」

フィールドを持たない旧 ehpk は**顔の上で動いている**一方、シミュレーターはこのフィールドを読むサーバーバイナリに同梱されて配られるので、**サーバーより古くなりようがない**。よって省略＝実機で正しい。

**ehpk の再リリースは不要**: 現行 v0.1.49 は省略扱いのまま正しく動く。サーバーリリース1本で足りる。

## 検証

dev で 4 パターン実測（生 WebSocket）:

| | `hook-event` | シミュレーターの受信 |
|---|---|---|
| シミュレーターのみ | フラグなし → **ブラウザ通知が出る** | 1件（表示はされる） |
| シミュレーター + 実機 | `true` → 抑制 | 両方1件 |
| 実機が抜けた後 | フラグなし → **通知が戻る** | 1件 |
| 旧ehpk（フラグ無し） | `true` → 抑制 | — |

テスト6件追加（シミュレーター単独 / 実機併存 / フラグ省略 / waiting との組み合わせ / 切断 / 同一ソケットの再購読で device 主張が落ちること）。`bun run test` 全パス（backend 499 / frontend 78 / glasses 83）、lint クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np