### PR TITLE
fix(glasses): scroll the recap by characters, in two lines

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -5,7 +5,7 @@ import { screenText, wrapForPanel, wrapHeader } from '../display.ts'
 import { BODY_WIDTH, HEADER_WIDTH, LIST_LINES, textWidth as width } from '../metrics.ts'
 import { listRows, rowCursor, selectableRows } from '../display.ts'
 import { NOTICE_DISMISS_MS } from '../controller.ts'
-import { noticeHeight, noticeScrollSteps } from '../display.ts'
+import { NOTICE_SCROLL_CHARS, noticeHeight, noticeScrollSteps } from '../display.ts'
 import { SPACE_W } from '../metrics.ts'
 import { MAX_LINES } from '../metrics.ts'
 
@@ -195,7 +195,7 @@ describe('conversation body', () => {
     // way to reach it. The strip windows it and the clock walks the rest.
     const first = (screenText(state(longRecap)).notice ?? '').split('\n')
     expect(first[0].startsWith('要約: ')).toBe(true)
-    expect(first.length).toBeLessThanOrEqual(3)
+    expect(first.length).toBeLessThanOrEqual(2)
     expect(first.join('')).not.toEndWith('…')
     expect(noticeScrollSteps(state(longRecap) as never)).toBeGreaterThan(1)
   })
@@ -1234,28 +1234,50 @@ describe('waiting shows what did not fit', () => {
     expect(noticeScrollSteps(none as never)).toBe(1)
   })
 
-  test('it scrolls a line at a time, keeping the reader their place', () => {
-    // Paging replaces the whole strip and the reader has to find where they
-    // were in text they were mid-sentence through. Two of three lines carry
-    // over instead, so the new line arrives with its context already up.
-    const numbered = Array.from({ length: 9 }, (_, i) => `行${i}`).join('\n')
+  test('it scrolls by characters, sliding the text instead of turning pages', () => {
+    // A line at a time replaced the whole strip in 27px jumps, and the reader
+    // had to find their place in a sentence they were mid-way through. Taking
+    // a few characters off the front and re-wrapping what is left slides the
+    // block instead, which is what reading along a line looks like.
+    const prose =
+      '認証まわりの実装を一通り終えてテストも通ったので次はエラー処理の見直しに入る予定です' +
+      'あわせてログ出力の粒度も揃えておきたいところですが優先度は低いので後回しにします'
     const state = st({
       sessions: [{
         id: 'a', name: 'g', state: 'idle' as const,
-        ccRecap: numbered, ccRecapAt: '2030-01-01T00:00:00Z',
+        ccRecap: prose, ccRecapAt: '2030-01-01T00:00:00Z',
       }],
     })
     const at = (o: number) => (screenText({ ...state, noticeWindow: o }).notice ?? '').split('\n')
+    const src = Array.from(`要約: ${prose}`)
     const first = at(0)
     const second = at(1)
-    expect(second[0]).toBe(first[1])
-    expect(second[1]).toBe(first[2])
-    // One line is new each step, and the last line is reached by the last one.
+
+    // Two lines at a time, and the first of them opens the recap.
+    expect(first.length).toBe(2)
+    expect(first[0].startsWith('要約: ')).toBe(true)
+
+    // One step on, the top line begins a few characters into the one before it
+    // — not at the line below it, which is what paging looked like.
+    expect(second[0]).not.toBe(first[1])
+    const dropped = src.slice(NOTICE_SCROLL_CHARS).join('').replace(/^\s+/, '')
+    expect(dropped.startsWith(second[0])).toBe(true)
+
+    // The walk ends with the recap's last characters on screen — the whole
+    // point of walking it — and holds there rather than wrapping round on its
+    // own. Going back to the top is the clock's decision, made after a rest.
     const steps = noticeScrollSteps(state as never)
-    expect(at(steps - 1)).toContain('行8')
+    expect(at(steps - 1).join('')).toContain(prose.slice(-10))
+    expect(at(steps + 5)).toEqual(at(steps - 1))
   })
 
   test('every line is on screen at some point', () => {
+    // Short lines are the shape that catches a stride longer than the strip:
+    // two display lines of `行N` hold barely six characters, so a step that
+    // always advanced `NOTICE_SCROLL_CHARS` would carry lines off the top that
+    // were never shown. Silently skipping part of the recap is the failure the
+    // scrolling exists to fix, so it is guarded here rather than in prose,
+    // which never steps far enough to notice.
     const numbered = Array.from({ length: 9 }, (_, i) => `行${i}`).join('\n')
     const state = st({
       sessions: [{

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -63,9 +63,22 @@ const AUTO_ADVANCE_IDLE_MS = 10_000
 const SECONDS_PER_LINE_MS = 5000
 
 /**
- * The notice scrolls a line at a time, so one line of reading buys one step.
+ * How often the notice gives up another `NOTICE_SCROLL_CHARS` from its front.
+ *
+ * The strip scrolls by character now, so a step is a fraction of a line rather
+ * than a whole one and has to come round proportionally sooner. Ten characters
+ * every two and a half seconds is four a second — the same reading pace the
+ * five-second line was approved at, in thirds of a line instead of whole ones.
+ *
+ * Paced with `NOTICE_SCROLL_CHARS` rather than independently of it: the two
+ * set the reading speed together, and only their ratio to each other sets how
+ * often the glasses redraw. Halving both would read identically and cost twice
+ * as much over BLE.
+ *
+ * It is also the clock every other interval below is counted in, so those stay
+ * multiples of it.
  */
-const AUTO_SCROLL_STEP_MS = SECONDS_PER_LINE_MS
+const AUTO_SCROLL_STEP_MS = 2500
 
 /**
  * A page turn replaces the whole body, so it is priced as the strip was: three
@@ -285,13 +298,13 @@ export class GlassesController {
       this.render()
       return
     }
-    // Nothing further to page to. Back to the top of the recap and round
-    // again, rather than sitting on its last three lines forever — the reader
-    // who looks up a minute later should find it readable from the start.
+    // Nothing further to page to. Back to the first character of the recap and
+    // round again, rather than sitting on its tail forever — the reader who
+    // looks up a minute later should find it readable from the start.
     if (steps > 1 && (st.noticeWindow ?? 0) !== 0) {
       // Back to the top, then count the pass. Resting at the top rather than
-      // on the last three lines: whenever the reader does look up, the recap
-      // reads from its beginning.
+      // on the tail: whenever the reader does look up, the recap reads from
+      // its beginning.
       st.noticeWindow = 0
       this.render()
       if (++this.autoPasses >= AUTO_SCROLL_MAX_PASSES) this.autoResting = true

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -350,7 +350,10 @@ export function startDebugUI(): void {
   const mirrorToggle = document.getElementById('g2-mirror') as HTMLInputElement
   const mirrorStatus = el('g2-mirror-status')
 
-  let lastScreen: { header: string; body: string; footer: string; headerless?: boolean } = {
+  // `notice` belongs here as much as the other three: the copy button is how a
+  // screen gets reported, and one that silently drops the recap reports a
+  // panel nobody is looking at.
+  let lastScreen: { header: string; body: string; footer: string; notice?: string; headerless?: boolean } = {
     header: '', body: '', footer: '',
   }
   let lastMode = 'session_list'
@@ -614,6 +617,10 @@ export function startDebugUI(): void {
       rule,
       lastScreen.header,
       rule,
+      // The panel draws this rule as a container border rather than a row of
+      // text; here it is a row like the others, so the copy reads the way the
+      // screen looks.
+      ...(lastScreen.notice ? [lastScreen.notice, rule] : []),
       lastScreen.body,
       rule,
       lastScreen.footer,

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -294,10 +294,14 @@ function spinnerFrame(state: AppState): string {
  * five or six rows, crowding out the conversation it was meant to introduce.
  */
 function recapBlock(recap: string | undefined, maxLines = 2): string[] {
-  // Every line, not the first two: the strip shows `NOTICE_LINES` of them at a
-  // time and the clock walks the rest. Cutting here would throw away what the
-  // walking is for.
-  return recapBlockLines(recap, maxLines).flatMap(splitDisplayLines)
+  // Every line, not the first two: the strip shows `NOTICE_MAX_LINES` of them
+  // at a time and the clock walks the rest. Cutting here would throw away what
+  // the walking is for.
+  //
+  // Unwrapped, too. The strip scrolls by character and re-wraps what is left,
+  // so wrapping here would freeze the line breaks at the offsets they had on
+  // the first step and the text would reflow against a stale grid.
+  return recapBlockLines(recap, maxLines)
 }
 
 /** Display label for a relay item's session (live session name, else the id). */
@@ -315,8 +319,10 @@ function relayBannerLines(state: AppState): string[] {
     const choiceHint = top.choices?.length ? `(選択${top.choices.length})` : ''
     const more = state.relayWaiting.length > 1 ? ` 他${state.relayWaiting.length - 1}件` : ''
     const head = splitDisplayLines(`[!]${relayLabel(state, top)}${choiceHint}${more}`)[0] || ''
-    // All of it; the strip windows what fits and the clock walks the rest.
-    return [head, ...splitDisplayLines(top.text)]
+    // All of it, unwrapped; the strip windows what fits and the clock walks the
+    // rest, re-wrapping at every step. Only the head is clamped — it is a
+    // label, and a label that takes two lines is not one.
+    return [head, top.text]
   }
   // Notifications get no body space here. The dialog already presented each
   // one full-screen, and the list keeps them in full afterwards; a third
@@ -538,12 +544,12 @@ export const NOTICE_BORDER = 1
  *  that it does not compete with the text it is separating. */
 export const NOTICE_BORDER_COLOR = 6
 /**
- * Everything the notice strip has to say, before it is windowed.
+ * Everything the notice strip has to say, before it is windowed — unwrapped.
  *
  * Shared with the auto-advance clock, which has to know how much is waiting
  * behind the strip without rendering it.
  */
-function conversationNoticeLines(state: AppState): string[] {
+function conversationNoticeText(state: AppState): string {
   const session = state.sessions[state.sessionIndex]
   const pane = state.selectedPaneId
     ? (session?.panes ?? []).find((p) => p.paneId === state.selectedPaneId)
@@ -555,30 +561,95 @@ function conversationNoticeLines(state: AppState): string[] {
   const recapText = pane ? pane.recap : session?.ccRecap
   const recapAt = pane ? pane.recapAt : session?.ccRecapAt
   const recap = onLatest && recapIsCurrent(recapAt, state.conversation) ? recapBlock(recapText) : []
-  return [...banner, ...recap]
+  return [...banner, ...recap].join('\n')
 }
 
 /** A notice longer than the conversation it introduces has stopped helping —
  *  so a long one is shown this many lines at a time instead of all at once. */
-const NOTICE_MAX_LINES = 3
+const NOTICE_MAX_LINES = 2
 
 /**
- * The notice, scrolled down by `offset` lines.
+ * Characters the strip gives up from its front on each step.
  *
- * A line at a time, not a page at a time: paging replaces the whole strip and
- * the reader has to find their place again in text they were mid-sentence
- * through. Scrolling keeps two of the three lines they were just reading, so
- * the new one arrives with its context already on screen.
+ * The unit of the scroll is the character, not the line: a line at a time
+ * moved the text in 27px jumps and read as three separate screens rather than
+ * one moving one. Taking a few characters off the front and re-wrapping what
+ * is left slides the whole block instead, which is what it looks like to read
+ * along a line rather than be shown another one.
+ *
+ * Ten and not one: every step is a redraw over BLE, and one character per
+ * redraw would spend a hundred and fifty of them on a recap. Ten is about a
+ * third of a Japanese line — coarse enough to keep the redraws near what line
+ * scrolling cost, fine enough that the block still reads as sliding rather
+ * than being replaced.
+ *
+ * Paired with `AUTO_SCROLL_STEP_MS`: the two move together, so changing this
+ * without changing that changes the reading speed as well as the granularity.
  */
-function noticeScrollOf(lines: string[], offset: number): string[] {
-  if (lines.length <= NOTICE_MAX_LINES) return lines
-  const last = noticeScrollStepsOf(lines.length) - 1
-  const o = Math.max(0, Math.min(offset, last))
-  return lines.slice(o, o + NOTICE_MAX_LINES)
+export const NOTICE_SCROLL_CHARS = 10
+
+/**
+ * What is left of the notice once `from` characters have gone past.
+ *
+ * Leading whitespace goes with them: a step can land on a line break or on the
+ * space a wrap fell on, and a strip that starts with a blank row reads as the
+ * notice having ended rather than having moved.
+ */
+function noticeFrom(chars: string[], from: number): string {
+  return chars.slice(from).join('').replace(/^\s+/, '')
 }
 
-function noticeScrollStepsOf(total: number): number {
-  return Math.max(1, total - NOTICE_MAX_LINES + 1)
+/** True once everything left of `from` fits the strip — i.e. the last
+ *  character of the notice is on screen. */
+function noticeFitsFrom(chars: string[], from: number): boolean {
+  return splitDisplayLines(noticeFrom(chars, from)).length <= NOTICE_MAX_LINES
+}
+
+/**
+ * Every offset the strip stops at, from the notice's first character to its
+ * last.
+ *
+ * Walked rather than multiplied out. A step is capped at what the reader can
+ * actually see, so it can never advance past the bottom of the strip: a notice
+ * of short lines — a banner over a bulleted recap, say — shows barely more
+ * than a step's worth at a time, and a fixed stride would carry lines off the
+ * top that were never on screen. Silently skipping part of the recap is the
+ * failure this scrolling exists to fix.
+ *
+ * Prose steps the full `NOTICE_SCROLL_CHARS` every time, which is the case
+ * this runs in almost always; the cap only bites on the shapes that need it.
+ */
+function noticeStops(text: string): number[] {
+  const chars = Array.from(text)
+  const stops = [0]
+  let from = 0
+  while (!noticeFitsFrom(chars, from)) {
+    const shown = splitDisplayLines(noticeFrom(chars, from)).slice(0, NOTICE_MAX_LINES).join('').length
+    // At least one character, so a strip that somehow shows nothing still
+    // terminates rather than walking the same offset forever.
+    from += Math.max(1, Math.min(NOTICE_SCROLL_CHARS, shown))
+    stops.push(from)
+  }
+  return stops
+}
+
+/** How many steps the strip takes to walk a notice from end to end. */
+function noticeScrollStepsOf(text: string): number {
+  return noticeStops(text).length
+}
+
+/**
+ * The notice with `window` steps' worth of characters taken off its front.
+ *
+ * Held at the last step rather than wrapped around: the clock decides when to
+ * go back to the beginning, and it waits at the end first so the last line is
+ * read rather than glimpsed.
+ */
+function noticeScrollOf(text: string, window: number): string[] {
+  if (!text) return []
+  const stops = noticeStops(text)
+  const from = stops[Math.max(0, Math.min(window, stops.length - 1))]
+  return splitDisplayLines(noticeFrom(Array.from(text), from)).slice(0, NOTICE_MAX_LINES)
 }
 
 /**
@@ -590,7 +661,7 @@ function noticeScrollStepsOf(total: number): number {
  */
 export function noticeScrollSteps(state: AppState): number {
   if (state.mode !== 'conversation') return 1
-  return noticeScrollStepsOf(conversationNoticeLines(state).length)
+  return noticeScrollStepsOf(conversationNoticeText(state))
 }
 
 export function noticeHeight(lines: number): number {
@@ -626,7 +697,7 @@ function conversationContent(state: AppState): {
     ? Math.max(0, msgs.length - 1 - state.conversationOffset)
     : -1
   const { text: convText, pageInfo } = paginateMessage(msgs, msgIndex, state.conversationPage)
-  const allNotice = conversationNoticeLines(state)
+  const allNotice = conversationNoticeText(state)
   // The body container clips overflow: cap the banner+recap+content block at
   // one page so a waiting overlay never pushes conversation text off-screen.
   // Everything is measured in display lines — counting the conversation in


### PR DESCRIPTION
実機フィードバック: 要約が3行表示で、スクロールが行単位だと「別の画面に切り替わった」ように見える。1文字ずつ削って滑らせてほしい。

## 変更

- **要約を 3 行 → 2 行**。空いた 27px は会話に戻る
- **行単位のウィンドウ → 文字送り**。毎回 10 文字を先頭から削って残りを折り返し直すので、ブロック全体が滑る
- **10 文字 / 2.5 秒 = 4 文字/秒**。承認済みの「5 秒/行」と同じ読み速度を、1/3 行ずつで刻む

```
0: 要約: CC Hub の issue #538（hook の cchub notify が PATH で
1: issue #538（hook の cchub notify が PATH で落ちる）を修
2: hook の cchub notify が PATH で落ちる）を修正・マージしま
```

末尾まで出したら 15 秒静止 → 先頭へ戻る → 2 周で打ち切り、は従来どおり。シミュレータで 76 秒回して周期を実測済み。

## 途中で見つけて直したもの

**短い行が並ぶ要約で内容が飛ぶ。** 1 ステップが「2 行に見えている量」を追い越すと、画面に出ないまま上へ流れる行ができる。ステップ幅を可視量で頭打ちにした。散文では到達しないので、テストは到達する形（短い行の連続）で当てている。

**シミュレータの「画面をコピー」が要約を落としていた。** `lastScreen` の型に `notice` が無く、貼り付けた画面から要約が消えていた。以前ミラーで直したのと同じ経路違い。

## 検証

- `bun test` 120 件全通過（うち文字送り・カバレッジ・末尾保持の 3 件を今回の挙動に更新／追加）
- `tsc --noEmit` / `biome check` クリーン
- シミュレータで 1 周期を実測: 0→15 送り(1.5s/step 当時) → 15 秒静止 → 先頭 → 2 周目 → 停止

## 描画回数

| 要約 | 変更前 | 変更後 |
|---|---|---|
| 79 字 | 2 | 8 |
| 125 字 | 6 | 18 |
| 154 字 | 8 | 24 |

なめらかさは描画回数で買っている。ただし実機で流れている描画は別経路（変化していない一覧の 5 秒ごとの描き直しで 0.2 回/秒）が支配的で、そちらは本 PR の対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np