### PR TITLE
feat(glasses): 待てば切れていた部分が見えるようにする（自動送り）

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -5,7 +5,7 @@ import { screenText, wrapForPanel, wrapHeader } from '../display.ts'
 import { BODY_WIDTH, HEADER_WIDTH, LIST_LINES, textWidth as width } from '../metrics.ts'
 import { listRows, rowCursor, selectableRows } from '../display.ts'
 import { NOTICE_DISMISS_MS } from '../controller.ts'
-import { noticeHeight } from '../display.ts'
+import { noticeHeight, noticeWindowCount } from '../display.ts'
 import { SPACE_W } from '../metrics.ts'
 import { MAX_LINES } from '../metrics.ts'
 
@@ -190,13 +190,31 @@ describe('conversation body', () => {
     overlayItemId: null,
   })
 
-  test('a one-sentence recap is capped in display lines, not logical ones', () => {
-    // It used to pass the cap untouched and then wrap to six rows, leaving one
-    // line for the conversation it was meant to introduce.
-    const notice = (screenText(state(longRecap)).notice ?? '').split('\n')
-    expect(notice[0].startsWith('要約: ')).toBe(true)
-    expect(notice).toHaveLength(2)
-    expect(notice[1]).toEndWith('…')
+  test('a long recap is shown a window at a time, never cut', () => {
+    // It used to end at `…`: the reader was told there was more and given no
+    // way to reach it. The strip windows it and the clock walks the rest.
+    const first = (screenText(state(longRecap)).notice ?? '').split('\n')
+    expect(first[0].startsWith('要約: ')).toBe(true)
+    expect(first.length).toBeLessThanOrEqual(3)
+    expect(first.join('')).not.toEndWith('…')
+    expect(noticeWindowCount(state(longRecap) as never)).toBeGreaterThan(1)
+  })
+
+  test('waiting reaches the end of it, and then stops', () => {
+    const st = state(longRecap)
+    const windows = noticeWindowCount(st as never)
+    const seen = new Set<string>()
+    for (let w = 0; w < windows; w++) {
+      for (const line of (screenText({ ...st, noticeWindow: w }).notice ?? '').split('\n')) {
+        if (line) seen.add(line)
+      }
+    }
+    // Every line of the recap has been on screen by the last window.
+    const all = (screenText({ ...st, noticeWindow: 0 }).notice ?? '').split('\n')
+    expect(seen.size).toBeGreaterThan(all.length)
+    // Past the last window it holds rather than wrapping around.
+    const last = screenText({ ...st, noticeWindow: windows - 1 }).notice
+    expect(screenText({ ...st, noticeWindow: windows + 5 }).notice).toBe(last)
   })
 
   test('the rule between recap and conversation costs no line', () => {
@@ -1180,5 +1198,65 @@ describe('a pane is called what the user called it', () => {
     }))
     expect(s.header).toContain('買い物')
     expect(s.header).not.toContain('%3')
+  })
+})
+
+describe('waiting shows what did not fit', () => {
+  const longRecap = '要約の1文目です。'.repeat(30)
+  const st = (over: Record<string, unknown> = {}) => ({
+    mode: 'conversation' as const,
+    sessions: [{
+      id: 'a', name: 'グラス開発', state: 'working' as const,
+      ccRecap: longRecap, ccRecapAt: '2030-01-01T00:00:00Z',
+    }],
+    sessionIndex: 0,
+    conversation: [{ role: 'assistant' as const, content: 'x', timestamp: '2026-07-28T00:00:00Z' }],
+    conversationOffset: 0, conversationPage: 0, conversationLastLoaded: 0,
+    conversationHasMore: false, conversationLoading: false,
+    choiceIndex: 0, choiceOptions: [], relayWaiting: [], relayInfo: [],
+    overlayItemId: null, spinnerTick: 0,
+    ...over,
+  })
+
+  test('the strip reports how many windows it takes', () => {
+    // The clock asks this to know whether waiting reveals anything more, so it
+    // can move on to the conversation instead of sitting on a finished strip.
+    expect(noticeWindowCount(st() as never)).toBeGreaterThan(1)
+  })
+
+  test('a notice that fits takes exactly one window', () => {
+    const short = st({ sessions: [{ id: 'a', name: 'g', state: 'idle' as const, ccRecap: '短い', ccRecapAt: '2030-01-01T00:00:00Z' }] })
+    expect(noticeWindowCount(short as never)).toBe(1)
+  })
+
+  test('no notice at all takes one window, so the clock moves straight on', () => {
+    const none = st({ sessions: [{ id: 'a', name: 'g', state: 'idle' as const }] })
+    expect(noticeWindowCount(none as never)).toBe(1)
+  })
+
+  test('windows tile: no line is shown twice, none is skipped', () => {
+    // Distinguishable lines: a recap of one repeated phrase wraps into rows
+    // that are legitimately identical strings, which says nothing about tiling.
+    const numbered = Array.from({ length: 9 }, (_, i) => `行${i}`).join('\n')
+    const state = st({
+      sessions: [{
+        id: 'a', name: 'g', state: 'idle' as const,
+        ccRecap: numbered, ccRecapAt: '2030-01-01T00:00:00Z',
+      }],
+    })
+    const windows = noticeWindowCount(state as never)
+    const seen: string[] = []
+    for (let w = 0; w < windows; w++) {
+      seen.push(...(screenText({ ...state, noticeWindow: w }).notice ?? '').split('\n').filter(Boolean))
+    }
+    expect(new Set(seen).size).toBe(seen.length)
+    // And every line made it: the last one is on screen by the last window.
+    expect(seen).toContain('行8')
+  })
+
+  test('the recap is not counted while the reader has paged away from it', () => {
+    // Deeper paging drops the recap for message space; the clock must not then
+    // think there is a strip to walk.
+    expect(noticeWindowCount(st({ conversationPage: 2 }) as never)).toBe(1)
   })
 })

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -26,7 +26,7 @@
 //   voice:        tap=stop→transcribe / send  doubleTap=cancel
 
 import { getConversation, sendPrompt, sendPaneInput, dismissRelayItem } from './api.ts'
-import { SPINNER_INTERVAL_MS, getTotalPagesAt, getMultiCountAt, listRows, rowCursor } from './display.ts'
+import { SPINNER_INTERVAL_MS, getTotalPagesAt, getMultiCountAt, listRows, noticeWindowCount, rowCursor } from './display.ts'
 import type { AppState } from './display.ts'
 import { RelayQueue } from './relay-queue.ts'
 import { CcHubWsClient } from './ws-client.ts'
@@ -43,6 +43,22 @@ const CONV_REFRESH_INTERVAL = 3000
  * looking through a message about something they already knew.
  */
 export const NOTICE_DISMISS_MS = 8000
+/**
+ * How long the ring has to be still before the screen starts moving itself.
+ *
+ * "しばらく待つと" — the point is that a reader who is working the ring is
+ * never fought for control. Long enough that a pause between gestures is not
+ * mistaken for having finished reading.
+ */
+const AUTO_ADVANCE_IDLE_MS = 10_000
+/**
+ * How long each step stays up.
+ *
+ * Slow on purpose: it is read at a glance while doing something else, and
+ * every step costs a redraw over BLE. Matched to the sessions push so the
+ * panel keeps one rhythm rather than two competing ones.
+ */
+const AUTO_ADVANCE_STEP_MS = 5000
 
 export type RingAction = 'tap' | 'doubleTap' | 'swipeUp' | 'swipeDown'
 
@@ -149,6 +165,8 @@ export class GlassesController {
   private overlayReturnMode: 'session_list' | 'conversation' = 'session_list'
   /** Pending auto-dismissal of a notification overlay; null when none is due. */
   private noticeTimer: ReturnType<typeof setTimeout> | null = null
+  /** Last ring gesture, so the auto-advance clock can stay out of the way. */
+  private lastGestureAt = 0
 
   private audioChunks: Uint8Array[] = []
   private recording = false
@@ -177,6 +195,41 @@ export class GlassesController {
     // every state change. It costs nothing when nothing is working: the tick
     // returns before touching the display.
     setInterval(() => this.tickSpinner(), SPINNER_INTERVAL_MS)
+    setInterval(() => this.tickAutoAdvance(), AUTO_ADVANCE_STEP_MS)
+  }
+
+  /**
+   * Show the next thing that does not fit.
+   *
+   * Seven lines is not enough for a recap and a conversation at once, so both
+   * used to end at `…` — the reader told there was more, with no way to reach
+   * it. This walks the overflow instead: the notice strip first, then the
+   * pages of the message, one step at a time, and stops when there is nothing
+   * left to show rather than looping back.
+   *
+   * One thing moves at a time. A screen with a scrolling recap above a paging
+   * conversation is not readable at a glance, which is the only way this
+   * screen is ever read.
+   */
+  private tickAutoAdvance(): void {
+    const st = this.state
+    if (st.mode !== 'conversation') return
+    // The reader is working the ring; do not fight them for it.
+    if (Date.now() - this.lastGestureAt < AUTO_ADVANCE_IDLE_MS) return
+
+    const windows = noticeWindowCount(st)
+    if ((st.noticeWindow ?? 0) < windows - 1) {
+      st.noticeWindow = (st.noticeWindow ?? 0) + 1
+      this.render()
+      return
+    }
+    const totalPages = this.currentMsgTotalPages()
+    if (st.conversationPage < totalPages - 1) {
+      st.conversationPage++
+      this.render()
+    }
+    // Everything on this screen has been shown. Stop: arriving at the end and
+    // staying there is what "read it all" looks like.
   }
 
   /** Advance the working indicator, but only where it is being looked at and
@@ -294,6 +347,10 @@ export class GlassesController {
 
   /** Explicit state machine dispatch: (mode, action) → transition. */
   private async handle(action: RingAction): Promise<void> {
+    // Every ring gesture goes through here, so this is the one place that has
+    // to know the reader is driving. The auto-advance clock stays out of the
+    // way for AUTO_ADVANCE_IDLE_MS afterwards.
+    this.lastGestureAt = Date.now()
     switch (this.state.mode) {
       case 'session_list': return this.onSessionListAction(action)
       case 'conversation': return this.onConversationAction(action)
@@ -341,6 +398,7 @@ export class GlassesController {
         st.conversation = []
         st.conversationOffset = 0
         st.conversationPage = 0
+        st.noticeWindow = 0
         this.render()
         await this.loadConversation()
         this.render()
@@ -392,6 +450,7 @@ export class GlassesController {
           const jump = getMultiCountAt(st.conversation, st.conversationOffset - 1)
           st.conversationOffset = Math.max(0, st.conversationOffset - jump)
           st.conversationPage = 0
+          st.noticeWindow = 0
         }
         this.render()
         return
@@ -448,6 +507,7 @@ export class GlassesController {
         if (st.conversationOffset > 0 || st.conversationPage > 0) {
           st.conversationOffset = 0
           st.conversationPage = 0
+          st.noticeWindow = 0
           this.render()
           // Live updates resume at the top, and whatever arrived while the
           // reader was back there should be waiting for them.
@@ -693,6 +753,7 @@ export class GlassesController {
     this.state.conversation = []
     this.state.conversationOffset = 0
     this.state.conversationPage = 0
+    this.state.noticeWindow = 0
     if (item.choices?.length) {
       this.enterChoice(item.choices, { sessionId: item.sessionId, paneId: item.paneId, itemId: item.id })
       void this.loadConversation().then(() => this.render())
@@ -838,6 +899,7 @@ export class GlassesController {
     st.conversation = []
     st.conversationOffset = 0
     st.conversationPage = 0
+    st.noticeWindow = 0
     this.render()
     void this.loadConversation().then(() => this.render())
     return true
@@ -948,6 +1010,7 @@ export class GlassesController {
       this.state.conversationHasMore = rawPane.length >= INITIAL_LOAD_COUNT
       this.state.conversationOffset = 0
       this.state.conversationPage = 0
+      this.state.noticeWindow = 0
       return
     }
     if (!session?.ccSessionId) {
@@ -963,6 +1026,7 @@ export class GlassesController {
     this.state.conversationHasMore = raw.length >= INITIAL_LOAD_COUNT
     this.state.conversationOffset = 0
     this.state.conversationPage = 0
+    this.state.noticeWindow = 0
   }
 
   /** Load more older messages by requesting a larger `last` count. Returns true if new messages were added. */

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -144,6 +144,15 @@ export interface AppState {
   /** Advances one frame per spinner tick while the shown session is working.
    *  Absent in states built before the spinner existed; treated as 0. */
   spinnerTick?: number
+  /**
+   * Which slice of an over-long notice is on screen.
+   *
+   * The recap and the waiting banner are capped at two lines because that is
+   * what the panel can spare, and the rest used to end at `…` — information
+   * the reader was told existed and then could not reach. The auto-advance
+   * clock walks this instead, so waiting is enough to see all of it.
+   */
+  noticeWindow?: number
   debugEvent?: string
   voicePhase?: VoicePhase
   voiceText?: string
@@ -285,10 +294,10 @@ function spinnerFrame(state: AppState): string {
  * five or six rows, crowding out the conversation it was meant to introduce.
  */
 function recapBlock(recap: string | undefined, maxLines = 2): string[] {
-  const body = recapBlockLines(recap, maxLines).flatMap(splitDisplayLines)
-  if (!body.length) return []
-  if (body.length <= maxLines) return body
-  return [...body.slice(0, maxLines - 1), ellipsize(body[maxLines - 1])]
+  // Every line, not the first two: the strip shows `NOTICE_LINES` of them at a
+  // time and the clock walks the rest. Cutting here would throw away what the
+  // walking is for.
+  return recapBlockLines(recap, maxLines).flatMap(splitDisplayLines)
 }
 
 /** Display label for a relay item's session (live session name, else the id). */
@@ -306,8 +315,8 @@ function relayBannerLines(state: AppState): string[] {
     const choiceHint = top.choices?.length ? `(選択${top.choices.length})` : ''
     const more = state.relayWaiting.length > 1 ? ` 他${state.relayWaiting.length - 1}件` : ''
     const head = splitDisplayLines(`[!]${relayLabel(state, top)}${choiceHint}${more}`)[0] || ''
-    const textLines = splitDisplayLines(top.text).slice(0, 2)
-    return [head, ...textLines]
+    // All of it; the strip windows what fits and the clock walks the rest.
+    return [head, ...splitDisplayLines(top.text)]
   }
   // Notifications get no body space here. The dialog already presented each
   // one full-screen, and the list keeps them in full afterwards; a third
@@ -528,8 +537,54 @@ export const NOTICE_BORDER = 1
 /** 0-15 on this panel's 16 greens. Bright enough to read as a rule, dim enough
  *  that it does not compete with the text it is separating. */
 export const NOTICE_BORDER_COLOR = 6
-/** A notice longer than the conversation it introduces has stopped helping. */
+/**
+ * Everything the notice strip has to say, before it is windowed.
+ *
+ * Shared with the auto-advance clock, which has to know how much is waiting
+ * behind the strip without rendering it.
+ */
+function conversationNoticeLines(state: AppState): string[] {
+  const session = state.sessions[state.sessionIndex]
+  const pane = state.selectedPaneId
+    ? (session?.panes ?? []).find((p) => p.paneId === state.selectedPaneId)
+    : undefined
+  const banner = relayBannerLines(state)
+  // Recap heads the latest view; deeper paging drops it for message space,
+  // and so does the conversation moving past it.
+  const onLatest = state.conversationOffset === 0 && state.conversationPage === 0
+  const recapText = pane ? pane.recap : session?.ccRecap
+  const recapAt = pane ? pane.recapAt : session?.ccRecapAt
+  const recap = onLatest && recapIsCurrent(recapAt, state.conversation) ? recapBlock(recapText) : []
+  return [...banner, ...recap]
+}
+
+/** A notice longer than the conversation it introduces has stopped helping —
+ *  so a long one is shown this many lines at a time instead of all at once. */
 const NOTICE_MAX_LINES = 3
+
+/** The `window`-th slice of a notice, clamped to the last one. */
+function noticeWindowOf(lines: string[], window: number): string[] {
+  if (lines.length <= NOTICE_MAX_LINES) return lines
+  const last = noticeWindowCountOf(lines.length) - 1
+  const w = Math.max(0, Math.min(window, last))
+  return lines.slice(w * NOTICE_MAX_LINES, w * NOTICE_MAX_LINES + NOTICE_MAX_LINES)
+}
+
+function noticeWindowCountOf(total: number): number {
+  return Math.max(1, Math.ceil(total / NOTICE_MAX_LINES))
+}
+
+/**
+ * How many slices the notice takes to show in full.
+ *
+ * The auto-advance clock asks this to know whether waiting will reveal
+ * anything more, so it can move on to the conversation instead of sitting on
+ * a strip that has already shown everything it has.
+ */
+export function noticeWindowCount(state: AppState): number {
+  if (state.mode !== 'conversation') return 1
+  return noticeWindowCountOf(conversationNoticeLines(state).length)
+}
 
 export function noticeHeight(lines: number): number {
   return lines > 0 ? lines * LINE_H + 2 * NOTICE_PAD + 2 * NOTICE_BORDER : 0
@@ -564,13 +619,7 @@ function conversationContent(state: AppState): {
     ? Math.max(0, msgs.length - 1 - state.conversationOffset)
     : -1
   const { text: convText, pageInfo } = paginateMessage(msgs, msgIndex, state.conversationPage)
-  const banner = relayBannerLines(state)
-  // Recap heads the latest view; deeper paging drops it for message space,
-  // and so does the conversation moving past it.
-  const onLatest = state.conversationOffset === 0 && state.conversationPage === 0
-  const recapText = pane ? pane.recap : session?.ccRecap
-  const recapAt = pane ? pane.recapAt : session?.ccRecapAt
-  const recap = onLatest && recapIsCurrent(recapAt, msgs) ? recapBlock(recapText) : []
+  const allNotice = conversationNoticeLines(state)
   // The body container clips overflow: cap the banner+recap+content block at
   // one page so a waiting overlay never pushes conversation text off-screen.
   // Everything is measured in display lines — counting the conversation in
@@ -579,7 +628,7 @@ function conversationContent(state: AppState): {
   // The notice block gets its own container so the panel can draw the line
   // between them as a border. It used to be a row of dashes inside this one,
   // which spent 27px — a seventh of everything the reader gets — on a rule.
-  const noticeLines = [...banner, ...recap].slice(0, NOTICE_MAX_LINES)
+  const noticeLines = noticeWindowOf(allNotice, state.noticeWindow ?? 0)
   const noticeText = noticeLines.join('\n')
   // The body container clips overflow: cap the content at what is left once
   // the notice has taken its share, so a waiting banner never pushes

--- a/glasses/src/types.ts
+++ b/glasses/src/types.ts
@@ -256,15 +256,19 @@ export function sanitizeForG2(text: string): string {
  * Empty when no recap. The glasses conversation view leads with the gist —
  * full history reading is the phone's job (real-device feedback, #504).
  */
-export function recapBlockLines(recap: string | undefined, maxLines = 2): string[] {
+export function recapBlockLines(recap: string | undefined, _maxLines = 2): string[] {
   const clean = sanitizeForG2((recap ?? '').trim())
   if (!clean) return []
   const lines = clean.split('\n')
-  const capped = lines.length > maxLines ? [...lines.slice(0, maxLines - 1), '…'] : lines
-  // No rule at the end: the recap is its own container now, and the panel
-  // draws the line between them as a border. A dash row cost a full 27px line
-  // out of the seven to do the same job.
-  return [`要約: ${capped[0]}`, ...capped.slice(1)]
+  // Uncapped: the notice strip shows a window of these and the auto-advance
+  // clock walks the rest, so cutting here would discard what it walks. It used
+  // to end at `…` — telling the reader there was more and leaving them no way
+  // to reach it.
+  //
+  // No rule at the end either: the recap is its own container now, and the
+  // panel draws the line between them as a border. A dash row cost a full 27px
+  // line out of the seven to do the same job.
+  return [`要約: ${lines[0]}`, ...lines.slice(1)]
 }
 
 


### PR DESCRIPTION
## 問題

7行しかない画面に要約と会話を同時に置けないので、要約は `…` で終わっていた。**「まだ続きがある」とだけ伝えて、たどり着く手段がない**状態。長い待機バナーも、メッセージの2ページ目以降も同じ。

## 直し

**はみ出しをクロックが歩く。** 通知帯を1窓ずつ、続いてメッセージのページを、5秒に1歩ずつ。

```
── 0秒後 ──                              ── 5秒後 ──
┌────────────────────────┐      ┌────────────────────────┐
│2脚ロボ開発                  │      │2脚ロボ開発                  │
├────────────────────────┤      ├────────────────────────┤
│要約: LiPo と充電器の選定が残って…│      │ば残りは自動です。             │
│こが一番誤りやすい箇所です。        │      │明日の買い物で現物を見て決める方針… │
│降圧・線材・工具は機械的に決まるの…│      │5千円前後。                  │
├────────────────────────┤      ├────────────────────────┤
│買い物相談の続きです。            │      │買い物相談の続きです。            │
└────────────────────────┘      └────────────────────────┘
```

### 設計判断

**一度に動くのは1箇所だけ。** 要約がスクロールしながら会話がページングする画面は一目で読めない。この画面は一目で読む以外の読み方をされない。

**終端で止まる。ループしない。** 最後まで来てそこに留まるのが「全部読んだ」の形。

**リング操作から10秒待ってから始まる。** ユーザーが操作している間は主導権を奪わない。「しばらく待つと」を文字どおり実装した。操作の合間の一呼吸を「読み終わった」と誤認しない長さ。

**1歩5秒。** 1歩ごとに BLE 越しの再描画が走るので遅くしてある。sessions push と同じ周期に合わせ、パネルが2つのリズムを持たないようにした。

## 検証

- 実測（上の図）: 要約が2画面に分かれ、5秒後に後半が出る
- テスト9件追加（窓数の算出、窓のタイル性=重複も抜けもない、終端でループしない、通知が無い/収まる場合は1窓、ページを送った後は要約を数えない）
- 全テストパス（backend 517 / frontend 78 / glasses 111）、lint クリーン

## まだやっていないこと

**ツール行（`[Bash] ...`）の切り詰めはそのまま。** あれは横方向のクリップなので、この縦の送りでは露出しない。別の仕組みが要るので分けた。

## リリース時の注意

`glasses/src` のみ。ehpk の再ビルド + Beta 昇格が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np