### PR TITLE
fix: close three gaps that a rename walks straight into

### DIFF
--- a/backend/src/services/__tests__/peer-registry-lock.test.ts
+++ b/backend/src/services/__tests__/peer-registry-lock.test.ts
@@ -2,27 +2,34 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { IDENTITY } from '../../../../shared/identity';
 
 // Force the data directory before the module loads so peers.json lands in our
-// scratch dir. ensureDataDir reads CC_HUB_DATA_DIR. #251
+// scratch dir. ensureDataDir reads this variable. #251
+//
+// Taken from identity rather than written out: renaming the variable (#459)
+// does not fail a test that spells it — it stops redirecting it, and the test
+// then writes peers.json into the real data directory and still passes.
+const DATA_DIR_ENV = IDENTITY.dataDirEnv;
+
 let tempDir: string;
 let originalDataDir: string | undefined;
 
 beforeEach(async () => {
-  tempDir = await mkdtemp(join(tmpdir(), 'cchub-peers-'));
-  originalDataDir = process.env.CC_HUB_DATA_DIR;
-  process.env.CC_HUB_DATA_DIR = tempDir;
+  tempDir = await mkdtemp(join(tmpdir(), `${IDENTITY.tmpPrefix}-peers-`));
+  originalDataDir = process.env[DATA_DIR_ENV];
+  process.env[DATA_DIR_ENV] = tempDir;
 });
 
 afterEach(async () => {
-  if (originalDataDir === undefined) delete process.env.CC_HUB_DATA_DIR;
-  else process.env.CC_HUB_DATA_DIR = originalDataDir;
+  if (originalDataDir === undefined) delete process.env[DATA_DIR_ENV];
+  else process.env[DATA_DIR_ENV] = originalDataDir;
   await rm(tempDir, { recursive: true, force: true });
 });
 
 describe('peer-registry mutation lock', () => {
   test('concurrent recordPeer* calls do not overwrite each other', async () => {
-    // Re-import after we set CC_HUB_DATA_DIR so the module picks up our temp.
+    // Re-import after we set the data dir so the module picks up our temp.
     const peerRegistry = await import('../peer-registry');
     const { createPeer, recordPeerSuccess, recordPeerFailure, getPeer } = peerRegistry;
 

--- a/backend/src/services/__tests__/session-metadata-lock.test.ts
+++ b/backend/src/services/__tests__/session-metadata-lock.test.ts
@@ -2,21 +2,28 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { IDENTITY } from '../../../../shared/identity';
 
 // Force the data directory before the module loads so session-metadata.json
-// lands in our scratch dir. ensureDataDir reads CC_HUB_DATA_DIR. #333
+// lands in our scratch dir. ensureDataDir reads this variable. #333
+//
+// Taken from identity rather than written out: renaming the variable (#459)
+// does not fail a test that spells it — it stops redirecting it, and the test
+// then writes its fixtures into the real data directory and still passes.
+const DATA_DIR_ENV = IDENTITY.dataDirEnv;
+
 let tempDir: string;
 let originalDataDir: string | undefined;
 
 beforeEach(async () => {
-  tempDir = await mkdtemp(join(tmpdir(), 'cchub-meta-'));
-  originalDataDir = process.env.CC_HUB_DATA_DIR;
-  process.env.CC_HUB_DATA_DIR = tempDir;
+  tempDir = await mkdtemp(join(tmpdir(), `${IDENTITY.tmpPrefix}-meta-`));
+  originalDataDir = process.env[DATA_DIR_ENV];
+  process.env[DATA_DIR_ENV] = tempDir;
 });
 
 afterEach(async () => {
-  if (originalDataDir === undefined) delete process.env.CC_HUB_DATA_DIR;
-  else process.env.CC_HUB_DATA_DIR = originalDataDir;
+  if (originalDataDir === undefined) delete process.env[DATA_DIR_ENV];
+  else process.env[DATA_DIR_ENV] = originalDataDir;
   await rm(tempDir, { recursive: true, force: true });
 });
 

--- a/backend/tests/unit/identity-operational.test.ts
+++ b/backend/tests/unit/identity-operational.test.ts
@@ -119,15 +119,27 @@ describe('no operational identity left as a literal', () => {
     { pattern: new RegExp(esc(IDENTITY.dataDirEnv)), what: 'the data directory env var' },
   ];
 
-  // Where the literals are the point: identity.ts defines them, and the tests
-  // assert against them on purpose.
-  const ALLOWED = /shared\/identity\.ts$|\/tests\/|__tests__\//;
+  /**
+   * Only the files whose whole job is to hold these names: identity.ts defines
+   * them, and three tests assert against them on purpose — the golden systemd
+   * units, the scratch paths, and this scan's own patterns.
+   *
+   * Exempting every test directory instead is what let #668's four tests keep
+   * `CC_HUB_DATA_DIR` written out. That is not a harmless place for it: a
+   * spelled-out variable stops redirecting the data directory when it is
+   * renamed, so the tests write their fixtures into the real one and still
+   * pass. Nothing was red; a data directory just filled up with fake sessions.
+   */
+  const ALLOWED =
+    /shared\/identity\.ts$|identity-consistency\.test\.ts$|identity-operational\.test\.ts$|setup-units\.test\.ts$/;
 
-  test('backend and shared sources go through identity', async () => {
+  test('sources and tests alike go through identity', async () => {
+    // backend/tests is in the list because that is where the misses were.
     const proc = Bun.spawnSync([
       'git',
       'ls-files',
       'backend/src',
+      'backend/tests',
       'shared',
       'frontend/src',
     ], { cwd: join(import.meta.dir, '..', '..', '..') });

--- a/backend/tests/unit/identity-operational.test.ts
+++ b/backend/tests/unit/identity-operational.test.ts
@@ -93,12 +93,30 @@ describe('hook detection pattern', () => {
  * say the name for the reader's benefit and nothing breaks when they are stale.
  */
 describe('no operational identity left as a literal', () => {
+  // Composed from identity.json rather than written out, because a scan that
+  // names one product keeps passing after that product is renamed — it just
+  // stops looking for anything that exists. Renaming the file has to rename
+  // what this looks for, or the guard quietly retires (#459).
+  const esc = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
   const OPERATIONAL = [
-    { pattern: /['"`][^'"`]*cchub\.service/, what: 'a systemd unit name' },
-    { pattern: /['"`][^'"`]*com\.cchub/, what: 'a launchd label' },
-    { pattern: /['"`]\/tmp\/cc-?hub/, what: 'a scratch path' },
-    { pattern: /['"`][^'"`]*\.cc-hub['"`/]/, what: 'the data directory' },
-    { pattern: /CC_HUB_DATA_DIR/, what: 'the data directory env var' },
+    {
+      pattern: new RegExp(`['"\`][^'"\`]*${esc(SERVICE.unitFile)}`),
+      what: 'a systemd unit name',
+    },
+    {
+      pattern: new RegExp(`['"\`][^'"\`]*${esc(IDENTITY.launchdPrefix)}`),
+      what: 'a launchd label',
+    },
+    {
+      pattern: new RegExp(`['"\`]/tmp/${esc(IDENTITY.tmpPrefix)}`),
+      what: 'a scratch path',
+    },
+    {
+      pattern: new RegExp(`['"\`][^'"\`]*${esc(IDENTITY.dataDirName)}['"\`/]`),
+      what: 'the data directory',
+    },
+    { pattern: new RegExp(esc(IDENTITY.dataDirEnv)), what: 'the data directory env var' },
   ];
 
   // Where the literals are the point: identity.ts defines them, and the tests

--- a/backend/tests/unit/jwt-secret.test.ts
+++ b/backend/tests/unit/jwt-secret.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
 import { rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { AuthService } from '../../src/services/auth';
+import { IDENTITY } from '../../../shared/identity';
 
 // Regression for #230: the JWT signing secret must never fall back to a
 // guessable hardcoded default. initJwtSecret() generates and persists a random
@@ -15,7 +16,9 @@ let getJwtSecret: () => string;
 
 beforeAll(async () => {
   delete process.env.JWT_SECRET;
-  process.env.CC_HUB_DATA_DIR = TEST_DATA_DIR;
+  // From identity: a spelled-out variable stops redirecting the data directory
+  // when it is renamed (#459), and the generated secret lands in the real one.
+  process.env[IDENTITY.dataDirEnv] = TEST_DATA_DIR;
   await rm(TEST_DATA_DIR, { recursive: true, force: true });
   // Import after env setup so the module's secret starts uninitialized.
   ({ initJwtSecret, getJwtSecret } = await import('../../src/middleware/auth'));

--- a/backend/tests/unit/sessions.test.ts
+++ b/backend/tests/unit/sessions.test.ts
@@ -9,18 +9,24 @@ import {
   deleteSession,
   updateSessionAccess,
 } from '../../src/services/sessions';
+import { IDENTITY } from '../../../shared/identity';
 
-const TEST_DATA_DIR = join(tmpdir(), 'cc-hub-test-sessions-' + Date.now());
+const TEST_DATA_DIR = join(tmpdir(), `${IDENTITY.tmpPrefix}-test-sessions-` + Date.now());
+
+// Taken from identity rather than written out: renaming the variable (#459)
+// does not fail a test that spells it — it stops redirecting it, and these
+// tests then create their fixture sessions in the real data directory.
+const DATA_DIR_ENV = IDENTITY.dataDirEnv;
 
 describe('Sessions Service', () => {
   beforeEach(async () => {
-    process.env.CC_HUB_DATA_DIR = TEST_DATA_DIR;
+    process.env[DATA_DIR_ENV] = TEST_DATA_DIR;
     await mkdir(TEST_DATA_DIR, { recursive: true });
   });
 
   afterEach(async () => {
     await rm(TEST_DATA_DIR, { recursive: true, force: true });
-    delete process.env.CC_HUB_DATA_DIR;
+    delete process.env[DATA_DIR_ENV];
   });
 
   describe('createSession', () => {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,26 @@ cd "$(dirname "$0")/.."
 # moment it needs the name; this script runs from a checkout and can, so it
 # reads rather than holding a third copy that nothing checks. release.yml
 # renames `dist/<binaryName>` — the two disagreeing breaks CI builds only.
-PRODUCT_NAME=$(bun -e 'console.log((await Bun.file("identity.json").json()).productName)')
-BINARY_NAME=$(bun -e 'console.log((await Bun.file("identity.json").json()).binaryName)')
+#
+# Read in one pass, and checked: a missing key prints "undefined" and exits 0,
+# so `set -e` lets it through and the build produces dist/undefined. That only
+# fails later, in the CI step that renames dist/<binaryName> — the same
+# build-time-only breakage this stopped being a third copy to avoid.
+# One line per field, because productName has a space in it and word
+# splitting would put "Hub" in the binary name.
+IDENTITY_FIELDS=$(bun -e 'const id = await Bun.file("identity.json").json();
+  const need = (k) => {
+    const v = id[k];
+    if (typeof v !== "string" || v.trim() === "") {
+      console.error(`identity.json: ${k} is missing or not a non-empty string`);
+      process.exit(1);
+    }
+    return v;
+  };
+  console.log(need("productName"));
+  console.log(need("binaryName"));')
+
+{ read -r PRODUCT_NAME; read -r BINARY_NAME; } <<< "$IDENTITY_FIELDS"
 
 echo "🏗️  Building $PRODUCT_NAME..."
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,15 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-echo "🏗️  Building CC Hub..."
+# What the binary is called is identity.json's to say (#459). install.sh and
+# release.yml keep their own copies because neither can read the file at the
+# moment it needs the name; this script runs from a checkout and can, so it
+# reads rather than holding a third copy that nothing checks. release.yml
+# renames `dist/<binaryName>` — the two disagreeing breaks CI builds only.
+PRODUCT_NAME=$(bun -e 'console.log((await Bun.file("identity.json").json()).productName)')
+BINARY_NAME=$(bun -e 'console.log((await Bun.file("identity.json").json()).binaryName)')
+
+echo "🏗️  Building $PRODUCT_NAME..."
 
 # Build frontend
 echo "📦 Building frontend..."
@@ -26,7 +34,7 @@ bun run scripts/generate-static-assets.ts
 # Build backend binary with embedded assets
 echo "🔧 Building backend binary (with embedded assets)..."
 cd backend
-bun build src/index.ts --compile --outfile ../dist/cchub
+bun build src/index.ts --compile --outfile "../dist/$BINARY_NAME"
 cd ..
 
 # Clean up generated file
@@ -36,7 +44,7 @@ echo ""
 echo "✅ Build complete!"
 echo ""
 echo "To run:"
-echo "  ./dist/cchub"
+echo "  ./dist/$BINARY_NAME"
 echo ""
 echo "Files:"
 ls -lh dist/


### PR DESCRIPTION
#459 の改名を fork で実際に走らせて見つかった3件。**どれも改名が入ることを前提にしていない** — 現状の cchub のままで存在している「誰も照合していない名前のコピー」で、#635 / #637 が潰そうとしたものと同じ形です。

挙動は完全に不変です（`build.sh` は今も `dist/cchub` を出し、テストは今も temp dir へ逃がし、スキャンは今のリテラルを検出する）。

## 1. `scripts/build.sh` が `dist/cchub` を自前で持っていた

identity.json を読めない consumer は2つ、ということになっていましたが、実際は3つ目がありました。しかも**このスクリプトだけは読める** — `install.sh` はチェックアウトが無く、Actions は matrix をどのステップより先に評価しますが、`build.sh` は冒頭で repo に `cd` します。

まずいのは照合されていない点です。`release.yml` はビルド後に `dist/<binaryName>` を rename し、`identity-consistency.test.ts` は release.yml と identity.json は突き合わせますが、**build.sh とは突き合わせません**。だから2つがズレても、リリースビルドが失敗するまで誰も気づかず、しかもリリースビルドだけが失敗します。

identity.json を読む形にしました（3つ目のコピーを増やさない）。

## 2. 4つのテストがデータディレクトリ env 変数をベタ書きしていた

これが一番たちが悪い形です。

```ts
process.env.CC_HUB_DATA_DIR = tempDir;
```

この変数名を変えると、この行は**失敗しません**。何も設定しない行になるだけです。テストは実データディレクトリに fixture を書き、そして **pass します**。

fork で改名した時に、これで `~/.hrdle` が偽セッション20件と `ses-a` / `ses-b` 入りの session-metadata.json で埋まりました。テストは緑のままです。

identity から読むようにしたので、名前が動けばリダイレクト先も一緒に動きます。

対象:
- `backend/tests/unit/sessions.test.ts`
- `backend/tests/unit/jwt-secret.test.ts`
- `backend/src/services/__tests__/peer-registry-lock.test.ts`
- `backend/src/services/__tests__/session-metadata-lock.test.ts`

## 3. `identity-operational` のスキャン自身がベタ書きだった

`cchub.service` / `com.cchub` / `/tmp/cc-hub` / `.cc-hub` / `CC_HUB_DATA_DIR` をリテラルで探していました。改名後も **pass し続けますが、どこにも存在しない名前を探しているだけ**になります。ハードコードされた identity を検出するガードが、それ自体ハードコードされた identity だった、という形です。

パターンを identity から合成するようにしたので、守るために存在している当の改名を生き延びます。

## 検証

`bun run test` 全 green（backend 535 / frontend 90 / glasses 126）、`bun run lint` エラー 0、`build.sh` は `CC Hub` / `cchub` を読む（出力名不変）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BM6RdHPWdceyowSzSwoz97