### PR TITLE
feat(glasses): 通知をダイアログ表示にして、自動で引っ込める

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -4,6 +4,7 @@ import { sanitizeForG2, formatMessage } from '../types.ts'
 import { screenText, wrapForPanel, wrapHeader } from '../display.ts'
 import { BODY_WIDTH, HEADER_WIDTH, LIST_LINES, textWidth as width } from '../metrics.ts'
 import { listRows, rowCursor, selectableRows } from '../display.ts'
+import { NOTICE_DISMISS_MS } from '../controller.ts'
 import { SPACE_W } from '../metrics.ts'
 import { MAX_LINES } from '../metrics.ts'
 
@@ -862,5 +863,99 @@ describe('notification banner on the list', () => {
     const many = { ...mk([info('a', 'x')], 12), sessionIndex: 11 }
     const body = screenText(many).body.split('\n')
     expect(body.some((l) => l.startsWith('>'))).toBe(true)
+  })
+})
+
+describe('notice dialog (overlay)', () => {
+  const relayItem = (kind: 'waiting' | 'info', id: string, text: string, extra = {}) => ({
+    id, sessionId: 'a', kind, text, source: 'auto' as const, createdAt: 1, ...extra,
+  })
+
+  const mk = (over: Record<string, unknown>) => ({
+    mode: 'overlay' as const,
+    sessions: [{ id: 'a', name: 'グラス開発', state: 'working' as const }],
+    sessionIndex: 0,
+    conversation: [],
+    conversationOffset: 0,
+    conversationPage: 0,
+    conversationLastLoaded: 0,
+    conversationHasMore: false,
+    conversationLoading: false,
+    choiceIndex: 0,
+    choiceOptions: [],
+    relayWaiting: [],
+    relayInfo: [],
+    overlayItemId: null,
+    spinnerTick: 0,
+    ...over,
+  })
+
+  test('a notification fills the panel, marked [i] and named by its workspace', () => {
+    const s = screenText(mk({
+      relayInfo: [relayItem('info', 'i1', '応答が完了しました')],
+      overlayItemId: 'i1',
+    }))
+    expect(s.header).toContain('グラス開発')
+    expect(s.header).toContain('[i]')
+    expect(s.body).toContain('応答が完了しました')
+  })
+
+  test('closing a notification is not answering it', () => {
+    // "後で" is a reply to a question. A notification asked nothing.
+    const s = screenText(mk({
+      relayInfo: [relayItem('info', 'i1', '応答が完了しました')],
+      overlayItemId: 'i1',
+    }))
+    expect(s.footer).toContain('dbl:閉じる')
+    expect(s.footer).not.toContain('後で')
+  })
+
+  test('a question keeps its own wording and mark', () => {
+    const s = screenText(mk({
+      relayWaiting: [relayItem('waiting', 'w1', 'Which approach?', { choices: ['A', 'B'] })],
+      overlayItemId: 'w1',
+    }))
+    expect(s.header).toContain('[!]')
+    expect(s.footer).toContain('dbl:後で')
+    expect(s.footer).toContain('tap:選択へ')
+  })
+
+  test('a queue of one drops the counter and the swipe hint', () => {
+    const s = screenText(mk({
+      relayInfo: [relayItem('info', 'i1', 'done')],
+      overlayItemId: 'i1',
+    }))
+    expect(s.header).not.toMatch(/\d+\/\d+/)
+    expect(s.footer).not.toContain('swipe')
+  })
+
+  test('a question outranks a notification when both are queued', () => {
+    const s = screenText(mk({
+      relayWaiting: [relayItem('waiting', 'w1', 'Which approach?')],
+      relayInfo: [relayItem('info', 'i1', '応答が完了しました')],
+      overlayItemId: 'w1',
+    }))
+    expect(s.header).toContain('[!] 1/2')
+    expect(s.footer).toContain('swipe:次')
+  })
+
+  test('the notification is second in that queue, not first', () => {
+    const s = screenText(mk({
+      relayWaiting: [relayItem('waiting', 'w1', 'Which approach?')],
+      relayInfo: [relayItem('info', 'i1', '応答が完了しました')],
+      overlayItemId: 'i1',
+    }))
+    expect(s.header).toContain('[i] 2/2')
+  })
+
+  test('an emptied queue says so instead of rendering a blank panel', () => {
+    expect(screenText(mk({ overlayItemId: 'gone' })).body).toBe('(なし)')
+  })
+
+  test('the dialog gives the panel back on its own', () => {
+    // The value is the guarantee, not the number: a wearer must never have to
+    // clear a completion by hand.
+    expect(NOTICE_DISMISS_MS).toBeGreaterThan(0)
+    expect(NOTICE_DISMISS_MS).toBeLessThanOrEqual(15_000)
   })
 })

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -35,6 +35,14 @@ import type { Session, Pane, ConversationMessage, GlassesRelayItem, ClientFocus 
 const INITIAL_LOAD_COUNT = 20
 const LOAD_MORE_INCREMENT = 20
 const CONV_REFRESH_INTERVAL = 3000
+/**
+ * How long a notification holds the panel before giving it back.
+ *
+ * Long enough to be read at a glance without hurrying — a completion line plus
+ * a sentence of recap — and short enough that a wearer walking around is not
+ * looking through a message about something they already knew.
+ */
+export const NOTICE_DISMISS_MS = 8000
 
 export type RingAction = 'tap' | 'doubleTap' | 'swipeUp' | 'swipeDown'
 
@@ -139,6 +147,8 @@ export class GlassesController {
   private choiceTarget: ReplyTarget | null = null
   private voiceTarget: ReplyTarget | null = null
   private overlayReturnMode: 'session_list' | 'conversation' = 'session_list'
+  /** Pending auto-dismissal of a notification overlay; null when none is due. */
+  private noticeTimer: ReturnType<typeof setTimeout> | null = null
 
   private audioChunks: Uint8Array[] = []
   private recording = false
@@ -456,15 +466,17 @@ export class GlassesController {
 
   private async onOverlayAction(action: RingAction): Promise<void> {
     const st = this.state
-    const waiting = this.queue.waitingItems()
-    const item = waiting.find((i) => i.id === st.overlayItemId) || waiting[0]
+    // The wearer is driving now; a notification must not vanish mid-gesture.
+    this.clearNoticeTimer()
+    const items = this.queue.sorted()
+    const item = (st.overlayItemId ? this.queue.get(st.overlayItemId) : undefined) || items[0]
     switch (action) {
       case 'swipeUp':
       case 'swipeDown': {
-        if (waiting.length < 2) return
-        const idx = item ? waiting.indexOf(item) : 0
+        if (items.length < 2) return
+        const idx = item ? items.indexOf(item) : 0
         const delta = action === 'swipeDown' ? 1 : -1
-        st.overlayItemId = waiting[(idx + delta + waiting.length) % waiting.length].id
+        st.overlayItemId = items[(idx + delta + items.length) % items.length].id
         this.render()
         return
       }
@@ -620,9 +632,49 @@ export class GlassesController {
   }
 
   private exitOverlay(): void {
+    this.clearNoticeTimer()
     this.state.mode = this.overlayReturnMode
     this.state.overlayItemId = null
     this.render()
+  }
+
+  /**
+   * Give the screen back on its own.
+   *
+   * A question is entitled to hold the panel until it is answered. A
+   * notification is not: an agent finishing is a thing to have been told once,
+   * and making the wearer raise a hand to clear every completion would turn
+   * the feature into a chore. So it behaves like a notification anywhere else
+   * — it appears, it is read, it leaves.
+   */
+  private scheduleNoticeDismiss(itemId: string): void {
+    this.clearNoticeTimer()
+    this.noticeTimer = setTimeout(() => {
+      this.noticeTimer = null
+      // Only if it is still the thing on screen. A gesture or a newer item in
+      // the meantime has already decided this item's fate.
+      if (this.state.mode === 'overlay' && this.state.overlayItemId === itemId) {
+        this.exitOverlay()
+      }
+    }, NOTICE_DISMISS_MS)
+  }
+
+  private clearNoticeTimer(): void {
+    if (!this.noticeTimer) return
+    clearTimeout(this.noticeTimer)
+    this.noticeTimer = null
+  }
+
+  /**
+   * Whether a notification may take the screen.
+   *
+   * Reading is interruptible — the overlay returns to the exact place it left,
+   * and eight seconds later it does so by itself. Choosing an option and
+   * dictating a prompt are not: the panel IS the input there, and replacing it
+   * mid-gesture would lose what the wearer was in the middle of saying.
+   */
+  private canInterruptForNotice(): boolean {
+    return this.state.mode === 'session_list' || this.state.mode === 'conversation'
   }
 
   /** Jump to a relay item's session: subscribe + open its conversation, and
@@ -805,6 +857,13 @@ export class GlassesController {
     // modes the banner / header badge surfaces it without yanking the view.
     if (isNew && item.kind === 'waiting' && this.state.mode === 'session_list') {
       this.enterOverlay(item.id)
+      return
+    }
+    // A notification is only a notification if it is seen, so it takes the
+    // screen the same way — and then hands it back without being asked.
+    if (isNew && item.kind === 'info' && this.canInterruptForNotice()) {
+      this.enterOverlay(item.id)
+      this.scheduleNoticeDismiss(item.id)
       return
     }
     this.render()

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -612,16 +612,28 @@ function choiceBody(state: AppState): string {
   }).join('\n')
 }
 
-/** Full-screen presentation of one waiting relay item (#504). Swipe cycles the
- *  waiting queue, tap jumps to the item's session, double-tap dismisses. */
+/**
+ * Full-screen presentation of one relay item (#504). Swipe cycles the queue,
+ * tap jumps to the item's session, double-tap dismisses.
+ *
+ * Questions and notifications share this screen because they are the same
+ * gesture problem — one thing, full width, reachable from the ring. They part
+ * ways in what happens when the wearer does nothing: a question waits, a
+ * notification takes itself away (the controller's dismissal timer).
+ */
 function overlayContent(state: AppState): { headerText: string; bodyText: string; footerText: string } {
-  const waiting = state.relayWaiting
-  const item = waiting.find((i) => i.id === state.overlayItemId) || waiting[0]
+  // Waiting first, matching the queue's own ordering, so a question is never
+  // buried behind an FYI that happens to be newer.
+  const items = [...state.relayWaiting, ...state.relayInfo]
+  const item = items.find((i) => i.id === state.overlayItemId) || items[0]
   if (!item) {
-    return { headerText: withClock('Relay'), bodyText: '(waiting なし)', footerText: 'dbl:戻る' }
+    return { headerText: withClock('Relay'), bodyText: '(なし)', footerText: 'dbl:戻る' }
   }
-  const idx = waiting.indexOf(item)
-  const headerText = withClock(`${relayLabel(state, item)} [!] ${idx + 1}/${waiting.length}`)
+  const idx = items.indexOf(item)
+  const badge = item.kind === 'waiting' ? '[!]' : '[i]'
+  // A counter over a queue of one says nothing, and the header is one line.
+  const counter = items.length > 1 ? ` ${idx + 1}/${items.length}` : ''
+  const headerText = withClock(`${relayLabel(state, item)} ${badge}${counter}`)
 
   const lines = splitDisplayLines(item.text)
   if (item.choices?.length) {
@@ -633,9 +645,14 @@ function overlayContent(state: AppState): { headerText: string; bodyText: string
   const bodyText = lines.length > MAX_LINES
     ? [...lines.slice(0, MAX_LINES - 1), '…'].join('\n')
     : lines.join('\n')
-  const footerText = item.choices?.length
-    ? 'tap:選択へ  dbl:後で  swipe:次'
-    : 'tap:開く  dbl:後で  swipe:次'
+  const next = items.length > 1 ? '  swipe:次' : ''
+  // "後で" is an answer to a question. A notification is not asking anything,
+  // so the same gesture is just closing it.
+  const footerText = item.kind === 'info'
+    ? `tap:開く  dbl:閉じる${next}`
+    : item.choices?.length
+      ? `tap:選択へ  dbl:後で${next}`
+      : `tap:開く  dbl:後で${next}`
   return { headerText, bodyText, footerText }
 }
 


### PR DESCRIPTION
## やったこと

通知を**全画面ダイアログ**で出すようにした。一覧の先頭の1行は見落とせるし、見落とされる通知は通知ではない。質問(`waiting`)が既に使っている `overlay` を、通知(`info`)にも使う。

```
┌────────────────────────────┐
│ cchub-work-2 [i]      08:53 │
├────────────────────────────┤
│ 応答が完了しました              │
├────────────────────────────┤
│ tap:開く  dbl:閉じる            │
└────────────────────────────┘
        ↓ 8秒後 自動で
一覧に戻る（バナーは残る）
```

### 消え方: 8秒で自動

質問は答えるまで画面を占有していい。**通知はよくない** — エージェントが終わるたびにリング操作で消すのでは作業になってしまう。なので自分から引っ込む。戻り先は割り込んだ場所そのもの（一覧、または読んでいた会話の位置）。

バナーはアイテムの寿命の間そのまま残るので、**ダイアログを見逃しても消えたことにはならない**。

### 割り込む範囲

一覧と会話のみ。**選択中・音声入力中は割り込まない** — あそこはパネル自体が入力なので、途中で差し替えたら言いかけたものが消える。

### overlay の一般化

画面としては元々正しかったが waiting キューに直結していた。任意のリレーアイテムを受けるようにし、順序は waiting 先頭を維持（新しいだけの FYI に質問が埋もれない）。何も聞いていない方は「後で」ではなく「閉じる」と言う。

## 検証

dev + シミュレーター（実機と同じ描画）で実測:

1. `/api/notify` に `Stop` を投げる → **ダイアログ表示**（`overlay` / `[i]cchub-work-2` / 応答が完了しました / `tap:開く dbl:閉じる`）
2. 8秒待つ → **`session_list` に自動復帰**、`[i]cchub-work-2: 応答が完了しました` のバナーは残存

テスト8件追加（`[i]`/`[!]` の出し分け、フッタ文言、1件時のカウンタ・swipe抑制、質問優先の順序、空キュー、自動解除の上限）。全パス（backend 499 / frontend 78 / glasses 91）、lint クリーン。

## リリース時の注意

**glasses/src の変更なので ehpk の再ビルド + Beta 昇格が必要**（サーバーだけでは実機に届かない）。シミュレーターはサーバー同梱なので本体リリースで反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np