### PR TITLE
Release v0.2.87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.87] - 2026-07-28
+
+### Fixed
+- **グラス: 実機ミラーが要約の帯を落としていた** (#642): 実機では要約が出るのにミラーでは出ない。ミラーは受信した画面を**フィールドごとに組み直していた**ので、#639 で追加した `notice` が名指しされておらず消えていた
+  ```ts
+  paint({ header: screen.header, body: wrapForPanel(screen.body), footer: screen.footer }, screen.mode)
+  //                                                                                  ↑ notice が無い
+  ```
+  - ローカル描画側は `{ ...raw }` と展開しているので通っていた。**2つある経路のうち片方だけが落とす**形だった
+  - フィールドを名指しして追加し、なぜ落ちたのかをコメントに残した。スプレッドに変えれば今回は直るが、次に増えるフィールドで同じことが起きたときに理由が読めなくなるため
+  - **ehpk は不要**。実機は publisher 側で `notice` を v0.1.54 から既に送っており、ミラーの受信側はサーバーバイナリ同梱のシミュレーター
+
 ## [0.2.86] - 2026-07-28
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.86",
+  "version": "0.2.87",
   "generated": "2026-07-28",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.86",
+  "version": "0.2.87",
   "generated": "2026-07-28",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.86",
+  "version": "0.2.87",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes

- **fix(glasses)**: 実機ミラーが要約の帯（`notice`）を落としていた問題を修正 (#642)

## Notes

**本体のみ。ehpk は不要** — 実機は publisher 側で `notice` を v0.1.54 から既に送っており、ミラーの受信側はサーバーバイナリ同梱のシミュレーターなので、このリリースで届く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np