### PR TITLE
feat: herdr の named session で動かせるようにする

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,7 +18,12 @@ import { parseArgs, runCli, VERSION } from './cli';
 import { conditionalAuthMiddleware, isAuthRequired, getJwtSecret, initJwtSecret } from './middleware/auth';
 import { AuthService } from './services/auth';
 import { getDataDir } from './utils/storage';
-import { herdrBinaryPath, herdrRpc, herdrSocketPath } from './services/herdr-client';
+import {
+  herdrBinaryPath,
+  herdrRpc,
+  herdrSessionName,
+  herdrSocketPath,
+} from './services/herdr-client';
 import { t } from './i18n';
 import { TMP_PATHS } from '../../shared/identity';
 
@@ -292,12 +297,29 @@ async function herdrPing(): Promise<HerdrPong | null> {
 
 let herdrPong = await herdrPing();
 if (!herdrPong) {
-  console.log('⏳ herdr server not running; starting it...');
-  Bun.spawn([herdrPath, 'server'], {
-    stdin: 'ignore',
-    stdout: 'ignore',
-    stderr: 'ignore',
-  }).unref();
+  const herdrSession = herdrSessionName();
+  console.log(
+    herdrSession
+      ? `⏳ herdr server not running; starting it (session ${herdrSession})...`
+      : '⏳ herdr server not running; starting it...',
+  );
+  // `--session` rather than only pointing the child at a socket: HERDR_SOCKET_PATH
+  // moves the socket but leaves the logs and session.json in the default session
+  // directory, so two servers started that way would write the same workspace
+  // state over each other. Dropping it from the child's environment keeps an
+  // inherited value from quietly putting us back there.
+  const { HERDR_SOCKET_PATH: _inherited, ...childEnv } = process.env;
+  Bun.spawn(
+    herdrSession
+      ? [herdrPath, '--session', herdrSession, 'server']
+      : [herdrPath, 'server'],
+    {
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'ignore',
+      env: herdrSession ? childEnv : process.env,
+    },
+  ).unref();
   for (let i = 0; i < 20 && !herdrPong; i++) {
     await new Promise((r) => setTimeout(r, 250));
     herdrPong = await herdrPing();

--- a/backend/src/services/herdr-client.ts
+++ b/backend/src/services/herdr-client.ts
@@ -17,8 +17,54 @@ import { connect } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+/**
+ * Name of the herdr session to run against, or null for the default one.
+ *
+ * A named session is a separate herdr server with its own socket, workspaces
+ * and persisted state, which is how two builds of this app share a machine
+ * without seeing each other's panes (#459).
+ */
+export function herdrSessionName(): string | null {
+  return process.env.HERDR_SESSION || null;
+}
+
 export function herdrSocketPath(): string {
-  return process.env.HERDR_SOCKET_PATH || `${homedir()}/.config/herdr/herdr.sock`;
+  // HERDR_SESSION is checked first, and this order matters: herdr exports
+  // HERDR_SOCKET_PATH into every pane it runs (alongside HERDR_PANE_ID and
+  // friends), so a copy of this app launched from a terminal inside another
+  // copy inherits a socket nobody chose. Letting that win would silently attach
+  // the two to the same herdr server — the collision named sessions exist to
+  // prevent, reached by the one route where it looks like it is working.
+  const session = herdrSessionName();
+  // Verified against herdr 0.7.4: `herdr --session <name> server` reports this
+  // path, and `herdr session list --json` returns it as `socket_path`. Reading
+  // it from the CLI would be sturdier, but this is called once per RPC
+  // connection — and it has to answer before the session exists, which is
+  // exactly when it is not in that listing.
+  if (session) {
+    return `${homedir()}/.config/herdr/sessions/${session}/herdr.sock`;
+  }
+
+  // No session named: an inherited or explicit socket is all we have to go on.
+  if (process.env.HERDR_SOCKET_PATH) return process.env.HERDR_SOCKET_PATH;
+
+  return `${homedir()}/.config/herdr/herdr.sock`;
+}
+
+/**
+ * Environment for herdr CLI children, pinned to the socket this process
+ * resolved.
+ *
+ * Inheritance is not enough. A child run from a systemd unit has no ambient
+ * HERDR_SOCKET_PATH and would fall back to the default socket, so a server
+ * addressed by HERDR_SESSION would end up driving panes in somebody else's
+ * session. Saying it outright leaves nothing to infer.
+ */
+export function herdrChildEnv(): Record<string, string> {
+  return {
+    ...(process.env as Record<string, string>),
+    HERDR_SOCKET_PATH: herdrSocketPath(),
+  };
 }
 
 let cachedHerdrBinary: string | null | undefined;
@@ -480,7 +526,7 @@ export class PaneController {
     const sizeArgs = size ? ['--cols', String(size.cols), '--rows', String(size.rows)] : [];
     this.proc = Bun.spawn(
       [herdrBin(), 'terminal', 'session', 'control', herdrPaneId, '--takeover', ...sizeArgs],
-      { stdin: 'pipe', stdout: 'pipe', stderr: 'ignore' },
+      { stdin: 'pipe', stdout: 'pipe', stderr: 'ignore', env: herdrChildEnv() },
     );
     this.stdinWriter = this.proc.stdin as unknown as { write(s: string): unknown };
 

--- a/backend/src/services/herdr-update.ts
+++ b/backend/src/services/herdr-update.ts
@@ -15,7 +15,7 @@
  */
 
 import type { HerdrUpdateStatus } from '../../../shared/types';
-import { herdrBin, herdrBinaryPath } from './herdr-client';
+import { herdrBin, herdrBinaryPath, herdrChildEnv } from './herdr-client';
 
 /** Matches the dashboard's own refresh cadence; a spawn per poll is plenty. */
 const CACHE_TTL_MS = 30_000;
@@ -105,7 +105,10 @@ export function buildHerdrApplyCommands(
 }
 
 async function runCapture(cmd: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' });
+  // Pinned to our socket like every other herdr child: `herdr status` reports
+  // the running server's version, and reading the default server's would make
+  // the skew warning describe a server we are not talking to.
+  const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe', env: herdrChildEnv() });
   const timer = setTimeout(() => proc.kill(), SPAWN_TIMEOUT_MS);
   try {
     const [stdout, stderr, exitCode] = await Promise.all([

--- a/backend/tests/unit/herdr-session.test.ts
+++ b/backend/tests/unit/herdr-session.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { homedir } from 'node:os';
+import {
+  herdrChildEnv,
+  herdrSessionName,
+  herdrSocketPath,
+} from '../../src/services/herdr-client';
+
+/**
+ * Which herdr server this process talks to (#459). Two builds of this app on
+ * one machine stay out of each other's panes by running against different herdr
+ * sessions, so resolving the wrong socket does not fail — it quietly drives
+ * somebody else's terminals.
+ */
+
+const ORIGINAL_SESSION = process.env.HERDR_SESSION;
+const ORIGINAL_SOCKET = process.env.HERDR_SOCKET_PATH;
+
+function restore(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterEach(() => {
+  restore('HERDR_SESSION', ORIGINAL_SESSION);
+  restore('HERDR_SOCKET_PATH', ORIGINAL_SOCKET);
+});
+
+describe('herdrSocketPath', () => {
+  test('falls back to the default session socket', () => {
+    delete process.env.HERDR_SESSION;
+    delete process.env.HERDR_SOCKET_PATH;
+
+    expect(herdrSocketPath()).toBe(`${homedir()}/.config/herdr/herdr.sock`);
+  });
+
+  test('resolves a named session to its own socket', () => {
+    delete process.env.HERDR_SOCKET_PATH;
+    process.env.HERDR_SESSION = 'hrdle';
+
+    expect(herdrSocketPath()).toBe(
+      `${homedir()}/.config/herdr/sessions/hrdle/herdr.sock`,
+    );
+  });
+
+  test('a named session beats an inherited socket', () => {
+    // herdr exports HERDR_SOCKET_PATH into every pane it runs, so this app
+    // launched from a terminal inside another copy of it inherits a socket
+    // nobody chose. If that won, the two would share a herdr server — the
+    // collision named sessions exist to prevent, via the one route where it
+    // looks like it is working.
+    process.env.HERDR_SOCKET_PATH = `${homedir()}/.config/herdr/herdr.sock`;
+    process.env.HERDR_SESSION = 'hrdle';
+
+    expect(herdrSocketPath()).toBe(
+      `${homedir()}/.config/herdr/sessions/hrdle/herdr.sock`,
+    );
+  });
+
+  test('an explicit socket still works when no session is named', () => {
+    delete process.env.HERDR_SESSION;
+    process.env.HERDR_SOCKET_PATH = '/run/somewhere/herdr.sock';
+
+    expect(herdrSocketPath()).toBe('/run/somewhere/herdr.sock');
+  });
+
+  test('an empty session name is not a session', () => {
+    process.env.HERDR_SESSION = '';
+    delete process.env.HERDR_SOCKET_PATH;
+
+    expect(herdrSessionName()).toBeNull();
+    expect(herdrSocketPath()).toBe(`${homedir()}/.config/herdr/herdr.sock`);
+  });
+});
+
+describe('herdrChildEnv', () => {
+  test('pins children to the resolved socket rather than leaving it inherited', () => {
+    // A child spawned from a systemd unit has no ambient HERDR_SOCKET_PATH and
+    // would otherwise fall back to the default socket, driving panes in a
+    // session this process is not talking to.
+    process.env.HERDR_SESSION = 'hrdle';
+    delete process.env.HERDR_SOCKET_PATH;
+
+    expect(herdrChildEnv().HERDR_SOCKET_PATH).toBe(
+      `${homedir()}/.config/herdr/sessions/hrdle/herdr.sock`,
+    );
+  });
+
+  test('overrides an inherited socket that disagrees', () => {
+    process.env.HERDR_SESSION = 'hrdle';
+    process.env.HERDR_SOCKET_PATH = `${homedir()}/.config/herdr/herdr.sock`;
+
+    expect(herdrChildEnv().HERDR_SOCKET_PATH).toBe(
+      `${homedir()}/.config/herdr/sessions/hrdle/herdr.sock`,
+    );
+  });
+
+  test('keeps the rest of the environment', () => {
+    process.env.HERDR_SESSION = 'hrdle';
+
+    expect(herdrChildEnv().PATH).toBe(process.env.PATH as string);
+  });
+});


### PR DESCRIPTION
## なぜ

#459 は cchub と hrdle を1台のマシンでしばらく並走させます。両者が同じ herdr サーバーを共有すると、**互いのワークスペースが一覧に出て、同じペインを奪い合います** — #520 を音量を上げてやるようなものです。

herdr には既に named session があり、サーバー・ソケット・ワークスペース・永続化がまるごと分かれます。`HERDR_SESSION` でそれを選べるようにしました。

## 3つ必要で、成り立っていたのは1つだけでした

### 1. `HERDR_SESSION` が `HERDR_SOCKET_PATH` に優先する必要がある

**herdr は自分が起動するすべてのペインに `HERDR_SOCKET_PATH` を注入します**（`HERDR_PANE_ID` / `HERDR_WORKSPACE_ID` と並んで）。実測:

```
$ env | grep HERDR
HERDR_ENV=1
HERDR_PANE_ID=w4Q:p1
HERDR_SOCKET_PATH=/home/m0a/.config/herdr/herdr.sock
HERDR_TAB_ID=w4Q:t1
HERDR_WORKSPACE_ID=w4Q
```

つまりこの変数は「意図的な指定」ではなく**環境由来**です。素直な優先順位（明示的なソケットが勝つ）にすると、**別インスタンスのターミナルから起動して試す**という一番自然な検証手順で、セッションを指定したのに環境由来のソケットに繋がります。しかも動いているように見えます。

### 2. サーバーは `--session` で起動する必要がある（ソケットを向けるだけでは駄目）

`HERDR_SOCKET_PATH=… herdr server` はそのソケットに bind はします。しかし出力はこうです。

```
api socket: ~/.config/herdr/sessions/hrdle-probe/herdr.sock   ← 分離される
logs:       ~/.config/herdr/herdr-server.log                   ← default のまま
```

**ソケットは動くがセッションディレクトリは動きません。** そこには `session.json`（ワークスペース復元情報）があるので、この方法で2つ起動すると両者が同じファイルを書き、互いのワークスペース状態を失います。`--session` ならディレクトリごと分かれます。子プロセスに継承された `HERDR_SOCKET_PATH` は明示的に落として、元に戻らないようにしました。

### 3. 子プロセスにソケットを伝える必要がある

`PaneController` の `herdr terminal session control` と herdr-update の `herdr status` は、どちらも**単なる env 継承**でした。systemd 配下には継承元の値が存在しないので、`HERDR_SESSION` で指定したサーバーを見ているのに**default セッションのペインを操作する**ことになります。`herdrChildEnv()` で明示するようにしました。

## 検証（読むのではなく、通して動かして）

`HERDR_SESSION` を設定しサーバー無しの状態で起動 → サーバーが立ち上がり、`herdr session list` に独自ソケット・独自 `herdr-server.log` を持つセッションが出現。**同じホストの同時刻で、2つのインスタンスが別のことを言いました**。

| | live workspaces | lost |
|---|---:|---:|
| named session (:3997) | **0** | 18 |
| 本番 (:5923) | **10** | 8 |

lost が一致するのは data dir をまだ共有しているためで、その分離は次の作業です。テスト用セッションは削除済み、本番は live=10 で無傷を確認しました。

backend 525 pass / frontend 87 pass、lint・tsc クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STv3pQwmpdxMa9fJ4TK7a6