### PR TITLE
fix(glasses): give the root page back to the host, and stop drawing when hidden

### DIFF
--- a/glasses/src/__tests__/display-format.test.ts
+++ b/glasses/src/__tests__/display-format.test.ts
@@ -4,7 +4,7 @@ import { sanitizeForG2, formatMessage } from '../types.ts'
 import { screenText, updateDisplay, updateHeader, wrapForPanel, wrapHeader } from '../display.ts'
 import { BODY_WIDTH, HEADER_WIDTH, LIST_LINES, textWidth as width } from '../metrics.ts'
 import { listRows, rowCursor, selectableRows } from '../display.ts'
-import { NOTICE_DISMISS_MS } from '../controller.ts'
+import { GlassesController, NOTICE_DISMISS_MS } from '../controller.ts'
 import { NOTICE_SCROLL_CHARS, noticeHeight, noticeScrollSteps } from '../display.ts'
 import { SPACE_W } from '../metrics.ts'
 import { MAX_LINES } from '../metrics.ts'
@@ -1478,6 +1478,72 @@ describe('a screen that has not changed is not sent again', () => {
     await updateDisplay(bridge, s)
     calls.length = 0
     await updateHeader(bridge, s)
+    expect(calls).toEqual([])
+  })
+})
+
+describe('the root page hands the exit gesture back to the host', () => {
+  // `SYSTEM_EXIT_EVENT` — the only exit this app has ever been given — is
+  // documented as the user confirming the host's exit dialogue. Even Hub
+  // review requires the root page to raise that dialogue on a double-tap, and
+  // an app that keeps the gesture for itself gets exited anyway by a wearer
+  // who thought they were doing something else.
+
+  function stubPlatform() {
+    const calls: string[] = []
+    const platform = {
+      onDevice: false,
+      render: () => { calls.push('render') },
+      renderHeader: () => { calls.push('renderHeader') },
+      startMicCapture: async () => false,
+      stopMicCapture: async () => {},
+      transcribeAudio: async () => '',
+      saveState: () => {},
+      loadState: async () => null,
+      requestExit: () => { calls.push('requestExit') },
+    }
+    return { platform, calls }
+  }
+
+  const twoSessions = [
+    { id: 'a', name: 'alpha', state: 'idle' as const },
+    { id: 'b', name: 'beta', state: 'idle' as const },
+  ]
+
+  test('double-tap on the session list asks for the exit dialogue', async () => {
+    const { platform, calls } = stubPlatform()
+    const c = new GlassesController(platform as never)
+    c.doubleTap()
+    await Promise.resolve()
+    expect(calls).toContain('requestExit')
+  })
+
+  test('the wearer\'s last gesture is available for the exit line', async () => {
+    const { platform } = stubPlatform()
+    const c = new GlassesController(platform as never)
+    expect(c.lastGesture().kind).toBe('none')
+    expect(c.lastGesture().agoMs).toBe(-1)
+    c.doubleTap()
+    await Promise.resolve()
+    expect(c.lastGesture().kind).toBe('doubleTap')
+    expect(c.lastGesture().agoMs).toBeGreaterThanOrEqual(0)
+  })
+
+  test('nothing is drawn while the glasses are showing something else', async () => {
+    // Render calls made from the background are consumed by the host and
+    // dropped before the display, so they are BLE traffic for nobody.
+    const { platform, calls } = stubPlatform()
+    const c = new GlassesController(platform as never)
+    c.state.sessions = twoSessions as never
+    c.swipeDown()
+    await Promise.resolve()
+    expect(calls).toContain('render')
+
+    c.onForegroundExit()
+    calls.length = 0
+    c.swipeDown()
+    c.swipeUp()
+    await Promise.resolve()
     expect(calls).toEqual([])
   })
 })

--- a/glasses/src/controller.ts
+++ b/glasses/src/controller.ts
@@ -136,6 +136,15 @@ export interface GlassesPlatform {
    *  storage, which outlives the page; the simulator uses localStorage. */
   saveState(json: string): void
   loadState(): Promise<string | null>
+  /**
+   * Ask the host to show its own exit confirmation.
+   *
+   * `shutDownPageContainer(1)`, not `(0)`: the user gets a dialogue they can
+   * cancel, and confirming it is what produces `SYSTEM_EXIT_EVENT`. Nothing is
+   * cleaned up here — the exit is not decided yet, and tearing down a listener
+   * for a dialogue the user then cancels leaves the app on screen and deaf.
+   */
+  requestExit(): void
 }
 
 /** Where a reply (choice keys / voice prompt) is routed. paneId targets the
@@ -215,6 +224,15 @@ export class GlassesController {
   private noticeTimer: ReturnType<typeof setTimeout> | null = null
   /** Last ring gesture, so the auto-advance clock can stay out of the way. */
   private lastGestureAt = 0
+  /** What that gesture was. Reported on the way out: `SYSTEM_EXIT_EVENT` is
+   *  the user confirming the host's exit dialogue, so what they pressed just
+   *  before it is the difference between "they meant to leave" and "the app
+   *  handed a gesture to the OS that the wearer meant for the app". */
+  private lastGestureKind: RingAction | 'none' = 'none'
+  /** Whether this app is the one the glasses are showing. Render calls made
+   *  while it is not are consumed by the host and never reach the display, so
+   *  they are pure BLE traffic for a panel nobody is looking at. */
+  private foreground = true
   /** Ticks since the last auto step, so a page turn can cost several of them. */
   private autoTicks = 0
   /** Completed passes over the recap, counted towards AUTO_SCROLL_MAX_PASSES. */
@@ -269,6 +287,10 @@ export class GlassesController {
   private tickAutoAdvance(): void {
     const st = this.state
     if (st.mode !== 'conversation') return
+    // Nobody is looking at this panel, and nothing sent to it would arrive.
+    // Advancing anyway would also walk the recap past the point the reader
+    // left it, so they come back to the middle of something.
+    if (!this.foreground) return
     // Everything has been shown, twice. Drawing again would be for nobody.
     if (this.autoResting) return
     // The reader is working the ring; do not fight them for it.
@@ -320,6 +342,9 @@ export class GlassesController {
    *  only while there is something to indicate. */
   private tickSpinner(): void {
     const st = this.state
+    // Nothing drawn from the background arrives, so an animation run there is
+    // spent entirely on the way to being dropped.
+    if (!this.foreground) return
     if (!this.somethingIsWorking()) return
     st.spinnerTick = (st.spinnerTick ?? 0) + 1
     this.platform.renderHeader(st)
@@ -404,6 +429,7 @@ export class GlassesController {
 
   /** The app is back. Its socket died while it slept and its screen is stale. */
   onForegroundEnter(): void {
+    this.foreground = true
     this.state.spinnerTick = 0
     this.ws.connect()
     this.render()
@@ -411,7 +437,20 @@ export class GlassesController {
   }
 
   onForegroundExit(): void {
+    // Stop drawing. The host consumes render calls made from the background
+    // and drops them before the display, so everything sent from here is BLE
+    // traffic that reaches nobody — and a WebView burning its budget on that
+    // is a WebView the phone has a reason to throttle.
+    this.foreground = false
     this.saveResumePoint()
+  }
+
+  /** What the wearer last did, and how long ago — for the exit line. */
+  lastGesture(): { kind: RingAction | 'none'; agoMs: number } {
+    return {
+      kind: this.lastGestureKind,
+      agoMs: this.lastGestureAt ? Date.now() - this.lastGestureAt : -1,
+    }
   }
 
   onHostExit(_kind: 'abnormal' | 'system'): void {
@@ -435,6 +474,7 @@ export class GlassesController {
     // to know the reader is driving. The auto-advance clock stays out of the
     // way for AUTO_ADVANCE_IDLE_MS afterwards.
     this.lastGestureAt = Date.now()
+    this.lastGestureKind = action
     // Someone is here. Whatever the screen had settled into, it starts over.
     this.autoPasses = 0
     this.autoResting = false
@@ -492,12 +532,18 @@ export class GlassesController {
         return
       }
       case 'doubleTap':
-        // Manual entry to the waiting overlay (auto-entry covers the rest).
-        if (this.queue.topWaiting()) {
-          this.enterOverlay()
-          return
-        }
-        this.render()
+        // The root page owes the host its exit dialogue. Even Hub review
+        // rejects an app whose home screen does not call
+        // `shutDownPageContainer(1)` on a double-tap ("Please ensure double
+        // tapping at the root page on OS can invoke exit dialogue"), and the
+        // OS treats root double-tap as the way out whether or not the app
+        // agrees — which is how an app with its own meaning for the gesture
+        // gets exited by someone who thought they were doing something else.
+        //
+        // The waiting overlay used to be here. It is not lost: an item that
+        // needs an answer opens the overlay by itself, which is the path
+        // every waiting item has actually arrived by.
+        this.platform.requestExit()
         return
     }
   }
@@ -1163,7 +1209,16 @@ export class GlassesController {
     void this.loadConversation().then(() => this.render())
   }
 
+  /**
+   * Draw the current state — unless nobody would see it.
+   *
+   * The host drops render calls made from the background before they reach
+   * the display, so every one of them is BLE traffic spent on nothing. State
+   * still updates underneath; `onForegroundEnter` draws whatever it has become
+   * in one frame, which is the only frame that was ever going to be seen.
+   */
   private render(): void {
+    if (!this.foreground) return
     this.platform.render(this.state)
   }
 }

--- a/glasses/src/debug-ui.ts
+++ b/glasses/src/debug-ui.ts
@@ -560,6 +560,12 @@ export function startDebugUI(): void {
     renderHeader(state) {
       platform.render(state)
     },
+    // There is no host here to show an exit dialogue and no app to be exited
+    // from, so this reports rather than acts — the simulator's job is to make
+    // the gesture's new meaning visible while it is being designed.
+    requestExit() {
+      setVoiceStatus('終了ダイアログを要求（実機ではホストの確認が出ます）')
+    },
     // No host store in a browser; localStorage plays the same part, and it
     // lets the simulator exercise the resume path without the device.
     saveState(json) {

--- a/glasses/src/main.ts
+++ b/glasses/src/main.ts
@@ -172,6 +172,17 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
     startMicCapture: () => startMic(bridge),
     stopMicCapture: () => stopMic(bridge),
     transcribeAudio: (pcm) => transcribe(pcm, MIC_SAMPLE_RATE),
+    requestExit() {
+      // Mode 1 — the host's own confirmation, which the user can cancel. Only
+      // if they confirm does `SYSTEM_EXIT_EVENT` arrive, and the cleanup goes
+      // there rather than here.
+      trace('exit dialogue requested (root double-tap)')
+      try {
+        void bridge.shutDownPageContainer(1)
+      } catch (err) {
+        trace(`shutDownPageContainer failed: ${err}`, 'error', (err as Error)?.stack)
+      }
+    },
   }
   const controller = new GlassesController(platform)
   trace('controller constructed')
@@ -208,10 +219,19 @@ async function startGlassesMode(bridge: NonNullable<Awaited<ReturnType<typeof in
       controller.onForegroundExit()
     },
     onExit(kind) {
-      // The host says why it is stopping us. Worth its own line: it is the
-      // difference between "backgrounded" and "killed", which no amount of
-      // guessing from inside the page could settle.
-      trace(`host exit: ${kind} fg=${foreground ? 1 : 0}`, 'error')
+      // The host says why it is stopping us, and the two kinds mean opposite
+      // things: `abnormal` is an unexpected disconnect, `system` is the user
+      // confirming the host's exit dialogue. Only ever having seen `system` is
+      // the finding — this app was being left, not crashing.
+      //
+      // So the gesture goes out with it. A double-tap moments before says the
+      // wearer walked out through the dialogue; silence says something else
+      // closed us, and that is a different problem entirely.
+      const g = controller.lastGesture()
+      trace(
+        `host exit: ${kind} fg=${foreground ? 1 : 0} gesture=${g.kind}@${g.agoMs < 0 ? 'never' : `${Math.round(g.agoMs / 100) / 10}s`}`,
+        'error',
+      )
       controller.onHostExit(kind)
     },
     onSwipeDown: () => controller.swipeDown(),


### PR DESCRIPTION
## 2日間「クラッシュ」だと思っていたものは、退出でした

Even Realities の公式リファレンス（[handle-input SKILL.md](https://github.com/even-realities/everything-evenhub/blob/main/plugins/everything-evenhub/skills/handle-input/SKILL.md)）:

> | 7 | SYSTEM_EXIT_EVENT | System-level exit (**e.g. user confirmed exit dialog**) |

異常終了は `ABNORMAL_EXIT_EVENT` (6) の側で、**このアプリは一度も受け取っていません**。18件すべてが `system` でした。

## なぜ意図せず終了していたか

うちは終了ダイアログを一度も要求していません。にもかかわらず「ユーザーが確定した」イベントが来ていた。

審査要件がこれです。

> Please ensure double tapping at the root page **on OS** can invoke exit dialogue (shutDownContainer(1))

**ルート画面のダブルタップ＝終了は OS 側の約束事**で、アプリが何に使っていようと関係ありません。うちはそれを待機オーバーレイに使っていました。**通知を見ようとしたら終了ダイアログが出て、確定してしまう** — ユーザーからはクラッシュにしか見えません。

心拍が死ぬ直前に伸びる件（18件中12件）も、ダイアログ表示中に WebView が後ろへ回ったと読めば繋がります。

## 変更

**1. ルート画面のダブルタップで `shutDownPageContainer(1)`**

- モード `1`（キャンセル可能な確認）。`0` は審査で同じく落ちる
- **後片付けはしない**。まだ終了は決まっておらず、先に unsubscribe すると「キャンセルされたのに反応しないアプリ」が残る。片付けは従来どおり exit ハンドラ側
- **オーバーレイは失われません**。待機アイテムは到着時と再接続時に自分で開きます（`controller.ts:1046,1058,1064`）。失われるのは「一度閉じたものを開き直す」操作だけで、件数はフッタに出ます

**2. 背面では描かない**

ログで `foreground: exited` の後も `writes` が増え続けていました。ホストは背面からの描画を**画面に届く前に捨てます**（[Quirk 14](https://github.com/aleapc/even-hub-devguide/blob/master/docs/sdk-quirks.md)）。誰も見ていないパネルへの BLE 送信でした。

描画・スピナー・自動送りを停止し、復帰時に全画面を1回描きます。要約も読みかけの位置のまま止まります。

**3. exit 行に直前のジェスチャ**

```
host exit: system fg=0 gesture=doubleTap@0.4s
```

上の説明が**議論ではなく検証可能**になります。直前にダブルタップがあれば退出、無ければ別の原因。

## 検証

- `bun test` 126件通過（新規3件: ルートで requestExit / lastGesture / 背面で描かない）
- `tsc --noEmit` / `biome check` クリーン
- シミュレータ実機確認: ルートのダブルタップ → mode 不変 + 終了要求、会話画面のダブルタップ → 従来どおり戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUp4qX1DiThXvBEgiyX5Np