### PR TITLE
fix(glasses): 見ているセッション自身の通知は出さない

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -959,3 +959,74 @@ describe('notice dialog (overlay)', () => {
     expect(NOTICE_DISMISS_MS).toBeLessThanOrEqual(15_000)
   })
 })
+
+describe('no notification about what is already on screen', () => {
+  const info = (sessionId: string, text: string, createdAt = 1) => ({
+    id: `i-${sessionId}`, sessionId, kind: 'info' as const, text,
+    source: 'auto' as const, createdAt,
+  })
+
+  const mk = (over: Record<string, unknown>) => ({
+    mode: 'conversation' as const,
+    sessions: [
+      { id: 'a', name: 'グラス開発', state: 'working' as const },
+      { id: 'b', name: '2脚ロボ開発', state: 'idle' as const },
+    ],
+    sessionIndex: 0, // reading 'a'
+    conversation: [
+      { role: 'assistant' as const, content: '本文です', timestamp: '2026-07-28T00:00:00Z' },
+    ],
+    conversationOffset: 0,
+    conversationPage: 0,
+    conversationLastLoaded: 0,
+    conversationHasMore: false,
+    conversationLoading: false,
+    choiceIndex: 0,
+    choiceOptions: [],
+    relayWaiting: [],
+    relayInfo: [],
+    overlayItemId: null,
+    spinnerTick: 0,
+    ...over,
+  })
+
+  test('the session being read does not announce itself', () => {
+    // An agent working in bursts fires one of these per turn; without this the
+    // banner never leaves, and it says only what the transcript below says.
+    const body = screenText(mk({ relayInfo: [info('a', '応答が完了しました')] })).body
+    expect(body).not.toContain('[i]')
+    expect(body).toContain('本文です')
+  })
+
+  test('another session still gets through', () => {
+    const body = screenText(mk({ relayInfo: [info('b', '応答が完了しました')] })).body
+    expect(body).toContain('[i]2脚ロボ開発: 応答が完了しました')
+  })
+
+  test('the open session is skipped over, not the whole queue', () => {
+    const body = screenText(mk({
+      relayInfo: [info('a', 'こちらは出ない', 2), info('b', 'こちらは出る', 1)],
+    })).body
+    expect(body).toContain('こちらは出る')
+    expect(body).not.toContain('こちらは出ない')
+  })
+
+  test('a question about the open session still shows — it carries the choices', () => {
+    const body = screenText(mk({
+      relayWaiting: [{
+        id: 'w', sessionId: 'a', kind: 'waiting' as const, text: 'Which one?',
+        source: 'auto' as const, createdAt: 1, choices: ['A', 'B'],
+      }],
+    })).body
+    expect(body).toContain('[!]グラス開発')
+  })
+
+  test('the list is untouched: nothing there is "on screen"', () => {
+    // sessionIndex is a cursor on the list, not a conversation being read.
+    const body = screenText(mk({
+      mode: 'session_list' as const,
+      relayInfo: [info('a', '応答が完了しました')],
+    })).body
+    expect(body).toContain('[i]グラス開発: 応答が完了しました')
+  })
+})

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -673,8 +673,13 @@ export class GlassesController {
    * dictating a prompt are not: the panel IS the input there, and replacing it
    * mid-gesture would lose what the wearer was in the middle of saying.
    */
-  private canInterruptForNotice(): boolean {
-    return this.state.mode === 'session_list' || this.state.mode === 'conversation'
+  private canInterruptForNotice(item: GlassesRelayItem): boolean {
+    if (this.state.mode === 'session_list') return true
+    if (this.state.mode !== 'conversation') return false
+    // Not about what is already on screen. "この会話が終わりました" thrown over
+    // the conversation itself tells the reader nothing they cannot see, and an
+    // agent working in bursts would raise it again every turn.
+    return item.sessionId !== this.currentSession()?.id
   }
 
   /** Jump to a relay item's session: subscribe + open its conversation, and
@@ -861,7 +866,7 @@ export class GlassesController {
     }
     // A notification is only a notification if it is seen, so it takes the
     // screen the same way — and then hands it back without being asked.
-    if (isNew && item.kind === 'info' && this.canInterruptForNotice()) {
+    if (isNew && item.kind === 'info' && this.canInterruptForNotice(item)) {
       this.enterOverlay(item.id)
       this.scheduleNoticeDismiss(item.id)
       return

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -288,12 +288,25 @@ function relayBannerLines(state: AppState): string[] {
     const textLines = splitDisplayLines(top.text).slice(0, 2)
     return [head, ...textLines, SEPARATOR]
   }
-  const info = state.relayInfo[0]
+  // Notifications about the session already on screen are dropped: the reader
+  // can see the agent finish. Announcing it spends one of seven lines to say
+  // what the other six are already showing, and an agent working in bursts
+  // keeps the line permanently occupied.
+  //
+  // Questions are exempt above — one carries the choices needed to answer it,
+  // which is not something the transcript shows.
+  const info = firstOtherSessionInfo(state)
   if (info) {
     const textLine = splitDisplayLines(info.text)[0] || ''
     return [splitDisplayLines(`[i]${relayLabel(state, info)}: ${textLine}`)[0] || '', SEPARATOR]
   }
   return []
+}
+
+/** The newest notification that is NOT about the session being read. */
+export function firstOtherSessionInfo(state: AppState): GlassesRelayItem | undefined {
+  const openId = state.sessions[state.sessionIndex]?.id
+  return state.relayInfo.find((i) => i.sessionId !== openId)
 }
 
 // ─── Content helpers (shared by build and in-place update) ───


### PR DESCRIPTION
## 症状

会話画面で通知が**出っぱなしに見える**（実機報告）。

## 原因

TTL は正常。**見ているセッション自身の通知**が繰り返し来ていた。

実機のミラーで捕まえた実物:

```
mode=conversation
header: グラス開発 …
  | [i]グラス開発: ファイル編集完了: 実機は **v0.1.50** で接続   ← 見ている当人の通知
  | ------------------------
  | $ 会話画面で通知の内容が表示しっぱなしに見えます
  | 実際の状態を確認します。…
```

エージェントは 1 ターン終えるたびに `Stop` を撃つ。その会話を読んでいる間、**毎ターン自分宛の通知が届く**ので、90秒 TTL が切れる前に次が入れ替わりで来る。結果「消えない行」に見える。

しかも内容が無い。「この会話が終わりました」を会話そのものの上に出すのは、**7行のうち1行を使って残り6行が既に示していることを言っている**だけ。

## 直し

画面に出ているセッションの通知(`info`)は、**ダイアログもバナーも出さない**。

- キュー全体を黙らせるのではなく**そのアイテムだけ飛ばす** — 別セッションの通知は今までどおり出る
- **質問(`waiting`)は対象外**。選択肢を持っていて、それは会話本文には出ていない情報だから
- **一覧画面は変更なし**。あそこの `sessionIndex` はカーソルであって「読んでいるもの」ではないので、冗長にならない

## 検証

テスト5件追加（自分宛は出ない / 他セッションは出る / 自分宛を飛ばして次を出す / 質問は例外 / 一覧は不変）。全パス（backend 499 / frontend 78 / glasses 96）、lint クリーン。

## リリース時の注意

`glasses/src` の変更なので **ehpk の再ビルド + Beta 昇格が必要**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np