### PR TITLE
refactor: 黙って壊れる名前をあと3件 identity に寄せる（＋走査で守る）

### DIFF
--- a/backend/src/commands/debug.ts
+++ b/backend/src/commands/debug.ts
@@ -9,13 +9,14 @@ import { spawn } from 'node:child_process';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { mkdir, writeFile, unlink, access } from 'node:fs/promises';
+import { SERVICE } from '../../../shared/identity';
 
 const DROP_IN_DIR = join(
   homedir(),
   '.config',
   'systemd',
   'user',
-  'cchub.service.d',
+  SERVICE.dropInDir,
 );
 const DROP_IN_FILE = join(DROP_IN_DIR, '99-inspect.conf');
 const DEFAULT_INSPECT_PORT = 9229;
@@ -57,8 +58,8 @@ async function enableInspector(): Promise<void> {
   await mkdir(DROP_IN_DIR, { recursive: true });
   await writeFile(DROP_IN_FILE, conf);
   await runSystemctl(['daemon-reload']);
-  console.log('🔧 Reloading systemd, restarting cchub.service…');
-  await runSystemctl(['restart', 'cchub.service']);
+  console.log(`🔧 Reloading systemd, restarting ${SERVICE.unitFile}…`);
+  await runSystemctl(['restart', SERVICE.unitFile]);
   console.log('');
   console.log(`✅ Inspector enabled on 0.0.0.0:${port}`);
   console.log('');
@@ -85,9 +86,9 @@ async function disableInspector(): Promise<void> {
     return;
   }
   await runSystemctl(['daemon-reload']);
-  console.log('🔧 Reloading systemd, restarting cchub.service…');
-  await runSystemctl(['restart', 'cchub.service']);
-  console.log('✅ Inspector disabled, cchub.service back to normal.');
+  console.log(`🔧 Reloading systemd, restarting ${SERVICE.unitFile}…`);
+  await runSystemctl(['restart', SERVICE.unitFile]);
+  console.log(`✅ Inspector disabled, ${SERVICE.unitFile} back to normal.`);
 }
 
 async function profileInspector(seconds: number): Promise<void> {

--- a/backend/src/services/codex-hook-config.ts
+++ b/backend/src/services/codex-hook-config.ts
@@ -1,6 +1,7 @@
 import { readFile, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { resolveNotifyCommand } from './notify-command';
+import { HOOK_COMMAND_PATTERN } from '../../../shared/identity';
 
 interface JsonHookCommand {
   type?: string;
@@ -20,10 +21,8 @@ interface CodexHooksJson {
   [key: string]: unknown;
 }
 
-const CCHUB_NOTIFY_PATTERN = /(?:^|\/)cchub\s+notify(?:\s|$)/;
-
 function isCchubNotify(command: unknown): command is string {
-  return typeof command === 'string' && CCHUB_NOTIFY_PATTERN.test(command.trim());
+  return typeof command === 'string' && HOOK_COMMAND_PATTERN.test(command.trim());
 }
 
 function hasCchubHook(entries: JsonHookEntry[] | undefined, matcher?: string): boolean {

--- a/backend/src/services/notify-command.ts
+++ b/backend/src/services/notify-command.ts
@@ -1,4 +1,5 @@
 import { basename } from 'node:path';
+import { HOOK_COMMAND, IDENTITY } from '../../../shared/identity';
 
 /**
  * The `cchub notify` invocation to write into an agent's hook config.
@@ -18,7 +19,7 @@ export function notifyCommandFor(execPath: string): string {
   // binary, and `<bun> notify` is not a command anyone wants baked into their
   // hooks. A bare name is the honest fallback there: dev is also where PATH is
   // most likely to be fine, since it was started from an interactive shell.
-  if (!basename(execPath).startsWith('cchub')) return 'cchub notify';
+  if (!basename(execPath).startsWith(IDENTITY.binaryName)) return HOOK_COMMAND;
   // Hook commands go through a shell, so a path with spaces needs quoting.
   return /\s/.test(execPath) ? `"${execPath}" notify` : `${execPath} notify`;
 }

--- a/backend/tests/unit/identity-operational.test.ts
+++ b/backend/tests/unit/identity-operational.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import {
+  HOOK_COMMAND,
+  HOOK_COMMAND_PATTERN,
+  IDENTITY,
+  SERVICE,
+} from '../../../shared/identity';
+import { notifyCommandFor } from '../../src/services/notify-command';
+
+/**
+ * A third round of names that a rename would break without breaking anything
+ * visibly — the same shape as the ones in #635 and #637, found while sorting
+ * the remaining literals into "display" and "not display".
+ *
+ * What each one costs when it stops agreeing with the binary:
+ *
+ * - The systemd drop-in directory: `cchub debug enable` writes a unit override
+ *   for a unit that no longer exists. systemd has nothing to complain about, so
+ *   the inspector simply never turns on.
+ * - The hook command: what gets written into the user's Claude/Codex config.
+ *   Wrong, and notifications stop with no error anywhere.
+ * - The hook pattern: how an already-installed hook is recognised. Stops
+ *   matching and setup writes a second one next to the first.
+ */
+
+describe('systemd drop-in', () => {
+  test('the drop-in directory belongs to the unit we restart', () => {
+    // systemd only reads <unit>.d/, so these two agreeing is the whole feature.
+    expect(SERVICE.dropInDir).toBe(`${SERVICE.unitFile}.d`);
+  });
+});
+
+describe('hook command', () => {
+  test('an absolute path to our binary is used as-is', () => {
+    expect(notifyCommandFor(`/home/me/bin/${IDENTITY.binaryName}`)).toBe(
+      `/home/me/bin/${IDENTITY.binaryName} notify`,
+    );
+  });
+
+  test('running from a different binary falls back to the bare command', () => {
+    // `bun run src/index.ts` makes execPath the bun binary, and `<bun> notify`
+    // is not something anyone wants baked into their hooks.
+    expect(notifyCommandFor('/home/me/.bun/bin/bun')).toBe(HOOK_COMMAND);
+  });
+
+  test('a path with spaces is quoted for the shell that runs it', () => {
+    expect(notifyCommandFor(`/home/my name/${IDENTITY.binaryName}`)).toBe(
+      `"/home/my name/${IDENTITY.binaryName}" notify`,
+    );
+  });
+});
+
+describe('hook detection pattern', () => {
+  test('matches the bare command', () => {
+    expect(HOOK_COMMAND_PATTERN.test(HOOK_COMMAND)).toBe(true);
+  });
+
+  test('matches an absolute path, which is what setup actually writes', () => {
+    expect(
+      HOOK_COMMAND_PATTERN.test(`/home/me/bin/${IDENTITY.binaryName} notify`),
+    ).toBe(true);
+  });
+
+  test('does not match a different subcommand', () => {
+    expect(HOOK_COMMAND_PATTERN.test(`${IDENTITY.binaryName} setup`)).toBe(false);
+  });
+
+  test('does not match a binary that merely ends with our name', () => {
+    // `/usr/bin/notcchub notify` is somebody else's program.
+    expect(HOOK_COMMAND_PATTERN.test(`not${IDENTITY.binaryName} notify`)).toBe(
+      false,
+    );
+  });
+
+  test('tolerates a name with regex metacharacters', () => {
+    // Nothing today needs this, but the pattern is built by interpolation and a
+    // future name containing a dot would otherwise match more than it should.
+    expect(() => new RegExp(HOOK_COMMAND_PATTERN.source)).not.toThrow();
+  });
+});
+
+/**
+ * Scans for the literals themselves, because the assertions above cannot.
+ *
+ * They check that `dropInDir` is `unitFile` plus `.d`, which stays true no
+ * matter what any call site does — and a call site holding its own
+ * `'cchub.service.d'` is exactly how these three got missed by the two rounds
+ * that came before. This is what those rounds were lacking.
+ *
+ * Deliberately narrow. It looks for names that have to agree with something
+ * else to work, not for every mention of the product: comments and log lines
+ * say the name for the reader's benefit and nothing breaks when they are stale.
+ */
+describe('no operational identity left as a literal', () => {
+  const OPERATIONAL = [
+    { pattern: /['"`][^'"`]*cchub\.service/, what: 'a systemd unit name' },
+    { pattern: /['"`][^'"`]*com\.cchub/, what: 'a launchd label' },
+    { pattern: /['"`]\/tmp\/cc-?hub/, what: 'a scratch path' },
+    { pattern: /['"`][^'"`]*\.cc-hub['"`/]/, what: 'the data directory' },
+    { pattern: /CC_HUB_DATA_DIR/, what: 'the data directory env var' },
+  ];
+
+  // Where the literals are the point: identity.ts defines them, and the tests
+  // assert against them on purpose.
+  const ALLOWED = /shared\/identity\.ts$|\/tests\/|__tests__\//;
+
+  test('backend and shared sources go through identity', async () => {
+    const proc = Bun.spawnSync([
+      'git',
+      'ls-files',
+      'backend/src',
+      'shared',
+      'frontend/src',
+    ], { cwd: join(import.meta.dir, '..', '..', '..') });
+    const files = new TextDecoder()
+      .decode(proc.stdout)
+      .split('\n')
+      .filter((f) => /\.tsx?$/.test(f) && !ALLOWED.test(f));
+    expect(files.length).toBeGreaterThan(50); // the scan actually found sources
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const text = await Bun.file(
+        join(import.meta.dir, '..', '..', '..', file),
+      ).text();
+      text.split('\n').forEach((line, i) => {
+        const code = line.trim();
+        if (code.startsWith('//') || code.startsWith('*') || code.startsWith('/*')) {
+          return;
+        }
+        for (const { pattern, what } of OPERATIONAL) {
+          if (pattern.test(line)) {
+            offenders.push(`${file}:${i + 1} holds ${what}: ${code.slice(0, 70)}`);
+          }
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/shared/identity.ts
+++ b/shared/identity.ts
@@ -86,6 +86,8 @@ export const SERVICE = {
   launchdUpdateLabel: `${IDENTITY.launchdPrefix}.update`,
   launchdServerPlist: `${IDENTITY.launchdPrefix}.server.plist`,
   launchdUpdatePlist: `${IDENTITY.launchdPrefix}.update.plist`,
+  /** `cchub.service.d` — where systemd looks for drop-in overrides. */
+  dropInDir: `${IDENTITY.serviceName}.service.d`,
 } as const;
 
 /** The release asset for a platform, e.g. `cchub-linux-x64`. */
@@ -95,6 +97,17 @@ export function assetName(platform: string, arch: string): string {
 
 /** The hook command hosts are told to run, e.g. `cchub notify`. */
 export const HOOK_COMMAND = `${IDENTITY.binaryName} notify`;
+
+/**
+ * Matches a hook command that invokes us, bare or by absolute path.
+ *
+ * Used to recognise an entry that is already there. A pattern that stops
+ * matching after a rename does not throw — it reports the hook as missing and
+ * writes a second one beside it.
+ */
+export const HOOK_COMMAND_PATTERN = new RegExp(
+  `(?:^|/)${IDENTITY.binaryName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+notify(?:\\s|$)`,
+);
 
 /** `User-Agent` for calls to the GitHub API. */
 export function userAgent(version: string): string {


### PR DESCRIPTION
## 経緯

表示文字列の一括置換に着手するため、残りのリテラルを「表示」と「表示でないもの」に仕分けていたら、**3件が表示ではありませんでした**。しかも #635 / #637 と同じ形 — 改名すると壊れるのに、何も壊れたように見えない類です。

| 箇所 | 壊れ方 |
|---|---|
| `debug.ts` の `cchub.service.d` | systemd は `<unit>.d/` しか読まない。存在しない unit 用の drop-in を書いてもエラーにならず、**`cchub debug enable` が黙って inspector を有効にしない** |
| `notify-command.ts` の `basename(execPath).startsWith('cchub')` | ユーザーの Claude/Codex hook 設定に何を書き込むかを決める箇所。**通知がどのログにも何も残さず止まる** |
| `codex-hook-config.ts` の hook 検出正規表現 | 既存エントリの認識に使う。マッチしなくなると**同じ hook をもう1つ書き足す** |

## 面白いのは「なぜ2回の点検が見逃したか」

**2回とも私が読んで探したから**です。なので今回は走査を足しました。

追跡下のソースを歩いて、unit 名・launchd ラベル・`/tmp` パス・データディレクトリが `identity.ts` の外でリテラルになっていないかを見ます。**これがあれば、この3件は誰も気づかなくても捕まっていました。**

意図的に狭くしてあります。**何かと一致していないと動かない名前**だけを対象にし、製品名のあらゆる言及は見ません。コメントやログ行は読み手のために名前を言っているだけで、古くなっても壊れません。

## 走査が本当に落ちることを確認

無関係なファイルに `/tmp/cchub-planted` と `com.cchub.something` を植えたら、両方ともファイル名と行番号付きで出ました。

```
backend/src/utils/keychain.ts:56 holds a scratch path: const PLANTED = '/tmp/cchub-planted';
backend/src/utils/keychain.ts:57 holds a launchd label: const PLANTED2 = 'com.cchub.something';
```

## テストは改名に追従します

上のアサーションは現在の文字列ではなく identity の値に対して書いてあるので、`identity.json` を `hrdle` に向けても通ります。**改名を妨げるのではなく、改名に追従します。**

## 実機確認

`cchub debug status` と `/api/notify/hook-status` が、このマシンの実設定に対して正しく答えることを確認しました（claude / codex / grok すべて `configured: true`, `missing: []`）。

backend 535 pass / frontend 87 pass、lint・tsc クリーン。

## 次

本来の表示文字列の作業（i18n カタログ60箇所 + 散在する UI テキスト）は別 PR にします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STv3pQwmpdxMa9fJ4TK7a6