### PR TITLE
Release v0.2.98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.98] - 2026-07-29
+
+### Fixed
+- **ポートと表示名を identity 経由にする** (#672): fork で改名を実際に走らせて見つかった、identity を通っていない値をまとめて戻した。`identity.json` は今も cchub / 5923 / 3456 を返すので挙動は不変
+  - **`cli.ts` が `--help` と違うポートを bind していた**。ヘルプは #658 で identity からポートを読むようになった一方、実際に bind する `DEFAULT_PORT` はベタ書きのままだった。今の名前では偶然一致しているが、改名すると**ヘルプが言う番号と bind する番号が食い違い、置き換える側の製品が使っているポートを奪いに行く**
+  - **`index.html` の FOUC スクリプトが移動済みの localStorage キーを読んでいた**。#653 で名前空間化した際、素の `<script>` は取り残されていた。**アプリがもう書かないキーを、first paint 前のテーマ判定が読み続けていた**（改名とは無関係な既存バグ）。`transformIndexHtml` プラグイン（`enforce: 'pre'`）でビルド時にプレースホルダを差し込み、アプリ本体と同じ prefix リスト（legacy 込み）を辿るようにした
+  - **`glasses.ts` が `notify.ts` の隣で本番/dev ポートを自前に持っていた**。改名すると `cchub glasses` のメモが別製品のサーバーへ飛ぶ
+  - **会話ビューの画像パス正規表現**が `/tmp/cchub-images` をベタ書きしていた。`tmpPrefix` が変わると**何にもマッチせず**、会話中のスクリーンショットが全部生パス表示に劣化する
+  - 起動バナーと、cwd の無い hook 通知のタイトルも identity 経由に
+  - dev ポート（vite の `server.port` / proxy target / playwright の `webServer.url` / e2e 5本）も同様に。frontend の dev ポートは `identity.json` に居場所が無かったが、`playwright.config.ts` の値が vite とズレると**テスト失敗ではなく、120秒待って「dev サーバーが起動しなかった」と報告する**形で落ちるため `frontendDevPort` を追加した
+  - **`shared/identity.ts` が Node から import できなかった**。Bun と Vite は attribute 無しの JSON import を通すが Node は要求する。`playwright.config.ts` が Bun/Vite 以外で初めての利用者になった瞬間、テストが1件も走らないまま `ERR_IMPORT_ATTRIBUTE_MISSING` で落ちていた
+- **dev サーバーが本番ポートを掴む状態になりかけていた** (#672): 上の変更で backend の dev スクリプトから `-p 3456` が外れ、ポートの決定が「argv に `--watch` があるか」という判定に委ねられた。**bun は `--watch` を子プロセスの argv に渡さないのでこの判定は常に false** で、dev サーバーが本番ポートに bind する（インストール済みサービスがあれば EADDRINUSE、無ければ dev が 5923 を占有して vite の proxy が空振りする）。`bun run stop` が開けるのは 3456/5173 なので、**dev が掴むポートを stop が解放しない**組み合わせにもなっていた。`scripts/dev-backend.sh` が `devPort` を読んで `-p` を渡す形にし、判定自体は**修復ではなく削除**した — 同じ既定値が `cchub send` / `cchub peek` のローカル宛先でもあり、そちらはインストール済みサービスを向くべきなので、判定が効くようにすると dev 起動した CLI からの送信が黙って dev サーバーへ向く
+- **グラスのスマホ UI がポート無し URL を旧ポートで補完していた** (#672): `phone-ui.ts` が `:5923` をベタ書きで足していた。ラベルではなく**端末が実際に繋ぎに行く先**なので、改名後は旧製品のサーバーへ接続する。`define` による注入にした（`import` ではないのは glasses/src が意図的に shared/ に依存しておらず、ehpk が端末に載るため）
+
 ## [0.2.97] - 2026-07-29
 
 ### Fixed

--- a/architecture.html
+++ b/architecture.html
@@ -121,7 +121,7 @@
   <div id="loading" class="loading">architecture.json を読み込み中…</div>
   <script type="application/json" id="arch-data">{
   "name": "CC Hub",
-  "version": "0.2.97",
+  "version": "0.2.98",
   "generated": "2026-07-29",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/architecture.json
+++ b/architecture.json
@@ -1,6 +1,6 @@
 {
   "name": "CC Hub",
-  "version": "0.2.97",
+  "version": "0.2.98",
   "generated": "2026-07-29",
   "summary": "Web-based terminal session manager for Claude Code / Codex. Runs agents in herdr workspaces and provides a web UI for remote access from tablets/mobile devices",
   "stack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-hub",
-  "version": "0.2.97",
+  "version": "0.2.98",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changes

- **fix: ポートと表示名を identity 経由にする** (#672) — fork で改名を実際に走らせて見つかった、identity を通っていない値をまとめて戻した。`identity.json` は今も cchub / 5923 / 3456 を返すので挙動は不変
  - `cli.ts` が `--help` と違うポートを bind していた（改名すると置き換える側の製品のポートを奪いに行く）
  - `index.html` の FOUC スクリプトが、#653 で移動済みの localStorage キーを first paint 前に読み続けていた（改名と無関係な既存バグ）
  - `glasses.ts` の本番/dev ポート、起動バナー、hook 通知のタイトル、会話ビューの画像パス正規表現（`tmpPrefix` が変わると何にもマッチしなくなる）
  - dev ポートも identity 経由に。`playwright.config.ts` のズレは「テスト失敗」ではなく「120秒待って dev サーバーが起動しなかった」として出るため `frontendDevPort` を追加
  - `shared/identity.ts` が Node から import できなかった（JSON import の attribute 不足）
- **fix: dev サーバーが本番ポートを掴む状態を潰す** (#672) — 上の変更で dev スクリプトから `-p 3456` が外れ、`--watch` を argv から探す判定にポート決定が委ねられた。bun はそれを子プロセスに渡さないので判定は常に false。`scripts/dev-backend.sh` が `devPort` を読んで渡す形にし、判定は削除（同じ既定値が `cchub send` / `cchub peek` のローカル宛先でもあるため）
- **fix: グラスのスマホ UI がポート無し URL を旧ポートで補完していた** (#672)

## Notes

**cc-hub としてはこのリリースでコードフリーズ**。以降の開発は改名先のフォークへ移る (#459)。

`identity.json` を書き換えれば製品名・バイナリ名・ポート・データディレクトリ・サービス名・ストレージ prefix が追従する状態になった。ガードは3層 — `install.sh` / `release.yml` との一致、ソース中のリテラル走査、i18n プレースホルダ — いずれもわざと壊して落ちることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STv3pQwmpdxMa9fJ4TK7a6
