### PR TITLE
Release v0.2.94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.94] - 2026-07-29
+
+### Changed
+- **黙って壊れる名前をあと3件 identity に寄せ、走査で守る** (#657): 表示文字列の一括置換に着手するため残りのリテラルを仕分けていたところ、3件が表示ではなく運用系だった。いずれも #635 / #637 と同じ形で、**改名すると壊れるのに何も壊れたように見えない**
+  - `debug.ts` の `cchub.service.d` — systemd は `<unit>.d/` しか読まない。存在しない unit 用の drop-in を書いてもエラーにならず、`cchub debug enable` が黙って inspector を有効にしない
+  - `notify-command.ts` の `basename(execPath).startsWith('cchub')` — ユーザーの Claude/Codex hook 設定に何を書き込むかを決める箇所。通知がどのログにも何も残さず止まる
+  - `codex-hook-config.ts` の hook 検出正規表現 — 既存エントリの認識に使う。マッチしなくなると同じ hook をもう1つ書き足す
+  - **見逃した原因のほうを修正**: 2回の点検はどちらも目視だった。追跡下のソースを歩いて、unit 名・launchd ラベル・`/tmp` パス・データディレクトリが `identity.ts` の外でリテラルになっていないかを検査するテストを追加（`backend/tests/unit/identity-operational.test.ts`）。無関係なファイルに違反を植えて、ファイル名と行番号付きで検出されることを確認済み。意図的に狭く、「何かと一致していないと動かない名前」だけを対象とし、コメントやログ行は見ない
+- **メッセージカタログが identity 経由で製品名を名乗るようにする** (#658): 「この製品が何と呼ばれているか」を言うユーザー向けテキストが、`identity.json` の外に残っていた最後の大きな塊だった（backend カタログ28箇所、frontend カタログ6箇所、CLI ヘルプ16箇所）
+  - **呼び出し側は1箇所も変えていない**。どちらのカタログにも既に `{{param}}` 補間があったので、注入する側だけを変えた。backend は `t()` が identity セット（`product` / `bin` / `port` / `service` / `configDir` / `keychain`）を呼び出し側の引数の下にマージし、frontend は i18next の `defaultVariables` に `product` / `bin` を渡す。呼び出し側が同じキーを明示的に渡せば勝つ
+  - **改名時の注意**: CLI ヘルプの桁揃えはリテラルの空白で行っているため、長さの違う名前にすると手で調整が要る（`cchub` と `hrdle` がどちらも5文字なのは偶然）。パラメータ定義箇所にコメントとして記載
+  - この仕組みは文字列が使われる場所からは見えず、`defaultVariables` が失われると `{{product}}` がそのままユーザーに出る。しかもその中には hook setup prompt（エージェントに渡され、エージェントがそれを見てユーザーの設定ファイルを編集するもの）が含まれるため、テストを2つ追加。アプリ自身の i18n モジュールを import して実際の init を検証し、両カタログを走査して `{{product}}` / `{{bin}}` の生き残りを探す。`defaultVariables` を削除すると3文字列がキー名付きで検出されることを確認済み
+  - ヘルプ出力は en / ja とも従来とバイト単位で同一
+
 ## [0.2.93] - 2026-07-28
 
 ### Added

--- a/architecture.html
+++ b/architecture.html
@@ -121,8 +121,8 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.93",
-  "generated": "2026-07-28",
+  "version": "0.2.94",
+  "generated": "2026-07-29",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/architecture.json
+++ b/architecture.json
@@ -1,7 +1,7 @@
 {
   "name": "CC Hub",
-  "version": "0.2.93",
-  "generated": "2026-07-28",
+  "version": "0.2.94",
+  "generated": "2026-07-29",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {
     "backend": "Bun runtime + Hono",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.93",
+  "version": "0.2.94",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes

- refactor: 黙って壊れる名前をあと3件 identity に寄せ、走査で守る (#657)
- refactor: メッセージカタログが identity 経由で製品名を名乗るようにする (#658)

## Notes

**ユーザー向けの挙動変更はありません。** どちらも #459（Hrdle への改名）の前提工事で、これで**上流側の工事は完了**です。`identity.json` を書き換えれば、サービス名・パス・ストレージキー・hook 検出・CLI ヘルプ・UI 文言まで追従します。

### #657 — 見逃した原因のほうを直しました

表示文字列の仕分け中に、3件が表示ではなく運用系だと分かりました。`cchub debug enable` が黙って効かなくなる drop-in ディレクトリ、通知がどのログにも残さず止まる hook コマンド判定、同じ hook を二重に書き足す検出正規表現です。

**2回の点検はどちらも目視でした。** なのでソース走査テストを足しています。unit 名・launchd ラベル・`/tmp` パス・データディレクトリが `identity.ts` の外でリテラルになっていたら落ちます。無関係なファイルに違反を植えて、実際に検出されることを確認済みです。

### #658 — 呼び出し側を1箇所も変えずに

カタログ50箇所を identity 経由にしましたが、どちらのカタログにも既に `{{param}}` 補間があったので、注入する側だけを変えました。

テストを2つ足しています。`defaultVariables` が失われると `{{product}}` がそのままユーザーに出るうえ、その中には **hook setup prompt**（エージェントに渡され、エージェントがそれを見てユーザーの設定ファイルを編集するもの）が含まれるためです。ガードが実際に落ちることも確認済みです。

ヘルプ出力は en / ja とも従来とバイト単位で同一、起動中の UI にプレースホルダの残りもゼロでした。

**改名時の注意**: CLI ヘルプの桁揃えはリテラルの空白なので、長さの違う名前にすると手で調整が要ります（`cchub` と `hrdle` がどちらも5文字なのは偶然）。