### PR TITLE
feat(glasses): ビルドにコミットハッシュを刻む

### DIFF
--- a/glasses/scripts/pack.ts
+++ b/glasses/scripts/pack.ts
@@ -24,11 +24,15 @@ if (bundles.length === 0) {
   process.exit(1)
 }
 
-const marker = /main: v([0-9][0-9.]*)/
+const marker = /main: v([0-9][0-9.]*) \(([^)]*)\)/
 const found = new Set<string>()
+const commits = new Set<string>()
 for (const rel of bundles) {
   const m = marker.exec(await Bun.file(`dist/${rel}`).text())
-  if (m) found.add(m[1])
+  if (m) {
+    found.add(m[1])
+    commits.add(m[2])
+  }
 }
 
 if (found.size === 0) {
@@ -41,5 +45,19 @@ if (found.size > 1 || !found.has(want)) {
   process.exit(1)
 }
 
-console.log(`✓ app.json and bundle agree on v${want}`)
+// A version number can be reused; a commit cannot. Shipping a build whose
+// source was uncommitted leaves the device naming a commit it does not match,
+// and nothing on the Hub or the device can tell afterwards which code it was.
+const commit = [...commits][0] ?? 'nogit'
+if (commit.endsWith('+dirty')) {
+  console.error(`✗ The bundle was built from uncommitted source (${commit}).`)
+  console.error('  Commit glasses/src (and shared/) first, rebuild, then pack —')
+  console.error('  otherwise the version on the device points at code that never existed.')
+  process.exit(1)
+}
+if (commit === 'nogit') {
+  console.warn('! No repository at build time: the bundle cannot name its commit.')
+}
+
+console.log(`✓ app.json and bundle agree on v${want} (${commit})`)
 await $`bunx --bun evenhub pack app.json dist`

--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -247,7 +247,7 @@ async function main(): Promise<void> {
   // gate on it, or the browser debug simulator would never start.
   const isEvenHub =
     typeof (window as unknown as Record<string, unknown>).flutter_inappwebview !== 'undefined'
-  trace(`main: v${__APP_VERSION__} isEvenHub=${isEvenHub}`)
+  trace(`main: v${__APP_VERSION__} (${__BUILD_COMMIT__}) isEvenHub=${isEvenHub}`)
   const bridge = isEvenHub ? await initDisplay() : null
   trace(`bridge=${bridge ? 'ready' : 'null'}`)
 

--- a/glasses/src/vite-env.d.ts
+++ b/glasses/src/vite-env.d.ts
@@ -4,3 +4,9 @@
  *  decides it. Lets a log line answer "which build is on the device?" outright
  *  instead of by comparing timestamps against when a build was promoted. */
 declare const __APP_VERSION__: string
+
+/** Short commit the bundle was built from, `+dirty` when `src/` or the shared
+ *  types had uncommitted edits, `nogit` when the build had no repository to
+ *  ask. The version says which number a build claims; this says which code it
+ *  contains, which is the question a log line actually has to answer. */
+declare const __BUILD_COMMIT__: string

--- a/glasses/vite.config.ts
+++ b/glasses/vite.config.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 
@@ -8,8 +9,39 @@ import { defineConfig } from 'vite'
 // from app.json so it cannot drift from what was packed.
 const APP_VERSION = JSON.parse(readFileSync(new URL('./app.json', import.meta.url), 'utf-8')).version
 
+/**
+ * The commit this bundle was built from.
+ *
+ * A version number says which number a build claims, not which code it
+ * contains: main can move past the last packed ehpk while `app.json` still
+ * reads the same, and then two different bundles both answer "v0.1.51". The
+ * hash cannot do that.
+ *
+ * `+dirty` means the source had uncommitted edits at build time, so the hash
+ * names a commit the bundle does not actually match. Only `src/` and the
+ * shared types count: `app.json` and `out.ehpk` are modified as a normal part
+ * of every release, and flagging those would make the mark meaningless.
+ */
+function buildCommit(): string {
+  const git = (args: string[]) =>
+    execFileSync('git', args, { cwd: new URL('.', import.meta.url).pathname, encoding: 'utf-8' }).trim()
+  try {
+    const head = git(['rev-parse', '--short', 'HEAD'])
+    const dirty = git(['status', '--porcelain', '--', 'src', '../shared']).length > 0
+    return dirty ? `${head}+dirty` : head
+  } catch {
+    // A tarball with no .git, or no git at all. Say so rather than invent one.
+    return 'nogit'
+  }
+}
+
+const BUILD_COMMIT = buildCommit()
+
 export default defineConfig(({ mode }) => ({
-  define: { __APP_VERSION__: JSON.stringify(APP_VERSION) },
+  define: {
+    __APP_VERSION__: JSON.stringify(APP_VERSION),
+    __BUILD_COMMIT__: JSON.stringify(BUILD_COMMIT),
+  },
   // public/ holds the simulator's backdrop photo, which only the web build
   // wants: the G2 bundle has no browser simulator, and the ehpk is shipped to
   // the device where every KB is dead weight. `--mode device` drops it.


### PR DESCRIPTION
## なぜ

版数は「どの番号を名乗るか」であって「どのコードを含むか」ではない。

今日それが実際に起きた。#627 をマージした後、main の `app.json` は `0.1.51` のままでソースだけ先に進んだ。**この状態で誰かが pack すると、EVEN Hub 上の v0.1.51 とは中身の違う「v0.1.51」ができる。** #612 で版数ガードを入れて潰したはずの問題が、そのガードが見ていない側の扉から入ってくる。

コミットハッシュなら同じことは起きない。

## やったこと

起動ログにコミットを載せる:

```
[glasses] main: v0.1.51 (cab2a76) isEvenHub=true
```

### `+dirty`

ビルド時にソースが未コミットだった場合に付く。ハッシュが指すコミットとバンドルの中身が一致しないことを意味する。

対象は `src/` と `shared/` のみ。`app.json` と `out.ehpk` はリリースのたびに変わるのが正常なので、それを拾うと印が常時点灯して意味を失う。

### pack が dirty を拒否する

```
✗ The bundle was built from uncommitted source (cab2a76+dirty).
  Commit glasses/src (and shared/) first, rebuild, then pack —
  otherwise the version on the device points at code that never existed.
```

dirty のまま出荷すると、実機が**存在しないコードを名乗る**ことになり、Hub 側からも実機側からも後で正体を突き止められない。版数不一致を止めるのと同じ理由で止める。

`.git` が無い環境では `nogit` を埋めて警告だけ出す（嘘のハッシュを作らない）。

## 検証

```
未コミット状態: main: v0.1.51 (cab2a76+dirty)  → pack が exit 1 で停止
コミット後    : main: v0.1.51 (e5a53a4)        → pack 成功
```

`out.ehpk` は再ビルドで変わるが、この PR は版上げではないので HEAD に戻してある（別物の v0.1.51 を作らないため）。

全テストパス（backend 499 / frontend 78 / glasses 100）、lint クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np