### PR TITLE
Release v0.2.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.93] - 2026-07-28
+
+### Added
+- **herdr の named session で動かせるようにする** (#655): #459 は cchub と hrdle を1台のマシンでしばらく並走させる。両者が同じ herdr サーバーを共有すると互いのワークスペースが一覧に出て同じペインを奪い合う（#520 を音量を上げてやるようなもの）。herdr には既に named session があり、サーバー・ソケット・ワークスペース・永続化がまるごと分かれるので、`HERDR_SESSION` でそれを選べるようにした。**未設定なら挙動は従来と完全に同じ**
+  - **`HERDR_SESSION` は `HERDR_SOCKET_PATH` に優先する**。herdr は自分が起動するすべてのペインに `HERDR_SOCKET_PATH` を注入する（`HERDR_ENV` / `HERDR_PANE_ID` / `HERDR_WORKSPACE_ID` と並んで）ため、この変数は意図的な指定ではなく環境由来。素直な優先順位（明示的なソケットが勝つ）にすると、「別インスタンスのターミナルから起動して試す」という一番自然な検証手順で、セッション指定が無視されて同じサーバーに繋がる — しかも動いているように見える
+  - **サーバーは `--session` で起動する**。`HERDR_SOCKET_PATH=… herdr server` はそのソケットに bind はするが `logs: ~/.config/herdr/herdr-server.log` を報告する。つまりソケットは動くがセッションディレクトリは動かず、そこにある `session.json`（ワークスペース復元情報）を2つのサーバーが同時に書いて互いの状態を失う。子プロセスに継承された `HERDR_SOCKET_PATH` は明示的に落として元に戻らないようにした
+  - **子プロセスにソケットを明示する**（`herdrChildEnv()`）。`PaneController` の `herdr terminal session control` と herdr-update の `herdr status` はどちらも env 継承だけだった。systemd 配下には継承元の値が存在しないため、`HERDR_SESSION` で指定したサーバーを見ているのに default セッションのペインを操作することになっていた
+  - 検証: `HERDR_SESSION` 設定・サーバー無しの状態から起動してサーバーが立ち、`herdr session list` に独自ソケットと独自 `herdr-server.log` を持つセッションが出現。同じホストの同時刻で named 側 live=0 / 本番 live=10 と、2つのインスタンスが別のことを言うところまで確認した
+
 ## [0.2.92] - 2026-07-28
 
 ### Changed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "generated": "2026-07-28",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "generated": "2026-07-28",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes

- feat: herdr の named session で動かせるようにする (#655)

## Notes

**`HERDR_SESSION` を設定しない限り挙動は従来と完全に同じです。** 設定するのは #459 の並走期に hrdle 側だけです。

ただし `herdrChildEnv()` により **PaneController の起動に env が明示されるようになった**ので、ターミナル全体が通る経路には触れています。リリース後に本番でペイン操作が正常なことを実機確認します。

### 検証で分かったこと

3つ必要で、成り立っていたのは1つだけでした。

1. **`HERDR_SESSION` が `HERDR_SOCKET_PATH` に優先する必要がある** — herdr は自分が起動する全ペインに `HERDR_SOCKET_PATH` を注入するので、この変数は環境由来であって意図的な指定ではない。素直な優先順位にすると「別インスタンスのターミナルから起動して試す」という一番自然な手順でセッション指定が無視され、しかも動いているように見える
2. **サーバーは `--session` で起動する必要がある** — `HERDR_SOCKET_PATH` だけではソケットしか動かず、`session.json` を2つのサーバーが同時に書いて互いのワークスペース状態を失う
3. **子プロセスにソケットを明示する必要がある** — systemd 配下には継承元が無く、named セッションを見ているのに default のペインを操作していた

同じホストの同時刻で named 側 live=0 / 本番 live=10 と、2インスタンスが別のことを言うところまで確認済みです。