### PR TITLE
feat(glasses): 音声認識に語彙プロンプトを渡す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,14 @@ Hook → cchub notify (stdin JSON) → POST /api/notify → WebSocket broadcast 
 
 herdr が `blocked` を報告して waiting アイテムがある間は、hook 由来の info は作らない（同じ状況を二重に言うだけなので）。逆に hook が先に届いていた場合、waiting 成立時に hook 由来の info（`source: 'auto'`）は消される。エージェント自身の `cchub glasses` メモ（`source: 'agent'`）は無関係なので残る。
 
+### グラスの音声入力（STT）
+
+G2 の SDK は生の PCM しか出さないため、書き起こしは `POST /api/glasses/stt`（`routes/glasses.ts`）でサーバ側が行う（Groq `whisper-large-v3-turbo`、`GROQ_API_KEY` はこのホストから出ない）。
+
+語彙バイアスの `prompt` を `services/stt-prompt.ts` が組み立てて送る。中身は **ユーザーのカスタムタイトル → 用語集 → herdr のラベル** の順で、Whisper の 224 トークン上限に収まるところまで（190文字）。この順序が仕様の要で、ワークスペースが増えると名前だけで予算を食い潰し、`リリース`（日に何度も言う語）が落ちる。ラベルはラテン文字で元から化けにくいので最後。`CCHUB_STT_PROMPT=off` で無効化、任意の文字列を入れればそれを使う（A/B 用）。
+
+なお**無音や極端に短いクリップでは幻聴が出る**（「ご視聴ありがとうございました」等）。prompt では消えないので、長さ・音量での足切りは別途必要。
+
 ### セットアップ手順
 
 1. Claude Code は `~/.claude/settings.json` の `hooks` に `cchub notify` を追加する。Codex は `~/.codex/hooks.json` に追加する（`config.toml` と併用するとCodexが警告するため、`cchub setup` が既存のCC Hub hookをJSONへ移行する）:

--- a/backend/src/routes/glasses.ts
+++ b/backend/src/routes/glasses.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { sttPrompt } from '../services/stt-prompt';
 
 const glasses = new Hono();
 
@@ -40,6 +41,9 @@ function pcmToWav(pcm: Uint8Array, sampleRate: number, channels = 1, bitsPerSamp
  * Query: `?sampleRate=<n>` (PCM only), `?lang=<code>` (default `ja`).
  * Response: `{ text }`.
  *
+ * Sends a vocabulary prompt built from live workspace names plus this
+ * product's own terms (see `stt-prompt.ts`); `CCHUB_STT_PROMPT=off` disables it.
+ *
  * Used by the G2 glasses voice-input flow (SDK gives raw mic PCM only, so STT
  * is done server-side; the key never leaves this host).
  */
@@ -76,6 +80,11 @@ glasses.post('/stt', async (c) => {
     form.append('response_format', 'json');
     // Greedy decoding keeps short commands fast and deterministic.
     form.append('temperature', '0');
+    // What the speech is about: product terms and the user's own workspace
+    // names. Without it the model has no reason to produce `herdr` or
+    // 「2脚ロボ開発」, and reaches for the ordinary Japanese word instead.
+    const prompt = await sttPrompt();
+    if (prompt) form.append('prompt', prompt);
 
     const res = await fetch(GROQ_STT_URL, {
       method: 'POST',

--- a/backend/src/services/__tests__/stt-prompt.test.ts
+++ b/backend/src/services/__tests__/stt-prompt.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { buildSttPrompt } from '../stt-prompt';
+
+/**
+ * The prompt is the only thing telling Whisper that `herdr` is a word and that
+ * 「2脚ロボ開発」 is a name. It is also capped, so what gets dropped when it is
+ * full is the part worth pinning: names are unguessable, glossary terms are not.
+ */
+describe('buildSttPrompt', () => {
+  test('names come first, since the glossary cannot cover them', () => {
+    const prompt = buildSttPrompt(['グラス開発', '2脚ロボ開発'], ['ペイン']);
+    expect(prompt).toBe('グラス開発、2脚ロボ開発、ペイン');
+  });
+
+  test('a name repeated as a title and a label is said once', () => {
+    expect(buildSttPrompt(['cchub-work-2', 'CCHub-Work-2'], [])).toBe('cchub-work-2');
+  });
+
+  test('blank names are skipped rather than left as empty slots', () => {
+    expect(buildSttPrompt(['', '   ', 'life'], [])).toBe('life');
+  });
+
+  test('no names and no glossary means no prompt at all', () => {
+    // The caller sends nothing rather than an empty `prompt` field.
+    expect(buildSttPrompt([], [])).toBe('');
+  });
+
+  test('the cap drops whole terms, never half of one', () => {
+    const titles = ['あ'.repeat(180)];
+    const prompt = buildSttPrompt({ titles }, ['ペイン', 'ワークスペース']);
+    // 180 + 1 + 3 fits ペイン; ワークスペース would exceed 190 and is left out
+    // whole — half a word biases nothing.
+    expect(prompt).toBe(`${titles[0]}、ペイン`);
+  });
+
+  test('the words the user says outrank the workspace labels', () => {
+    // The first cut spent the budget on names and dropped `リリース`, which is
+    // said ten times a day, to keep a label that is said approximately never.
+    const prompt = buildSttPrompt(
+      { titles: ['グラス開発'], labels: ['い'.repeat(180)] },
+      ['リリース'],
+    );
+    expect(prompt).toBe('グラス開発、リリース');
+  });
+
+  test('a name too long to fit does not block the shorter ones behind it', () => {
+    const prompt = buildSttPrompt(['い'.repeat(200), 'life'], []);
+    expect(prompt).toBe('life');
+  });
+
+  test('a full workspace list does not push out the words that get misheard', () => {
+    // This is the regression: the first cut listed names first, and thirteen
+    // workspaces ate the budget before `リリース` — the word reported as being
+    // misheard several times a day — ever got in.
+    const labels = [
+      'hrdle', 'cchub-work-3', 'cchub-work-1', 'cchub-work-2', 'wheel-leg-bot',
+      'life', 'linux', 'pixel-customrom', 'repos', 'lifestyle-app-work-1',
+    ];
+    const prompt = buildSttPrompt({ titles: ['グラス開発', '2脚ロボ開発'], labels });
+    for (const term of ['リリース', 'マージ', 'リベース', 'ペイン']) {
+      expect(prompt).toContain(term);
+    }
+    expect(prompt).toContain('2脚ロボ開発');
+  });
+
+  test('the whole prompt stays inside the cap', () => {
+    const titles = Array.from({ length: 40 }, (_, i) => `ワークスペース名前${i}`);
+    expect(buildSttPrompt({ titles }).length).toBeLessThanOrEqual(190);
+  });
+});

--- a/backend/src/services/stt-prompt.ts
+++ b/backend/src/services/stt-prompt.ts
@@ -1,0 +1,156 @@
+import { listWorkspaces } from './herdr-client';
+import { getAllSessionMetadata } from './session-metadata';
+
+/**
+ * Vocabulary bias for the glasses' speech-to-text.
+ *
+ * Whisper takes an initial prompt and treats it as transcript that came just
+ * before, which is the supported way to tell it what words to expect. Left
+ * empty it guesses from Japanese at large, where `herdr` is not a word and
+ * `ペイン` is `ペイント` — every term this product is actually made of is a term
+ * it has no reason to pick.
+ *
+ * The names are the half that cannot be hardcoded: a workspace called
+ * 「2脚ロボ開発」 is the user's own coinage, said out loud constantly, and
+ * unguessable. This is why the prompt is built per request from live state
+ * rather than shipped as a constant.
+ */
+
+/**
+ * Terms this product's speech is made of, most-said first.
+ *
+ * These are ordinary-sounding words that the model has a competing reading for
+ * — `リリース` and `リベース` are the ones that come back wrong most — so the
+ * order here is the order they survive in when the budget runs out.
+ */
+const GLOSSARY = [
+  'リリース',
+  'マージ',
+  'コミット',
+  'リベース',
+  'ブランチ',
+  'プルリクエスト',
+  'ペイン',
+  'ワークスペース',
+  'セッション',
+  'cchub',
+  'herdr',
+  'issue',
+  'プッシュ',
+  'コンフリクト',
+  'ビルド',
+  'デプロイ',
+  'テスト',
+  'リント',
+  'タブ',
+  'ターミナル',
+  'Claude Code',
+  'Codex',
+  'グラス',
+  'バージョン',
+  'タグ',
+  'エラー',
+  'ログ',
+  'バグ',
+  'リファクタ',
+  'スクショ',
+  'フロントエンド',
+  'バックエンド',
+  'Kimi',
+  'Grok',
+];
+
+/**
+ * Whisper's prompt is capped at 224 tokens and Japanese runs close to a token
+ * per character, so this is deliberately short of it. Overflow is not an error
+ * — the provider keeps the tail — but relying on that would silently drop
+ * whichever terms happen to sort first.
+ */
+const MAX_PROMPT_CHARS = 190;
+
+/**
+ * Fold the vocabulary into one line of plausible preceding transcript.
+ *
+ * The three groups are in the order they are worth their characters, because
+ * the budget does run out — thirteen workspaces spend two thirds of it on
+ * names alone:
+ *
+ *  1. **Titles.** A person named these, out loud, in Japanese. Nothing else
+ *     can supply 「2脚ロボ開発」.
+ *  2. **Glossary.** Said constantly and misheard constantly. These lost to the
+ *     names in the first cut, which is exactly backwards: `リリース` is spoken
+ *     ten times a day and `lifestyle-app-work-1` approximately never.
+ *  3. **Labels.** herdr's own workspace names — directory-ish Latin text that
+ *     the model was never going to render as a Japanese word anyway.
+ *
+ * Terms are taken whole: half a word biases nothing.
+ */
+export function buildSttPrompt(
+  names: { titles?: string[]; labels?: string[] } | string[],
+  glossary: string[] = GLOSSARY,
+): string {
+  const { titles = [], labels = [] } = Array.isArray(names) ? { titles: names } : names;
+  const terms: string[] = [];
+  const seen = new Set<string>();
+  let length = 0;
+
+  for (const term of [...titles, ...glossary, ...labels]) {
+    const trimmed = term.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    // +1 for the separator this term would bring with it.
+    const cost = trimmed.length + (terms.length > 0 ? 1 : 0);
+    if (length + cost > MAX_PROMPT_CHARS) continue;
+    seen.add(key);
+    terms.push(trimmed);
+    length += cost;
+  }
+
+  return terms.join('、');
+}
+
+/**
+ * Workspace names as spoken: the user's custom titles first, then herdr's own
+ * labels. A title is chosen by a person and is usually the Japanese one; a
+ * label is a directory-ish name that Whisper tends to get right anyway.
+ */
+export async function currentWorkspaceNames(): Promise<{ titles: string[]; labels: string[] }> {
+  const [workspaces, metadata] = await Promise.all([
+    listWorkspaces().catch(() => []),
+    getAllSessionMetadata().catch(() => ({})),
+  ]);
+  return {
+    titles: Object.values(metadata)
+      .map((meta) => meta.title)
+      .filter((title): title is string => !!title),
+    labels: workspaces.map((w) => w.label).filter(Boolean),
+  };
+}
+
+// The STT path is interactive — the glasses are showing "transcribing" while it
+// runs — so it does not wait on herdr for a list that changes a few times a day.
+const CACHE_TTL_MS = 60_000;
+let cached: { prompt: string; at: number } | null = null;
+
+/**
+ * The prompt to send with a transcription, or `undefined` to send none.
+ *
+ * `CCHUB_STT_PROMPT=off` disables the bias, which is how the two are compared
+ * without a rebuild; any other value is used verbatim.
+ */
+export async function sttPrompt(now = Date.now()): Promise<string | undefined> {
+  const override = process.env.CCHUB_STT_PROMPT;
+  if (override === 'off') return undefined;
+  if (override) return override;
+
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached.prompt || undefined;
+  const prompt = buildSttPrompt(await currentWorkspaceNames());
+  cached = { prompt, at: now };
+  return prompt || undefined;
+}
+
+/** Drop the memoized prompt (tests, and after a workspace is renamed). */
+export function resetSttPromptCache(): void {
+  cached = null;
+}


### PR DESCRIPTION
## 背景

グラスの音声入力で**固有名詞・技術用語が化ける**（「リリース」をしょっちゅう聞き間違える、という報告）。

`routes/glasses.ts` は Groq に `model` / `language` / `temperature` しか渡しておらず、**Whisper の `prompt`（語彙バイアス）が未使用**だった。空のままだと日本語一般から推測するので、`herdr` は語彙に無く、`ペイン` は `ペイント` になり、ユーザーが名付けた `2脚ロボ開発` は `二脚ロボ開発` になる。**最後のは表記の問題では済まない** — グラスはこのテキストをそのままエージェントへ送るので、名前が一致しなければ解決できない。

## 変更

`services/stt-prompt.ts`（新規）がリクエストごとにライブ状態から組み立てる:

1. **カスタムタイトル** — 人が日本語で名付けたもの。`2脚ロボ開発` は他のどこからも供給できない
2. **用語集** — 口に出す頻度が高く、化ける頻度も高い語（リリース/マージ/リベース/ペイン…34語）
3. **herdr のラベル** — ラテン文字のディレクトリ的な名前。元から日本語語彙と競合しない

**この順序が仕様の要**。最初は名前を先頭に置いたが、ワークスペース13個で予算190文字の3分の2を食い、`リリース` が一度も入らなかった（`lifestyle-app-work-1` を残して `リリース` を落とすのは明確に逆）。テストで固定した。

Whisper の 224 トークン上限に対し、切り詰めをプロバイダ任せにせず手前で打ち切る（どちら端を削るかに依存しないため）。`CCHUB_STT_PROMPT=off` で無効化、任意文字列でA/B可。

## 実測

同一発話（Gemini TTS で生成した「2脚ロボ開発をリリースしてリベースもお願いします」）を Groq に投げた結果:

| | 認識結果 |
|---|---|
| プロンプト無し | 「**二脚**ロボ開発をリリースしてリベースもお願いします」 |
| プロンプト有り | 「**2脚**ロボ開発をリリースしてリベースもお願いします」 |

各2回で安定。レイテンシは 350〜450ms（変更前の実測 300〜750ms の範囲内、悪化なし）。ライブ状態から実際に生成されるプロンプトも dev で確認済み。

## このPRで直していないこと

**無音・極端に短いクリップで幻聴が出る**（「ご視聴ありがとうございました」が 3/3 で再現）。プロンプトでは消えない（実プロンプト付きでも再現）。長さ・音量での足切りが要るので、CLAUDE.md に負債として記録した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFJJ7FBdg7koTsEKatL1pa