### PR TITLE
refactor: 実行時パスも identity に寄せる

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import { AuthService } from './services/auth';
 import { getDataDir } from './utils/storage';
 import { herdrBinaryPath, herdrRpc, herdrSocketPath } from './services/herdr-client';
 import { t } from './i18n';
+import { TMP_PATHS } from '../../shared/identity';
 
 // Global error handlers to prevent silent crashes
 process.on('uncaughtException', (err) => {
@@ -116,7 +117,7 @@ addLog('Version: ${VERSION}',true);
 app.route('/api/auth', auth);
 
 // Public images route (no auth required - images are user-uploaded screenshots)
-const IMAGES_DIR = '/tmp/cchub-images';
+const IMAGES_DIR = TMP_PATHS.imagesDir;
 app.get('/api/images/:filename', async (c) => {
   const { readFile } = await import('node:fs/promises');
   const { join, basename } = await import('node:path');

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -6,6 +6,7 @@ import { FileService } from '../services/file-service';
 import { FileChangeTracker } from '../services/file-change-tracker';
 import { HerdrService } from '../services/herdr';
 import type { FileListResponse, FileReadResponse, FileChangesResponse, FileInfo, GitChangesResponse, GitDiffResponse, GitFileChange, GitChangeStatus } from '../../../shared/types';
+import { TMP_PATHS } from '../../../shared/identity';
 
 const fileService = new FileService();
 const changeTracker = new FileChangeTracker();
@@ -333,7 +334,7 @@ files.get('/language', async (c) => {
  * GET /files/images/:filename - Serve conversation images
  * Only serves images from /tmp/cchub-images/ for security
  */
-const IMAGES_DIR = '/tmp/cchub-images';
+const IMAGES_DIR = TMP_PATHS.imagesDir;
 
 files.get('/images/:filename', async (c) => {
   const filename = c.req.param('filename');

--- a/backend/src/routes/logs.ts
+++ b/backend/src/routes/logs.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
 import { appendFile } from 'node:fs/promises';
+import { TMP_PATHS } from '../../../shared/identity';
 
-const LOG_FILE = '/tmp/cc-hub-browser.log';
+const LOG_FILE = TMP_PATHS.browserLogFile;
 
 const logs = new Hono();
 

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -2,11 +2,12 @@ import { Hono } from 'hono';
 import { randomBytes } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { TMP_PATHS } from '../../../shared/identity';
 
 const upload = new Hono();
 
 // Directory for uploaded images (accessible from terminal sessions on this host)
-const UPLOAD_DIR = '/tmp/cchub-images';
+const UPLOAD_DIR = TMP_PATHS.imagesDir;
 
 async function ensureUploadDir() {
   try {

--- a/backend/src/services/__tests__/usage-history-legacy.test.ts
+++ b/backend/src/services/__tests__/usage-history-legacy.test.ts
@@ -2,9 +2,10 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import type { UsageScopedLimit } from '../../../../shared/types';
 import { UsageHistoryService } from '../usage-history';
+import { TMP_PATHS } from '../../../../shared/identity';
 
 // getHistory reads this fixed path; the service has no injection seam.
-const HISTORY_FILE = '/tmp/cchub-usage-history.json';
+const HISTORY_FILE = TMP_PATHS.usageHistoryFile;
 
 const snap = (timestamp: string) => ({
   timestamp,

--- a/backend/src/services/usage-history.ts
+++ b/backend/src/services/usage-history.ts
@@ -1,7 +1,8 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import type { UsageScopedLimit, UsageSnapshot } from '../../../shared/types';
+import { TMP_PATHS } from '../../../shared/identity';
 
-const HISTORY_FILE = '/tmp/cchub-usage-history.json';
+const HISTORY_FILE = TMP_PATHS.usageHistoryFile;
 const THROTTLE_MS = 30 * 1000; // 30 seconds
 const MAX_AGE_MS = 8 * 24 * 60 * 60 * 1000; // 8 days
 

--- a/backend/src/utils/keychain.ts
+++ b/backend/src/utils/keychain.ts
@@ -3,10 +3,12 @@
 // Linux has no equivalent reliable headless secret store, so these helpers are
 // no-ops on non-darwin platforms.
 
-const SERVICE = 'cchub';
+import { IDENTITY } from '../../../shared/identity';
+
+const SERVICE = IDENTITY.keychainService;
 
 function getAccount(): string {
-  return process.env.USER || 'cchub';
+  return process.env.USER || IDENTITY.keychainService;
 }
 
 /** Read the cchub password from the macOS Keychain. Returns undefined if not stored or not on darwin. */

--- a/backend/tests/unit/identity-consistency.test.ts
+++ b/backend/tests/unit/identity-consistency.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
-import { assetName, IDENTITY, SERVICE } from '../../../shared/identity';
+import {
+  assetName,
+  IDENTITY,
+  SERVICE,
+  TMP_PATHS,
+} from '../../../shared/identity';
 
 /**
  * `identity.json` is the single source of truth for what this product is
@@ -79,5 +84,33 @@ describe('derived service names', () => {
   test('asset names match what update.ts asks GitHub for', () => {
     expect(assetName('linux', 'x64')).toBe(`${IDENTITY.assetPrefix}-linux-x64`);
     expect(assetName('macos', 'arm64')).toBe(`${IDENTITY.assetPrefix}-macos-arm64`);
+  });
+});
+
+/**
+ * These are the paths of files that already exist on running installs. A
+ * refactor that moves one of them does not fail — it silently starts reading an
+ * empty history, or serving uploads from a directory nothing writes to.
+ */
+describe('scratch paths keep the values installs already use', () => {
+  test('images dir is what the three consumers used to hardcode', () => {
+    expect(TMP_PATHS.imagesDir).toBe('/tmp/cchub-images');
+  });
+
+  test('usage history file is unchanged', () => {
+    expect(TMP_PATHS.usageHistoryFile).toBe('/tmp/cchub-usage-history.json');
+  });
+
+  test('browser log keeps its hyphenated spelling', () => {
+    // Not `cchub-browser.log`: CLAUDE.md tells people to `tail -f` this exact
+    // path, so the odd spelling is load-bearing until a rename fixes it on
+    // purpose.
+    expect(TMP_PATHS.browserLogFile).toBe('/tmp/cc-hub-browser.log');
+  });
+
+  test('keychain service name is unchanged', () => {
+    // The macOS password lives under this service name. Changing it does not
+    // fail — it just stops finding the password that is already stored.
+    expect(IDENTITY.keychainService).toBe('cchub');
   });
 });

--- a/identity.json
+++ b/identity.json
@@ -12,5 +12,8 @@
   "configDirName": "cchub",
   "serviceName": "cchub",
   "launchdPrefix": "com.cchub",
-  "storagePrefix": "cchub-"
+  "storagePrefix": "cchub-",
+  "tmpPrefix": "cchub",
+  "browserLogName": "cc-hub-browser.log",
+  "keychainService": "cchub"
 }

--- a/shared/identity.ts
+++ b/shared/identity.ts
@@ -34,6 +34,28 @@ export const IDENTITY = {
   serviceName: raw.serviceName,
   launchdPrefix: raw.launchdPrefix,
   storagePrefix: raw.storagePrefix,
+  tmpPrefix: raw.tmpPrefix,
+  browserLogName: raw.browserLogName,
+  keychainService: raw.keychainService,
+} as const;
+
+/**
+ * Scratch paths under /tmp.
+ *
+ * `imagesDir` had three separate copies of its literal (the server's static
+ * route, the upload handler and the file route) which only work as long as all
+ * three agree — one edit away from uploads landing where nothing serves them.
+ *
+ * `browserLogFile` does not follow `tmpPrefix`: it has always been
+ * `cc-hub-browser.log`, with the hyphen, and CLAUDE.md tells people to tail it
+ * by that name. Normalising the spelling is a real change to something someone
+ * has in their shell history, so it is recorded here as-is rather than quietly
+ * corrected — a rename can decide to fix it deliberately.
+ */
+export const TMP_PATHS = {
+  imagesDir: `/tmp/${IDENTITY.tmpPrefix}-images`,
+  usageHistoryFile: `/tmp/${IDENTITY.tmpPrefix}-usage-history.json`,
+  browserLogFile: `/tmp/${IDENTITY.browserLogName}`,
 } as const;
 
 /** systemd unit / launchd label names, all composed from `serviceName`. */


### PR DESCRIPTION
## なぜ

#635 はインストーラとサービスマネージャが使う名前を集約しましたが、**動いているサーバーが触るパス**が残っていました。しかもこちらのほうが性質が悪く、**間違えても失敗しません**。

- **`/tmp/cchub-images` が3箇所に別々に書かれていた** — `index.ts` の静的ルート、アップロードハンドラ、ファイルルート。3つが一致している限りだけ動き、一致を確かめるものが何もない。1箇所ズレるとアップロードは「何も配信していないディレクトリ」に着地し、症状は 404 だけ
- **`/tmp/cchub-usage-history.json`** — パスがズレるとエラーではなく**空の履歴**が返る。「まだ使用量が無い」に見える
- **macOS Keychain のサービス名** — サーバーのパスワードの保管先。変えても起動に失敗せず、**パスワード無しで起動する**

## `/tmp/cc-hub-browser.log` について

`tmpPrefix` に合わせて `cchub-browser.log` に正規化せず、ハイフン入りの現行スペルのまま `identity.json` に記録しました。CLAUDE.md がこのパスを `tail -f` しろと書いているので、この不整合なスペルは load-bearing です。改名時に意図して直すのは構いませんが、この PR の副作用で変えるべきではありません。

## 変更

`identity.json` に `tmpPrefix` / `browserLogName` / `keychainService` を追加し、`shared/identity.ts` に `TMP_PATHS` を置いて6ファイルを配線しました。`usage-history-legacy.test.ts` は自前のパス定数を捨てて共通のものを import するようにしたので、改名に追従します。

## 検証（読んで確かめるのではなく、動かして確認）

- 8x8 PNG をアップロード → `/tmp/cchub-images` に着地 → `/api/files/images` からバイト単位で同じものが返る。**これで三重化していた3つの消費者を1往復で通せる**
- `/api/logs` への POST が `/tmp/cc-hub-browser.log` に追記される
- ダッシュボード取得が `/tmp/cchub-usage-history.json` にスナップショットを書く

テスト: backend 517 pass / 0 fail、lint・tsc クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STv3pQwmpdxMa9fJ4TK7a6