### PR TITLE
fix(glasses): 実機ミラーが要約の帯を落としていた

### DIFF
--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -978,7 +978,15 @@ export function startDebugUI(): void {
       setMirrorUi(false, '実機が接続されていません')
       return
     }
-    paint({ header: screen.header, body: wrapForPanel(screen.body), footer: screen.footer }, screen.mode)
+    // Rebuilt field by field, so a new one added to GlassesScreen is dropped
+    // here unless it is named — which is exactly how the notice strip went
+    // missing from the mirror while the local panel drew it.
+    paint({
+      header: screen.header,
+      notice: screen.notice ? wrapForPanel(screen.notice) : undefined,
+      body: wrapForPanel(screen.body),
+      footer: screen.footer,
+    }, screen.mode)
     setMirrorUi(true, '実機と同期中')
   })
 


### PR DESCRIPTION
## 症状

実機では要約が出るのに、**実機ミラーでは出ない**（実機報告）。

## 原因

ミラーは受信した画面を**フィールドごとに組み直していた**ので、#639 で追加した `notice` が名指しされておらず、そのまま落ちていた。

```ts
paint({ header: screen.header, body: wrapForPanel(screen.body), footer: screen.footer }, screen.mode)
//                                                                                  ↑ notice が無い
```

ローカル描画側は `{ ...raw }` と展開しているので通っていた。**2つある経路のうち片方だけが落とす形**だった。

## 直し

フィールドを名指しして追加し、**なぜ落ちたのかをコメントに残した**。スプレッドに変えれば今回は直るが、次に増えるフィールドで同じことが起きたときに理由が読めなくなるため。

## 実機側は不要

**この修正に ehpk はいらない。** 実機は publisher 側で、`notice` は v0.1.54 から既に送っている。ミラーの受信側はシミュレーターで、シミュレーターは**サーバーバイナリに同梱**されている。よって**本体リリースのみ**で届く。

## 検証

シミュレーターで要約が枠線付きで描画されることを実測（要約を新しいものに差し替えて表示条件を満たした状態）:

```
2脚ロボ開発 買い物 [!] WAITING              15:03
┌────────────────────────────────────┐
│要約: テストが全部通ったのでレビューをお願いします。差分  │
│は3ファイルです。                              │
└────────────────────────────────────┘
完了しました。UI 上でも「買い物」と表示されるはずです。
...
```

なお最初に要約が出なかったキャプチャは**正しい抑制**だった（ペインの要約が 07-26 21:50、最新メッセージが 07-27 22:57 で、読者が要約より先に進んでいる）。

全テストパス（backend 517 / frontend 78 / glasses 105）、lint クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np