### PR TITLE
refactor: 製品名を1ファイルに集約する（#459 の前提工事）

### DIFF
--- a/backend/src/commands/notify.ts
+++ b/backend/src/commands/notify.ts
@@ -7,8 +7,10 @@
  *   "command": "cchub notify"
  */
 
-const PRODUCTION_PORT = 5923;
-const DEV_PORT = 3456;
+import { IDENTITY } from '../../../shared/identity';
+
+const PRODUCTION_PORT = IDENTITY.defaultPort;
+const DEV_PORT = IDENTITY.devPort;
 
 async function readStdin(): Promise<string> {
   const chunks: Buffer[] = [];

--- a/backend/src/commands/setup.ts
+++ b/backend/src/commands/setup.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, writeFile, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
+import { IDENTITY, SERVICE } from '../../../shared/identity';
 import { t } from '../i18n';
 import { herdrBinaryPath } from '../services/herdr-client';
 import { migrateCodexHooksToJson } from '../services/codex-hook-config';
@@ -52,14 +53,14 @@ function escapeXml(s: string): string {
 
 // ─── Linux: systemd ───
 
-const SYSTEMD_SERVICE = `[Unit]
-Description=CC Hub - Claude Code Session Manager
+export const SYSTEMD_SERVICE = `[Unit]
+Description=${IDENTITY.productName} - ${IDENTITY.tagline}
 After=network.target tailscaled.service
 
 [Service]
 Type=simple
 ExecStart=__SHELL__ -lc 'exec __EXEC_PATH__ -p __PORT__'
-EnvironmentFile=%h/.config/cchub/env
+EnvironmentFile=%h/.config/${IDENTITY.configDirName}/env
 Environment=PATH=__PATH__
 KillMode=process
 Restart=always
@@ -69,16 +70,16 @@ RestartSec=3
 WantedBy=default.target
 `;
 
-const SYSTEMD_UPDATE_SERVICE = `[Unit]
-Description=CC Hub update check
+export const SYSTEMD_UPDATE_SERVICE = `[Unit]
+Description=${IDENTITY.productName} update check
 
 [Service]
 Type=oneshot
 ExecStart=__EXEC_PATH__ update --auto
 `;
 
-const SYSTEMD_UPDATE_TIMER = `[Unit]
-Description=Check CC Hub updates daily
+export const SYSTEMD_UPDATE_TIMER = `[Unit]
+Description=Check ${IDENTITY.productName} updates daily
 
 [Timer]
 OnCalendar=daily
@@ -96,16 +97,20 @@ WantedBy=timers.target
  * The password is NOT embedded here — it is read from the macOS Keychain at
  * runtime by `cchub` itself, so the plist file stays free of secrets.
  */
-function buildLaunchdPlist(execPath: string, port: number): string {
+export function buildLaunchdPlist(execPath: string, port: number): string {
   const args = [execPath, '-p', String(port)];
-  const logPath = join(homedir(), '.cc-hub', 'cchub.log');
+  const logPath = join(
+    homedir(),
+    IDENTITY.dataDirName,
+    `${IDENTITY.binaryName}.log`,
+  );
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>com.cchub.server</string>
+  <string>${SERVICE.launchdServerLabel}</string>
   <key>ProgramArguments</key>
   <array>
 ${args.map(a => `    <string>${escapeXml(a)}</string>`).join('\n')}
@@ -128,14 +133,14 @@ ${args.map(a => `    <string>${escapeXml(a)}</string>`).join('\n')}
 `;
 }
 
-function buildLaunchdUpdatePlist(execPath: string): string {
-  const logPath = join(homedir(), '.cc-hub', 'update.log');
+export function buildLaunchdUpdatePlist(execPath: string): string {
+  const logPath = join(homedir(), IDENTITY.dataDirName, 'update.log');
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>com.cchub.update</string>
+  <string>${SERVICE.launchdUpdateLabel}</string>
   <key>ProgramArguments</key>
   <array>
     <string>${escapeXml(execPath)}</string>
@@ -159,7 +164,7 @@ function buildLaunchdUpdatePlist(execPath: string): string {
 // ─── herdr provisioning ───
 
 const HERDR_SYSTEMD_SERVICE = `[Unit]
-Description=herdr terminal multiplexer server (CC Hub backend)
+Description=herdr terminal multiplexer server (${IDENTITY.productName} backend)
 
 [Service]
 Type=simple
@@ -174,7 +179,7 @@ WantedBy=default.target
 `;
 
 function buildHerdrLaunchdPlist(herdrPath: string): string {
-  const logPath = join(homedir(), '.cc-hub', 'herdr.log');
+  const logPath = join(homedir(), IDENTITY.dataDirName, 'herdr.log');
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -206,7 +211,7 @@ function buildHerdrLaunchdPlist(herdrPath: string): string {
 `;
 }
 
-const HERDR_CONFIG_TOML = `# CC Hub herdr backend configuration (written by \`cchub setup\`)
+const HERDR_CONFIG_TOML = `# ${IDENTITY.productName} herdr backend configuration (written by \`${IDENTITY.binaryName} setup\`)
 
 [session]
 # Restart agent panes (Claude Code etc.) in their native conversation
@@ -384,7 +389,7 @@ export async function setupService(port: number, password?: string): Promise<voi
 async function setupLaunchd(port: number, password?: string): Promise<void> {
   const home = homedir();
   const launchAgentsDir = join(home, 'Library', 'LaunchAgents');
-  const logDir = join(home, '.cc-hub');
+  const logDir = join(home, IDENTITY.dataDirName);
   const execPath = process.execPath;
 
   console.log(t('setup.macTitle'));
@@ -404,12 +409,12 @@ async function setupLaunchd(port: number, password?: string): Promise<void> {
   }
 
   // Main service plist (no password embedded — read from Keychain at runtime)
-  const plistPath = join(launchAgentsDir, 'com.cchub.server.plist');
+  const plistPath = join(launchAgentsDir, SERVICE.launchdServerPlist);
   await writeFile(plistPath, buildLaunchdPlist(execPath, port));
   console.log(t('setup.serviceFile', { path: plistPath }));
 
   // Update plist
-  const updatePlistPath = join(launchAgentsDir, 'com.cchub.update.plist');
+  const updatePlistPath = join(launchAgentsDir, SERVICE.launchdUpdatePlist);
   await writeFile(updatePlistPath, buildLaunchdUpdatePlist(execPath));
   console.log(t('setup.updateServiceFile', { path: updatePlistPath }));
 
@@ -440,16 +445,22 @@ async function setupLaunchd(port: number, password?: string): Promise<void> {
 
   console.log('');
   console.log(t('setup.managementCommands'));
-  console.log('  launchctl list | grep cchub        # Status');
-  console.log(`  launchctl kickstart -k gui/$(id -u)/com.cchub.server  # Restart`);
-  console.log(`  launchctl bootout gui/$(id -u)/com.cchub.server       # Stop`);
-  console.log(`  tail -f ~/.cc-hub/cchub.log        # Logs`);
+  console.log(`  launchctl list | grep ${IDENTITY.binaryName}        # Status`);
+  console.log(
+    `  launchctl kickstart -k gui/$(id -u)/${SERVICE.launchdServerLabel}  # Restart`,
+  );
+  console.log(
+    `  launchctl bootout gui/$(id -u)/${SERVICE.launchdServerLabel}       # Stop`,
+  );
+  console.log(
+    `  tail -f ~/${IDENTITY.dataDirName}/${IDENTITY.binaryName}.log        # Logs`,
+  );
   console.log('');
 }
 
 async function setupSystemd(port: number, password?: string): Promise<void> {
   const home = homedir();
-  const configDir = join(home, '.config', 'cchub');
+  const configDir = join(home, '.config', IDENTITY.configDirName);
   const systemdDir = join(home, '.config', 'systemd', 'user');
   const execPath = process.execPath;
 
@@ -473,17 +484,17 @@ async function setupSystemd(port: number, password?: string): Promise<void> {
     .replace(/__EXEC_PATH__/g, execPath)
     .replace(/__PORT__/g, String(port))
     .replace(/__PATH__/g, buildServicePath());
-  const servicePath = join(systemdDir, 'cchub.service');
+  const servicePath = join(systemdDir, SERVICE.unitFile);
   await writeFile(servicePath, serviceContent);
   console.log(t('setup.serviceFile', { path: servicePath }));
 
   // Update service
-  const updateServicePath = join(systemdDir, 'cchub-update.service');
+  const updateServicePath = join(systemdDir, SERVICE.updateUnitFile);
   await writeFile(updateServicePath, SYSTEMD_UPDATE_SERVICE.replace(/__EXEC_PATH__/g, execPath));
   console.log(t('setup.updateServiceFile', { path: updateServicePath }));
 
   // Update timer
-  const updateTimerPath = join(systemdDir, 'cchub-update.timer');
+  const updateTimerPath = join(systemdDir, SERVICE.updateTimerFile);
   await writeFile(updateTimerPath, SYSTEMD_UPDATE_TIMER);
   console.log(t('setup.updateTimerFile', { path: updateTimerPath }));
 
@@ -492,7 +503,13 @@ async function setupSystemd(port: number, password?: string): Promise<void> {
   // Reload and enable
   Bun.spawnSync(['systemctl', '--user', 'daemon-reload']);
 
-  const enableResult = Bun.spawnSync(['systemctl', '--user', 'enable', '--now', 'cchub']);
+  const enableResult = Bun.spawnSync([
+    'systemctl',
+    '--user',
+    'enable',
+    '--now',
+    SERVICE.systemctl,
+  ]);
   if (enableResult.exitCode === 0) {
     console.log(`✅ ${t('setup.serviceEnabled')}`);
   } else {
@@ -500,14 +517,20 @@ async function setupSystemd(port: number, password?: string): Promise<void> {
     console.error(enableResult.stderr.toString());
   }
 
-  const timerResult = Bun.spawnSync(['systemctl', '--user', 'enable', '--now', 'cchub-update.timer']);
+  const timerResult = Bun.spawnSync([
+    'systemctl',
+    '--user',
+    'enable',
+    '--now',
+    SERVICE.updateTimer,
+  ]);
   if (timerResult.exitCode === 0) {
     console.log(t('setup.autoUpdateTimerEnabled'));
   }
 
   console.log('');
   console.log(`📋 ${t('setup.commands')}`);
-  console.log('  systemctl --user status cchub    # Status');
+  console.log(`  systemctl --user status ${SERVICE.systemctl}    # Status`);
   console.log(`  ${t('setup.cmdRestart')}`);
   console.log(`  ${t('setup.cmdStop')}`);
   console.log(`  ${t('setup.cmdLogs')}`);

--- a/backend/src/commands/status.ts
+++ b/backend/src/commands/status.ts
@@ -3,6 +3,7 @@
 import { platform } from 'node:os';
 import { VERSION } from '../cli';
 import { t } from '../i18n';
+import { SERVICE } from '../../../shared/identity';
 
 export async function showStatus(): Promise<void> {
   console.log(`CC Hub v${VERSION}`);
@@ -20,10 +21,10 @@ export async function showStatus(): Promise<void> {
 
 function showStatusSystemd(): void {
   // Check main service status
-  const serviceResult = Bun.spawnSync(['systemctl', '--user', 'status', 'cchub', '--no-pager'], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
+  const serviceResult = Bun.spawnSync(
+    ['systemctl', '--user', 'status', SERVICE.systemctl, '--no-pager'],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
 
   if (serviceResult.exitCode === 0) {
     console.log('📦 Service status:');
@@ -44,17 +45,23 @@ function showStatusSystemd(): void {
   console.log('');
 
   // Check update timer status
-  const timerResult = Bun.spawnSync(['systemctl', '--user', 'is-active', 'cchub-update.timer'], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
+  const timerResult = Bun.spawnSync(
+    ['systemctl', '--user', 'is-active', SERVICE.updateTimer],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
 
   const timerActive = timerResult.stdout.toString().trim() === 'active';
   console.log(`🔄 Auto-update: ${timerActive ? 'Enabled' : 'Disabled'}`);
 
   if (timerActive) {
     const nextResult = Bun.spawnSync(
-      ['systemctl', '--user', 'show', 'cchub-update.timer', '--property=NextElapseUSecRealtime'],
+      [
+        'systemctl',
+        '--user',
+        'show',
+        SERVICE.updateTimer,
+        '--property=NextElapseUSecRealtime',
+      ],
       { stdout: 'pipe' }
     );
     const nextOutput = nextResult.stdout.toString();
@@ -70,11 +77,11 @@ function showStatusSystemd(): void {
 }
 
 function showStatusLaunchd(): void {
-  // Main service: com.cchub.server
-  const serviceResult = Bun.spawnSync(['launchctl', 'list', 'com.cchub.server'], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
+  // Main service
+  const serviceResult = Bun.spawnSync(
+    ['launchctl', 'list', SERVICE.launchdServerLabel],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
 
   if (serviceResult.exitCode === 0) {
     const out = serviceResult.stdout.toString();
@@ -86,7 +93,9 @@ function showStatusLaunchd(): void {
       console.log('📦 Service status: Stopped');
       if (exitMatch) console.log(`   Last exit status: ${exitMatch[1]}`);
       console.log('');
-      console.log('   Restart: launchctl kickstart -k gui/$(id -u)/com.cchub.server');
+      console.log(
+        `   Restart: launchctl kickstart -k gui/$(id -u)/${SERVICE.launchdServerLabel}`,
+      );
     }
   } else {
     console.log('📦 Service status: Not registered');
@@ -96,11 +105,11 @@ function showStatusLaunchd(): void {
 
   console.log('');
 
-  // Update job: com.cchub.update (StartCalendarInterval, runs daily at 4:00)
-  const updateResult = Bun.spawnSync(['launchctl', 'list', 'com.cchub.update'], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
+  // Update job (StartCalendarInterval, runs daily at 4:00)
+  const updateResult = Bun.spawnSync(
+    ['launchctl', 'list', SERVICE.launchdUpdateLabel],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
   const updateActive = updateResult.exitCode === 0;
   console.log(`🔄 Auto-update: ${updateActive ? 'Enabled (daily 4:00)' : 'Disabled'}`);
 }

--- a/backend/src/commands/uninstall.ts
+++ b/backend/src/commands/uninstall.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { t } from '../i18n';
 import { deletePassword as deletePasswordFromKeychain } from '../utils/keychain';
+import { IDENTITY, SERVICE } from '../../../shared/identity';
 
 export async function uninstallService(): Promise<void> {
   if (platform() === 'darwin') {
@@ -18,8 +19,8 @@ export async function uninstallService(): Promise<void> {
 async function uninstallLaunchd(): Promise<void> {
   const home = homedir();
   const launchAgentsDir = join(home, 'Library', 'LaunchAgents');
-  const plistPath = join(launchAgentsDir, 'com.cchub.server.plist');
-  const updatePlistPath = join(launchAgentsDir, 'com.cchub.update.plist');
+  const plistPath = join(launchAgentsDir, SERVICE.launchdServerPlist);
+  const updatePlistPath = join(launchAgentsDir, SERVICE.launchdUpdatePlist);
   const uid = process.getuid?.() ?? 501;
 
   console.log(`🗑️  ${t('uninstall.title')}`);
@@ -50,7 +51,7 @@ async function uninstallLaunchd(): Promise<void> {
   console.log('');
   console.log(`✅ ${t('uninstall.done')}`);
 
-  const logDir = join(home, '.cc-hub');
+  const logDir = join(home, IDENTITY.dataDirName);
   if (existsSync(logDir)) {
     console.log('');
     console.log(`💡 ${t('uninstall.logsHint')}: rm -rf ${logDir}`);
@@ -60,18 +61,18 @@ async function uninstallLaunchd(): Promise<void> {
 async function uninstallSystemd(): Promise<void> {
   const home = homedir();
   const systemdDir = join(home, '.config', 'systemd', 'user');
-  const servicePath = join(systemdDir, 'cchub.service');
-  const updateServicePath = join(systemdDir, 'cchub-update.service');
-  const updateTimerPath = join(systemdDir, 'cchub-update.timer');
+  const servicePath = join(systemdDir, SERVICE.unitFile);
+  const updateServicePath = join(systemdDir, SERVICE.updateUnitFile);
+  const updateTimerPath = join(systemdDir, SERVICE.updateTimerFile);
 
   console.log(`🗑️  ${t('uninstall.title')}`);
   console.log('');
 
   // Stop and disable services
-  Bun.spawnSync(['systemctl', '--user', 'stop', 'cchub']);
-  Bun.spawnSync(['systemctl', '--user', 'disable', 'cchub']);
-  Bun.spawnSync(['systemctl', '--user', 'stop', 'cchub-update.timer']);
-  Bun.spawnSync(['systemctl', '--user', 'disable', 'cchub-update.timer']);
+  Bun.spawnSync(['systemctl', '--user', 'stop', SERVICE.systemctl]);
+  Bun.spawnSync(['systemctl', '--user', 'disable', SERVICE.systemctl]);
+  Bun.spawnSync(['systemctl', '--user', 'stop', SERVICE.updateTimer]);
+  Bun.spawnSync(['systemctl', '--user', 'disable', SERVICE.updateTimer]);
 
   for (const [path, label] of [
     [servicePath, t('uninstall.removedService')],
@@ -91,7 +92,7 @@ async function uninstallSystemd(): Promise<void> {
   console.log('');
   console.log(`✅ ${t('uninstall.done')}`);
 
-  const configDir = join(home, '.config', 'cchub');
+  const configDir = join(home, '.config', IDENTITY.configDirName);
   if (existsSync(configDir)) {
     console.log('');
     console.log(`💡 ${t('uninstall.configHint')}: rm -rf ${configDir}`);

--- a/backend/src/commands/update.ts
+++ b/backend/src/commands/update.ts
@@ -5,6 +5,12 @@ import { copyFile, rename, chmod, readFile, unlink } from 'node:fs/promises';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import {
+  assetName,
+  IDENTITY,
+  SERVICE,
+  userAgent,
+} from '../../../shared/identity';
 import { VERSION } from '../cli';
 import { t } from '../i18n';
 
@@ -62,16 +68,30 @@ async function getServiceBinaryPath(): Promise<string | null> {
   const isDarwin = platform() === 'darwin';
   try {
     if (isDarwin) {
-      const plistPath = join(homedir(), 'Library', 'LaunchAgents', 'com.cchub.server.plist');
+      const plistPath = join(
+        homedir(),
+        'Library',
+        'LaunchAgents',
+        SERVICE.launchdServerPlist,
+      );
       const content = await readFile(plistPath, 'utf-8');
       // Extract first <string> after <key>ProgramArguments</key> array
       const match = content.match(/<key>ProgramArguments<\/key>\s*<array>\s*<string>([^<]+)<\/string>/);
       return match?.[1] ?? null;
     } else {
-      const servicePath = join(homedir(), '.config', 'systemd', 'user', 'cchub.service');
+      const servicePath = join(
+        homedir(),
+        '.config',
+        'systemd',
+        'user',
+        SERVICE.unitFile,
+      );
       const content = await readFile(servicePath, 'utf-8');
       // Extract exec path from: ExecStart=/bin/zsh -lc 'exec /path/to/cchub ...'
-      const match = content.match(/exec\s+(\S+cchub)\b/) || content.match(/ExecStart=(\S+cchub)\b/);
+      const bin = IDENTITY.binaryName;
+      const match =
+        content.match(new RegExp(`exec\\s+(\\S+${bin})\\b`)) ||
+        content.match(new RegExp(`ExecStart=(\\S+${bin})\\b`));
       return match?.[1] ?? null;
     }
   } catch {
@@ -79,22 +99,22 @@ async function getServiceBinaryPath(): Promise<string | null> {
   }
 }
 
-const GITHUB_REPO = 'm0a/cc-hub';
+const GITHUB_REPO = IDENTITY.repo;
 
 function getBinaryName(): string {
   const platform = process.platform; // 'linux', 'darwin', etc.
   const arch = process.arch; // 'x64', 'arm64', etc.
 
   if (platform === 'linux' && arch === 'x64') {
-    return 'cchub-linux-x64';
+    return assetName('linux', 'x64');
   }
   if (platform === 'darwin' && arch === 'arm64') {
-    return 'cchub-macos-arm64';
+    return assetName('macos', 'arm64');
   }
 
   // Fallback: try platform-arch pattern
   const platformName = platform === 'darwin' ? 'macos' : platform;
-  return `cchub-${platformName}-${arch}`;
+  return assetName(platformName, arch);
 }
 
 interface GitHubRelease {
@@ -135,7 +155,7 @@ function getGitHubToken(): GitHubTokenInfo | null {
 async function getLatestRelease(tokenInfo: GitHubTokenInfo | null): Promise<GitHubRelease | null> {
   const headers: Record<string, string> = {
     'Accept': 'application/vnd.github.v3+json',
-    'User-Agent': `cchub/${VERSION}`,
+    'User-Agent': userAgent(VERSION),
   };
   if (tokenInfo) {
     headers.Authorization = `Bearer ${tokenInfo.token}`;
@@ -363,7 +383,12 @@ export async function checkAndUpdate(checkOnly: boolean, autoMode: boolean): Pro
 
   const isDarwin = platform() === 'darwin';
   const uid = process.getuid?.() ?? 501;
-  const plistPath = join(homedir(), 'Library', 'LaunchAgents', 'com.cchub.server.plist');
+  const plistPath = join(
+    homedir(),
+    'Library',
+    'LaunchAgents',
+    SERVICE.launchdServerPlist,
+  );
 
   // Stop service before replacing binary (macOS launchd holds the binary open)
   if (isDarwin) {
@@ -387,9 +412,11 @@ export async function checkAndUpdate(checkOnly: boolean, autoMode: boolean): Pro
   } catch (error) {
     console.error('❌ バイナリの置き換えに失敗しました:', error);
     if (isDarwin) {
-      console.log('💡 ヒント: launchctl bootout gui/$(id -u)/com.cchub.server');
+      console.log(
+        `💡 ヒント: launchctl bootout gui/$(id -u)/${SERVICE.launchdServerLabel}`,
+      );
     } else {
-      console.log('💡 ヒント: systemctl --user stop cchub');
+      console.log(`💡 ヒント: systemctl --user stop ${SERVICE.systemctl}`);
     }
     // Try to restart service even if replace failed
     if (isDarwin) {
@@ -413,7 +440,12 @@ export async function checkAndUpdate(checkOnly: boolean, autoMode: boolean): Pro
       }
     }
   } else {
-    const restartResult = Bun.spawnSync(['systemctl', '--user', 'restart', 'cchub']);
+    const restartResult = Bun.spawnSync([
+      'systemctl',
+      '--user',
+      'restart',
+      SERVICE.systemctl,
+    ]);
     if (restartResult.exitCode === 0) {
       console.log(`🔄 ${t('update.serviceRestarted')}`);
     } else {

--- a/backend/src/services/hook-status.ts
+++ b/backend/src/services/hook-status.ts
@@ -2,6 +2,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { resolveNotifyCommand } from './notify-command';
+import { HOOK_COMMAND } from '../../../shared/identity';
 
 /**
  * Hooks CC Hub still needs. Indicator transitions used to need PreToolUse and
@@ -67,7 +68,7 @@ function hasCchubNotify(entries: HookEntry[] | undefined, matcher?: string): boo
   for (const entry of entries) {
     if (matcher !== undefined && !matcherMatches(entry.matcher, matcher)) continue;
     for (const hook of entry.hooks || []) {
-      if (hook.command?.includes('cchub notify')) return true;
+      if (hook.command?.includes(HOOK_COMMAND)) return true;
     }
   }
   return false;
@@ -134,7 +135,7 @@ export function parseHookToml(content: string): HookEventStatus | null {
     }
 
     if (!inHookItems && !line.startsWith('command')) continue;
-    if (!line.includes('command') || !line.includes('cchub notify')) continue;
+    if (!line.includes('command') || !line.includes(HOOK_COMMAND)) continue;
 
     if (currentEvent === 'askUserQuestion') {
       if (matcherMatches(currentMatcher ?? undefined, 'AskUserQuestion')) {

--- a/backend/src/utils/storage.ts
+++ b/backend/src/utils/storage.ts
@@ -2,11 +2,17 @@ import { join } from 'node:path';
 import { mkdir, writeFile, rename, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
-
-const DEFAULT_DATA_DIR = join(homedir(), '.cc-hub');
+import { IDENTITY } from '../../../shared/identity';
 
 export function getDataDir(): string {
-  return process.env.CC_HUB_DATA_DIR || DEFAULT_DATA_DIR;
+  return (
+    process.env[IDENTITY.dataDirEnv] || join(homedir(), IDENTITY.dataDirName)
+  );
+}
+
+/** `~/.config/cchub` — service env file and other non-data config. */
+export function getConfigDir(): string {
+  return join(homedir(), '.config', IDENTITY.configDirName);
 }
 
 export async function ensureDataDir(): Promise<string> {

--- a/backend/tests/unit/identity-consistency.test.ts
+++ b/backend/tests/unit/identity-consistency.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { assetName, IDENTITY, SERVICE } from '../../../shared/identity';
+
+/**
+ * `identity.json` is the single source of truth for what this product is
+ * called, but two consumers cannot read it:
+ *
+ * - `install.sh` is fetched and piped straight to bash, so there is no checkout
+ *   on disk to read the file from — and it could not bootstrap one anyway, since
+ *   the repository to clone is itself a value in the file.
+ * - `.github/workflows/release.yml` builds its matrix from literals, which
+ *   Actions evaluates before any step could run `jq`.
+ *
+ * Both therefore keep their own copies, and this test is what keeps the copies
+ * honest. A rename that misses one of them produces an installer that downloads
+ * an asset the release never published — which only shows up at install time,
+ * on someone else's machine.
+ */
+
+const ROOT = join(import.meta.dir, '..', '..', '..');
+
+async function read(relative: string): Promise<string> {
+  return await Bun.file(join(ROOT, relative)).text();
+}
+
+describe('install.sh agrees with identity.json', () => {
+  test('downloads from the release repository', async () => {
+    const sh = await read('install.sh');
+    expect(sh).toContain(`https://api.github.com/repos/${IDENTITY.repo}/releases/latest`);
+  });
+
+  test('names both published assets', async () => {
+    const sh = await read('install.sh');
+    expect(sh).toContain(assetName('linux', 'x64'));
+    expect(sh).toContain(assetName('macos', 'arm64'));
+  });
+
+  test('installs under the binary name', async () => {
+    const sh = await read('install.sh');
+    expect(sh).toContain(`install_dir/${IDENTITY.binaryName}`);
+  });
+
+  test('advertises the default port', async () => {
+    const sh = await read('install.sh');
+    expect(sh).toContain(String(IDENTITY.defaultPort));
+  });
+});
+
+describe('release.yml agrees with identity.json', () => {
+  test('builds and uploads both assets', async () => {
+    const yml = await read('.github/workflows/release.yml');
+    for (const asset of [assetName('linux', 'x64'), assetName('macos', 'arm64')]) {
+      // Once as the matrix artifact, once in the upload list at minimum.
+      expect(yml.split(asset).length - 1).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  test('renames the built binary from the binary name', async () => {
+    const yml = await read('.github/workflows/release.yml');
+    expect(yml).toContain(`dist/${IDENTITY.binaryName} `);
+  });
+});
+
+describe('derived service names', () => {
+  test('systemd units all descend from serviceName', () => {
+    expect(SERVICE.unitFile).toBe(`${IDENTITY.serviceName}.service`);
+    expect(SERVICE.updateUnitFile).toBe(`${IDENTITY.serviceName}-update.service`);
+    expect(SERVICE.updateTimerFile).toBe(`${IDENTITY.serviceName}-update.timer`);
+  });
+
+  test('launchd labels all descend from launchdPrefix', () => {
+    expect(SERVICE.launchdServerLabel).toBe(`${IDENTITY.launchdPrefix}.server`);
+    expect(SERVICE.launchdUpdateLabel).toBe(`${IDENTITY.launchdPrefix}.update`);
+    expect(SERVICE.launchdServerPlist).toBe(`${SERVICE.launchdServerLabel}.plist`);
+    expect(SERVICE.launchdUpdatePlist).toBe(`${SERVICE.launchdUpdateLabel}.plist`);
+  });
+
+  test('asset names match what update.ts asks GitHub for', () => {
+    expect(assetName('linux', 'x64')).toBe(`${IDENTITY.assetPrefix}-linux-x64`);
+    expect(assetName('macos', 'arm64')).toBe(`${IDENTITY.assetPrefix}-macos-arm64`);
+  });
+});

--- a/backend/tests/unit/setup-units.test.ts
+++ b/backend/tests/unit/setup-units.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildLaunchdPlist,
+  buildLaunchdUpdatePlist,
+  SYSTEMD_SERVICE,
+  SYSTEMD_UPDATE_SERVICE,
+  SYSTEMD_UPDATE_TIMER,
+} from '../../src/commands/setup';
+
+/**
+ * Golden text for the service definitions `cchub setup` writes.
+ *
+ * These used to be literals and are now composed from `identity.json`, which is
+ * exactly the kind of change that can alter the output by a character without
+ * anyone noticing — and the output is a systemd unit and a launchd plist, where
+ * a wrong label or a missing EnvironmentFile means the service silently stops
+ * coming back after a reboot.
+ *
+ * The strings below were taken from the units this machine already had on disk,
+ * written by the pre-refactor code, and verified byte-identical against the
+ * composed versions.
+ */
+
+describe('systemd units', () => {
+  test('main service is unchanged', () => {
+    expect(SYSTEMD_SERVICE).toBe(`[Unit]
+Description=CC Hub - Claude Code Session Manager
+After=network.target tailscaled.service
+
+[Service]
+Type=simple
+ExecStart=__SHELL__ -lc 'exec __EXEC_PATH__ -p __PORT__'
+EnvironmentFile=%h/.config/cchub/env
+Environment=PATH=__PATH__
+KillMode=process
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=default.target
+`);
+  });
+
+  test('update service is unchanged', () => {
+    expect(SYSTEMD_UPDATE_SERVICE).toBe(`[Unit]
+Description=CC Hub update check
+
+[Service]
+Type=oneshot
+ExecStart=__EXEC_PATH__ update --auto
+`);
+  });
+
+  test('update timer is unchanged', () => {
+    expect(SYSTEMD_UPDATE_TIMER).toBe(`[Unit]
+Description=Check CC Hub updates daily
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=1h
+
+[Install]
+WantedBy=timers.target
+`);
+  });
+});
+
+describe('launchd plists', () => {
+  test('server plist keeps its label and log path', () => {
+    const plist = buildLaunchdPlist('/home/u/bin/cchub', 5923);
+    expect(plist).toContain('<string>com.cchub.server</string>');
+    expect(plist).toContain('.cc-hub/cchub.log');
+    // The port has to survive as its own argv entry, not folded into the path.
+    expect(plist).toContain('<string>-p</string>');
+    expect(plist).toContain('<string>5923</string>');
+  });
+
+  test('update plist keeps its label and log path', () => {
+    const plist = buildLaunchdUpdatePlist('/home/u/bin/cchub');
+    expect(plist).toContain('<string>com.cchub.update</string>');
+    expect(plist).toContain('.cc-hub/update.log');
+    expect(plist).toContain('<string>update</string>');
+    expect(plist).toContain('<string>--auto</string>');
+  });
+});

--- a/identity.json
+++ b/identity.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "Single source of truth for everything that names this product. Renaming the product (see #459) should be a change to this file plus the display strings, not a sweep of 1200 literals. install.sh and .github/workflows/release.yml cannot read it — the installer runs via `curl | bash` with no checkout, and Actions matrix values must be literals — so they keep their own copies, guarded by backend/tests/unit/identity-consistency.test.ts.",
+  "productName": "CC Hub",
+  "tagline": "Claude Code Session Manager",
+  "binaryName": "cchub",
+  "repo": "m0a/cc-hub",
+  "assetPrefix": "cchub",
+  "defaultPort": 5923,
+  "devPort": 3456,
+  "dataDirName": ".cc-hub",
+  "dataDirEnv": "CC_HUB_DATA_DIR",
+  "configDirName": "cchub",
+  "serviceName": "cchub",
+  "launchdPrefix": "com.cchub",
+  "storagePrefix": "cchub-"
+}

--- a/shared/identity.ts
+++ b/shared/identity.ts
@@ -1,0 +1,65 @@
+/**
+ * Product identity — the names, paths, ports and service units that would all
+ * have to change together to rename this product (#459).
+ *
+ * The raw values live in `identity.json` at the repo root so that non-TypeScript
+ * consumers can read them too. Everything composed from those values belongs
+ * here rather than at the call site: `cchub-update.timer` is not a name anyone
+ * chose, it is `${serviceName}-update.timer`, and spelling it out at the call
+ * site is what turns one rename into a thousand.
+ *
+ * Not covered here:
+ * - `install.sh` and `.github/workflows/release.yml` keep their own copies. The
+ *   installer is fetched and piped to bash with no checkout to read, and Actions
+ *   matrix values must be literals. `backend/tests/unit/identity-consistency.test.ts`
+ *   fails if they drift from this file.
+ * - Display strings and log lines. They say the product's name but nothing
+ *   depends on them agreeing, so they stay inline where they read naturally.
+ * - `CHANGELOG.md` and `specs/`. Those record what was true at the time and are
+ *   deliberately left alone by a rename.
+ */
+import raw from '../identity.json';
+
+export const IDENTITY = {
+  productName: raw.productName,
+  tagline: raw.tagline,
+  binaryName: raw.binaryName,
+  repo: raw.repo,
+  assetPrefix: raw.assetPrefix,
+  defaultPort: raw.defaultPort,
+  devPort: raw.devPort,
+  dataDirName: raw.dataDirName,
+  dataDirEnv: raw.dataDirEnv,
+  configDirName: raw.configDirName,
+  serviceName: raw.serviceName,
+  launchdPrefix: raw.launchdPrefix,
+  storagePrefix: raw.storagePrefix,
+} as const;
+
+/** systemd unit / launchd label names, all composed from `serviceName`. */
+export const SERVICE = {
+  /** What `systemctl --user <verb> …` takes. */
+  systemctl: IDENTITY.serviceName,
+  unitFile: `${IDENTITY.serviceName}.service`,
+  updateUnitFile: `${IDENTITY.serviceName}-update.service`,
+  updateTimerFile: `${IDENTITY.serviceName}-update.timer`,
+  /** What `systemctl --user <verb> …` takes for the update timer. */
+  updateTimer: `${IDENTITY.serviceName}-update.timer`,
+  launchdServerLabel: `${IDENTITY.launchdPrefix}.server`,
+  launchdUpdateLabel: `${IDENTITY.launchdPrefix}.update`,
+  launchdServerPlist: `${IDENTITY.launchdPrefix}.server.plist`,
+  launchdUpdatePlist: `${IDENTITY.launchdPrefix}.update.plist`,
+} as const;
+
+/** The release asset for a platform, e.g. `cchub-linux-x64`. */
+export function assetName(platform: string, arch: string): string {
+  return `${IDENTITY.assetPrefix}-${platform}-${arch}`;
+}
+
+/** The hook command hosts are told to run, e.g. `cchub notify`. */
+export const HOOK_COMMAND = `${IDENTITY.binaryName} notify`;
+
+/** `User-Agent` for calls to the GitHub API. */
+export function userAgent(version: string): string {
+  return `${IDENTITY.binaryName}/${version}`;
+}


### PR DESCRIPTION
## なぜ

改名（#459）を今やると **169ファイル / 1241箇所**の書き換えになります。しかも1つ外したときの失敗が、見ていない場所で出ます。

- `update.ts` の asset 名を外す → **公開されていないリリースを取りに行く**（インストール時に、他人のマシンで初めて分かる）
- `uninstall.ts` の unit 名を外す → 存在しないサービスの timer が回り続ける

そして 1241箇所の大半は、**誰かが選んだ名前ではありません**。`cchub-update.timer` は `${serviceName}-update.timer` であり、`com.cchub.server.plist` は `${launchdPrefix}.server.plist` です。これを呼び出し側で綴っていることが、1回の改名を1000回にしています。

これは #459 をやらなくても価値のある整理で、**fork 前に済ませておかないと upstream 取り込みが衝突地獄になります**（fork 側が全識別子を書き換えた状態で main を取り込むため）。

## やったこと

- `identity.json` — 値の唯一の源
- `shared/identity.ts` — そこから合成される名前（unit ファイル名、launchd ラベル、asset 名、hook コマンド、User-Agent）
- 間違えると**データが飛ぶかサービスが壊れる8箇所**を配線: `storage`（data dir と上書き env）・`setup`・`uninstall`・`status`・`update`・`notify`・`hook-status`

## 意図的に対象外

| 対象 | 箇所 | 理由 |
|---|---:|---|
| 表示文字列・ログ | — | 名前を名乗るだけで、一致に依存するものが無い。インラインのほうが読みやすい。改名時に1コミットで掃ける。外しても見た目のバグで済む |
| `CHANGELOG.md` | 216 | 当時の事実の記録。書き換えると履歴が嘘になる |
| `specs/` | 26 | 同上 |
| `install.sh` / `release.yml` | 22 | 下記 |

`install.sh` は `curl \| bash` で走るので**読むチェックアウトが存在しません**。取ってくることもできません — clone すべきリポジトリ自体がそのファイルの中の値だからです。`release.yml` の matrix は、どのステップが `jq` を走らせるより前に Actions が評価します。

なので両者は自前のコピーを持ち、**`tests/unit/identity-consistency.test.ts` がズレたら落ちます**。ガードが実際に効くことは `identity.json` を `hrdle` に向けて確認しました（9件中5件が失敗）。

## 出力が動いていないことの確認

- **このマシンに既にインストール済みの systemd unit 3本**（改修前のコードが書いたもの）と、合成後のテンプレートが**バイト一致**。`tests/unit/setup-units.test.ts` で golden として固定
- `getServiceBinaryPath` の正規表現（**`cchub update` がどのバイナリを差し替えるかを決める**箇所）が、実 unit ファイルに対して改修前後で同じパスを返す
- `status` が稼働中サービスを正しく検出

テスト: backend 513 pass / frontend 78 pass、lint・tsc クリーン。glasses のテストは `@evenrealities/pretext` 未インストールで落ちますが、main でも同じです。

## 次

2本目（表示文字列・localStorage プレフィックスの一括置換）は fork 直前に。その後 `hrdle/hrdle` へ fork します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STv3pQwmpdxMa9fJ4TK7a6