### PR TITLE
fix: ports and display names go through identity

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun run --watch src/index.ts -- -p 3456",
-    "dev:auth": "bun run --watch src/index.ts -- -p 3456 -P devpass",
+    "dev": "bun run --watch src/index.ts",
+    "dev:auth": "bun run --watch src/index.ts -- -P devpass",
     "build": "bun build src/index.ts --outdir dist --target bun",
     "start": "bun run dist/index.js",
     "test": "bun test",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun run --watch src/index.ts",
-    "dev:auth": "bun run --watch src/index.ts -- -P devpass",
+    "dev": "bash ../scripts/dev-backend.sh",
+    "dev:auth": "bash ../scripts/dev-backend.sh -P devpass",
     "build": "bun build src/index.ts --outdir dist --target bun",
     "start": "bun run dist/index.js",
     "test": "bun test",

--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -7,7 +7,12 @@ const VERSION = pkg.version;
 
 // Development mode detection (running with bun run --watch)
 const isDev = process.argv.some(arg => arg.includes('--watch'));
-const DEFAULT_PORT = isDev ? 3456 : 5923;
+// Both ports are identity's (#459). Spelled out, they survive a rename in the
+// worst way: `--help` reads its number from identity and says one thing, while
+// the server binds the other. A renamed build then goes for the port the
+// product it replaces is already serving on, and dies with EADDRINUSE on a
+// machine where both are installed.
+const DEFAULT_PORT = isDev ? IDENTITY.devPort : IDENTITY.defaultPort;
 
 interface CliOptions {
   command: 'serve' | 'setup' | 'uninstall' | 'update' | 'status' | 'notify' | 'help' | 'version' | 'debug' | 'send' | 'peek' | 'glasses';

--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -5,14 +5,23 @@ import { IDENTITY } from '../../shared/identity';
 
 const VERSION = pkg.version;
 
-// Development mode detection (running with bun run --watch)
-const isDev = process.argv.some(arg => arg.includes('--watch'));
-// Both ports are identity's (#459). Spelled out, they survive a rename in the
-// worst way: `--help` reads its number from identity and says one thing, while
-// the server binds the other. A renamed build then goes for the port the
-// product it replaces is already serving on, and dies with EADDRINUSE on a
-// machine where both are installed.
-const DEFAULT_PORT = isDev ? IDENTITY.devPort : IDENTITY.defaultPort;
+/**
+ * The port, from identity (#459). Spelled out, it survives a rename in the
+ * worst way: `--help` reads its number from identity and says one thing, while
+ * the server binds the other. A renamed build then goes for the port the
+ * product it replaces is already serving on, and dies with EADDRINUSE on a
+ * machine where both are installed.
+ *
+ * There is deliberately no dev branch here. One used to sit in front of this,
+ * picking `devPort` when `--watch` appeared in argv — but bun does not pass
+ * `--watch` to the script, so it was false in every run and the explicit
+ * `-p` in the dev script was what actually chose the port. Restoring the
+ * detection would do more than undo dead code: this default is also where
+ * `cchub send` and `cchub peek` address the local server (`options.port`
+ * below), and those want the installed service, not whatever a checkout
+ * happens to be running. scripts/dev-backend.sh passes `-p` instead.
+ */
+const DEFAULT_PORT = IDENTITY.defaultPort;
 
 interface CliOptions {
   command: 'serve' | 'setup' | 'uninstall' | 'update' | 'status' | 'notify' | 'help' | 'version' | 'debug' | 'send' | 'peek' | 'glasses';

--- a/backend/src/commands/__tests__/send-base64-exclusive.test.ts
+++ b/backend/src/commands/__tests__/send-base64-exclusive.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { runSend, type SendOptions } from '../send';
+import { IDENTITY } from '../../../../shared/identity';
 
 /**
  * #351: --base64 must not be combined with --submit / --newline. Those flags
@@ -16,7 +17,7 @@ function opts(over: Partial<SendOptions>): SendOptions {
     newline: false,
     submit: false,
     base64: false,
-    localPort: 3456,
+    localPort: IDENTITY.devPort,
     wait: false,
     waitMs: 800,
     lines: 20,

--- a/backend/src/commands/glasses.ts
+++ b/backend/src/commands/glasses.ts
@@ -6,13 +6,16 @@
  *
  * セッション解決: cwd unique 一致 → 曖昧なら /proc の ppid 祖先と pane の
  * foreground pid 照合（worktree 対策）→ それでも駄目なら --session 必須エラー。
- * 送信は notify と同じく本番(5923)/dev(3456) 両叩き・静黙失敗（-p で単一宛）。
+ * 送信は notify と同じく本番/dev 両叩き・静黙失敗（-p で単一宛）。
  */
 
 import { readFileSync } from 'node:fs';
+import { IDENTITY } from '../../../shared/identity';
 
-const PRODUCTION_PORT = 5923;
-const DEV_PORT = 3456;
+// notify.ts と同じく identity 由来 (#459)。ベタ書きだと改名後も旧製品の
+// ポートへ送り続け、届いた側には解決できないセッションとして出る。
+const PRODUCTION_PORT = IDENTITY.defaultPort;
+const DEV_PORT = IDENTITY.devPort;
 
 export interface GlassesCliOptions {
   text?: string;

--- a/backend/src/commands/notify.ts
+++ b/backend/src/commands/notify.ts
@@ -1,7 +1,7 @@
 /**
  * cchub notify - Claude Code / Codex hookイベントをCC Hubサーバーに送信する。
  * stdinからhookのJSON入力を読み取り、CC Hubの /api/notify エンドポイントにPOSTする。
- * デフォルトで本番(5923)とdev(3456)の両方に送信する（失敗は無視）。
+ * デフォルトで本番と dev の両方に送信する（ポートは identity 由来・失敗は無視）。
  *
  * 使い方（hook設定）:
  *   "command": "cchub notify"

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,7 +25,7 @@ import {
   herdrSocketPath,
 } from './services/herdr-client';
 import { t } from './i18n';
-import { TMP_PATHS } from '../../shared/identity';
+import { IDENTITY, TMP_PATHS } from '../../shared/identity';
 
 // Global error handlers to prevent silent crashes
 process.on('uncaughtException', (err) => {
@@ -442,7 +442,7 @@ const port = args.port;
 const host = args.host;
 process.env.CCHUB_PORT = String(port);
 
-console.log(`🚀 CC Hub v${VERSION}`);
+console.log(`🚀 ${IDENTITY.productName} v${VERSION}`);
 console.log(`   URL: https://${tailscaleHostname}:${port}`);
 console.log(`   Static: ${EMBEDDED_MODE ? '(embedded)' : staticRoot}`);
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-    <title>CC Hub</title>
+    <title>%PRODUCT_NAME%</title>
 
     <!-- PWA -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -11,7 +11,7 @@
     <meta name="theme-color" content="#1a1a1a" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="CC Hub" />
+    <meta name="apple-mobile-web-app-title" content="%PRODUCT_NAME%" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -21,7 +21,12 @@
     <!-- FOUC prevention: apply saved theme before first paint -->
     <script>
       (function() {
-        var t = localStorage.getItem('cchub-theme') || 'dark';
+        var prefixes = %STORAGE_PREFIXES%;
+        var t = null;
+        for (var i = 0; i < prefixes.length && !t; i++) {
+          t = localStorage.getItem(prefixes[i] + 'theme');
+        }
+        t = t || 'dark';
         document.documentElement.setAttribute('data-theme', t);
         var meta = document.querySelector('meta[name="theme-color"]');
         if (meta) meta.setAttribute('content', t === 'light' ? '#f8fafc' : '#1a1a1a');
@@ -41,7 +46,7 @@
     <div id="root"></div>
     <!-- Fallback UI: if React fails to mount within 4s, show cache clear button -->
     <div id="fallback" style="display:none;position:fixed;inset:0;z-index:99999;background:#1a1a1a;color:#fff;font-family:'JetBrains Mono',monospace;padding:40px 20px;text-align:center;">
-      <h2 style="margin-bottom:12px;">CC Hub</h2>
+      <h2 style="margin-bottom:12px;">%PRODUCT_NAME%</h2>
       <p style="color:#999;margin-bottom:24px;">アプリの読み込みに問題が発生しています</p>
       <button onclick="clearCacheAndReload()" style="padding:14px 28px;font-size:16px;background:#3b82f6;color:#fff;border:none;border-radius:8px;cursor:pointer;margin:8px;min-width:200px;">キャッシュクリア &amp; リロード</button>
       <br>

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig, devices } from '@playwright/test';
+import { IDENTITY } from '../shared/identity';
 
 // The dev server serves over HTTPS when a Tailscale cert is present (see
 // vite.config.ts), which is the normal local setup but never the case in CI.
-const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:5173';
+//
+// The port is identity's: webServer waits on this URL before running anything,
+// so a number that disagrees with vite's does not fail a test — it hangs until
+// the 120s timeout and reports the server as never having come up (#459).
+const BASE_URL =
+  process.env.E2E_BASE_URL ?? `http://localhost:${IDENTITY.frontendDevPort}`;
 
 const RESPONSIVE = /responsive\/.*\.spec\.ts/;
 

--- a/frontend/playwright.missing-agent.config.ts
+++ b/frontend/playwright.missing-agent.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
+import { IDENTITY } from '../shared/identity';
 
 // Standalone config for the missing-agent test. Assumes the dev server is
-// already running on https://localhost:5173 (started outside playwright).
+// already running on the frontend dev port (started outside playwright).
 export default defineConfig({
   testDir: './tests/e2e',
   testMatch: ['missing-agent.spec.ts', 'file-viewer-selection.spec.ts', 'self-verify-channel-c.spec.ts', 'state-sync-visual.spec.ts', 'state-sync-idle-drift.spec.ts'],
@@ -10,7 +11,7 @@ export default defineConfig({
   workers: 1,
   reporter: 'list',
   use: {
-    baseURL: 'https://localhost:5173',
+    baseURL: `https://localhost:${IDENTITY.frontendDevPort}`,
     ignoreHTTPSErrors: true,
     trace: 'retain-on-failure',
   },

--- a/frontend/src/components/ConversationViewer.tsx
+++ b/frontend/src/components/ConversationViewer.tsx
@@ -23,6 +23,7 @@ import {
 import { agentBadge } from "../utils/agentDisplay";
 import { getTerminalThemes } from "./terminal-themes";
 import { storageKey } from "../utils/app-storage";
+import { TMP_PATHS } from "../../../shared/identity";
 
 const API_BASE = import.meta.env.VITE_API_URL || "";
 
@@ -60,10 +61,22 @@ function getPinchDistance(touches: TouchList): number {
 	return Math.sqrt(dx * dx + dy * dy);
 }
 
-// Convert [Image: source: /tmp/cchub-images/xxx.png] to actual image
+// Convert [Image: source: <imagesDir>/xxx.png] into an actual image.
+//
+// The directory is identity's (#459) — spelled out, it stops matching the
+// moment the name changes and every screenshot in the conversation degrades
+// into its own raw path. Transcripts written under the old name keep the old
+// path forever, but the files they point at live in the previous install's
+// /tmp and this server does not serve them, so matching those too would
+// trade raw text for a broken image.
+const IMAGE_REF_PATTERN = new RegExp(
+	`\\[Image: source: ${TMP_PATHS.imagesDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\/([^\\]]+)\\]`,
+	"g",
+);
+
 function processImageReferences(content: string): string {
 	return content.replace(
-		/\[Image: source: \/tmp\/cchub-images\/([^\]]+)\]/g,
+		IMAGE_REF_PATTERN,
 		(_, filename) => `![Screenshot](${API_BASE}/api/images/${filename})`,
 	);
 }

--- a/frontend/src/utils/bench.ts
+++ b/frontend/src/utils/bench.ts
@@ -9,7 +9,7 @@ import { storageKey } from "./app-storage";
  * summary report when it is seen.
  *
  * Recommended usage:
- *   1. PC で https://localhost:3456 を開いて DevTools コンソールを開く
+ *   1. PC で dev backend (identity.json の devPort) を開いて DevTools コンソールを開く
  *   2. `__cchub_bench.start()` を実行
  *   3. 任意のセッションで:
  *        cat /tmp/bench-color.txt; echo __BENCH_END__

--- a/frontend/src/utils/hookNotification.ts
+++ b/frontend/src/utils/hookNotification.ts
@@ -7,6 +7,7 @@
 
 import { toHomeShortPath } from "./path";
 import { dispatchNotificationNavigation } from "./notificationNavigation";
+import { IDENTITY } from "../../../shared/identity";
 
 const EVENT_MESSAGES: Record<string, string> = {
 	Stop: "応答が完了しました",
@@ -83,7 +84,7 @@ export function fireHookNotification(
 	lastNotification = { key, time: now };
 
 	// Title: project/directory name (e.g. "~/lifestyle-app-work-1")
-	const projectName = toHomeShortPath(cwd) || "CC Hub";
+	const projectName = toHomeShortPath(cwd) || IDENTITY.productName;
 	// Body: smart message from transcript, or fallback
 	const body = smartMessage || EVENT_MESSAGES[event] || `Hook: ${event}`;
 

--- a/frontend/tests/e2e/file-viewer-selection.spec.ts
+++ b/frontend/tests/e2e/file-viewer-selection.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
+import { IDENTITY } from '../../../shared/identity';
 
 // Regression test: switching files in the FileViewer must
 //   (a) keep the file-list scroll position
@@ -7,8 +8,8 @@ import { test, expect, type APIRequestContext } from '@playwright/test';
 // in useFileViewer, which unmounted the file tree (replaced with a "読み込み中…"
 // placeholder) and reset scroll to the top on next mount.
 
-const FRONTEND_URL = 'https://localhost:5173';
-const BACKEND_URL = 'https://localhost:3456';
+const FRONTEND_URL = `https://localhost:${IDENTITY.frontendDevPort}`;
+const BACKEND_URL = `https://localhost:${IDENTITY.devPort}`;
 
 test.use({
   ignoreHTTPSErrors: true,

--- a/frontend/tests/e2e/missing-agent.spec.ts
+++ b/frontend/tests/e2e/missing-agent.spec.ts
@@ -1,14 +1,15 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
+import { IDENTITY } from '../../../shared/identity';
 
 // Regression test for the v0.1.106 / v0.1.107 "会話を表示できません" bug.
 // ChatView must not render the missing-agent error when /api/sessions
 // returns a session with `agent` set.
 //
-// Requires the dev server (frontend 5173 + backend 3456) running with at
+// Requires the dev server (frontend + backend, ports per identity.json) with at
 // least one tmux session that has a claude (or codex) process attached.
 
-const FRONTEND_URL = 'https://localhost:5173';
-const BACKEND_URL = 'https://localhost:3456';
+const FRONTEND_URL = `https://localhost:${IDENTITY.frontendDevPort}`;
+const BACKEND_URL = `https://localhost:${IDENTITY.devPort}`;
 
 test.use({
   ignoreHTTPSErrors: true,

--- a/frontend/tests/e2e/self-verify-channel-c.spec.ts
+++ b/frontend/tests/e2e/self-verify-channel-c.spec.ts
@@ -1,12 +1,13 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
+import { IDENTITY } from '../../../shared/identity';
 import { readFileSync, existsSync } from 'node:fs';
 
 // Channel C smoke test. Requires the dev server to be started with
 // CCHUB_SELF_VERIFY=1. Drives a brief session and asserts the server wrote
 // drift records to /tmp/cchub-drift.log.
 
-const FRONTEND_URL = 'https://localhost:5173';
-const BACKEND_URL = 'https://localhost:3456';
+const FRONTEND_URL = `https://localhost:${IDENTITY.frontendDevPort}`;
+const BACKEND_URL = `https://localhost:${IDENTITY.devPort}`;
 const DRIFT_LOG = '/tmp/cchub-drift.log';
 
 test.use({

--- a/frontend/tests/e2e/state-sync-idle-drift.spec.ts
+++ b/frontend/tests/e2e/state-sync-idle-drift.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
+import { IDENTITY } from '../../../shared/identity';
 // @ts-ignore - node builtin
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 
-const FRONTEND_URL = 'https://localhost:5173';
-const BACKEND_URL = 'https://localhost:3456';
+const FRONTEND_URL = `https://localhost:${IDENTITY.frontendDevPort}`;
+const BACKEND_URL = `https://localhost:${IDENTITY.devPort}`;
 const DRIFT_LOG = '/tmp/cchub-drift.log';
 
 test.use({ ignoreHTTPSErrors: true, baseURL: FRONTEND_URL });

--- a/frontend/tests/e2e/state-sync-visual.spec.ts
+++ b/frontend/tests/e2e/state-sync-visual.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
+import { IDENTITY } from '../../../shared/identity';
 
 // Verify the state-sync transport renders pane content into xterm by reading
 // terminal text back from the DOM.
 
-const FRONTEND_URL = 'https://localhost:5173';
-const BACKEND_URL = 'https://localhost:3456';
+const FRONTEND_URL = `https://localhost:${IDENTITY.frontendDevPort}`;
+const BACKEND_URL = `https://localhost:${IDENTITY.devPort}`;
 
 test.use({ ignoreHTTPSErrors: true, baseURL: FRONTEND_URL });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import os from 'os';
+import { IDENTITY, LEGACY_STORAGE_PREFIXES } from '../shared/identity';
 
 // The release version lives in the root package.json. Baking it into the bundle
 // keeps the frontend in step with the backend it talks to: every release changes
@@ -73,7 +74,7 @@ function getTailscaleCert(): { key: Buffer; cert: Buffer } | undefined {
       }
     }
 
-    console.log(`🔒 HTTPS: https://${hostname}:5173`);
+    console.log(`🔒 HTTPS: https://${hostname}:${IDENTITY.frontendDevPort}`);
     return {
       key: fs.readFileSync(keyPath),
       cert: fs.readFileSync(certPath),
@@ -91,6 +92,24 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(APP_VERSION),
   },
   plugins: [
+    // index.html is a static file that cannot import identity, and the two
+    // names it holds are load-bearing: the title is what a PWA installs itself
+    // as, and the FOUC script reads the theme key before any bundle runs — a
+    // stale prefix there means every load flashes the wrong theme. Substituted
+    // at build time so a rename reaches them (#459). `pre` so this runs before
+    // Vite's own %VITE_*% substitution looks at the placeholders.
+    {
+      name: 'identity-html',
+      enforce: 'pre' as const,
+      transformIndexHtml(html: string) {
+        return html
+          .replaceAll('%PRODUCT_NAME%', IDENTITY.productName)
+          .replaceAll(
+            '%STORAGE_PREFIXES%',
+            JSON.stringify([IDENTITY.storagePrefix, ...LEGACY_STORAGE_PREFIXES]),
+          );
+      },
+    },
     react(),
     tailwindcss(),
     VitePWA({
@@ -108,9 +127,9 @@ export default defineConfig({
       injectRegister: null,
       includeAssets: ['favicon.svg', 'icon-192.png', 'icon-512.png'],
       manifest: {
-        name: 'CC Hub',
-        short_name: 'CC Hub',
-        description: 'Claude Code Terminal Hub',
+        name: IDENTITY.productName,
+        short_name: IDENTITY.productName,
+        description: IDENTITY.tagline,
         theme_color: '#1a1a1a',
         background_color: '#1a1a1a',
         display: 'standalone',
@@ -158,7 +177,7 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: 5173,
+    port: IDENTITY.frontendDevPort,
     host: '0.0.0.0',
     allowedHosts: true,
     https: httpsConfig,
@@ -176,7 +195,7 @@ export default defineConfig({
     },
     proxy: {
       '/api': {
-        target: 'https://localhost:3456',
+        target: `https://localhost:${IDENTITY.devPort}`,
         changeOrigin: true,
         secure: false,
         // Allow long uploads (videos etc.)
@@ -194,7 +213,7 @@ export default defineConfig({
         },
       },
       '/ws': {
-        target: 'wss://localhost:3456',
+        target: `wss://localhost:${IDENTITY.devPort}`,
         ws: true,
         secure: false,
       },

--- a/glasses/src/phone-ui.ts
+++ b/glasses/src/phone-ui.ts
@@ -105,7 +105,7 @@ export async function startPhoneUI(bridge: Bridge | null): Promise<void> {
                 <div>
                   <div style="font-weight: 600; margin-bottom: 2px;">CC Hub を起動</div>
                   <code style="background: #1a1a1a; padding: 4px 8px; border-radius: 4px; font-size: 11px; color: #0f0;">cchub</code>
-                  <span style="color: #888; font-size: 12px; margin-left: 8px;">（デフォルトポート: 5923）</span>
+                  <span style="color: #888; font-size: 12px; margin-left: 8px;">（デフォルトポート: ${__DEFAULT_PORT__}）</span>
                 </div>
               </div>
               <div style="display: flex; gap: 10px; margin-bottom: 12px;">
@@ -130,7 +130,7 @@ export async function startPhoneUI(bridge: Bridge | null): Promise<void> {
           <h2 style="font-size: 15px; color: #0f0; margin: 0 0 12px; font-weight: 600;">CC Hub 接続設定</h2>
           <div style="font-size: 12px; color: #888; margin-bottom: 8px;">CC Hub サーバーの Tailscale URL を入力してください</div>
           <input id="url-input" type="url" value="${savedUrl}"
-            placeholder="https://hostname.tail*****.ts.net:5923"
+            placeholder="https://hostname.tail*****.ts.net:${__DEFAULT_PORT__}"
             style="width: 100%; padding: 12px; border-radius: 8px; border: 1px solid #333; background: #1a1a1a; color: #eee; font-size: 14px; margin-bottom: 10px; box-sizing: border-box; font-family: monospace;"
           />
           <div style="display: flex; gap: 8px;">
@@ -204,9 +204,9 @@ export async function startPhoneUI(bridge: Bridge | null): Promise<void> {
     if (!url.match(/^https?:\/\//)) {
       url = `https://${url}`
     }
-    // Add :5923 if no port
+    // Add the default port if none was typed
     if (!url.match(/:\d+$/)) {
-      url = `${url}:5923`
+      url = `${url}:${__DEFAULT_PORT__}`
     }
     return url
   }

--- a/glasses/src/vite-env.d.ts
+++ b/glasses/src/vite-env.d.ts
@@ -5,6 +5,11 @@
  *  instead of by comparing timestamps against when a build was promoted. */
 declare const __APP_VERSION__: string
 
+/** The server's default port, injected at build time from identity.json. The
+ *  phone UI appends it to a URL typed without one, so it is what the device
+ *  actually connects to — not a label. */
+declare const __DEFAULT_PORT__: number
+
 /** Short commit the bundle was built from, `+dirty` when `src/` or the shared
  *  types had uncommitted edits, `nogit` when the build had no repository to
  *  ask. The version says which number a build claims; this says which code it

--- a/glasses/vite.config.ts
+++ b/glasses/vite.config.ts
@@ -49,6 +49,12 @@ export default defineConfig(({ mode }) => ({
   define: {
     __APP_VERSION__: JSON.stringify(APP_VERSION),
     __BUILD_COMMIT__: JSON.stringify(BUILD_COMMIT),
+    // Injected rather than imported: glasses/src deliberately keeps no
+    // dependency on shared/ (see the mirrored types in src/types.ts), and the
+    // ehpk is shipped to a device where every KB counts. It still has to come
+    // from identity — the phone UI completes a port-less URL with it, so a
+    // literal would keep pointing the device at the previous product (#459).
+    __DEFAULT_PORT__: JSON.stringify(IDENTITY.defaultPort),
   },
   // public/ holds the simulator's backdrop photo, which only the web build
   // wants: the G2 bundle has no browser simulator, and the ehpk is shipped to

--- a/glasses/vite.config.ts
+++ b/glasses/vite.config.ts
@@ -1,6 +1,14 @@
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
+import { IDENTITY } from '../shared/identity'
+
+// Where the simulator proxies API and WS traffic during development. Both the
+// override variable and the fallback port come from identity (#459): spelled
+// out, they keep pointing at the previous product's dev server after a rename.
+const OVERRIDE_ENV = `${IDENTITY.binaryName.toUpperCase()}_URL`
+const BACKEND_URL =
+  process.env[OVERRIDE_ENV] || `https://localhost:${IDENTITY.devPort}`
 
 // The ehpk version, from the one file that decides it. Twice today the
 // question "which build is on the device?" had to be answered by comparing a
@@ -55,12 +63,12 @@ export default defineConfig(({ mode }) => ({
     allowedHosts: true,
     proxy: {
       '/api': {
-        target: process.env.CCHUB_URL || 'https://localhost:3456',
+        target: BACKEND_URL,
         secure: false,
         changeOrigin: true,
       },
       '/ws/mux': {
-        target: process.env.CCHUB_URL || 'https://localhost:3456',
+        target: BACKEND_URL,
         secure: false,
         ws: true,
         changeOrigin: true,

--- a/identity.json
+++ b/identity.json
@@ -7,6 +7,7 @@
   "assetPrefix": "cchub",
   "defaultPort": 5923,
   "devPort": 3456,
+  "frontendDevPort": 5173,
   "dataDirName": ".cc-hub",
   "dataDirEnv": "CC_HUB_DATA_DIR",
   "configDirName": "cchub",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:auth": "bun run stop; bun run --filter backend dev:auth & bun run --filter frontend dev",
     "dev:backend": "bun run --filter backend dev",
     "dev:frontend": "bun run --filter frontend dev",
-    "stop": "fuser -k 3456/tcp 5173/tcp 2>/dev/null || true",
+    "stop": "bash scripts/stop.sh",
     "build": "bun run --filter '*' build",
     "build:binary": "bash scripts/build.sh",
     "test": "bun run --filter '*' test",

--- a/scripts/dev-backend.sh
+++ b/scripts/dev-backend.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Start the backend dev server on the dev port.
+#
+# The port has to be passed in. `bun run --watch src/index.ts` does not put
+# `--watch` into the child's argv, so a dev check inside the CLI that looks for
+# it is always false and the server falls back to the production port — which
+# is the port the installed service is already serving on. package.json is
+# static JSON and cannot read identity.json, so the lookup lives here, same as
+# stop.sh. Checked the same way too: a missing key would expand to nothing and
+# `-p` would swallow the next argument.
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+PORT=$(cd "$ROOT" && bun -e 'const id = await Bun.file("identity.json").json();
+  const v = id.devPort;
+  if (!Number.isInteger(v) || v <= 0) {
+    console.error("identity.json: devPort is missing or not a positive integer");
+    process.exit(1);
+  }
+  console.log(v);')
+
+# staticRoot is resolved relative to the working directory, so the server has to
+# run from backend/ the way `bun run --filter backend dev` used to start it.
+cd "$ROOT/backend"
+exec bun run --watch src/index.ts -p "$PORT" "$@"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Free the dev ports so `bun run dev` can bind them.
+#
+# The numbers are identity.json's (#459). package.json is static JSON and cannot
+# read the file, so the lookup lives here instead of as a pair of literals in a
+# script line — stale ones would kill nothing and leave `dev` failing on an
+# address already in use, which reads as a port conflict rather than a stale
+# number. Checked the same way build.sh checks its fields: a missing key would
+# otherwise expand to nothing and `fuser -k` would take the remaining argument
+# as its target.
+set -e
+
+cd "$(dirname "$0")/.."
+
+PORTS=$(bun -e 'const id = await Bun.file("identity.json").json();
+  const need = (k) => {
+    const v = id[k];
+    if (!Number.isInteger(v) || v <= 0) {
+      console.error(`identity.json: ${k} is missing or not a positive integer`);
+      process.exit(1);
+    }
+    return v;
+  };
+  console.log(`${need("devPort")}/tcp ${need("frontendDevPort")}/tcp`);')
+
+fuser -k $PORTS 2>/dev/null || true

--- a/shared/identity.ts
+++ b/shared/identity.ts
@@ -18,7 +18,11 @@
  * - `CHANGELOG.md` and `specs/`. Those record what was true at the time and are
  *   deliberately left alone by a rename.
  */
-import raw from '../identity.json';
+// The attribute is required by Node's ESM loader and ignored by Bun and Vite.
+// Without it this module is unreadable from anything Node runs — which is how
+// playwright.config.ts, the first consumer outside the Bun/Vite toolchain,
+// found it: ERR_IMPORT_ATTRIBUTE_MISSING before a single test started.
+import raw from '../identity.json' with { type: 'json' };
 
 export const IDENTITY = {
   productName: raw.productName,
@@ -28,6 +32,7 @@ export const IDENTITY = {
   assetPrefix: raw.assetPrefix,
   defaultPort: raw.defaultPort,
   devPort: raw.devPort,
+  frontendDevPort: raw.frontendDevPort,
   dataDirName: raw.dataDirName,
   dataDirEnv: raw.dataDirEnv,
   configDirName: raw.configDirName,


### PR DESCRIPTION
#668 の続き。fork で改名を実際に走らせて動かした結果、見つかった identity 非経由の値をまとめて戻します。

**挙動は変わりません。**`identity.json` は今も cchub / 5923 / 3456 を返すので、以下の値はすべて従来と同じものに解決します。変わるのは「解決するようになった」ことだけです。全テスト green (backend 535 / frontend 90 / glasses 131)、lint / typecheck 通過。

## 現時点で実際のバグ2件

### 1. `cli.ts` が `--help` と違うポートを bind する

```ts
const DEFAULT_PORT = isDev ? 3456 : 5923;   // IDENTITY を import しているのに
```

`--help` は #658 で identity からポートを読むようになった一方、**実際に bind する値はベタ書きのまま**でした。今の名前では偶然一致しているので誰も踏みませんが、改名すると **ヘルプが言う番号と bind する番号が食い違い、置き換える側の製品が使っているポートを奪いに行きます**。fork で実測すると、引数なし起動が `URL: ...:5923` を表示して EADDRINUSE で落ちました。

### 2. `index.html` の FOUC スクリプトが移動済みのキーを読んでいる

```js
var t = localStorage.getItem('cchub-theme') || 'dark';
```

#653 で localStorage を名前空間化した際、`index.html` は素の `<script>` なので取り残されていました。**アプリがもう書かないキーを、first paint 前のテーマ判定が読み続けています**。改名とは無関係な既存バグです。

`pre` の `transformIndexHtml` プラグインでビルド時に差し込み、アプリ本体と同じ prefix リスト（legacy 込み）を辿るようにしました。`index.html` は identity を import できないので、この経路が必要です。

## 静かに壊れるもの

- **`glasses.ts`** — 隣の `notify.ts` は identity 経由なのに、こちらは `PRODUCTION_PORT` / `DEV_PORT` を自前で持っていました。改名すると `<binary> glasses` のメモが**別製品のサーバーへ飛びます**
- **起動バナー** — `--help` だけが #658 で名前を覚え、`index.ts` が起動時に出す行は旧名のまま
- **通知タイトル** — cwd の無い hook 通知のフォールバックがリテラル
- **会話ビューの画像パス正規表現** — `tmpPrefix` が変わると**何にもマッチしなくなり**、会話中のスクリーンショットが全部生パス表示に劣化します

## dev ポートと `frontendDevPort`

dev 側も identity 経由にしました。frontend のポートは identity.json に居場所が無かったのですが、**`playwright.config.ts` が `webServer.url` でそれを待っています**。vite と食い違ってもテストは失敗せず、120秒待って「dev サーバーが起動しなかった」と報告するだけです。

`scripts/stop.sh` は package.json にインラインだったポート対を置き換えるものです（package.json は静的 JSON で identity を読めないため）。build.sh と同じ欠けキーチェック付き — 未定義だと展開が消えて `fuser -k` が残った引数を対象にしてしまうので。

## ついでに直った1件

`shared/identity.ts` は **Node から import できませんでした**。Bun と Vite は attribute 無しの JSON import を通しますが Node は要求します。`playwright.config.ts` が Bun/Vite 以外の初めての利用者になった瞬間、テストが1件も走らないまま `ERR_IMPORT_ATTRIBUTE_MISSING` で落ちました。

## 含めていないもの

`peer-discovery.ts` の `DEFAULT_PORT = 5923` はそのままです。単一製品なら identity に従わせるのが正しいのですが、改名は「2つの製品がしばらく同じ tailnet に共存する」ことを意味し、discovery は**両方**を見つける必要があります。この変更に紛れ込ませず、単独で判断すべきだと考えました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BM6RdHPWdceyowSzSwoz97