### PR TITLE
perf(glasses): stop sending the panel what it is already showing

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { OsEventTypeList } from '@evenrealities/even_hub_sdk'
 import { sanitizeForG2, formatMessage } from '../types.ts'
-import { screenText, wrapForPanel, wrapHeader } from '../display.ts'
+import { screenText, updateDisplay, updateHeader, wrapForPanel, wrapHeader } from '../display.ts'
 import { BODY_WIDTH, HEADER_WIDTH, LIST_LINES, textWidth as width } from '../metrics.ts'
 import { listRows, rowCursor, selectableRows } from '../display.ts'
 import { NOTICE_DISMISS_MS } from '../controller.ts'
@@ -1412,5 +1412,72 @@ describe('the screen stops drawing once nobody is being shown anything new', () 
     // which is the whole point of the feature.
     const r = run(4, 3, 200)
     expect(r.draws).toBeGreaterThanOrEqual(3 + 2)
+  })
+})
+
+describe('a screen that has not changed is not sent again', () => {
+  // The panel was redrawn on every `sessions-updated` push — every five
+  // seconds, whether or not anything on it had changed. On the device that
+  // measured 0.2 full draws a second, indefinitely, over BLE, for a screen
+  // showing exactly what it showed five seconds ago.
+
+  function stubBridge() {
+    const calls: Array<{ id: number; content: string }> = []
+    let rebuilds = 0
+    const bridge = {
+      textContainerUpgrade: (u: { containerID: number; content: string }) => {
+        calls.push({ id: u.containerID, content: u.content })
+        return Promise.resolve()
+      },
+      rebuildPageContainer: () => {
+        rebuilds++
+        return Promise.resolve()
+      },
+    }
+    return { bridge: bridge as never, calls, rebuilds: () => rebuilds }
+  }
+
+  const listState = (name: string) =>
+    ({
+      mode: 'session_list' as const,
+      sessions: [{ id: 'a', name, state: 'idle' as const }],
+      sessionIndex: 0, selectedPaneId: null,
+      conversation: [], conversationOffset: 0, conversationPage: 0,
+      conversationHasMore: false, conversationLoading: false,
+      choiceIndex: 0, choiceOptions: [], relayWaiting: [], relayInfo: [],
+      overlayItemId: null, spinnerTick: 0,
+    }) as never
+
+  test('an identical frame sends no container at all', async () => {
+    const { bridge, calls } = stubBridge()
+    await updateDisplay(bridge, listState('alpha'))
+    calls.length = 0
+    await updateDisplay(bridge, listState('alpha'))
+    // Container 1 holds the rows. Asserted rather than the whole call list
+    // because container 2 is the footer, and the footer carries the clock —
+    // it legitimately changes once a minute, and a test that forbade it would
+    // fail whenever the two calls straddled a minute boundary.
+    expect(calls.filter((c) => c.id === 1)).toEqual([])
+  })
+
+  test('a frame that changes one container sends only that one', async () => {
+    const { bridge, calls } = stubBridge()
+    await updateDisplay(bridge, listState('alpha'))
+    calls.length = 0
+    await updateDisplay(bridge, listState('beta'))
+    const rows = calls.filter((c) => c.id === 1)
+    expect(rows.length).toBe(1)
+    expect(rows[0].content).toContain('beta')
+  })
+
+  test('the spinner tick is skipped too when the rows read the same', async () => {
+    // It fires every three seconds for as long as any agent is working, and
+    // the rows it redraws only move when the spinner glyph does.
+    const { bridge, calls } = stubBridge()
+    const s = listState('alpha')
+    await updateDisplay(bridge, s)
+    calls.length = 0
+    await updateHeader(bridge, s)
+    expect(calls).toEqual([])
   })
 })

--- a/glasses/src/display.ts
+++ b/glasses/src/display.ts
@@ -1223,22 +1223,92 @@ export async function initDisplay(): Promise<Bridge | null> {
  * where one will do — three times the traffic, every tick, for the whole time
  * a session is working.
  */
+/**
+ * What each container was last told to show, so an upgrade that would change
+ * nothing is not sent at all.
+ *
+ * The screen was redrawn on every `sessions-updated` push — every five
+ * seconds, whether or not anything on it had changed. Measured on the device
+ * that is 0.2 full draws a second, indefinitely, over BLE, for a panel showing
+ * exactly what it showed five seconds ago. What actually changes on an idle
+ * list is the clock in the footer, once a minute.
+ *
+ * Recorded only after the device has taken the write, so an upgrade that fails
+ * is retried on the next render rather than assumed applied.
+ */
+const drawn = new Map<number, string>()
+
+/**
+ * Container writes actually sent to the panel.
+ *
+ * Reported on the heartbeat next to the frame count, because they are no
+ * longer the same number and the difference is the whole point: a frame that
+ * changes nothing now costs nothing, and only this counter says so from the
+ * device rather than from reasoning about the code.
+ */
+let writes = 0
+export function panelWrites(): number {
+  return writes
+}
+
+/** Send a container's new content, or nothing if that is what it already
+ *  shows. Returns null when there was nothing to send. */
+function upgrade(
+  bridge: Bridge,
+  containerID: number,
+  containerName: string,
+  content: string,
+): Promise<void> | null {
+  if (drawn.get(containerID) === content) return null
+  return Promise.resolve(
+    bridge.textContainerUpgrade(new TextContainerUpgrade({ containerID, containerName, content })),
+  ).then(() => {
+    writes++
+    drawn.set(containerID, content)
+  })
+}
+
+/**
+ * Take note of what a rebuild just put on screen.
+ *
+ * Container ids mean different things in different modes — id 1 is the list on
+ * one screen and the header on another — so the record is only ever read
+ * between rebuilds, and every rebuild replaces it wholesale.
+ */
+function recordRebuild(container: RebuildPageContainer): void {
+  drawn.clear()
+  const objects = (container.textObject ?? []) as Array<{ containerID?: number; content?: string }>
+  writes += objects.length
+  for (const t of objects) {
+    if (typeof t.containerID === 'number') drawn.set(t.containerID, t.content ?? '')
+  }
+}
+
+/**
+ * Forget what the panel is showing, so the next render builds it from nothing.
+ *
+ * The skip-if-unchanged record is only worth trusting while this app is the
+ * only thing writing to the panel. Across a suspend the host may have taken
+ * the page down, and a stale record would then skip exactly the writes needed
+ * to put it back — a blank screen that no amount of waiting fixes, which is a
+ * far worse failure than the one rebuild this costs on every resume.
+ */
+export function invalidatePanel(): void {
+  drawn.clear()
+  currentMode = null
+  currentNoticeLines = 0
+}
+
 export async function updateHeader(bridge: Bridge | null, state: AppState): Promise<void> {
   if (!bridge || state.mode !== currentMode) return
   // Whichever container the spinner lives in — the conversation's header, or
   // the list's rows. One container either way; a full update sends three.
   if (state.mode === 'session_list') {
-    await bridge.textContainerUpgrade(new TextContainerUpgrade({
-      containerID: 1, containerName: 'list',
-      content: sessionListBody(state),
-    }))
+    await upgrade(bridge, 1, 'list', sessionListBody(state))
     return
   }
   const { headerText } = conversationContent(state)
-  await bridge.textContainerUpgrade(new TextContainerUpgrade({
-    containerID: 1, containerName: 'header',
-    content: headerText,
-  }))
+  await upgrade(bridge, 1, 'header', headerText)
 }
 
 export async function updateDisplay(bridge: Bridge | null, state: AppState): Promise<void> {
@@ -1262,22 +1332,18 @@ export async function updateDisplay(bridge: Bridge | null, state: AppState): Pro
       case 'overlay': container = buildOverlay(state); break
     }
     await bridge.rebuildPageContainer(container)
+    recordRebuild(container)
     return
   }
 
-  // In-place text updates
+  // In-place text updates. Each one is sent only if it would change what the
+  // container is already showing; `Promise.all` over the ones that survive.
   switch (state.mode) {
     case 'session_list': {
       await Promise.all([
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 1, containerName: 'list',
-          content: sessionListBody(state),
-        })),
+        upgrade(bridge, 1, 'list', sessionListBody(state)),
         // The footer moves now — it holds the clock and the position.
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 2, containerName: 'footer',
-          content: sessionListFooter(state),
-        })),
+        upgrade(bridge, 2, 'footer', sessionListFooter(state)),
       ])
       break
     }
@@ -1285,71 +1351,35 @@ export async function updateDisplay(bridge: Bridge | null, state: AppState): Pro
       const { headerText, noticeText, bodyText, footerText } = conversationContent(state)
       const hasNotice = notice > 0
       await Promise.all([
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 1, containerName: 'header',
-          content: headerText,
-        })),
-        ...(hasNotice ? [bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 2, containerName: 'notice',
-          content: noticeText,
-        }))] : []),
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: hasNotice ? 3 : 2, containerName: 'body',
-          content: bodyText,
-        })),
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: hasNotice ? 4 : 3, containerName: 'footer',
-          content: footerText,
-        })),
+        upgrade(bridge, 1, 'header', headerText),
+        ...(hasNotice ? [upgrade(bridge, 2, 'notice', noticeText)] : []),
+        upgrade(bridge, hasNotice ? 3 : 2, 'body', bodyText),
+        upgrade(bridge, hasNotice ? 4 : 3, 'footer', footerText),
       ])
       break
     }
     case 'choice': {
       await Promise.all([
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 1, containerName: 'header',
-          content: choiceHeader(state),
-        })),
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 2, containerName: 'body',
-          content: choiceBody(state),
-        })),
+        upgrade(bridge, 1, 'header', choiceHeader(state)),
+        upgrade(bridge, 2, 'body', choiceBody(state)),
       ])
       break
     }
     case 'voice': {
       const { headerText, bodyText, footerText } = voiceContent(state)
       await Promise.all([
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 1, containerName: 'header',
-          content: headerText,
-        })),
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 2, containerName: 'body',
-          content: bodyText,
-        })),
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 3, containerName: 'footer',
-          content: footerText,
-        })),
+        upgrade(bridge, 1, 'header', headerText),
+        upgrade(bridge, 2, 'body', bodyText),
+        upgrade(bridge, 3, 'footer', footerText),
       ])
       break
     }
     case 'overlay': {
       const { headerText, bodyText, footerText } = overlayContent(state)
       await Promise.all([
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 1, containerName: 'header',
-          content: headerText,
-        })),
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 2, containerName: 'body',
-          content: bodyText,
-        })),
-        bridge.textContainerUpgrade(new TextContainerUpgrade({
-          containerID: 3, containerName: 'footer',
-          content: footerText,
-        })),
+        upgrade(bridge, 1, 'header', headerText),
+        upgrade(bridge, 2, 'body', bodyText),
+        upgrade(bridge, 3, 'footer', footerText),
       ])
       break
     }

--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -6,7 +6,7 @@
 // Groq STT) and the LocalStorage URL setup flow.
 
 import { setBaseUrl, transcribe, reportLog } from './api.ts'
-import { initDisplay, updateDisplay, updateHeader, setupEvents, buildSetupGuide, screenText, startMic, stopMic } from './display.ts'
+import { initDisplay, updateDisplay, updateHeader, setupEvents, buildSetupGuide, screenText, panelWrites, invalidatePanel, startMic, stopMic } from './display.ts'
 import type { AppState } from './display.ts'
 import { GlassesController } from './controller.ts'
 import type { GlassesPlatform } from './controller.ts'
@@ -179,12 +179,31 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
   trace('ws connect issued')
   platform.render(controller.state)
 
+  /**
+   * Front or back, as far as the host has told us.
+   *
+   * The transitions were already traced, but only as events — so a death with
+   * no transition before it was unreadable: it could have been the foreground
+   * dying, or the background dying long after the last logged transition, and
+   * pairing them up after the fact turned out to depend entirely on how the
+   * pairing was written. Carried on the heartbeat and on the exit line
+   * instead, every death states which one it was.
+   *
+   * Starts true: the host launches the app into the foreground.
+   */
+  let foreground = true
+
   setupEvents(bridge, {
     onForegroundEnter() {
+      foreground = true
       trace('foreground: entered — reconnecting after suspend')
+      // The panel may not be ours any more; draw the next frame in full rather
+      // than trusting a record of what it showed before the suspend.
+      invalidatePanel()
       controller.onForegroundEnter()
     },
     onForegroundExit() {
+      foreground = false
       trace('foreground: exited — saving resume point')
       controller.onForegroundExit()
     },
@@ -192,7 +211,7 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
       // The host says why it is stopping us. Worth its own line: it is the
       // difference between "backgrounded" and "killed", which no amount of
       // guessing from inside the page could settle.
-      trace(`host exit: ${kind}`, 'error')
+      trace(`host exit: ${kind} fg=${foreground ? 1 : 0}`, 'error')
       controller.onHostExit(kind)
     },
     onSwipeDown: () => controller.swipeDown(),
@@ -231,7 +250,7 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
   const bootAt = Date.now()
   setInterval(() => {
     trace(
-      `alive ${((Date.now() - bootAt) / 1000).toFixed(1)}s renders=${renders} ws=${controller.ws.getState()}${heapNote()}`,
+      `alive ${((Date.now() - bootAt) / 1000).toFixed(1)}s renders=${renders} writes=${panelWrites()} fg=${foreground ? 1 : 0} ws=${controller.ws.getState()}${heapNote()}`,
     )
   }, HEARTBEAT_MS)
 }


### PR DESCRIPTION
実機ログから: セッション一覧に居るだけで **0.2 回/秒の全画面描画が無限に続いていた**。5 秒ごとの `sessions-updated` プッシュが、中身が変わったかを見ずに毎回描き直していたため。アイドル時に実際に変わるのはフッタの時計（1 分に 1 回）だけ。

## 変更

**コンテナ単位で「前回と同じなら送らない」。**

- 記録は**デバイスが書き込みを受け取ってから**。失敗した更新は次の描画で再送される（成功と見なして飛ばさない）
- **復帰時は記録を破棄**。サスペンドを跨ぐとホストがページを落としている可能性があり、古い記録は「画面を戻すための書き込み」をちょうど飛ばしてしまう。空白画面はリビルド 1 回よりはるかに悪い

## クラッシュ修正ではありません

これは明示しておきます。

| 観測 | 値 |
|---|---|
| v0.1.58 の 1 本目 | 985 描画で死亡 |
| v0.1.58 の 2 本目 | **217 描画**で死亡 |

**描画レートでも累積描画数でも死を説明できません。** 全件 `host exit: system`・JS 例外なし・ヒープ平坦のままです。

また「クラッシュは背面移行の後にしか起きない」という以前の読みは、**ログの突き合わせ方の副作用**でした。起動単位で取り直すと、7 件は背面移行の記録なしに落ちています。

## 代わりに、次は判定できるようにした

ハートビートに 2 つ足しました。

```
alive 858.6s renders=217 writes=48 fg=1 ws=OPEN heap=15/21MB(limit 3586)
```

- **`fg=1/0`** — ホスト自身の前面/背面イベント由来。毎ビートと `host exit` 行に載るので、**次に落ちたときどちら側だったかが推測でなく分かる**
- **`writes=`** — 実際に送ったコンテナ書き込み数。`renders=` とはもう別の数字で、**その差だけが本変更の効果の正直な指標**

## 検証

- `bun test` 123 件通過（重複排除の 3 件を新規追加）
- `tsc --noEmit` / `biome check` クリーン
- シミュレータは自前の painter を通るためこの経路を再現しない（既知の device-only 領域）。ロジックはテストで担保し、効果は実機の `writes=` で測る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np