### PR TITLE
docs: archive notice on both READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,18 @@
 
 日本語 | [English](README.md)
 
+> ## ⚠️ このリポジトリはアーカイブされました
+>
+> **CC Hub は [v0.2.98](https://github.com/m0a/cc-hub/releases/tag/v0.2.98)（2026-07-29）で凍結しました。開発は [Hrdle](https://github.com/hrdle/hrdle) として続きます。**
+>
+> 「CC Hub」という名前は Claude Code を名乗っていましたが、このツールはとうにそれだけのものではなくなっていました（Codex / Grok / Kimi のセッションも扱います）。Hrdle は、説明を足さなくて済む名前になった同じプロジェクトです。移行の経緯は [#459](https://github.com/m0a/cc-hub/issues/459) にあります。
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/hrdle/hrdle/main/install.sh | bash
+> ```
+>
+> 既存のインストールはそのまま動きます。アーカイブされても読み取りは変わらないので、リリース資産と `install.sh` は取得でき、`cchub update` も従来どおり解決します。Hrdle は上書きではなく**並べて**入ります（バイナリ・サービス・ポート・herdr セッションが別）。1台で両方を動かしながら切り替えられます。できなくなるのは新しいコードだけで、issue と pull request は閉じられます。
+
 Claude Codeセッションをリモート管理するWebベースのターミナルマネージャー。タブレットやスマートフォンからClaude Codeを操作できます。
 
 ## スクリーンショット

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 [日本語](README.ja.md) | English
 
+> ## ⚠️ This repository is archived
+>
+> **CC Hub is frozen at [v0.2.98](https://github.com/m0a/cc-hub/releases/tag/v0.2.98) (2026-07-29). Development continues as [Hrdle](https://github.com/hrdle/hrdle).**
+>
+> The name "CC Hub" said Claude Code, and the tool had long since stopped being only that — it manages Codex, Grok, and Kimi sessions too. Hrdle is the same project under a name that does not have to be explained away. See [#459](https://github.com/m0a/cc-hub/issues/459) for the migration.
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/hrdle/hrdle/main/install.sh | bash
+> ```
+>
+> Existing installs keep working: this repository stays readable, so its releases and `install.sh` remain available and `cchub update` still resolves. Hrdle installs alongside rather than over it — a separate binary, service, port, and herdr session — so both can run on one machine while you switch over. What no longer happens here is new code: issues and pull requests are closed.
+
 A web-based terminal manager for remotely managing Claude Code sessions. Control Claude Code from your tablet or smartphone.
 
 ## Screenshot


### PR DESCRIPTION
アーカイブ後は README を直せないので、移行先を README の先頭に固定する。英日どちらにも同じ内容を置いた。

- 凍結点 (v0.2.98) と移行先 ([hrdle/hrdle](https://github.com/hrdle/hrdle))
- 改名した理由（「CC Hub」は Claude Code を名乗るが、実際には Codex / Grok / Kimi も扱う）
- **既存インストールが失われないこと** — アーカイブは書き込みを止めるだけで読み取りは変わらないため、リリース資産と `install.sh` は引き続き取得でき、`cchub update` も解決する。hrdle は上書きではなく並べて入る

#459 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STv3pQwmpdxMa9fJ4TK7a6