### PR TITLE
feat(glasses): 区切り線を描画にして1行取り戻す

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -5,6 +5,7 @@ import { screenText, wrapForPanel, wrapHeader } from '../display.ts'
 import { BODY_WIDTH, HEADER_WIDTH, LIST_LINES, textWidth as width } from '../metrics.ts'
 import { listRows, rowCursor, selectableRows } from '../display.ts'
 import { NOTICE_DISMISS_MS } from '../controller.ts'
+import { noticeHeight } from '../display.ts'
 import { SPACE_W } from '../metrics.ts'
 import { MAX_LINES } from '../metrics.ts'
 
@@ -192,18 +193,28 @@ describe('conversation body', () => {
   test('a one-sentence recap is capped in display lines, not logical ones', () => {
     // It used to pass the cap untouched and then wrap to six rows, leaving one
     // line for the conversation it was meant to introduce.
-    const body = screenText(state(longRecap)).body.split('\n')
-    expect(body[0].startsWith('要約: ')).toBe(true)
-    // Two recap lines, then the separator — the rest of the page is the
-    // conversation.
-    expect(body.indexOf('-'.repeat(24))).toBe(2)
-    expect(body[1]).toEndWith('…')
+    const notice = (screenText(state(longRecap)).notice ?? '').split('\n')
+    expect(notice[0].startsWith('要約: ')).toBe(true)
+    expect(notice).toHaveLength(2)
+    expect(notice[1]).toEndWith('…')
   })
 
-  test('the body never exceeds one page, recap or not', () => {
+  test('the rule between recap and conversation costs no line', () => {
+    // It used to be a row of dashes inside the body — 27px, a seventh of
+    // everything the reader gets, spent on a separator the panel can draw.
+    const s = screenText(state(longRecap))
+    expect(s.notice).not.toContain('-'.repeat(24))
+    expect(s.body).not.toContain('-'.repeat(24))
+  })
+
+  test('notice and conversation together never exceed one page', () => {
     for (const recap of [undefined, longRecap]) {
-      const body = screenText(state(recap)).body
-      expect(wrapForPanel(body).split('\n').length).toBeLessThanOrEqual(7)
+      const s = screenText(state(recap))
+      const noticeLines = s.notice ? s.notice.split('\n').length : 0
+      const bodyLines = wrapForPanel(s.body).split('\n').length
+      // The strip is shorter than the lines it holds would be in the body:
+      // its padding is 2 where the body's is 6.
+      expect(noticeHeight(noticeLines) + bodyLines * 27).toBeLessThanOrEqual(288 - 2 * 36)
     }
   })
 })
@@ -416,7 +427,7 @@ describe('recap lifetime', () => {
     relayInfo: [],
     overlayItemId: null,
   })
-  const hasRecap = (st: ReturnType<typeof state>) => screenText(st).body.startsWith('要約: ')
+  const hasRecap = (st: ReturnType<typeof state>) => (screenText(st).notice ?? '').startsWith('要約: ')
 
   test('shows while nothing newer has arrived', () => {
     expect(hasRecap(state('2026-07-27T06:00:00.000Z', '2026-07-27T05:00:00.000Z'))).toBe(true)
@@ -1035,13 +1046,13 @@ describe('no notification about what is already on screen', () => {
   })
 
   test('a question about the open session still shows — it carries the choices', () => {
-    const body = screenText(mk({
+    const s = screenText(mk({
       relayWaiting: [{
         id: 'w', sessionId: 'a', kind: 'waiting' as const, text: 'Which one?',
         source: 'auto' as const, createdAt: 1, choices: ['A', 'B'],
       }],
-    })).body
-    expect(body).toContain('[!]グラス開発')
+    }))
+    expect(s.notice).toContain('[!]グラス開発')
   })
 
   test('the list is untouched: nothing there is "on screen"', () => {

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -12,7 +12,7 @@
 import { setBaseUrl, transcribe } from './api.ts'
 import { GlassesController } from './controller.ts'
 import type { GlassesPlatform } from './controller.ts'
-import { screenText, wrapForPanel } from './display.ts'
+import { NOTICE_BORDER, NOTICE_BORDER_COLOR, NOTICE_PAD, noticeHeight, screenText, wrapForPanel } from './display.ts'
 import { BAR_H, LINE_H, PANEL_H, PANEL_W, advance } from './metrics.ts'
 import type { AppState } from './display.ts'
 
@@ -361,11 +361,11 @@ export function startDebugUI(): void {
   // them with the same painter it uses for its own state. What the audience
   // sees is the wearer's screen, not a second interpretation of it.
   let mirroring = false
-  let localScreen = { header: '', body: '', footer: '' }
+  let localScreen: { header: string; body: string; footer: string; notice?: string; headerless?: boolean } = { header: '', body: '', footer: '' }
   let localMode = 'session_list'
 
   function paint(
-    screen: { header: string; body: string; footer: string; headerless?: boolean },
+    screen: { header: string; body: string; footer: string; notice?: string; headerless?: boolean },
     mode: string,
   ): void {
     lastScreen = screen
@@ -430,7 +430,7 @@ export function startDebugUI(): void {
     }
   }
 
-  function drawPanel(screen: { header: string; body: string; footer: string; headerless?: boolean }): void {
+  function drawPanel(screen: { header: string; body: string; footer: string; notice?: string; headerless?: boolean }): void {
     const ctx = canvas.getContext('2d')
     if (!ctx) return
     ctx.clearRect(0, 0, canvas.width, canvas.height)
@@ -443,9 +443,26 @@ export function startDebugUI(): void {
     ctx.fillStyle = `rgb(${GREEN})`
     if (!screen.headerless) drawRow(ctx, screen.header, HEADER_PAD, HEADER_BASE)
 
+    // The notice strip is its own container on the device, with a drawn border
+    // where a row of dashes used to be. Its height decides where the
+    // conversation starts, so this has to match the device's arithmetic or the
+    // window stops being worth the phrase in its own subtitle.
+    const noticeLines = screen.notice ? screen.notice.split('\n') : []
+    const nHeight = noticeHeight(noticeLines.length)
+    for (const [i, line] of noticeLines.entries()) {
+      drawRow(ctx, line, 4 + NOTICE_PAD + NOTICE_BORDER, BAR_H + NOTICE_PAD + NOTICE_BORDER + BASELINE + i * LINE_H)
+    }
+    if (nHeight > 0) {
+      // The container's own border, at the panel's own width and grey level.
+      ctx.strokeStyle = `rgba(${GREEN}, ${NOTICE_BORDER_COLOR / 15})`
+      ctx.lineWidth = NOTICE_BORDER
+      ctx.strokeRect(4 + NOTICE_BORDER / 2, BAR_H + NOTICE_BORDER / 2, PANEL_W - 8 - NOTICE_BORDER, nHeight - NOTICE_BORDER)
+      ctx.fillStyle = `rgb(${GREEN})`
+    }
+
     // Without a header container the body owns that band too, and starts where
     // it does rather than a bar below it.
-    const bodyTop = screen.headerless ? BODY_PAD + BASELINE : BODY_TOP
+    const bodyTop = screen.headerless ? BODY_PAD + BASELINE : BODY_TOP + nHeight
     for (const [i, line] of screen.body.split('\n').entries()) {
       drawRow(ctx, line, 4 + BODY_PAD, bodyTop + i * LINE_H)
     }
@@ -453,8 +470,6 @@ export function startDebugUI(): void {
     ctx.fillStyle = `rgba(${GREEN}, 0.78)`
     drawRow(ctx, screen.footer, HEADER_PAD, FOOTER_BASE)
 
-    // No rules between the zones: the containers carry borderWidth 0, so the
-    // panel has nothing there and neither should this.
     ctx.shadowBlur = 0
 
     // 4-bit: 16 alpha levels, nothing in between.

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -8,10 +8,14 @@ import {
   AudioInputSource,
 } from '@evenrealities/even_hub_sdk'
 import {
+  BAR_H,
+  BODY_PAD,
   BODY_WIDTH,
   HEADER_WIDTH,
+  LINE_H,
   LIST_LINES,
   MAX_LINES,
+  PANEL_H,
   SPACE_W,
   ellipsize,
   splitLines,
@@ -281,12 +285,10 @@ function spinnerFrame(state: AppState): string {
  * five or six rows, crowding out the conversation it was meant to introduce.
  */
 function recapBlock(recap: string | undefined, maxLines = 2): string[] {
-  const block = recapBlockLines(recap, maxLines)
-  if (!block.length) return []
-  const body = block.slice(0, -1).flatMap(splitDisplayLines)
-  const separator = block[block.length - 1]
-  if (body.length <= maxLines) return [...body, separator]
-  return [...body.slice(0, maxLines - 1), ellipsize(body[maxLines - 1]), separator]
+  const body = recapBlockLines(recap, maxLines).flatMap(splitDisplayLines)
+  if (!body.length) return []
+  if (body.length <= maxLines) return body
+  return [...body.slice(0, maxLines - 1), ellipsize(body[maxLines - 1])]
 }
 
 /** Display label for a relay item's session (live session name, else the id). */
@@ -305,7 +307,7 @@ function relayBannerLines(state: AppState): string[] {
     const more = state.relayWaiting.length > 1 ? ` 他${state.relayWaiting.length - 1}件` : ''
     const head = splitDisplayLines(`[!]${relayLabel(state, top)}${choiceHint}${more}`)[0] || ''
     const textLines = splitDisplayLines(top.text).slice(0, 2)
-    return [head, ...textLines, SEPARATOR]
+    return [head, ...textLines]
   }
   // Notifications get no body space here. The dialog already presented each
   // one full-screen, and the list keeps them in full afterwards; a third
@@ -512,7 +514,39 @@ function recapIsCurrent(recapAt: string | undefined, msgs: ConversationMessage[]
   return newestTime <= recapTime
 }
 
-function conversationContent(state: AppState): { headerText: string; bodyText: string; footerText: string } {
+/**
+ * Geometry of the notice strip: how tall it is, and what the conversation has
+ * left underneath it.
+ *
+ * The rule between them is a container border, not a row of text, so it costs
+ * `NOTICE_BORDER` pixels instead of a 27px line. Padding is cut to 2 for the
+ * same reason — this strip is a label, not a page, and every pixel it does not
+ * take is one the conversation does.
+ */
+export const NOTICE_PAD = 2
+export const NOTICE_BORDER = 1
+/** 0-15 on this panel's 16 greens. Bright enough to read as a rule, dim enough
+ *  that it does not compete with the text it is separating. */
+export const NOTICE_BORDER_COLOR = 6
+/** A notice longer than the conversation it introduces has stopped helping. */
+const NOTICE_MAX_LINES = 3
+
+export function noticeHeight(lines: number): number {
+  return lines > 0 ? lines * LINE_H + 2 * NOTICE_PAD + 2 * NOTICE_BORDER : 0
+}
+
+/** Display lines the conversation keeps once the notice has taken its share. */
+export function conversationLines(noticeLines: number): number {
+  const body = PANEL_H - 2 * BAR_H - noticeHeight(noticeLines)
+  return Math.max(0, Math.floor((body - 2 * BODY_PAD) / LINE_H))
+}
+
+function conversationContent(state: AppState): {
+  headerText: string
+  noticeText: string
+  bodyText: string
+  footerText: string
+} {
   const session = state.sessions[state.sessionIndex]
   // Reading one pane of a workspace, its status is the one that applies — the
   // workspace's is a summary of panes the reader is not looking at.
@@ -542,7 +576,17 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
   // Everything is measured in display lines — counting the conversation in
   // logical lines let a wrapped paragraph run off the bottom unnoticed.
   const content = convText.split('\n').flatMap(splitDisplayLines)
-  const bodyText = [...banner, ...recap, ...content].slice(0, MAX_LINES).join('\n')
+  // The notice block gets its own container so the panel can draw the line
+  // between them as a border. It used to be a row of dashes inside this one,
+  // which spent 27px — a seventh of everything the reader gets — on a rule.
+  const noticeLines = [...banner, ...recap].slice(0, NOTICE_MAX_LINES)
+  const noticeText = noticeLines.join('\n')
+  // The body container clips overflow: cap the content at what is left once
+  // the notice has taken its share, so a waiting banner never pushes
+  // conversation text off-screen. Everything is measured in display lines —
+  // counting the conversation in logical lines let a wrapped paragraph run off
+  // the bottom unnoticed.
+  const bodyText = content.slice(0, conversationLines(noticeLines.length)).join('\n')
   // With a waiting banner up, the ring is routed to the overlay item:
   // tap = respond/jump, double-tap = dismiss ("later / on PC").
   // Read some way back, the double-tap returns to the newest message rather
@@ -564,6 +608,7 @@ function conversationContent(state: AppState): { headerText: string; bodyText: s
   const notices = otherSessionInfoCount(state)
   const noticeMark = notices > 0 ? `  [i]${notices}` : ''
   return {
+    noticeText,
     headerText: withClock(
       `${session ? sName(session) : '---'}${pane ? ` ${paneName(pane, pane.paneId)}` : ''}`,
       `${statusBadge}${noticeMark}`,
@@ -628,6 +673,12 @@ export function screenText(state: AppState): {
   header: string
   body: string
   footer: string
+  /** Recap / waiting banner, in its own strip above the conversation with a
+   *  drawn rule between. Empty when there is nothing to say. Separate from
+   *  `body` because the rule is a container border on the device, so anything
+   *  redrawing these strings has to put a line there too or it shows a panel
+   *  the wearer is not looking at. */
+  notice?: string
   /** The list screen drops its header container, so its body starts at the top
    *  of the panel rather than below a bar. Anything drawing these strings has
    *  to know, or it renders a row lower than the device does. */
@@ -638,8 +689,8 @@ export function screenText(state: AppState): {
       // No header: the list screen gave that bar back to the list.
       return { header: '', body: sessionListBody(state), footer: sessionListFooter(state), headerless: true }
     case 'conversation': {
-      const { headerText, bodyText, footerText } = conversationContent(state)
-      return { header: headerText, body: bodyText, footer: footerText }
+      const { headerText, noticeText, bodyText, footerText } = conversationContent(state)
+      return { header: headerText, notice: noticeText, body: bodyText, footer: footerText }
     }
     case 'choice':
       return { header: choiceHeader(state), body: choiceBody(state), footer: FOOTER_CHOICE }
@@ -767,8 +818,21 @@ function buildSessionList(state: AppState): RebuildPageContainer {
   })
 }
 
+/**
+ * How many lines the notice strip is showing, which is the only thing about
+ * the conversation page whose *geometry* changes. Everything else is content,
+ * and content goes out as an in-place upgrade; a different height needs the
+ * page rebuilt, so `updateDisplay` watches this.
+ */
+function noticeLineCount(state: AppState): number {
+  const { noticeText } = conversationContent(state)
+  return noticeText ? noticeText.split('\n').length : 0
+}
+
 function buildConversation(state: AppState): RebuildPageContainer {
-  const { headerText, bodyText, footerText } = conversationContent(state)
+  const { headerText, noticeText, bodyText, footerText } = conversationContent(state)
+  const nLines = noticeText ? noticeText.split('\n').length : 0
+  const nHeight = noticeHeight(nLines)
 
   const header = new TextContainerProperty({
     xPosition: 0, yPosition: 0,
@@ -780,12 +844,28 @@ function buildConversation(state: AppState): RebuildPageContainer {
     content: headerText,
   })
 
+  // The strip and its border are what used to be a row of dashes. Drawn by the
+  // panel, the rule costs NOTICE_BORDER px where the dashes cost a 27px line.
+  const notice = nLines > 0
+    ? new TextContainerProperty({
+        xPosition: 4, yPosition: 36,
+        width: W - 8, height: nHeight,
+        borderWidth: NOTICE_BORDER,
+        borderColor: NOTICE_BORDER_COLOR,
+        borderRadius: 0,
+        paddingLength: NOTICE_PAD,
+        containerID: 2, containerName: 'notice',
+        isEventCapture: 0,
+        content: noticeText,
+      })
+    : null
+
   const body = new TextContainerProperty({
-    xPosition: 4, yPosition: 36,
-    width: W - 8, height: H - 36 - 36,
+    xPosition: 4, yPosition: 36 + nHeight,
+    width: W - 8, height: H - 36 - 36 - nHeight,
     borderWidth: 0,
     paddingLength: 6,
-    containerID: 2, containerName: 'body',
+    containerID: notice ? 3 : 2, containerName: 'body',
     isEventCapture: 0,
     content: bodyText,
   })
@@ -795,14 +875,15 @@ function buildConversation(state: AppState): RebuildPageContainer {
     width: W, height: 36,
     borderWidth: 0,
     paddingLength: 4,
-    containerID: 3, containerName: 'footer',
+    containerID: notice ? 4 : 3, containerName: 'footer',
     isEventCapture: 1,
     content: footerText,
   })
 
+  const objects = notice ? [header, notice, body, footer] : [header, body, footer]
   return new RebuildPageContainer({
-    containerTotalNum: 3,
-    textObject: [header, body, footer],
+    containerTotalNum: objects.length,
+    textObject: objects,
   })
 }
 
@@ -962,6 +1043,9 @@ export function buildSetupGuide(): RebuildPageContainer {
 // ─── Display controller ───
 
 let currentMode: Mode | null = null
+/** Notice-strip height last sent, so a change in it triggers the rebuild the
+ *  new geometry needs. */
+let currentNoticeLines = 0
 
 export async function initDisplay(): Promise<Bridge | null> {
   try {
@@ -1033,8 +1117,13 @@ export async function updateHeader(bridge: Bridge | null, state: AppState): Prom
 export async function updateDisplay(bridge: Bridge | null, state: AppState): Promise<void> {
   if (!bridge) return
 
-  const needsRebuild = state.mode !== currentMode
+  // Geometry, not content, is what forces a rebuild: the notice strip changes
+  // the body container's height and the ids below it. Content alone goes out
+  // as in-place upgrades, which is why the panel is not rebuilt every render.
+  const notice = state.mode === 'conversation' ? noticeLineCount(state) : 0
+  const needsRebuild = state.mode !== currentMode || notice !== currentNoticeLines
   currentMode = state.mode
+  currentNoticeLines = notice
 
   if (needsRebuild) {
     let container: RebuildPageContainer
@@ -1066,18 +1155,23 @@ export async function updateDisplay(bridge: Bridge | null, state: AppState): Pro
       break
     }
     case 'conversation': {
-      const { headerText, bodyText, footerText } = conversationContent(state)
+      const { headerText, noticeText, bodyText, footerText } = conversationContent(state)
+      const hasNotice = notice > 0
       await Promise.all([
         bridge.textContainerUpgrade(new TextContainerUpgrade({
           containerID: 1, containerName: 'header',
           content: headerText,
         })),
+        ...(hasNotice ? [bridge.textContainerUpgrade(new TextContainerUpgrade({
+          containerID: 2, containerName: 'notice',
+          content: noticeText,
+        }))] : []),
         bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 2, containerName: 'body',
+          containerID: hasNotice ? 3 : 2, containerName: 'body',
           content: bodyText,
         })),
         bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 3, containerName: 'footer',
+          containerID: hasNotice ? 4 : 3, containerName: 'footer',
           content: footerText,
         })),
       ])

--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -134,11 +134,11 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
   let lastPublished = ''
   function publishScreen(state: AppState): void {
     try {
-      const { header, body, footer } = screenText(state)
-      const key = `${state.mode}\u0000${header}\u0000${body}\u0000${footer}`
+      const { header, body, footer, notice } = screenText(state)
+      const key = `${state.mode}\u0000${header}\u0000${notice ?? ''}\u0000${body}\u0000${footer}`
       if (key === lastPublished) return
       lastPublished = key
-      controller.ws.publishScreen({ header, body, footer, mode: state.mode, at: Date.now() })
+      controller.ws.publishScreen({ header, body, footer, notice, mode: state.mode, at: Date.now() })
     } catch (err) {
       // A mirror is a nicety; never let it take the panel down with it.
       trace(`publishScreen failed: ${err}`, 'error', (err as Error)?.stack)

--- a/glasses/src/metrics.ts
+++ b/glasses/src/metrics.ts
@@ -28,7 +28,7 @@ export const BAR_H = 36
 export const LINE_H = 27
 
 const HEADER_PAD = 4
-const BODY_PAD = 6
+export const BODY_PAD = 6
 
 /** Usable width of the header (and footer) container. Holds exactly one line:
  *  28px of inner height against a 27px line, so anything that wraps is gone. */

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -105,6 +105,9 @@ export interface GlassesScreen {
   header: string
   body: string
   footer: string
+  /** Recap / waiting banner strip, drawn above the body with a rule between.
+   *  Separate because that rule is a container border, not a row of text. */
+  notice?: string
   mode: string
   at: number
 }
@@ -258,7 +261,10 @@ export function recapBlockLines(recap: string | undefined, maxLines = 2): string
   if (!clean) return []
   const lines = clean.split('\n')
   const capped = lines.length > maxLines ? [...lines.slice(0, maxLines - 1), '…'] : lines
-  return [`要約: ${capped[0]}`, ...capped.slice(1), '-'.repeat(24)]
+  // No rule at the end: the recap is its own container now, and the panel
+  // draws the line between them as a border. A dash row cost a full 27px line
+  // out of the seven to do the same job.
+  return [`要約: ${capped[0]}`, ...capped.slice(1)]
 }
 
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -991,6 +991,13 @@ export interface GlassesScreen {
   header: string;
   body: string;
   footer: string;
+  /**
+   * Recap / waiting banner, drawn in its own strip above the body with a rule
+   * between. Separate from `body` because that rule is a container border on
+   * the panel, not a row of text — a mirror that concatenates the two shows a
+   * screen the wearer is not looking at.
+   */
+  notice?: string;
   /** Which screen this is, for the mirror's status line. */
   mode: string;
   /** Epoch ms the frame was produced, so a stalled mirror is visible. */
@@ -1140,6 +1147,7 @@ export const MuxClientMessageSchema = z.discriminatedUnion('type', [
       header: z.string().max(500),
       body: z.string().max(4000),
       footer: z.string().max(500),
+      notice: z.string().max(1000).optional(),
       mode: z.string().max(40),
       at: z.number(),
     }),


### PR DESCRIPTION
## 相談 #1 の実装

要約や質問バナーと会話の間の区切りが `------------------------` という**テキスト行**だった。**27px、読者が持つ7行の1/7** を線1本に使っている。

パネル自身が線を引ける。`TextContainerProperty` は `borderWidth`（0-5）と `borderColor`（0-15階調）を持っていて、**このアプリの全コンテナで 0 にしていた**。

## 変更

通知（要約・待機バナー）を独立コンテナにして 1px の枠線を付けた。罫線のコストは**余白込みで 6px**、旧方式の 27px に対して 1/4 以下。

```
状況        通知行  罫線   会話行  旧方式  差
通知なし        0      0px    7      7      ±0
要約1行        1      6px    6      5      ★+1
要約2行        2      6px    5      4      ★+1
質問バナー       2      6px    5      4      ★+1
```

**通知が出ているとき、会話が1行増える。**

## 再構築コストへの配慮

このアプリはモードが変わった時だけページを再構築し、それ以外はコンテナ単位の部分更新をしている（BLE 越しなので再構築は高い）。

そこで **`updateDisplay` が見るのは通知の「行数」であって本文ではない**。テキストが変わるだけなら今までどおり部分更新で、再構築が要るのは通知が出る/伸びる/消える時だけ。これは滅多に起きない。

## シミュレーターとミラー

**同じ定数から同じ枠線を描く**ようにした。`GlassesScreen` にも `notice` を独立して載せている。`body` に連結してしまうと、`実機と同じ描画` を名乗る窓が実機と違う画面を出すことになる。

## 検証

- 実測（上の表）
- テスト107件パス（backend 517 / frontend 78 / glasses 105）、lint クリーン
- **枠線の実機での見え方（太さ・濃さ）は未検証**。`borderColor: 6` から始めているので、濃すぎ/薄すぎなら定数1つで調整できる

## リリース時の注意

`glasses/src` と `shared/types.ts` の変更。ehpk の再ビルド + Beta 昇格が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np